### PR TITLE
fix(urns): prevent corrupted urns from being created

### DIFF
--- a/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
@@ -66,7 +66,7 @@ export default function CreateTagModal({
             })
             .catch((e) => {
                 message.destroy();
-                message.error({ content: `Failed to remove term: \n ${e.message || ''}`, duration: 3 });
+                message.error({ content: `Failed to create & add tag: \n ${e.message || ''}`, duration: 3 });
                 onClose();
             });
     };

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -202,6 +202,11 @@ public class EbeanEntityService extends EntityService {
       @Nonnull final SystemMetadata systemMetadata) {
 
     log.debug("Invoked ingestAspect with urn: {}, aspectName: {}, newValue: {}", urn, aspectName, newValue);
+
+    if (!urn.toString().trim().equals(urn.toString())) {
+      throw new IllegalArgumentException("Error: cannot provide an URN with leading or trailing whitespace");
+    }
+
     Timer.Context ingestToLocalDBTimer = MetricUtils.timer(this.getClass(), "ingestAspectToLocalDB").time();
     UpdateAspectResult result = ingestAspectToLocalDB(urn, aspectName, ignored -> newValue, auditStamp, systemMetadata,
         DEFAULT_MAX_TRANSACTION_RETRY);


### PR DESCRIPTION
Leading or trailing whitespace causes issues for us when persisting urns to the storage layer. This adds a check to prevent such urns from being persisted. Leaving in EbeanEntityService for now because this issue is explicitly wrapped up in ebean and not neccessarily an issue for Datahub as a whole.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
