### PR TITLE
fix(ingest): resolve click-default-group deprecation warning

### DIFF
--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -26,13 +26,13 @@ RUNS_TABLE_COLUMNS = ["runId", "rows", "created at"]
 RUN_TABLE_COLUMNS = ["urn", "aspect name", "created at"]
 
 
-@click.group(cls=DefaultGroup)
+@click.group(cls=DefaultGroup, default="run")
 def ingest() -> None:
     """Ingest metadata into DataHub."""
     pass
 
 
-@ingest.command(default=True)
+@ingest.command()
 @click.option(
     "-c",
     "--config",


### PR DESCRIPTION
No behavioral changes.

The warning used to say:
```
DeprecationWarning: Use default param of DefaultGroup or set_default_command() instead
```

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
