### PR TITLE
fix(ingestion): Fix bug in the SchemaField type computation for AVRO logical types.

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
+++ b/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
@@ -90,8 +90,12 @@ class AvroToMceSchemaConverter:
 
     field_logical_type_mapping: Dict[str, Any] = {
         "date": DateTypeClass,
-        "timestamp-millis": TimeTypeClass,
         "decimal": NumberTypeClass,
+        "time-micros": TimeTypeClass,
+        "time-millis": TimeTypeClass,
+        "timestamp-micros": TimeTypeClass,
+        "timestamp-millis": TimeTypeClass,
+        "uuid": StringTypeClass,
     }
 
     def __init__(self, is_key_schema: bool, default_nullable: bool = False) -> None:
@@ -125,7 +129,7 @@ class AvroToMceSchemaConverter:
         }
 
     def _get_column_type(
-        self, field_type: Union[str, dict], logical_type: str
+        self, field_type: Union[str, dict], logical_type: Optional[str]
     ) -> SchemaFieldDataType:
         tp = field_type
         if hasattr(tp, "type"):
@@ -283,7 +287,7 @@ class AvroToMceSchemaConverter:
                     # Populate it with the simple native type for now.
                     nativeDataType=native_data_type,
                     type=self._converter._get_column_type(
-                        actual_schema.type, actual_schema.props.get("logicalType")
+                        actual_schema.type, self._actual_schema.props.get("logicalType")
                     ),
                     description=description,
                     recursive=False,

--- a/metadata-ingestion/tests/unit/test_schema_util.py
+++ b/metadata-ingestion/tests/unit/test_schema_util.py
@@ -2,14 +2,17 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import List
+from typing import List, Type
 
 import pytest
 
 from datahub.ingestion.extractor.schema_util import avro_schema_to_mce_fields
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
+    DateTypeClass,
+    NumberTypeClass,
     SchemaField,
     StringTypeClass,
+    TimeTypeClass,
 )
 
 logger = logging.getLogger(__name__)
@@ -661,6 +664,7 @@ def test_logical_types():
 }
     """
     fields: List[SchemaField] = avro_schema_to_mce_fields(schema, is_key_schema=False)
+    # validate field paths
     expected_field_paths: List[str] = [
         "[version=2.0].[type=test_logical_types].[type=bytes].decimal_logical",
         "[version=2.0].[type=test_logical_types].[type=string].uuid_logical",
@@ -671,6 +675,18 @@ def test_logical_types():
         "[version=2.0].[type=test_logical_types].[type=long].timestamp_micros_logical",
     ]
     assert_field_paths_match(fields, expected_field_paths)
+
+    # validate field types.
+    expected_types: List[Type] = [
+        NumberTypeClass,
+        StringTypeClass,
+        DateTypeClass,
+        TimeTypeClass,
+        TimeTypeClass,
+        TimeTypeClass,
+        TimeTypeClass,
+    ]
+    assert expected_types == [type(field.type.type) for field in fields]
 
 
 def test_ignore_exceptions():


### PR DESCRIPTION
1. Adds coverage for computing the SchemaField type for all AVRO logical types.
2. Fixes a minor bug in the 'logicalType' value retrieval logic.
3. Adds test coverage

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
