### PR TITLE
fix(tags): fix links to tags when there are special chars in the urls

### DIFF
--- a/datahub-web-react/src/app/entity/tag/TagProfile.tsx
+++ b/datahub-web-react/src/app/entity/tag/TagProfile.tsx
@@ -78,7 +78,9 @@ type TagPageParams = {
  * Responsible for displaying metadata about a tag
  */
 export default function TagProfile() {
-    const { urn } = useParams<TagPageParams>();
+    const { urn: encodedUrn } = useParams<TagPageParams>();
+    const urn = decodeURIComponent(encodedUrn);
+
     const { loading, error, data } = useGetTagQuery({ variables: { urn } });
     const entityRegistry = useEntityRegistry();
     const history = useHistory();

--- a/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
@@ -151,10 +151,7 @@ export default function TagTermGroup({
     return (
         <TagWrapper>
             {uneditableGlossaryTerms?.terms?.map((term) => (
-                <TagLink
-                    to={`/${entityRegistry.getPathName(EntityType.GlossaryTerm)}/${term.term.urn}`}
-                    key={term.term.urn}
-                >
+                <TagLink to={entityRegistry.getEntityUrl(EntityType.GlossaryTerm, term.term.urn)} key={term.term.urn}>
                     <Tag closable={false}>
                         {term.term.name}
                         <BookOutlined style={{ marginLeft: '2%' }} />
@@ -162,10 +159,7 @@ export default function TagTermGroup({
                 </TagLink>
             ))}
             {editableGlossaryTerms?.terms?.map((term) => (
-                <TagLink
-                    to={`/${entityRegistry.getPathName(EntityType.GlossaryTerm)}/${term.term.urn}`}
-                    key={term.term.urn}
-                >
+                <TagLink to={entityRegistry.getEntityUrl(EntityType.GlossaryTerm, term.term.urn)} key={term.term.urn}>
                     <Tag
                         closable={canRemove}
                         onClose={(e) => {
@@ -183,7 +177,7 @@ export default function TagTermGroup({
                 renderedTags += 1;
                 if (maxShow && renderedTags > maxShow) return null;
                 return (
-                    <TagLink to={`/${entityRegistry.getPathName(EntityType.Tag)}/${tag.tag.urn}`} key={tag.tag.urn}>
+                    <TagLink to={entityRegistry.getEntityUrl(EntityType.Tag, tag.tag.urn)} key={tag.tag.urn}>
                         <StyledTag $colorHash={tag.tag.urn} closable={false}>
                             {tag.tag.name}
                         </StyledTag>
@@ -195,7 +189,7 @@ export default function TagTermGroup({
                 renderedTags += 1;
                 if (maxShow && renderedTags > maxShow) return null;
                 return (
-                    <TagLink to={`/${entityRegistry.getPathName(EntityType.Tag)}/${tag.tag.urn}`} key={tag.tag.urn}>
+                    <TagLink to={entityRegistry.getEntityUrl(EntityType.Tag, tag.tag.urn)} key={tag.tag.urn}>
                         <StyledTag
                             $colorHash={tag.tag.urn}
                             closable={canRemove}


### PR DESCRIPTION
We missed using the getEntityUrl method for these links causing some encoding problems.

Now:
![image](https://user-images.githubusercontent.com/2455694/138939563-d492556a-e2bd-4027-a13f-4d66f86196f3.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
