### PR TITLE
fix(restli entity client): fix case where sortCriterion is null

### DIFF
--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -392,9 +392,11 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
             ENTITIES_REQUEST_BUILDERS.actionFilter()
                 .entityParam(entity)
                 .filterParam(filter)
-                .sortParam(sortCriterion)
                 .startParam(start)
                 .countParam(count);
+        if (sortCriterion != null) {
+            requestBuilder.sortParam(sortCriterion);
+        }
         return sendClientRequest(requestBuilder, actor).getEntity();
     }
 }


### PR DESCRIPTION
Restli does not support adding null values as params, even if they are optional params. Adding a check in case a null sortCriterion is passed through

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
