### PR TITLE
fix(graphQL): Populating deprecated Dataset description field

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetSnapshotMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetSnapshotMapper.java
@@ -65,6 +65,7 @@ public class DatasetSnapshotMapper implements ModelMapper<DatasetSnapshot, Datas
                     properties.setCustomProperties(StringMapMapper.map(gmsProperties.getCustomProperties()));
                 }
                 result.setProperties(properties);
+                result.setDescription(properties.getDescription());
                 if (gmsProperties.hasUri()) {
                     // Deprecated field.
                     result.setUri(gmsProperties.getUri().toString());


### PR DESCRIPTION
Populate the deprecated "description" field at the top level of the Dataset model, which is still used by the UI. This bug was introduced in the recent GraphQL refactor. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
