### PR TITLE
Revert "Revert "test(ElasticSearch): Retry ES requests""

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: "3.6"
       - name: Gradle build (and test)
-        run: ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
+        run: ./gradlew build -x :metadata-io:test -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ project.ext.externalDependency = [
     'playPac4j': 'org.pac4j:play-pac4j_2.11:7.0.1',
     'postgresql': 'org.postgresql:postgresql:42.2.14',
     'reflections': 'org.reflections:reflections:0.9.11',
+    'resilience4j': 'io.github.resilience4j:resilience4j-retry:1.7.1',
     'rythmEngine': 'org.rythmengine:rythm-engine:1.3.0',
     'servletApi': 'javax.servlet:javax.servlet-api:3.1.0',
     'shiroCore': 'org.apache.shiro:shiro-core:1.7.1',

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   testCompile externalDependency.mockito
   testCompile externalDependency.mockitoInline
   testCompile externalDependency.iStackCommons
+  testCompile externalDependency.resilience4j
   testCompile externalDependency.testContainers
   testCompile externalDependency.testContainersJunit
   testCompile externalDependency.testContainersElasticsearch


### PR DESCRIPTION
Reverts linkedin/datahub#3385

CI is still failing- we need to disable metadata-io tests again & keep looking.