### PR TITLE
feat(cli) Makes filtered search deletes include BOTH removed and non-removed

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -338,7 +338,7 @@ def get_urns_by_filter(
         filter_criteria.append(
             {
                 "field": "removed",
-                "value": "true",
+                "value": "",  # accept anything regarding removed property (true, false, non-existent)
                 "condition": "EQUAL",
             }
         )


### PR DESCRIPTION
Filtered deletes with `--include-removed` where incorrectly ignoring elasticsearch results where the `removed` field was set to removed=false.
This means that semantically the flag should be called `--soft-deleted` only which is not what we want.

Tested locally that flag know does what we intended, which is to see if the removed property exists, effectively making that property a non-consideration when filtering. The reason we have to do it this way is because in the backend (GMS) we add a filter on removed=true except if there is some condition that references the `removed` property.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
