### PR TITLE
build(frontend):  unzip depend on yarnBuild

### DIFF
--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -79,7 +79,7 @@ model {
   }
 }
 
-task unzipAssets(type: Copy, dependsOn: configurations.assets) {
+task unzipAssets(type: Copy, dependsOn: [configurations.assets, ':datahub-web-react:yarnBuild']) {
   into "${buildDir}/assets"
   from {
     configurations.assets.collect { zipTree(it) }


### PR DESCRIPTION
Unzip will error if yarnBuild hasn't run, but it does not explicitly depend on yarnBuild. This pr fixes that.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
