### PR TITLE
feat(ingest): add parallelism to looker source and datahub rest sink

### DIFF
--- a/metadata-ingestion/sink_docs/datahub.md
+++ b/metadata-ingestion/sink_docs/datahub.md
@@ -38,6 +38,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `timeout_sec` |     | 30      | Per-HTTP request timeout.    |
 | `token` |     |       | Bearer token used for authentication.    |
 | `extra_headers` |     |       | Extra headers which will be added to the request.    |
+| `max_threads`   |          | `1` |  Experimental: Max parallelism for REST API calls     |
 
 ## DataHub Kafka
 

--- a/metadata-ingestion/source_docs/looker.md
+++ b/metadata-ingestion/source_docs/looker.md
@@ -91,6 +91,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `view_browse_pattern` |   | `/{env}/{platform}/{project}/views/{name}` | Pattern for providing browse paths to views. Allowed variables are `{project}`, `{model}`, `{name}`, `{platform}` and `{env}` | 
 | `explore_naming_pattern` |   | `{model}.explore.{name}` | Pattern for providing dataset names to explores. Allowed variables are `{project}`, `{model}`, `{name}` | 
 | `explore_browse_pattern` |   | `/{env}/{platform}/{project}/explores/{model}.{name}` | Pattern for providing browse paths to explores. Allowed variables are `{project}`, `{model}`, `{name}`, `{platform}` and `{env}` | 
+| `max_threads`                                |          | `os.cpuCount or 40` |  Max parallelism for Looker API calls                   |
 
 
 ## Compatibility

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -1,3 +1,5 @@
+import concurrent.futures
+import functools
 import logging
 from dataclasses import dataclass
 from typing import Dict, Optional, Union, cast
@@ -24,6 +26,7 @@ class DatahubRestSinkConfig(ConfigModel):
     token: Optional[str]
     timeout_sec: Optional[int]
     extra_headers: Optional[Dict[str, str]]
+    max_threads: int = 1
 
 
 @dataclass
@@ -45,6 +48,9 @@ class DatahubRestSink(Sink):
             extra_headers=self.config.extra_headers,
         )
         self.emitter.test_connection()
+        self.executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.config.max_threads
+        )
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "DatahubRestSink":
@@ -60,6 +66,53 @@ class DatahubRestSink(Sink):
     def handle_work_unit_end(self, workunit: WorkUnit) -> None:
         pass
 
+    def _write_done_callback(
+        self,
+        record_envelope: RecordEnvelope,
+        write_callback: WriteCallback,
+        future: concurrent.futures.Future,
+    ) -> None:
+        if future.cancelled():
+            self.report.report_failure({"error": "future was cancelled"})
+            write_callback.on_failure(
+                record_envelope, OperationalError("future was cancelled"), {}
+            )
+        elif future.done():
+            e = future.exception()
+            if not e:
+                self.report.report_record_written(record_envelope)
+                start_time, end_time = future.result()
+                self.report.report_downstream_latency(start_time, end_time)
+                write_callback.on_success(record_envelope, {})
+            elif isinstance(e, OperationalError):
+                # only OperationalErrors should be ignored
+                if not self.treat_errors_as_warnings:
+                    self.report.report_failure({"error": e.message, "info": e.info})
+                else:
+                    # trim exception stacktraces when reporting warnings
+                    if "stackTrace" in e.info:
+                        try:
+                            e.info["stackTrace"] = "\n".join(
+                                e.info["stackTrace"].split("\n")[0:2]
+                            )
+                        except Exception:
+                            # ignore failures in trimming
+                            pass
+                    record = record_envelope.record
+                    if isinstance(record, MetadataChangeProposalWrapper):
+                        # include information about the entity that failed
+                        entity_id = cast(
+                            MetadataChangeProposalWrapper, record
+                        ).entityUrn
+                        e.info["id"] = entity_id
+                    else:
+                        entity_id = None
+                    self.report.report_warning({"warning": e.message, "info": e.info})
+                write_callback.on_failure(record_envelope, e, e.info)
+            else:
+                self.report.report_failure({"e": e})
+                write_callback.on_failure(record_envelope, Exception(e), {})
+
     def write_record_async(
         self,
         record_envelope: RecordEnvelope[
@@ -74,38 +127,15 @@ class DatahubRestSink(Sink):
     ) -> None:
         record = record_envelope.record
 
-        try:
-            self.emitter.emit(record)
-            self.report.report_record_written(record_envelope)
-            write_callback.on_success(record_envelope, {})
-        except OperationalError as e:
-            # only OperationalErrors should be ignored
-            if not self.treat_errors_as_warnings:
-                self.report.report_failure({"error": e.message, "info": e.info})
-            else:
-                # trim exception stacktraces when reporting warnings
-                if "stackTrace" in e.info:
-                    try:
-                        e.info["stackTrace"] = "\n".join(
-                            e.info["stackTrace"].split("\n")[0:2]
-                        )
-                    except Exception:
-                        # ignore failures in trimming
-                        pass
-                if isinstance(record, MetadataChangeProposalWrapper):
-                    # include information about the entity that failed
-                    entity_id = cast(MetadataChangeProposalWrapper, record).entityUrn
-                    e.info["id"] = entity_id
-                else:
-                    entity_id = None
-                self.report.report_warning({"warning": e.message, "info": e.info})
-            write_callback.on_failure(record_envelope, e, e.info)
-        except Exception as e:
-            self.report.report_failure({"e": e})
-            write_callback.on_failure(record_envelope, e, {})
+        write_future = self.executor.submit(self.emitter.emit, record)
+        write_future.add_done_callback(
+            functools.partial(
+                self._write_done_callback, record_envelope, write_callback
+            )
+        )
 
     def get_report(self) -> SinkReport:
         return self.report
 
     def close(self):
-        pass
+        self.executor.shutdown(wait=True)

--- a/metadata-ingestion/src/datahub/ingestion/source/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker_common.py
@@ -575,10 +575,15 @@ class LookerExplore:
                 upstream_views=list(views),
                 source_file=explore.source_file,
             )
-        except SDKError:
+        except SDKError as e:
             logger.warn(
                 "Failed to extract explore {} from model {}.".format(
                     explore_name, model
+                )
+            )
+            logger.debug(
+                "Failed to extract explore {} from model {} with {}".format(
+                    explore_name, model, e
                 )
             )
         except AssertionError:


### PR DESCRIPTION
Speeds up Looker API ingestion significantly (2x - 5x based on my tests)
Also added parallelism to REST API sink to speed things up, but kept the current default threads to 1 and marked the config as experimental until we get more confidence on the feature. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
