### PR TITLE
fix(ui): Extract customProperties map from "properties" OR "info" entity field

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
@@ -19,9 +19,10 @@ export function getDataForEntityType<T>({
     }
     const entityData = data[Object.keys(data)[0]];
     let modifiedEntityData = entityData;
-    // Bring 'customProperties' field to the root level.
-    if (entityData.properties?.customProperties) {
-        const customProperties = entityData.properties?.customProperties;
+    // Bring 'customProperties' field to the root level,
+    // from the GQL info or properties fields, respectively.
+    const customProperties = entityData.properties?.customProperties || entityData.info?.customProperties;
+    if (customProperties) {
         modifiedEntityData = {
             ...entityData,
             customProperties,


### PR DESCRIPTION
Before the migration of data flow and datajob, dashboard and chart entities to the new UI, there was an assumption about where "customProperties" lived. That assumption is no longer true, as not all entities have a consistent "properties" field being fetched. This PR fixes this. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
