### PR TITLE
feat(oidc): Adding support for extracting single string groups claim

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -2,7 +2,6 @@ package auth.sso.oidc;
 
 import client.AuthServiceClient;
 import com.datahub.authentication.Authentication;
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.CorpGroupUrnArray;
 import com.linkedin.common.CorpuserUrnArray;


### PR DESCRIPTION
**Summary**
Currently, we assume that the groups claim returned by an IdP is a collection is strings. In this PR, we introduce support for claims that are of type "string", which indicates that a single group should be minted, with the user added to it. 

**Verification** 
Verified using a custom "Department" attribute created in Okta. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
