### PR TITLE
test(airflow): remove unneeded execution_date parameter from test

### DIFF
--- a/metadata-ingestion/tests/unit/test_airflow.py
+++ b/metadata-ingestion/tests/unit/test_airflow.py
@@ -230,7 +230,16 @@ def test_lineage_backend(mock_emit, inlets, outlets):
             )
             op1 >> op2
 
-        ti = TaskInstance(task=op2)
+        # Airflow <= 2.1 requires the execution_date parameter. Newer Airflow
+        # versions do not require it, but will attempt to find the associated
+        # run_id in the database if execution_date is provided. As such, we
+        # must fake the run_id parameter for newer Airflow versions.
+        if any(
+            airflow.version.version.startswith(prefix) for prefix in ["1", "2.0", "2.1"]
+        ):
+            ti = TaskInstance(task=op2, execution_date=DEFAULT_DATE)
+        else:
+            ti = TaskInstance(task=op2, run_id=f"test_airflow-{DEFAULT_DATE}")
         ctx1 = {
             "dag": dag,
             "task": op2,


### PR DESCRIPTION
Also does a bit of cleanup in the test file. Follow up on #3366.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
