### PR TITLE
fix(search): Reduce default batch size

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchServiceFactory.java
@@ -32,7 +32,7 @@ public class SearchServiceFactory {
   @Autowired
   private CacheManager cacheManager;
 
-  @Value("${SEARCH_SERVICE_BATCH_SIZE:1000}")
+  @Value("${SEARCH_SERVICE_BATCH_SIZE:100}")
   private Integer batchSize;
 
   @Bean(name = "searchService")


### PR DESCRIPTION
Batch size of 1000 is showing high latency. Taking a hit on relevance to make search faster.  
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
