### PR TITLE
oidc: Add "name" claim extraction if present

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -185,6 +185,10 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
     String email = profile.getEmail();
     URI picture = profile.getPictureUrl();
     String displayName = profile.getDisplayName();
+    String fullName = (String) profile.getAttribute("name"); // Name claim is sometimes provided, including by Google.
+    if (fullName == null && firstName != null && lastName != null) {
+      fullName = String.format("%s %s", firstName, lastName);
+    }
 
     // TODO: Support custom claims mapping. (e.g. department, title, etc)
 
@@ -192,7 +196,7 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
     userInfo.setActive(true);
     userInfo.setFirstName(firstName, SetMode.IGNORE_NULL);
     userInfo.setLastName(lastName, SetMode.IGNORE_NULL);
-    userInfo.setFullName(String.format("%s %s", firstName, lastName), SetMode.IGNORE_NULL);
+    userInfo.setFullName(fullName, SetMode.IGNORE_NULL);
     userInfo.setEmail(email, SetMode.IGNORE_NULL);
     // If there is a display name, use it. Otherwise fall back to full name.
     userInfo.setDisplayName(displayName == null ? userInfo.getFullName() : displayName, SetMode.IGNORE_NULL);


### PR DESCRIPTION
Google provides a "name" claim that is used to provide a user's full name. 

This PR introduces name claim extraction for full name if present. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
