### PR TITLE
fix(mysql): Update default mysql collation to utf8mb4_bin

### DIFF
--- a/docker/docker-compose-without-neo4j.override.yml
+++ b/docker/docker-compose-without-neo4j.override.yml
@@ -6,7 +6,7 @@ services:
     hostname: mysql
     image: mysql:5.7
     env_file: mysql/env/docker.env
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     ports:
       - "3306:3306"
     volumes:

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
     hostname: mysql
     image: mysql:5.7
     env_file: mysql/env/docker.env
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     ports:
       - "3306:3306"
     volumes:

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -1,5 +1,5 @@
 -- create datahub database
-CREATE DATABASE IF NOT EXISTS DATAHUB_DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE DATABASE IF NOT EXISTS DATAHUB_DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 USE DATAHUB_DB_NAME;
 
 -- create metadata aspect table

--- a/docker/mysql/docker-compose.mysql.yml
+++ b/docker/mysql/docker-compose.mysql.yml
@@ -7,7 +7,7 @@ services:
     hostname: mysql
     image: mysql:5.7
     env_file: env/docker.env
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     ports:
       - "3306:3306"
     volumes:

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -9,7 +9,7 @@ CREATE TABLE metadata_aspect_v2 (
   createdby                     VARCHAR(255) NOT NULL,
   createdfor                    VARCHAR(255),
   CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn,aspect,version)
-) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) VALUES(
   'urn:li:corpuser:datahub',

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -105,7 +105,7 @@ services:
     hostname: kafka-setup
     image: linkedin/datahub-kafka-setup:${DATAHUB_VERSION:-head}
   mysql:
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     container_name: mysql
     environment:
     - MYSQL_DATABASE=datahub

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -109,7 +109,7 @@ services:
     hostname: kafka-setup
     image: linkedin/datahub-kafka-setup:${DATAHUB_VERSION:-head}
   mysql:
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
     container_name: mysql
     environment:
     - MYSQL_DATABASE=datahub


### PR DESCRIPTION
Previously, the collation we were using for permitting unicode and emoji style characters was case insensitive. This was causing conflicts among URNs that had the same characters but different casing. This PR updates the default to use a case sensitive collation. 

Existing deployments can be updated to use the new collation by executing the following command against your SQL store (verified against MySQL): 

```ALTER TABLE metadata_aspect_v2 CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;```

Verified this works on demo.datahubproject.io, which previously was erroring out on URNs that were same exception for casing. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
