### PR TITLE
docs(frontend): remove confusing suggestion to manually create users

### DIFF
--- a/datahub-frontend/README.md
+++ b/datahub-frontend/README.md
@@ -22,25 +22,6 @@ However, if you only want to build `DataHub Frontend` specifically:
 Before starting `DataHub Frontend`, you need to make sure that [DataHub GMS](../metadata-service) and
 all its dependencies have already started and running.
 
-Also, user information should already be registered into the DB,
-otherwise user will not be able to sign in.
-To do that, first create a file named `user.dat` containing below line and filling the parts `<<something>>`
-with your information:
-```
-{"auditHeader": None, "proposedSnapshot": ("com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot", {"urn": "urn:li:corpuser:<<username>>", "aspects": [{"active": True, "fullName": "<<Full Name>>", "email": "<<e-mail address>>"}, {}]}), "proposedDelta": None}
-```
-And run `mce producer` script as below:
-```
-python metadata-ingestion/mce_cli.py produce -d user.dat
-```
-
-Or, you can run the script without providing any data file. In this case, the script will use `bootstrap_mce.dat` file
-to bootstrap some sample users and datasets:
-```
-python metadata-ingestion/mce_cli.py produce
-```
-This will create a default user with username `datahub`. You can sign in to the app using `datahub` as your username.
-
 ## Start via Docker image
 Quickest way to try out `DataHub Frontend` is running the [Docker image](../docker/datahub-frontend).
 
@@ -57,7 +38,8 @@ into your favorite web browser:
 ```
 http://localhost:9001
 ```
-To be able to sign in, you need to provide your user name. You don't need to type any password.
+
+To be able to sign in, you need to provide your user name. The default account is `datahub`, password `datahub`.
 
 ## Authentication
 DataHub frontend leverages [Java Authentication and Authorization Service (JAAS)](https://docs.oracle.com/javase/7/docs/technotes/guides/security/jaas/JAASRefGuide.html) to perform the authentication. By default we provided a [DummyLoginModule](app/security/DummyLoginModule.java) which will accept any username/password combination. You can update [jaas.conf](conf/jaas.conf) to match your authentication requirement. For example, use the following config for LDAP-based authentication,


### PR DESCRIPTION
This guidance was confusing and is no longe in line with how we recommend managing users.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
