### PR TITLE
fix(ingest): fix lookml derived tables parsing

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -99,7 +99,7 @@ plugins: Dict[str, Set[str]] = {
     "kafka-connect": sql_common | {"requests"},
     "ldap": {"python-ldap>=2.4"},
     "looker": looker_common,
-    "lookml": looker_common | {"lkml>=1.1.0", "sql-metadata==2.2.1"},
+    "lookml": looker_common | {"lkml>=1.1.0", "sql-metadata==2.2.2"},
     "mongodb": {"pymongo>=3.11"},
     "mssql": sql_common | {"sqlalchemy-pytds>=0.3"},
     "mssql-odbc": sql_common | {"pyodbc"},

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -640,10 +640,10 @@ class LookerView:
                 return fields, sql_table_names
             # Looker supports sql fragments that omit the SELECT and FROM parts of the query
             # Add those in if we detect that it is missing
-            if not re.match(r"^\s*SELECT", sql_query):
+            if not re.search(r"SELECT\s", sql_query, flags=re.I):
                 # add a SELECT clause at the beginning
                 sql_query = "SELECT " + sql_query
-            if not re.search(r" FROM\s", sql_query):
+            if not re.search(r"FROM\s", sql_query, flags=re.I):
                 # add a FROM clause at the end
                 sql_query = f"{sql_query} FROM {sql_table_name if sql_table_name is not None else view_name}"
                 # Get the list of tables in the query
@@ -824,7 +824,7 @@ class LookMLSource(Source):
         # Check if table name matches cascading derived tables pattern
         # derived tables can be referred to using aliases that look like table_name.SQL_TABLE_NAME
         # See https://docs.looker.com/data-modeling/learning-lookml/derived-tables#syntax_for_referencing_a_derived_table
-        if re.fullmatch(r"\w+\.SQL_TABLE_NAME", sql_table_name):
+        if re.fullmatch(r"\w+\.SQL_TABLE_NAME", sql_table_name, flags=re.I):
             sql_table_name = sql_table_name.lower().split(".")[0]
             # upstream dataset is a looker view based on current view id's project and model
             view_id = LookerViewId(


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

This PR fixes parsing SQL queries from lookml derived tables that is currently case-sensitive. Also fix an issue with queries with CTEs that don't start with `\s*SELECT` but still contain a `SELECT` statement.

Also update `sql-metadata` to latest version that improves parsing (no breaking changes).