### PR TITLE
fix(CI): Stabalize gradle build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,12 @@ jobs:
         with:
           python-version: "3.6"
       - name: Gradle build (and test)
-        run: ./gradlew build -x :metadata-io:test -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
+        # there is some race condition in gradle build, which makes gradle never terminate in ~30% of the runs
+        # running build first without datahub-web-react:yarnBuild and then with it is 100% stable
+        # datahub-frontend:unzipAssets depends on datahub-web-react:yarnBuild but gradle does not know about it
+        run: |
+          ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x datahub-web-react:yarnBuild -x datahub-frontend:unzipAssets
+          ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
       - uses: actions/upload-artifact@v2
         if: always()
         with:


### PR DESCRIPTION
In [~30% of the runs](https://github.com/EnricoMi/datahub/actions/runs/1351182915), the `build` job of the`build & test` workflow does not terminate and eventually times out after 6 hours (GitHub default) or 1 hour as set recently (#3364).

Looking into the logs of the failing build jobs shows that `datahub-web-react:yarnBuild` task is started but never terminates until timeout. Other tasks start and all complete withing the usual 20 minutes but `yarnBuild` does not output anything, progress or terminate at any point.

When running `yarn run build | tee` locally and `yarn` exits on an error, for some reason it does not terminate the command. Maybe `yarn` runs into a problem in 30% of the times and GitHub action setup makes `yarn` not terminate.

Excluding `datahub-web-react:yarnBuild` from the `gradle build` command and including it in a subsequent run makes the problem disappear in [100 out of 100 runs](https://github.com/EnricoMi/datahub/actions/runs/1351671999). So this problem looks to be a race condition in gradle in conjunction with yarn.

Excluding `datahub-web-react:yarnBuild` makes `datahub-frontend:unzipAssets` fail as it requires the output `yarnBuild`. Gradle seem not to know about that dependency, so both are excluded here.