### PR TITLE
fix(k8s): fix kafka-setup-job.yml datahub-certs-dir mountPath

### DIFF
--- a/datahub-kubernetes/datahub/templates/kafka-setup-job.yml
+++ b/datahub-kubernetes/datahub/templates/kafka-setup-job.yml
@@ -67,7 +67,7 @@ spec:
           volumeMounts:
           {{- if .Values.global.credentialsAndCertsSecrets }}
             - name: datahub-certs-dir
-              mountPath: {{ .Values.global.credentialsAndCertsSecretPath | default "/mnt/certs" }}
+              mountPath: {{ .Values.global.credentialsAndCertsSecrets.path | default "/mnt/certs" }}
           {{- end }}
           {{- with .Values.kafkaSetupJob.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
**What**
Modified `kafka-setup-job` to use `.Values.global.credentialsAndCertsSecrets.path` instead of `.Values.global.credentialsAndCertsSecretPath`

**Why**
Figured out that the Kafka setup job uses a different variable compared to DataHub GMS, seems like a bug but might not be.

Before my changes...
`kafka-setup-job`: `.Values.global.credentialsAndCertsSecretPath` at https://github.com/linkedin/datahub/blob/ae4def2f256aac1c652ece4ae17c733fe76c2947/datahub-kubernetes/datahub/templates/kafka-setup-job.yml#L67-L71
`datahub-gms`: `.Values.global.credentialsAndCertsSecrets.path` at https://github.com/linkedin/datahub/blob/ae4def2f256aac1c652ece4ae17c733fe76c2947/datahub-kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml#L126-L130

The example `values.yml` also doesn't define `global.credentialsAndCertsSecretPath`
https://github.com/linkedin/datahub/blob/ae4def2f256aac1c652ece4ae17c733fe76c2947/datahub-kubernetes/datahub/values.yaml#L99-L103

**Risks**
This would break people actually depending on `.Values.global.credentialsAndCertsSecretPath` in `kafka-setup-job`.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
    - NA
- [x] Tests for the changes have been added/updated (if applicable)
    - There are no tests, I ran `helm upgrade` in local development
- [x] Docs related to the changes have been added/updated (if applicable)
    - NA, docs doesn't mention the old reference