### PR TITLE
fix(ci): add run_id to the task instance constructor for airflow

### DIFF
--- a/metadata-ingestion/tests/unit/test_airflow.py
+++ b/metadata-ingestion/tests/unit/test_airflow.py
@@ -233,7 +233,11 @@ def test_lineage_backend(mock_emit, inlets, outlets):
             )
             op1 >> op2
 
-        ti = TI(task=op2)
+        if airflow.version.version.startswith("1"):
+            ti = TI(task=op2, execution_date=DEFAULT_DATE)
+        else:
+            ti = TI(task=op2)
+
         ctx1 = {
             "dag": dag,
             "task": op2,


### PR DESCRIPTION
Airflow recently released 2.2.0 which changes the behavior of task instance construction when a run_id is not provided (attempts to load up the run_id from the sqlite db).
 This breaks CI tests. 

Fixing this by providing a dummy run_id since we don't really use it. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
