### PR TITLE
feat: add support for specialization of models through subtypes with …

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -493,6 +493,9 @@ public class GmsGraphQLEngine {
                 .dataFetcher("schemaMetadata", new AuthenticatedResolver<>(
                     new AspectResolver())
                 )
+               .dataFetcher("subTypes", new AuthenticatedResolver(new SubTypesResolver(GmsClientFactory.getAspectsClient(),
+                           "dataset",
+                       "subTypes")))
             )
             .type("Owner", typeWiring -> typeWiring
                     .dataFetcher("owner", new AuthenticatedResolver<>(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/SubTypesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/SubTypesResolver.java
@@ -1,0 +1,42 @@
+package com.linkedin.datahub.graphql;
+
+import com.linkedin.common.SubTypes;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.entity.client.AspectClient;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@AllArgsConstructor
+public class SubTypesResolver implements DataFetcher<CompletableFuture<SubTypes>> {
+
+    AspectClient _aspectClient;
+    String _entityType;
+    String _aspectName;
+
+
+    @Override
+    public CompletableFuture<SubTypes> get(DataFetchingEnvironment environment) throws Exception {
+        return CompletableFuture.supplyAsync(() -> {
+            final QueryContext context = environment.getContext();
+            final String urn = ((Entity) environment.getSource()).getUrn();
+            Optional<SubTypes> subType;
+            try {
+                subType = _aspectClient.getVersionedAspect(urn, _aspectName, 0L, context.getActor(), SubTypes.class);
+            } catch (RemoteInvocationException e) {
+                throw new RuntimeException("Failed to fetch aspect " + _aspectName + " for urn " + urn + " ", e);
+            }
+            if (subType.isPresent()) {
+                return subType.get();
+            } else {
+                return null;
+            }
+        });
+    }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
@@ -99,7 +99,7 @@ public class DatasetType implements SearchableEntityType<Dataset>, BrowsableEnti
             return gmsResults.stream()
                 .map(gmsDataset ->
                     gmsDataset == null ? null : DataFetcherResult.<Dataset>newResult()
-                        .data(DatasetSnapshotMapper.map(gmsDataset.getValue().getDatasetSnapshot()))
+                            .data(DatasetSnapshotMapper.map(gmsDataset.getValue().getDatasetSnapshot()))
                         .localContext(AspectExtractor.extractAspects(gmsDataset.getValue().getDatasetSnapshot()))
                         .build()
                 )

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetSnapshotMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetSnapshotMapper.java
@@ -20,7 +20,6 @@ import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
 import com.linkedin.dataset.DatasetDeprecation;
 import com.linkedin.dataset.DatasetProperties;
 import com.linkedin.dataset.EditableDatasetProperties;
-import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.snapshot.DatasetSnapshot;
 import com.linkedin.schema.EditableSchemaMetadata;
 import com.linkedin.schema.SchemaMetadata;
@@ -52,7 +51,7 @@ public class DatasetSnapshotMapper implements ModelMapper<DatasetSnapshot, Datas
         partialPlatform.setUrn(dataset.getUrn().getPlatformEntity().toString());
         result.setPlatform(partialPlatform);
 
-        ModelUtils.getAspectsFromSnapshot(dataset).forEach(aspect -> {
+        NewModelUtils.getAspectsFromSnapshot(dataset).forEach(aspect -> {
             if (aspect instanceof DatasetProperties) {
                 final DatasetProperties gmsProperties = (DatasetProperties) aspect;
                 final com.linkedin.datahub.graphql.generated.DatasetProperties properties = new com.linkedin.datahub.graphql.generated.DatasetProperties();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/NewModelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/NewModelUtils.java
@@ -1,0 +1,378 @@
+package com.linkedin.datahub.graphql.types.dataset.mappers;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.ArrayDataSchema;
+import com.linkedin.data.schema.DataSchema.Type;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.TyperefDataSchema;
+import com.linkedin.data.schema.UnionDataSchema.Member;
+import com.linkedin.data.template.DataTemplate;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.TemplateOutputCastException;
+import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.data.template.WrappingArrayTemplate;
+import com.linkedin.metadata.aspect.AspectVersion;
+import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.metadata.dummy.DummySnapshot;
+import com.linkedin.metadata.validator.AspectValidator;
+import com.linkedin.metadata.validator.DeltaValidator;
+import com.linkedin.metadata.validator.DocumentValidator;
+import com.linkedin.metadata.validator.EntityValidator;
+import com.linkedin.metadata.validator.InvalidSchemaException;
+import com.linkedin.metadata.validator.RelationshipValidator;
+import com.linkedin.metadata.validator.SnapshotValidator;
+import com.linkedin.metadata.validator.ValidationUtils;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanner;
+
+
+public class NewModelUtils {
+  private static final ClassLoader CLASS_LOADER = DummySnapshot.class.getClassLoader();
+  private static final String METADATA_AUDIT_EVENT_PREFIX = "METADATA_AUDIT_EVENT";
+
+  private NewModelUtils() {
+  }
+
+  public static <T extends DataTemplate> String getAspectName(@Nonnull Class<T> aspectClass) {
+    return aspectClass.getCanonicalName();
+  }
+
+  @Nonnull
+  public static Class<? extends RecordTemplate> getAspectClass(@Nonnull String aspectName) {
+    return getClassFromName(aspectName, RecordTemplate.class);
+  }
+
+  @Nonnull
+  public static <ASPECT_UNION extends UnionTemplate> Set<Class<? extends RecordTemplate>> getValidAspectTypes(
+      @Nonnull Class<ASPECT_UNION> aspectUnionClass) {
+    AspectValidator.validateAspectUnionSchema(aspectUnionClass);
+    Set<Class<? extends RecordTemplate>> validTypes = new HashSet();
+    Iterator var2 = ValidationUtils.getUnionSchema(aspectUnionClass).getMembers().iterator();
+
+    while (var2.hasNext()) {
+      Member member = (Member) var2.next();
+      if (member.getType().getType() == Type.RECORD) {
+        String fqcn = ((RecordDataSchema) member.getType()).getBindingName();
+
+        try {
+          validTypes.add(CLASS_LOADER.loadClass(fqcn).asSubclass(RecordTemplate.class));
+        } catch (ClassCastException | ClassNotFoundException var6) {
+          throw new RuntimeException(var6);
+        }
+      }
+    }
+
+    return validTypes;
+  }
+
+  @Nonnull
+  public static <T> Class<? extends T> getClassFromName(@Nonnull String className, @Nonnull Class<T> parentClass) {
+    try {
+      return CLASS_LOADER.loadClass(className).asSubclass(parentClass);
+    } catch (ClassNotFoundException var3) {
+      throw new RuntimeException(var3);
+    }
+  }
+
+  @Nonnull
+  public static Class<? extends RecordTemplate> getMetadataSnapshotClassFromName(@Nonnull String className) {
+    Class<? extends RecordTemplate> snapshotClass = getClassFromName(className, RecordTemplate.class);
+    SnapshotValidator.validateSnapshotSchema(snapshotClass);
+    return snapshotClass;
+  }
+
+  @Nonnull
+  public static <SNAPSHOT extends RecordTemplate> Urn getUrnFromSnapshot(@Nonnull SNAPSHOT snapshot) {
+    SnapshotValidator.validateSnapshotSchema(snapshot.getClass());
+    return (Urn) RecordUtils.getRecordTemplateField(snapshot, "urn", urnClassForSnapshot(snapshot.getClass()));
+  }
+
+  @Nonnull
+  public static Urn getUrnFromSnapshotUnion(@Nonnull UnionTemplate snapshotUnion) {
+    return getUrnFromSnapshot(RecordUtils.getSelectedRecordTemplateFromUnion(snapshotUnion));
+  }
+
+  @Nonnull
+  public static <DELTA extends RecordTemplate> Urn getUrnFromDelta(@Nonnull DELTA delta) {
+    DeltaValidator.validateDeltaSchema(delta.getClass());
+    return (Urn) RecordUtils.getRecordTemplateField(delta, "urn", urnClassForDelta(delta.getClass()));
+  }
+
+  @Nonnull
+  public static Urn getUrnFromDeltaUnion(@Nonnull UnionTemplate deltaUnion) {
+    return getUrnFromDelta(RecordUtils.getSelectedRecordTemplateFromUnion(deltaUnion));
+  }
+
+  @Nonnull
+  public static <DOCUMENT extends RecordTemplate> Urn getUrnFromDocument(@Nonnull DOCUMENT document) {
+    DocumentValidator.validateDocumentSchema(document.getClass());
+    return (Urn) RecordUtils.getRecordTemplateField(document, "urn", urnClassForDocument(document.getClass()));
+  }
+
+  @Nonnull
+  public static <ENTITY extends RecordTemplate> Urn getUrnFromEntity(@Nonnull ENTITY entity) {
+    EntityValidator.validateEntitySchema(entity.getClass());
+    return (Urn) RecordUtils.getRecordTemplateField(entity, "urn", urnClassForDocument(entity.getClass()));
+  }
+
+  @Nonnull
+  private static <RELATIONSHIP extends RecordTemplate> Urn getUrnFromRelationship(@Nonnull RELATIONSHIP relationship,
+      @Nonnull String fieldName) {
+    RelationshipValidator.validateRelationshipSchema(relationship.getClass());
+    return (Urn) RecordUtils.getRecordTemplateField(relationship, fieldName,
+        urnClassForRelationship(relationship.getClass(), fieldName));
+  }
+
+  @Nonnull
+  public static <RELATIONSHIP extends RecordTemplate> Urn getSourceUrnFromRelationship(
+      @Nonnull RELATIONSHIP relationship) {
+    return getUrnFromRelationship(relationship, "source");
+  }
+
+  @Nonnull
+  public static <RELATIONSHIP extends RecordTemplate> Urn getDestinationUrnFromRelationship(
+      @Nonnull RELATIONSHIP relationship) {
+    return getUrnFromRelationship(relationship, "destination");
+  }
+
+  @Nonnull
+  public static <SNAPSHOT extends RecordTemplate> List<RecordTemplate> getAspectsFromSnapshot(
+      @Nonnull SNAPSHOT snapshot) {
+    SnapshotValidator.validateSnapshotSchema(snapshot.getClass());
+    return getAspects(snapshot);
+  }
+
+  @Nonnull
+  public static <SNAPSHOT extends RecordTemplate, ASPECT extends DataTemplate> Optional<ASPECT> getAspectFromSnapshot(
+      @Nonnull SNAPSHOT snapshot, @Nonnull Class<ASPECT> aspectClass) {
+    Optional var10000 = getAspectsFromSnapshot(snapshot).stream().filter((aspect) -> {
+      return aspect.getClass().equals(aspectClass);
+    }).findFirst();
+    Objects.requireNonNull(aspectClass);
+    return var10000.map(aspectClass::cast);
+  }
+
+  @Nonnull
+  public static List<RecordTemplate> getAspectsFromSnapshotUnion(@Nonnull UnionTemplate snapshotUnion) {
+    return getAspects(RecordUtils.getSelectedRecordTemplateFromUnion(snapshotUnion));
+  }
+
+  @Nonnull
+  private static List<RecordTemplate> getAspects(@Nonnull RecordTemplate snapshot) {
+    Class<? extends WrappingArrayTemplate> clazz = getAspectsArrayClass(snapshot.getClass());
+    WrappingArrayTemplate aspectArray =
+        (WrappingArrayTemplate) RecordUtils.getRecordTemplateWrappedField(snapshot, "aspects", clazz);
+    List<RecordTemplate> aspects = new ArrayList();
+    aspectArray.forEach((item) -> {
+      try {
+        aspects.add(RecordUtils.getSelectedRecordTemplateFromUnion((UnionTemplate) item));
+      } catch (InvalidSchemaException e) {
+        // ignore fields that are not part of the union
+      } catch (TemplateOutputCastException e) {
+        // ignore fields that are not part of the union
+      }
+    });
+    return aspects;
+  }
+
+  @Nonnull
+  public static <SNAPSHOT extends RecordTemplate, ASPECT_UNION extends UnionTemplate, URN extends Urn> SNAPSHOT newSnapshot(
+      @Nonnull Class<SNAPSHOT> snapshotClass, @Nonnull URN urn, @Nonnull List<ASPECT_UNION> aspects) {
+    SnapshotValidator.validateSnapshotSchema(snapshotClass);
+    Class aspectArrayClass = getAspectsArrayClass(snapshotClass);
+
+    try {
+      SNAPSHOT snapshot = (SNAPSHOT) snapshotClass.newInstance();
+      RecordUtils.setRecordTemplatePrimitiveField(snapshot, "urn", urn.toString());
+      WrappingArrayTemplate aspectArray = (WrappingArrayTemplate) aspectArrayClass.newInstance();
+      aspectArray.addAll(aspects);
+      RecordUtils.setRecordTemplateComplexField(snapshot, "aspects", aspectArray);
+      return snapshot;
+    } catch (IllegalAccessException | InstantiationException var6) {
+      throw new RuntimeException(var6);
+    }
+  }
+
+  @Nonnull
+  private static <SNAPSHOT extends RecordTemplate> Class<? extends WrappingArrayTemplate> getAspectsArrayClass(
+      @Nonnull Class<SNAPSHOT> snapshotClass) {
+    try {
+      return snapshotClass.getMethod("getAspects").getReturnType().asSubclass(WrappingArrayTemplate.class);
+    } catch (ClassCastException | NoSuchMethodException var2) {
+      throw new RuntimeException(var2);
+    }
+  }
+
+  @Nonnull
+  public static <ASPECT_UNION extends UnionTemplate, ASPECT extends RecordTemplate> ASPECT_UNION newAspectUnion(
+      @Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull ASPECT aspect) {
+    AspectValidator.validateAspectUnionSchema(aspectUnionClass);
+
+    try {
+      ASPECT_UNION aspectUnion = (ASPECT_UNION) aspectUnionClass.newInstance();
+      RecordUtils.setSelectedRecordTemplateInUnion(aspectUnion, aspect);
+      return aspectUnion;
+    } catch (IllegalAccessException | InstantiationException var3) {
+      throw new RuntimeException(var3);
+    }
+  }
+
+  @Nonnull
+  public static <ASPECT extends RecordTemplate> AspectVersion newAspectVersion(@Nonnull Class<ASPECT> aspectClass,
+      long version) {
+    AspectVersion aspectVersion = new AspectVersion();
+    aspectVersion.setAspect(getAspectName(aspectClass));
+    aspectVersion.setVersion(version);
+    return aspectVersion;
+  }
+
+  @Nonnull
+  public static Class<? extends UnionTemplate> aspectClassForSnapshot(
+      @Nonnull Class<? extends RecordTemplate> snapshotClass) {
+    SnapshotValidator.validateSnapshotSchema(snapshotClass);
+    String aspectClassName = ((TyperefDataSchema) ((ArrayDataSchema) ValidationUtils.getRecordSchema(snapshotClass)
+        .getField("aspects")
+        .getType()).getItems()).getBindingName();
+    return getClassFromName(aspectClassName, UnionTemplate.class);
+  }
+
+  @Nonnull
+  public static Class<? extends Urn> urnClassForEntity(@Nonnull Class<? extends RecordTemplate> entityClass) {
+    EntityValidator.validateEntitySchema(entityClass);
+    return urnClassForField(entityClass, "urn");
+  }
+
+  @Nonnull
+  public static Class<? extends Urn> urnClassForSnapshot(@Nonnull Class<? extends RecordTemplate> snapshotClass) {
+    SnapshotValidator.validateSnapshotSchema(snapshotClass);
+    return urnClassForField(snapshotClass, "urn");
+  }
+
+  @Nonnull
+  public static Class<? extends Urn> urnClassForDelta(@Nonnull Class<? extends RecordTemplate> deltaClass) {
+    DeltaValidator.validateDeltaSchema(deltaClass);
+    return urnClassForField(deltaClass, "urn");
+  }
+
+  @Nonnull
+  public static Class<? extends Urn> urnClassForDocument(@Nonnull Class<? extends RecordTemplate> documentClass) {
+    DocumentValidator.validateDocumentSchema(documentClass);
+    return urnClassForField(documentClass, "urn");
+  }
+
+  @Nonnull
+  private static Class<? extends Urn> urnClassForRelationship(
+      @Nonnull Class<? extends RecordTemplate> relationshipClass, @Nonnull String fieldName) {
+    RelationshipValidator.validateRelationshipSchema(relationshipClass);
+    return urnClassForField(relationshipClass, fieldName);
+  }
+
+  @Nonnull
+  public static Class<? extends Urn> sourceUrnClassForRelationship(
+      @Nonnull Class<? extends RecordTemplate> relationshipClass) {
+    return urnClassForRelationship(relationshipClass, "source");
+  }
+
+  @Nonnull
+  public static Class<? extends Urn> destinationUrnClassForRelationship(
+      @Nonnull Class<? extends RecordTemplate> relationshipClass) {
+    return urnClassForRelationship(relationshipClass, "destination");
+  }
+
+  @Nonnull
+  private static Class<? extends Urn> urnClassForField(@Nonnull Class<? extends RecordTemplate> recordClass,
+      @Nonnull String fieldName) {
+    String urnClassName = ((DataMap) ValidationUtils.getRecordSchema(recordClass)
+        .getField(fieldName)
+        .getType()
+        .getProperties()
+        .get("java")).getString("class");
+    return getClassFromName(urnClassName, Urn.class);
+  }
+
+  public static <SNAPSHOT extends RecordTemplate, ASPECT_UNION extends UnionTemplate> void validateSnapshotAspect(
+      @Nonnull Class<SNAPSHOT> snapshotClass, @Nonnull Class<ASPECT_UNION> aspectUnionClass) {
+    SnapshotValidator.validateSnapshotSchema(snapshotClass);
+    AspectValidator.validateAspectUnionSchema(aspectUnionClass);
+    if (!aspectClassForSnapshot(snapshotClass).equals(aspectUnionClass)) {
+      throw new InvalidSchemaException(aspectUnionClass.getCanonicalName() + " is not a supported aspect class of "
+          + snapshotClass.getCanonicalName());
+    }
+  }
+
+  public static <SNAPSHOT extends RecordTemplate, URN extends Urn> void validateSnapshotUrn(
+      @Nonnull Class<SNAPSHOT> snapshotClass, @Nonnull Class<URN> urnClass) {
+    SnapshotValidator.validateSnapshotSchema(snapshotClass);
+    if (!urnClassForSnapshot(snapshotClass).isAssignableFrom(urnClass)) {
+      throw new InvalidSchemaException(
+          urnClass.getCanonicalName() + " is not a supported URN class of " + snapshotClass.getCanonicalName());
+    }
+  }
+
+  @Nonnull
+  public static <RELATIONSHIP_UNION extends UnionTemplate, RELATIONSHIP extends RecordTemplate> RELATIONSHIP_UNION newRelationshipUnion(
+      @Nonnull Class<RELATIONSHIP_UNION> relationshipUnionClass, @Nonnull RELATIONSHIP relationship) {
+    RelationshipValidator.validateRelationshipUnionSchema(relationshipUnionClass);
+
+    try {
+      RELATIONSHIP_UNION relationshipUnion = (RELATIONSHIP_UNION) relationshipUnionClass.newInstance();
+      RecordUtils.setSelectedRecordTemplateInUnion(relationshipUnion, relationship);
+      return relationshipUnion;
+    } catch (IllegalAccessException | InstantiationException var3) {
+      throw new RuntimeException(var3);
+    }
+  }
+
+  @Nonnull
+  public static Set<Class<? extends RecordTemplate>> getAllEntities() {
+    return (Set) (new Reflections("com.linkedin.metadata.entity", new Scanner[0])).getSubTypesOf(RecordTemplate.class)
+        .stream()
+        .filter(EntityValidator::isValidEntitySchema)
+        .collect(Collectors.toSet());
+  }
+
+  @Nonnull
+  public static String getEntityTypeFromUrnClass(@Nonnull Class<? extends Urn> urnClass) {
+    try {
+      return urnClass.getDeclaredField("ENTITY_TYPE").get((Object) null).toString();
+    } catch (IllegalAccessException | NoSuchFieldException var2) {
+      throw new RuntimeException(var2);
+    }
+  }
+
+  @Nonnull
+  public static <URN extends Urn, ASPECT extends RecordTemplate> String getAspectSpecificMAETopicName(@Nonnull URN urn,
+      @Nonnull ASPECT newValue) {
+    return String.format("%s_%s_%s", "METADATA_AUDIT_EVENT", urn.getEntityType().toUpperCase(),
+        newValue.getClass().getSimpleName().toUpperCase());
+  }
+
+  public static boolean isCommonAspect(@Nonnull Class<? extends RecordTemplate> clazz) {
+    return clazz.getPackage().getName().startsWith("com.linkedin.common");
+  }
+
+  @Nonnull
+  public static <ENTITY_UNION extends UnionTemplate, ENTITY extends RecordTemplate> ENTITY_UNION newEntityUnion(
+      @Nonnull Class<ENTITY_UNION> entityUnionClass, @Nonnull ENTITY entity) {
+    EntityValidator.validateEntityUnionSchema(entityUnionClass);
+
+    try {
+      ENTITY_UNION entityUnion = (ENTITY_UNION) entityUnionClass.newInstance();
+      RecordUtils.setSelectedRecordTemplateInUnion(entityUnion, entity);
+      return entityUnion;
+    } catch (IllegalAccessException | InstantiationException var3) {
+      throw new RuntimeException(var3);
+    }
+  }
+}
+

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -572,6 +572,11 @@ type Dataset implements EntityWithRelationships & Entity {
     The structured tags associated with the dataset
     """
     globalTags: GlobalTags @deprecated
+
+    """
+    Sub Types that this entity implements
+    """
+    subTypes: SubTypes
 }
 
 """
@@ -599,6 +604,7 @@ type DatasetProperties {
     """
     externalUrl: String
 }
+
 
 """
 A Glossary Term, or a node in a Business Glossary representing a standardized domain
@@ -4856,4 +4862,11 @@ enum CostType {
     Org Cost Type to which the Cost of this entity should be attributed to
     """
     ORG_COST_TYPE
+}
+
+type SubTypes {
+   """
+    The sub-types that this entity implements. e.g. Datasets that are views will implement the "view" subtype
+   """
+   typeNames: [String!]
 }

--- a/datahub-web-react/datahub-frontend.graphql
+++ b/datahub-web-react/datahub-frontend.graphql
@@ -168,6 +168,10 @@ type PropertyTuple {
     value: String
 }
 
+type SubTypes {
+    typeNames: [String!]
+}
+
 type Dataset {
     urn: String!
 
@@ -192,6 +196,8 @@ type Dataset {
     modifiedTime: Long!
 
     ownership: Ownership
+
+    subTypes: SubTypes
 }
 
 type CorpUserInfo {

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -406,6 +406,7 @@ export const dataset3 = {
             ],
         },
     ],
+    subTypes: null,
 } as Dataset;
 
 export const dataset4 = {

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -21,6 +21,7 @@ import { SidebarTagsSection } from '../shared/containers/profile/sidebar/Sidebar
 import { SidebarStatsSection } from '../shared/containers/profile/sidebar/Dataset/StatsSidebarSection';
 import StatsTab from '../shared/tabs/Dataset/Stats/StatsTab';
 import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
+import { capitalizeFirstLetter } from '../../shared/capitalizeFirstLetter';
 
 const MatchTag = styled(Tag)`
     &&& {
@@ -137,9 +138,11 @@ export class DatasetEntity implements Entity<Dataset> {
     );
 
     getOverrideProperties = (dataset: GetDatasetQuery): GenericEntityProperties => {
-        // TODO(@shirshanka): calcualte entityTypeOverride value and return it in the object below
+        // if dataset has subTypes filled out, pick the most specific subtype and return it
+        const subTypes = dataset?.dataset?.subTypes;
         return {
             externalUrl: dataset.dataset?.properties?.externalUrl,
+            entityTypeOverride: subTypes ? capitalizeFirstLetter(subTypes.typeNames?.[0]) : '',
         };
     };
 
@@ -149,6 +152,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 urn={data.urn}
                 name={data.name}
                 origin={data.origin}
+                subtype={data.subTypes?.typeNames?.[0]}
                 description={data.editableProperties?.description || data.description}
                 platformName={data.platform.displayName || data.platform.name}
                 platformLogo={data.platform.info?.logoUrl}
@@ -171,6 +175,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 platformLogo={data.platform.info?.logoUrl}
                 owners={data.ownership?.owners}
                 globalTags={data.globalTags}
+                subtype={data.subTypes?.typeNames?.[0]}
                 snippet={
                     // Add match highlights only if all the matched fields are in the FIELDS_TO_HIGHLIGHT
                     result.matchedFields.length > 0 &&
@@ -192,6 +197,7 @@ export class DatasetEntity implements Entity<Dataset> {
             urn: entity.urn,
             name: entity.name,
             type: EntityType.Dataset,
+            subtype: entity.subTypes?.typeNames?.[0] || undefined,
             upstreamChildren: getChildren({ entity, type: EntityType.Dataset }, Direction.Upstream).map(
                 (child) => child.entity.urn,
             ),

--- a/datahub-web-react/src/app/entity/dataset/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/dataset/preview/Preview.tsx
@@ -15,6 +15,7 @@ export const Preview = ({
     globalTags,
     snippet,
     glossaryTerms,
+    subtype,
 }: {
     urn: string;
     name: string;
@@ -26,6 +27,7 @@ export const Preview = ({
     globalTags?: GlobalTags | null;
     snippet?: React.ReactNode | null;
     glossaryTerms?: GlossaryTerms | null;
+    subtype?: string | null;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     const capitalPlatformName = capitalizeFirstLetter(platformName);
@@ -34,7 +36,7 @@ export const Preview = ({
             url={entityRegistry.getEntityUrl(EntityType.Dataset, urn)}
             name={name || ''}
             description={description || ''}
-            type="Dataset"
+            type={capitalizeFirstLetter(subtype) || 'Dataset'}
             logoUrl={platformLogo || ''}
             platform={capitalPlatformName}
             qualifier={origin}

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -180,7 +180,7 @@ export default function LineageEntityNode({
                             |{' '}
                         </tspan>
                         <tspan dx=".25em" dy="-2px">
-                            {truncate(capitalizeFirstLetter(node.data.type?.split('.').slice(-1)[0]), 16)}
+                            {capitalizeFirstLetter(node.data.subtype || node.data.type)}
                         </tspan>
                     </text>
                     <text

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -26,6 +26,7 @@ export type FetchedEntity = {
     urn: string;
     name: string;
     type: EntityType;
+    subtype?: string;
     icon?: string;
     // children?: Array<string>;
     upstreamChildren?: Array<string>;
@@ -38,6 +39,7 @@ export type NodeData = {
     urn?: string;
     name: string;
     type?: EntityType;
+    subtype?: string;
     children?: Array<NodeData>;
     unexploredChildren?: number;
     icon?: string;

--- a/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
@@ -23,6 +23,7 @@ export default function constructFetchedNode(
             name: fetchedNode.name,
             urn: fetchedNode.urn,
             type: fetchedNode.type,
+            subtype: fetchedNode.subtype,
             icon: fetchedNode.icon,
             unexploredChildren:
                 fetchedNode?.[direction === Direction.Upstream ? 'upstreamChildren' : 'downstreamChildren']?.filter(

--- a/datahub-web-react/src/app/lineage/utils/constructTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructTree.ts
@@ -18,6 +18,7 @@ export default function constructTree(
         name: fetchedEntity?.name || '',
         urn: fetchedEntity?.urn,
         type: fetchedEntity?.type,
+        subtype: fetchedEntity?.subtype,
         icon: fetchedEntity?.icon,
         platform: fetchedEntity?.platform,
         unexploredChildren: 0,

--- a/datahub-web-react/src/graphql-mock/fixtures/entity/datasetEntity.ts
+++ b/datahub-web-react/src/graphql-mock/fixtures/entity/datasetEntity.ts
@@ -81,5 +81,6 @@ export const datasetEntity = ({
         schemaMetadata: null,
         previousSchemaMetadata: null,
         __typename: 'Dataset',
+        subTypes: null,
     };
 };

--- a/datahub-web-react/src/graphql/browse.graphql
+++ b/datahub-web-react/src/graphql/browse.graphql
@@ -28,6 +28,9 @@ query getBrowseResults($input: BrowseInput!) {
                 glossaryTerms {
                     ...glossaryTerms
                 }
+                subTypes {
+                    typeNames
+                }
             }
             ... on Dashboard {
                 urn

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -73,6 +73,9 @@ query getDataset($urn: String!) {
         glossaryTerms {
             ...glossaryTerms
         }
+        subTypes {
+            typeNames
+        }
         usageStats(resource: $urn, range: MONTH) {
             buckets {
                 bucket

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -160,6 +160,9 @@ fragment nonRecursiveDatasetFields on Dataset {
     glossaryTerms {
         ...glossaryTerms
     }
+    subTypes {
+        typeNames
+    }
 }
 
 fragment nonRecursiveDataFlowFields on DataFlow {
@@ -581,3 +584,4 @@ fragment nonRecursiveMLModelGroupFields on MLModelGroup {
         ...ownershipFields
     }
 }
+

--- a/datahub-web-react/src/graphql/genericLineage.graphql
+++ b/datahub-web-react/src/graphql/genericLineage.graphql
@@ -110,6 +110,9 @@ fragment upstreamRelationshipFields on UpstreamEntityRelationships {
                 editableProperties {
                     description
                 }
+                subTypes {
+                    typeNames
+                }
             }
             ... on MLModelGroup {
                 urn
@@ -204,6 +207,9 @@ fragment downstreamRelationshipFields on DownstreamEntityRelationships {
                     ...ownershipFields
                 }
                 ...shallowLineageFields
+                subTypes {
+                   typeNames
+                }
             }
             ... on MLModelGroup {
                 urn

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -54,6 +54,9 @@ query getSearchResults($input: SearchInput!) {
                     glossaryTerms {
                         ...glossaryTerms
                     }
+                    subTypes {
+                        typeNames
+                    }
                 }
                 ... on CorpUser {
                     username

--- a/metadata-ingestion/src/datahub/ingestion/api/workunit.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/workunit.py
@@ -15,6 +15,8 @@ class MetadataWorkUnit(WorkUnit):
     metadata: Union[
         MetadataChangeEvent, MetadataChangeProposal, MetadataChangeProposalWrapper
     ]
+    # A workunit creator can determine if this workunit is allowed to fail
+    treat_errors_as_warnings: bool = False
 
     @overload
     def __init__(self, id: str, mce: MetadataChangeEvent):
@@ -27,7 +29,13 @@ class MetadataWorkUnit(WorkUnit):
         ...
 
     @overload
-    def __init__(self, id: str, *, mcp: MetadataChangeProposalWrapper):
+    def __init__(
+        self,
+        id: str,
+        *,
+        mcp: MetadataChangeProposalWrapper,
+        treat_errors_as_warnings: bool = False,
+    ):
         # We force `mcp` to be a keyword-only argument.
         ...
 
@@ -37,8 +45,10 @@ class MetadataWorkUnit(WorkUnit):
         mce: MetadataChangeEvent = None,
         mcp: MetadataChangeProposalWrapper = None,
         mcp_raw: MetadataChangeProposal = None,
+        treat_errors_as_warnings: bool = False,
     ):
         super().__init__(id)
+        self.treat_errors_as_warnings = treat_errors_as_warnings
 
         if sum(1 if v else 0 for v in [mce, mcp, mcp_raw]) != 1:
             raise ValueError("exactly one of mce, mcp, or mcp_raw must be provided")

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -1,12 +1,13 @@
 import logging
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, cast
 
 from datahub.configuration.common import ConfigModel, OperationalError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope, WorkUnit
 from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
     MetadataChangeEvent,
     MetadataChangeProposal,
@@ -30,6 +31,7 @@ class DatahubRestSink(Sink):
     config: DatahubRestSinkConfig
     emitter: DatahubRestEmitter
     report: SinkReport
+    treat_errors_as_warnings: bool = False
 
     def __init__(self, ctx: PipelineContext, config: DatahubRestSinkConfig):
         super().__init__(ctx)
@@ -50,6 +52,9 @@ class DatahubRestSink(Sink):
         return cls(ctx, config)
 
     def handle_work_unit_start(self, workunit: WorkUnit) -> None:
+        if isinstance(workunit, MetadataWorkUnit):
+            mwu: MetadataWorkUnit = cast(MetadataWorkUnit, workunit)
+            self.treat_errors_as_warnings = mwu.treat_errors_as_warnings
         pass
 
     def handle_work_unit_end(self, workunit: WorkUnit) -> None:
@@ -74,7 +79,26 @@ class DatahubRestSink(Sink):
             self.report.report_record_written(record_envelope)
             write_callback.on_success(record_envelope, {})
         except OperationalError as e:
-            self.report.report_failure({"error": e.message, "info": e.info})
+            # only OperationalErrors should be ignored
+            if not self.treat_errors_as_warnings:
+                self.report.report_failure({"error": e.message, "info": e.info})
+            else:
+                # trim exception stacktraces when reporting warnings
+                if "stackTrace" in e.info:
+                    try:
+                        e.info["stackTrace"] = "\n".join(
+                            e.info["stackTrace"].split("\n")[0:2]
+                        )
+                    except Exception:
+                        # ignore failures in trimming
+                        pass
+                if isinstance(record, MetadataChangeProposalWrapper):
+                    # include information about the entity that failed
+                    entity_id = cast(MetadataChangeProposalWrapper, record).entityUrn
+                    e.info["id"] = entity_id
+                else:
+                    entity_id = None
+                self.report.report_warning({"warning": e.message, "info": e.info})
             write_callback.on_failure(record_envelope, e, e.info)
         except Exception as e:
             self.report.report_failure({"e": e})

--- a/metadata-ingestion/tests/integration/looker/golden_test_allow_ingest.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_allow_ingest.json
@@ -66,7 +66,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.type": "explore",
                             "looker.explore.label": "My Explore View",
                             "looker.explore.file": "test_source_file.lkml"
                         },
@@ -153,6 +152,19 @@
         "runId": "looker-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,data.explore.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"explore\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest.json
@@ -66,7 +66,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.type": "explore",
                             "looker.explore.label": "My Explore View",
                             "looker.explore.file": "test_source_file.lkml"
                         },
@@ -153,6 +152,19 @@
         "runId": "looker-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,data.explore.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"explore\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-ingestion/tests/integration/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/lookml/expected_output.json
@@ -200,6 +200,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
@@ -377,6 +390,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -517,6 +543,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
@@ -554,6 +593,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -612,6 +664,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
@@ -664,6 +729,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -775,6 +853,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
@@ -830,6 +921,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
@@ -882,5 +986,18 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 }
 ]

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
@@ -200,6 +200,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
@@ -377,6 +390,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -517,6 +543,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
@@ -554,6 +593,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -612,6 +664,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
@@ -664,6 +729,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -775,6 +853,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
@@ -830,6 +921,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
@@ -882,6 +986,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
@@ -200,6 +200,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
@@ -377,6 +390,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -517,6 +543,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
@@ -554,6 +593,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -612,6 +664,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
@@ -664,6 +729,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -775,6 +853,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
@@ -830,6 +921,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
@@ -882,6 +986,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
@@ -185,6 +185,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
@@ -347,6 +360,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -387,6 +413,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
@@ -424,6 +463,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -482,6 +534,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
@@ -534,6 +599,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -645,6 +723,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
@@ -700,6 +791,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
@@ -752,6 +856,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
@@ -200,6 +200,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
@@ -377,6 +390,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -517,6 +543,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
@@ -554,6 +593,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -612,6 +664,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
@@ -664,6 +729,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -775,6 +853,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
@@ -830,6 +921,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
@@ -882,6 +986,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
@@ -200,6 +200,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
@@ -377,6 +390,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.my_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -517,6 +543,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
@@ -554,6 +593,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.customer_facts,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -612,6 +664,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
@@ -664,6 +729,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,
@@ -775,6 +853,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
@@ -830,6 +921,19 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
@@ -882,6 +986,19 @@
         "runId": "lookml-test",
         "properties": null
     }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": null
 },
 {
     "auditHeader": null,

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/RecordTemplateValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/RecordTemplateValidator.java
@@ -1,0 +1,44 @@
+package com.linkedin.metadata.entity;
+
+import com.linkedin.common.urn.UrnValidator;
+import com.linkedin.data.schema.validation.CoercionMode;
+import com.linkedin.data.schema.validation.RequiredMode;
+import com.linkedin.data.schema.validation.UnrecognizedFieldMode;
+import com.linkedin.data.schema.validation.ValidateDataAgainstSchema;
+import com.linkedin.data.schema.validation.ValidationOptions;
+import com.linkedin.data.schema.validation.ValidationResult;
+import com.linkedin.data.template.RecordTemplate;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Consumer;
+
+@Slf4j
+public class RecordTemplateValidator {
+
+    private static final ValidationOptions DEFAULT_VALIDATION_OPTIONS = new ValidationOptions(
+            RequiredMode.CAN_BE_ABSENT_IF_HAS_DEFAULT,
+            CoercionMode.NORMAL,
+            UnrecognizedFieldMode.DISALLOW
+    );
+
+    private static final UrnValidator URN_VALIDATOR = new UrnValidator();
+
+    /**
+     * Validates a {@link RecordTemplate} and applies a function if validation fails
+     *
+     * @param record record to be validated.ailure.
+     */
+    public static void validate(RecordTemplate record, Consumer<ValidationResult> onValidationFailure) {
+        final ValidationResult result = ValidateDataAgainstSchema.validate(
+                record,
+                DEFAULT_VALIDATION_OPTIONS,
+                URN_VALIDATOR);
+        if (!result.isValid()) {
+            onValidationFailure.accept(result);
+        }
+    }
+
+    private RecordTemplateValidator() {
+
+    }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -366,7 +366,7 @@ public class EbeanEntityService extends EntityService {
 
     if (aspectSpec == null) {
       throw new RuntimeException(
-          String.format("Unknown aspect {} for entity {}", metadataChangeProposal.getAspectName(),
+          String.format("Unknown aspect %s for entity %s", metadataChangeProposal.getAspectName(),
               metadataChangeProposal.getEntityType()));
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanUtils.java
@@ -3,18 +3,21 @@ package com.linkedin.metadata.entity.ebean;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.entity.RecordTemplateValidator;
 import com.linkedin.metadata.utils.PegasusUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.mxe.SystemMetadata;
+import lombok.extern.slf4j.Slf4j;
+
 import javax.annotation.Nonnull;
 
 import static com.linkedin.metadata.utils.PegasusUtils.getDataTemplateClassFromSchema;
 import static com.linkedin.metadata.entity.EntityService.*;
 
-
+@Slf4j
 public class EbeanUtils {
   private EbeanUtils() {
   }
@@ -29,12 +32,26 @@ public class EbeanUtils {
       @Nonnull final String jsonAspect, @Nonnull final EntityRegistry entityRegistry) {
     return toAspectRecord(PegasusUtils.urnToEntityName(entityUrn), aspectName, jsonAspect, entityRegistry);
   }
+
+  /**
+   *
+   * @param entityName
+   * @param aspectName
+   * @param jsonAspect
+   * @param entityRegistry
+   * @return a RecordTemplate which has been validated, validation errors are logged as warnings
+   */
   public static RecordTemplate toAspectRecord(@Nonnull final String entityName, @Nonnull final String aspectName,
       @Nonnull final String jsonAspect, @Nonnull final EntityRegistry entityRegistry) {
     final EntitySpec entitySpec = entityRegistry.getEntitySpec(entityName);
     final AspectSpec aspectSpec = entitySpec.getAspectSpec(aspectName);
     final RecordDataSchema aspectSchema = aspectSpec.getPegasusSchema();
-    return RecordUtils.toRecordTemplate(getDataTemplateClassFromSchema(aspectSchema, RecordTemplate.class), jsonAspect);
+    RecordTemplate aspectRecord = RecordUtils.toRecordTemplate(getDataTemplateClassFromSchema(aspectSchema,
+            RecordTemplate.class), jsonAspect);
+    RecordTemplateValidator.validate(aspectRecord, validationFailure -> {
+      log.warn(String.format("Failed to validate record %s against its schema.", aspectRecord));
+    });
+    return aspectRecord;
   }
 
   public static SystemMetadata parseSystemMetadata(String jsonSystemMetadata) {

--- a/metadata-models/src/main/pegasus/com/linkedin/common/SubTypes.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/SubTypes.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.common
+
+/**
+ * Sub Types. Use this aspect to specialize a generic Entity
+ * e.g. Making a Dataset also be a View or also be a LookerExplore
+ */
+@Aspect = {
+  "name": "subTypes"
+}
+record SubTypes {
+  
+  /**
+   * The names of the specific types.
+   **/
+  typeNames: array[string]
+
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -2,6 +2,7 @@ entities:
   - name: dataset
     keyAspect: datasetKey
     aspects:
+      - subTypes
       - datasetProfile
       - datasetUsageStatistics
   - name: dataHubPolicy

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/AspectClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/AspectClient.java
@@ -1,21 +1,28 @@
 package com.linkedin.entity.client;
 
 import com.linkedin.common.client.BaseClient;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.AspectsDoGetTimeseriesAspectValuesRequestBuilder;
 import com.linkedin.entity.AspectsDoIngestProposalRequestBuilder;
 import com.linkedin.entity.AspectsGetRequestBuilder;
 import com.linkedin.entity.AspectsRequestBuilders;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.aspect.VersionedAspect;
+import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.restli.client.Client;
 import com.linkedin.restli.client.Response;
+import com.linkedin.restli.client.RestLiResponseException;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-
+@Slf4j
 public class AspectClient extends BaseClient {
 
   private static final AspectsRequestBuilders ASPECTS_REQUEST_BUILDERS = new AspectsRequestBuilders();
@@ -99,4 +106,38 @@ public class AspectClient extends BaseClient {
             .proposalParam(metadataChangeProposal);
     return sendClientRequest(requestBuilder, actor);
   }
+
+  public <T extends RecordTemplate> Optional<T> getVersionedAspect(
+          @Nonnull String urn,
+          @Nonnull String aspect,
+          @Nonnull Long version,
+          @Nonnull String actor,
+          @Nonnull Class<T> aspectClass)
+          throws RemoteInvocationException {
+
+    AspectsGetRequestBuilder requestBuilder =
+            ASPECTS_REQUEST_BUILDERS.get().id(urn).aspectParam(aspect).versionParam(version);
+
+    try {
+      VersionedAspect entity = sendClientRequest(requestBuilder, actor).getEntity();
+      if (entity.hasAspect()) {
+        DataMap rawAspect = ((DataMap) entity.data().get("aspect"));
+        if (rawAspect.containsKey(aspectClass.getCanonicalName())) {
+          DataMap aspectDataMap = rawAspect.getDataMap(aspectClass.getCanonicalName());
+          return Optional.of(RecordUtils.toRecordTemplate(aspectClass, aspectDataMap));
+        }
+      }
+    } catch (RestLiResponseException e) {
+      if (e.getStatus() == 404) {
+        log.debug("Could not find aspect {} for entity {}", aspect, urn);
+        return Optional.empty();
+      } else {
+        // re-throw other exceptions
+        throw e;
+      }
+    }
+
+    return Optional.empty();
+  }
+
 }

--- a/metadata-service/restli-impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
+++ b/metadata-service/restli-impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
@@ -1,13 +1,7 @@
 package com.linkedin.metadata.resources;
 
-import com.linkedin.common.urn.UrnValidator;
-import com.linkedin.data.schema.validation.CoercionMode;
-import com.linkedin.data.schema.validation.RequiredMode;
-import com.linkedin.data.schema.validation.UnrecognizedFieldMode;
-import com.linkedin.data.schema.validation.ValidateDataAgainstSchema;
-import com.linkedin.data.schema.validation.ValidationOptions;
-import com.linkedin.data.schema.validation.ValidationResult;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.entity.RecordTemplateValidator;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.RestLiServiceException;
 import lombok.extern.slf4j.Slf4j;
@@ -15,13 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ResourceUtils {
-
-  private static final ValidationOptions DEFAULT_VALIDATION_OPTIONS = new ValidationOptions(
-      RequiredMode.CAN_BE_ABSENT_IF_HAS_DEFAULT,
-      CoercionMode.NORMAL,
-      UnrecognizedFieldMode.DISALLOW
-  );
-  private static final UrnValidator URN_VALIDATOR = new UrnValidator();
 
   /**
    * Validates a {@link RecordTemplate} and throws {@link com.linkedin.restli.server.RestLiServiceException}
@@ -31,15 +18,10 @@ public class ResourceUtils {
    * @param status the status code to return to the client on failure.
    */
   public static void validateOrThrow(RecordTemplate record, HttpStatus status) {
-    final ValidationResult result = ValidateDataAgainstSchema.validate(
-        record,
-        DEFAULT_VALIDATION_OPTIONS,
-        URN_VALIDATOR);
-    if (!result.isValid()) {
-      throw new RestLiServiceException(status, result.getMessages().toString());
-    }
+    RecordTemplateValidator.validate(record, validationResult -> {
+      throw new RestLiServiceException(status, validationResult.getMessages().toString());
+    });
   }
-
 
   /**
    * Validates a {@link RecordTemplate} and logs a warning if validation fails.
@@ -47,15 +29,11 @@ public class ResourceUtils {
    * @param record record to be validated.ailure.
    */
   public static void validateOrWarn(RecordTemplate record) {
-    final ValidationResult result = ValidateDataAgainstSchema.validate(
-        record,
-        DEFAULT_VALIDATION_OPTIONS,
-        URN_VALIDATOR);
-    if (!result.isValid()) {
+    RecordTemplateValidator.validate(record, validationResult -> {
       log.warn(String.format("Failed to validate record %s against its schema.", record));
-    }
+    });
   }
 
-  private ResourceUtils() { }
-
+  private ResourceUtils() {
+  }
 }


### PR DESCRIPTION
…looker integration

This PR
- Adds a new aspect called SubTypes to allow for specializing of the base models (like Datasets). 
- Allows this aspect to be added to the Dataset Entity without needing to be added to the DatasetSnapshot model
- Adds support for Looker views and explore ingestion to emit this new aspect, while being compatible with old servers that don't have this aspect yet
- Adds support in the UI to use the subtype information to specialize the rendering


![Subtypes-rendered](https://user-images.githubusercontent.com/67564030/136329117-0a0a5cd3-83ea-4940-9b66-88c3c7e759fc.png)

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
