### PR TITLE
fix(autocomplete): Fix empty autocomplete server error

### DIFF
--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -61,6 +61,9 @@ export const SearchablePage = ({ initialQuery, onSearch, onAutoComplete, childre
     };
 
     const autoComplete = (query: string) => {
+        if (query === '') {
+            return;
+        }
         getAutoCompleteResults({
             variables: {
                 input: {


### PR DESCRIPTION
When you autocomplete against empty string, our backend API says "no". Adding client side logic to avoid autocompleting against empty string. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
