### PR TITLE
fix(fk): trim whitespace from fk constraints in the case the fieldspec has leading or trailing whitespace characters

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/utils/schemaTitleRenderer.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/utils/schemaTitleRenderer.tsx
@@ -65,8 +65,9 @@ export default function useSchemaTitleRenderer(
                     {schemaMetadata?.foreignKeys
                         ?.filter(
                             (constraint) =>
-                                (constraint?.sourceFields?.filter((sourceField) => sourceField?.fieldPath === fieldPath)
-                                    .length || 0) > 0,
+                                (constraint?.sourceFields?.filter(
+                                    (sourceField) => sourceField?.fieldPath.trim() === fieldPath.trim(),
+                                ).length || 0) > 0,
                         )
                         .map((constraint) => (
                             <ForeignKeyLabel

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/ForeignKeyLabel.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/ForeignKeyLabel.tsx
@@ -38,7 +38,7 @@ export default function ForeignKeyLabel({
     const selectedFk = useContext(FkContext);
 
     const onOpenFk = () => {
-        if (selectedFk?.fieldPath === fieldPath && selectedFk?.constraint?.name === constraint?.name) {
+        if (selectedFk?.fieldPath.trim() === fieldPath.trim() && selectedFk?.constraint?.name === constraint?.name) {
             onClick(null);
         } else {
             onClick({ fieldPath, constraint });


### PR DESCRIPTION
These were introduced by an error in the ingestion system, patching them for users who already ingested fk metadata.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
