### PR TITLE
fix(graph service): fix case where certain mcps can incorrectly delete graph edges

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
@@ -211,7 +211,7 @@ public class MetadataAuditEventsProcessor {
         }
       }
     }
-    if (relationshipTypesBeingAdded.size() > 0) {
+    if (edgesToAdd.size() > 0) {
       new Thread(() -> {
         _graphService.removeEdgesFromNode(sourceUrn, new ArrayList<>(relationshipTypesBeingAdded),
             createRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));


### PR DESCRIPTION
In the MCP processor, we would always emit the delete lineage call. When relationship types was empty, this would provide an empty relationship filter to the graph service. The graph service would interpret this as a wildcard relationship type and delete all edges. The fix here checks that relationshipTypes is not empty.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
