### PR TITLE
fix(subtypes): Fix subtypes tab visibility

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -98,7 +98,7 @@ export class DatasetEntity implements Entity<Dataset> {
                     component: ViewDefinitionTab,
                     display: {
                         visible: (_, dataset: GetDatasetQuery) =>
-                            (dataset?.dataset?.subTypes?.typeNames?.includes(SUBTYPES.VIEW) as boolean) || false,
+                            (dataset?.dataset?.subTypes?.typeNames?.includes(SUBTYPES.VIEW) && true) || false,
                         enabled: (_, dataset: GetDatasetQuery) =>
                             (dataset?.dataset?.viewProperties?.logic && true) || false,
                     },

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityTabs.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityTabs.tsx
@@ -37,7 +37,7 @@ export const EntityTabs = <T,>({ tabs, selectedTab }: Props) => {
         }
     }, [tabs, selectedTab, routeToTab]);
 
-    const visibleTabs = tabs.filter((tab) => tab.display?.visible);
+    const visibleTabs = tabs.filter((tab) => tab.display?.visible(entityData, baseEntity));
 
     return (
         <UnborderedTabs


### PR DESCRIPTION
Previously, subtype tabs were going to always show because we were not properly evaluating the "visible" function. This PR addresses this issue. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
