### PR TITLE
fix(subtypes): fix case where subtypes are not being fetched for leaf datasets

### DIFF
--- a/datahub-web-react/src/graphql/relationships.graphql
+++ b/datahub-web-react/src/graphql/relationships.graphql
@@ -48,6 +48,9 @@ fragment relationshipFields on Entity {
         ownership {
             ...ownershipFields
         }
+        subTypes {
+            typeNames
+        }
         ...datasetRelationshipsLeaf
     }
     ... on MLModelGroup {


### PR DESCRIPTION
Subtype was only being fetched for full dataset loads, leaving leaf nodes without subtype specification until expanded.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
