### PR TITLE
build: Fix line endings for Windows check-out

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+gradlew text eol=lf
+metadata-utils/src/test/resources/filterQuery/* text eol=lf


### PR DESCRIPTION
To avoid the need for dos2unix when checking out the repo on Windows.

See: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings