### PR TITLE
feat(metadata-model): un-deprecates DataProcess

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/common/DatasetInputOutputLineage.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/DatasetInputOutputLineage.pdl
@@ -1,0 +1,48 @@
+namespace com.linkedin.common
+
+/**
+ * Input and output datasets to be consumed and produced by an entity
+ */
+@Aspect = {
+  "name": "datasetInputOutputLineage"
+}
+record DatasetInputOutputLineage {
+
+  /**
+   * Input datasets to be consumed
+   */
+  @Relationship = {
+    "/*": {
+      "name": "Consumes",
+      "entityTypes": [ "dataset" ]
+    }
+  }
+  @Searchable = {
+    "/*": {
+      "fieldName": "inputs",
+      "fieldType": "URN",
+      "numValuesFieldName": "numInputDatasets",
+      "queryByDefault": false
+    }
+  }
+  inputDatasets: array[DatasetUrn]
+
+  /**
+   * Output datasets to be produced
+   */
+  @Relationship = {
+    "/*": {
+      "name": "Produces",
+      "entityTypes": [ "dataset" ]
+    }
+  }
+  @Searchable = {
+    "/*": {
+      "fieldName": "outputs",
+      "fieldType": "URN",
+      "numValuesFieldName": "numOutputDatasets",
+      "queryByDefault": false
+    }
+  }
+  outputDatasets: array[DatasetUrn]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInputOutput.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInputOutput.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.datajob
 
 import com.linkedin.common.DatasetUrn
 import com.linkedin.common.DataJobUrn
+import com.linkedin.common.DatasetInputOutputLineage
 
 
 /**
@@ -10,45 +11,7 @@ import com.linkedin.common.DataJobUrn
 @Aspect = {
   "name": "dataJobInputOutput"
 }
-record DataJobInputOutput {
-
-  /**
-   * Input datasets consumed by the data job during processing
-   */
-  @Relationship = {
-    "/*": {
-      "name": "Consumes",
-      "entityTypes": [ "dataset" ]
-    }
-  }
-  @Searchable = {
-    "/*": {
-      "fieldName": "inputs",
-      "fieldType": "URN",
-      "numValuesFieldName": "numInputDatasets",
-      "queryByDefault": false
-    }
-  }
-  inputDatasets: array[DatasetUrn]
-
-  /**
-   * Output datasets produced by the data job during processing
-   */
-  @Relationship = {
-    "/*": {
-      "name": "Produces",
-      "entityTypes": [ "dataset" ]
-    }
-  }
-  @Searchable = {
-    "/*": {
-      "fieldName": "outputs",
-      "fieldType": "URN",
-      "numValuesFieldName": "numOutputDatasets",
-      "queryByDefault": false
-    }
-  }
-  outputDatasets: array[DatasetUrn]
+record DataJobInputOutput includes DatasetInputOutputLineage {
 
   /**
    * Input datajobs that this data job depends on

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInfo.pdl
@@ -36,10 +36,17 @@ record DataProcessInfo includes CustomProperties, ExternalReference, TimeseriesA
    * Process type
    */
   @Searchable = {
-    "fieldType": "TEXT",
-    "hasValuesFieldName": "hasType"
+    "fieldType": "KEYWORD",
+    "addToFilters": true,
+    "filterNameOverride": "Process Type"
   }
-  type: optional string
+  type: optional enum DataProcessType {
+    BATCH_SCHEDULED,
+    BATCH_AD_HOC,
+    STREAMING,
+    MICROSERVICE,
+    OTHER,
+  }
 
   /**
    * Status of the process

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInfo.pdl
@@ -1,6 +1,7 @@
 namespace com.linkedin.dataprocess
 
-import com.linkedin.common.DatasetUrn
+import com.linkedin.common.CustomProperties
+import com.linkedin.common.ExternalReference
 
 /**
  * The inputs and outputs of this data process
@@ -8,43 +9,38 @@ import com.linkedin.common.DatasetUrn
 @Aspect = {
   "name": "dataProcessInfo"
 }
-record DataProcessInfo {
+record DataProcessInfo includes CustomProperties, ExternalReference {
 
   /**
-   * the inputs of the data process
+   * Process name
    */
-  @Relationship = {
-    "/*": {
-      "name": "Consumes",
-      "entityTypes": [ "dataset" ]
-    }
-  }
   @Searchable = {
-    "/*": {
-      "fieldName": "inputs",
-      "fieldType": "URN",
-      "numValuesFieldName": "numInputDatasets",
-      "queryByDefault": false
-    }
+    "fieldType": "TEXT_PARTIAL",
+    "enableAutocomplete": true,
+    "boostScore": 10.0
   }
-  inputs: optional array[DatasetUrn]
+  name: string
 
   /**
-   * the outputs of the data process
+   * Process description
    */
-  @Relationship = {
-    "/*": {
-      "name": "Consumes",
-      "entityTypes": [ "dataset" ]
-    }
-  }
   @Searchable = {
-    "/*": {
-      "fieldName": "outputs",
-      "fieldType": "URN",
-      "numValuesFieldName": "numOutputDatasets",
-      "queryByDefault": false
-    }
+    "fieldType": "TEXT",
+    "hasValuesFieldName": "hasDescription"
   }
-  outputs: optional array[DatasetUrn]
+  description: optional string
+
+  /**
+   * Process type
+   */
+  @Searchable = {
+    "fieldType": "TEXT",
+    "hasValuesFieldName": "hasType"
+  }
+  type: optional string
+
+  /**
+   * Status of the process
+   */
+  status: optional ProcessStatus
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInfo.pdl
@@ -2,14 +2,16 @@ namespace com.linkedin.dataprocess
 
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
+import com.linkedin.timeseries.TimeseriesAspectBase
 
 /**
  * The inputs and outputs of this data process
  */
 @Aspect = {
-  "name": "dataProcessInfo"
+  "name": "dataProcessInfo",
+  "type": "timeseries",
 }
-record DataProcessInfo includes CustomProperties, ExternalReference {
+record DataProcessInfo includes CustomProperties, ExternalReference, TimeseriesAspectBase {
 
   /**
    * Process name
@@ -42,5 +44,6 @@ record DataProcessInfo includes CustomProperties, ExternalReference {
   /**
    * Status of the process
    */
+  @TimeseriesField = {}
   status: optional ProcessStatus
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInputOutput.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInputOutput.pdl
@@ -1,0 +1,51 @@
+namespace com.linkedin.dataprocess
+
+import com.linkedin.common.DatasetUrn
+
+
+/**
+ * Information about the inputs and outputs of a Data process
+ */
+@Aspect = {
+  "name": "dataProcessInputOutput"
+}
+record DataProcessInputOutput {
+
+  /**
+   * Input datasets consumed by the data process during processing
+   */
+  @Relationship = {
+    "/*": {
+      "name": "Consumes",
+      "entityTypes": [ "dataset" ]
+    }
+  }
+  @Searchable = {
+    "/*": {
+      "fieldName": "inputs",
+      "fieldType": "URN",
+      "numValuesFieldName": "numInputDatasets",
+      "queryByDefault": false
+    }
+  }
+  inputDatasets: array[DatasetUrn]
+
+  /**
+   * Output datasets produced by the data process during processing
+   */
+  @Relationship = {
+    "/*": {
+      "name": "Produces",
+      "entityTypes": [ "dataset" ]
+    }
+  }
+  @Searchable = {
+    "/*": {
+      "fieldName": "outputs",
+      "fieldType": "URN",
+      "numValuesFieldName": "numOutputDatasets",
+      "queryByDefault": false
+    }
+  }
+  outputDatasets: array[DatasetUrn]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInputOutput.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInputOutput.pdl
@@ -1,6 +1,7 @@
 namespace com.linkedin.dataprocess
 
 import com.linkedin.common.DatasetUrn
+import com.linkedin.common.DatasetInputOutputLineage
 
 
 /**
@@ -9,43 +10,6 @@ import com.linkedin.common.DatasetUrn
 @Aspect = {
   "name": "dataProcessInputOutput"
 }
-record DataProcessInputOutput {
+record DataProcessInputOutput includes DatasetInputOutputLineage {
 
-  /**
-   * Input datasets consumed by the data process during processing
-   */
-  @Relationship = {
-    "/*": {
-      "name": "Consumes",
-      "entityTypes": [ "dataset" ]
-    }
-  }
-  @Searchable = {
-    "/*": {
-      "fieldName": "inputs",
-      "fieldType": "URN",
-      "numValuesFieldName": "numInputDatasets",
-      "queryByDefault": false
-    }
-  }
-  inputDatasets: array[DatasetUrn]
-
-  /**
-   * Output datasets produced by the data process during processing
-   */
-  @Relationship = {
-    "/*": {
-      "name": "Produces",
-      "entityTypes": [ "dataset" ]
-    }
-  }
-  @Searchable = {
-    "/*": {
-      "fieldName": "outputs",
-      "fieldType": "URN",
-      "numValuesFieldName": "numOutputDatasets",
-      "queryByDefault": false
-    }
-  }
-  outputDatasets: array[DatasetUrn]
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/EditableDataProcessProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/EditableDataProcessProperties.pdl
@@ -1,0 +1,21 @@
+namespace com.linkedin.dataprocess
+
+import com.linkedin.common.ChangeAuditStamps
+
+/**
+ * Stores editable changes made to properties. This separates changes made from
+ * ingestion pipelines and edits in the UI to avoid accidental overwrites of user-provided data by ingestion pipelines
+ */
+@Aspect = {
+  "name": "editableDataProcessProperties"
+}
+record EditableDataProcessProperties includes ChangeAuditStamps {
+  /**
+   * Edited documentation of the data process
+   */
+  @Searchable = {
+    "fieldType": "TEXT",
+    "fieldName": "editedDescription",
+  }
+  description: optional string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/ProcessStatus.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/ProcessStatus.pdl
@@ -1,0 +1,47 @@
+namespace com.linkedin.dataprocess
+
+/**
+ * Process statuses
+ */
+enum ProcessStatus {
+
+  /**
+   * Processes being initialized.
+   */
+  STARTING
+
+  /**
+   * Processes currently running.
+   */
+  IN_PROGRESS
+  
+  /**
+   * Processes being stopped.
+   */
+  STOPPING
+
+  /**
+   * Processes that have stopped.
+   */
+  STOPPED
+
+  /**
+   * Processes with successful completion.
+   */
+  COMPLETED
+
+  /**
+   * Processes that have failed.
+   */
+  FAILED
+
+  /**
+   * Processes with unknown status (either unmappable or unavailable)
+   */  
+  UNKNOWN
+
+  /**
+   * Processes that have been skipped.
+   */
+  SKIPPED
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataProcessAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataProcessAspect.pdl
@@ -10,6 +10,7 @@ import com.linkedin.common.GlobalTags
 import com.linkedin.common.BrowsePaths
 import com.linkedin.common.GlossaryTerms
 import com.linkedin.common.InstitutionalMemory
+import com.linkedin.common.Deprecation
 import com.linkedin.common.DataPlatformInstance
 
 /**
@@ -27,5 +28,6 @@ typeref DataProcessAspect = union[
   BrowsePaths,
   GlossaryTerms,
   InstitutionalMemory,
+  Deprecation,
   DataPlatformInstance
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataProcessAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataProcessAspect.pdl
@@ -2,12 +2,30 @@ namespace com.linkedin.metadata.aspect
 
 import com.linkedin.metadata.key.DataProcessKey
 import com.linkedin.dataprocess.DataProcessInfo
+import com.linkedin.dataprocess.DataProcessInputOutput
+import com.linkedin.dataprocess.EditableDataProcessProperties
 import com.linkedin.common.Ownership
 import com.linkedin.common.Status
+import com.linkedin.common.GlobalTags
+import com.linkedin.common.BrowsePaths
+import com.linkedin.common.GlossaryTerms
+import com.linkedin.common.InstitutionalMemory
 import com.linkedin.common.DataPlatformInstance
 
 /**
  * A union of all supported metadata aspects for a data process
  */
 @deprecated = "Use DataJob instead."
-typeref DataProcessAspect = union[DataProcessKey, Ownership, DataProcessInfo, Status]
+typeref DataProcessAspect = union[
+  DataProcessKey,
+  DataProcessInfo,
+  DataProcessInputOutput,
+  EditableDataProcessProperties,
+  Ownership,
+  Status,
+  GlobalTags,
+  BrowsePaths,
+  GlossaryTerms,
+  InstitutionalMemory,
+  DataPlatformInstance
+]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataProcessSnapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataProcessSnapshot.pdl
@@ -10,7 +10,6 @@ import com.linkedin.metadata.aspect.DataProcessAspect
   "name": "dataProcess",
   "keyAspect": "dataProcessKey"
 }
-@deprecated = "Use DataJob instead."
 record DataProcessSnapshot {
 
   /**

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -31,6 +31,21 @@ entities:
     aspects:
       - domains
       - deprecation
+  - name: dataProcess
+    keyAspect: dataProcessKey
+    aspects:
+      - dataProcessInfo
+      - dataProcessInputOutput
+      - editableDataProcessProperties
+      - ownership
+      - status
+      - globalTags
+      - browsePaths
+      - glossaryTerms
+      - institutionalMemory
+      - deprecation
+      - dataPlatformInstance
+      - domains
   - name: chart
     keyAspect: chartKey
     aspects:


### PR DESCRIPTION
Un-deprecating `DataProcess`.

This is in the context of the following feature request: https://feature-requests.datahubproject.io/b/Developer-Experience/p/entity-model-for-streaming-applications-or-microservices

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
