### PR TITLE
test(CI): Timeout build job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8


### PR DESCRIPTION
The `build` job of the `build-and-test` workflow very often runs forever and times out after 6 hours (the GitHub default): https://github.com/linkedin/datahub/actions/runs/1321007431

This reduces the timeout to more sensible 1h. The job finishes in 15-20 minutes, or fails after 45 minutes on `yarnBuild`. One hour should be enough to be sure it will not make it.