### PR TITLE
fix(search): fixing user and group links in search results

### DIFF
--- a/datahub-web-react/src/app/entity/group/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/group/preview/Preview.tsx
@@ -73,7 +73,7 @@ export const Preview = ({
     membersCount?: number;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
-    const url = entityRegistry.getEntityUrl(EntityType.Dataset, urn);
+    const url = entityRegistry.getEntityUrl(EntityType.CorpGroup, urn);
 
     return (
         <PreviewContainer>

--- a/datahub-web-react/src/app/entity/user/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/user/preview/Preview.tsx
@@ -66,7 +66,7 @@ export const Preview = ({
     title?: string | undefined;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
-    const url = entityRegistry.getEntityUrl(EntityType.Dataset, urn);
+    const url = entityRegistry.getEntityUrl(EntityType.CorpUser, urn);
 
     return (
         <PreviewContainer>


### PR DESCRIPTION
User and group search previews were linking to datasets pages. Fixing that.

Introduced in: https://github.com/linkedin/datahub/pull/3381

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
