### PR TITLE
feat(ingest) kafka-connect: prefix server to table name using a flag

### DIFF
--- a/metadata-ingestion/adding-source.md
+++ b/metadata-ingestion/adding-source.md
@@ -51,8 +51,7 @@ Tests go in the `tests` directory. We use the [pytest framework](https://pytest.
 
 ### 7. Write docs
 
-Add the plugin to the table at the top of the README file, and add the source's documentation underneath the sources
-header.
+Add the plugin to the table under [CLI Sources List](../docs/cli.md#sources), and add the source's documentation underneath the [sources folder](https://github.com/linkedin/datahub/tree/master/metadata-ingestion/source_docs).
 
 ### 8. Add SQL Alchemy mapping (if applicable)
 

--- a/metadata-ingestion/source_docs/kafka-connect.md
+++ b/metadata-ingestion/source_docs/kafka-connect.md
@@ -58,20 +58,20 @@ sink:
 
 Note that a `.` is used to denote nested fields in the YAML recipe.
 
-| Field                      | Required | Default                    | Description                                             |
-| -------------------------- | -------- | -------------------------- | ------------------------------------------------------- |
-| `connect_uri`              |    ✅    | `"http://localhost:8083/"` | URI to connect to.                                      |
-| `username`                 |          |                            | Kafka Connect username.                                 |
-| `password`                 |          |                            | Kafka Connect password.                                 |
-| `cluster_name`             |          | `"connect-cluster"`        | Cluster to ingest from.                                 |
-| `provided_configs`         |          |                            | Provided Configurations                                 |
-| `construct_lineage_workunits`    |    | `True`                     | Whether to create the input and output Dataset entities |
-| `connector_patterns.deny`  |          |                            | List of regex patterns for connectors to include in ingestion.   |
-| `connector_patterns.allow` |          |                            | List of regex patterns for connectors to exclude from ingestion. |
-| `connector_pattern.ignoreCase`  |     | `True`      | Whether to ignore case sensitivity during pattern matching.            |
-| `env`                      |          | `"PROD"`                   | Environment to use in namespace when constructing URNs. |
-| `platform_instance_map` |     |     | Platform instance mapping to use when constructing URNs. e.g.`platform_instance_map: { "hive": "warehouse" }` |
-
+| Field                          | Required | Default                    | Description                                                                                                                                                                                                                                                            |
+|--------------------------------| -------- |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `connect_uri`                  |    ✅    | `"http://localhost:8083/"` | URI to connect to.                                                                                                                                                                                                                                                     |
+| `username`                     |          |                            | Kafka Connect username.                                                                                                                                                                                                                                                |
+| `password`                     |          |                            | Kafka Connect password.                                                                                                                                                                                                                                                |
+| `cluster_name`                 |          | `"connect-cluster"`        | Cluster to ingest from.                                                                                                                                                                                                                                                |
+| `provided_configs`             |          |                            | Provided Configurations                                                                                                                                                                                                                                                |
+| `construct_lineage_workunits`  |    | `True`                     | Whether to create the input and output Dataset entities                                                                                                                                                                                                                |
+| `connector_patterns.deny`      |          |                            | List of regex patterns for connectors to include in ingestion.                                                                                                                                                                                                         |
+| `connector_patterns.allow`     |          |                            | List of regex patterns for connectors to exclude from ingestion.                                                                                                                                                                                                       |
+| `connector_pattern.ignoreCase` |     | `True`                     | Whether to ignore case sensitivity during pattern matching.                                                                                                                                                                                                            |
+| `env`                          |          | `"PROD"`                   | Environment to use in namespace when constructing URNs.                                                                                                                                                                                                                |
+| `platform_instance_map`        |     |                            | Platform instance mapping to use when constructing URNs. e.g.`platform_instance_map: { "hive": "warehouse" }`                                                                                                                                                          | 
+| `prefix_server_to_table_name`  |          | `False`                    | Whether to prefix Database server name to the table name. When multiple instances are ingested for a single platform then the platform_instance name in the recipe could be matched to the database server name in Kafka connect and there by making the lineage work. |
 ## Compatibility
 
 Coming soon!

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -36,7 +36,7 @@ class KafkaConnectSourceConfig(DatasetLineageProviderConfigBase):
     construct_lineage_workunits: bool = True
     connector_patterns: AllowDenyPattern = AllowDenyPattern.allow_all()
     provided_configs: Optional[List[ProvidedConfig]] = None
-    prefix_server_to_table_name: Optional[str] = None
+    prefix_server_to_table_name: bool = False
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -541,8 +541,6 @@ class DebeziumSourceConnector:
                 else:
                     table_name = found.group(2)
 
-                logger.info(f"Topic Name: {topic},  Table Name: {table_name}")
-
                 lineage = KafkaConnectLineage(
                     source_dataset=table_name,
                     source_platform=source_platform,

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -550,7 +550,6 @@ class BigQuerySource(SQLAlchemySource):
         num_entries: int = 0
         num_skipped_entries: int = 0
         for e in entries:
-            logger.warning(f"Entry:{e}")
             num_entries += 1
             if e.destinationTable is None or not e.referencedTables:
                 num_skipped_entries += 1


### PR DESCRIPTION
## Checklist
- [X ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ X] Links to related issues (if applicable)
- [ X] Docs related to the changes have been added/updated (if applicable)


**Conversation in Slack:**
Based on this conversation here - https://datahubspace.slack.com/archives/CUMUWQU66/p1646256415909719

**Background:**
     When ingesting multiple instances for the same source such as PostgreSQL the urn ingested would be for example: `urn:li:dataset:(urn:li:dataPlatform:postgres,{platform_instance_name}.{db name}.{schema name}.{table name},PROD)`

So when Kafka Connect ingests data from Debezium connector the table name that it builts will have `{db name}.{schema + table name}` 
In order to add the `platform_instance_name` to the table name, 2 things needs to be followed:
 1. Matching its value with `database.server.name` in debezium 
 2. Enabling this flag `prefix_server_to_table_name` to prefix the server name to the table

This will have no impact to existing flows.

