### PR TITLE
fix(graphql): fixing Graphql engine factory when analytics are disabled

### DIFF
--- a/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLEngineFactory.java
@@ -56,6 +56,6 @@ public class GraphQLEngineFactory {
           new AnalyticsService(elasticClient, indexConvention.getPrefix()), _entityService, _graphClient, _entityClient
       ).builder().build();
     }
-    return new GmsGraphQLEngine().builder().build();
+    return new GmsGraphQLEngine(null, _entityService, _graphClient, _entityClient).builder().build();
   }
 }


### PR DESCRIPTION
If `ANALYTICS_ENABLED` was set to false, then the constructor for GmsGraphQLEngine would not get its proper references and would 500 when trying to load entities.

This was introduced in: https://github.com/linkedin/datahub/pull/3213.

Some questions to think about:
- How can we effectively test both ANALYTICS_ENABLED states (and other env var states) so this type of issue could be caught in the future?

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
