### PR TITLE
feat: Enable the ingestion of bigquery audit logs to parse usage info…

### DIFF
--- a/metadata-ingestion/tests/integration/bigquery-usage/test_bigquery_usage.py
+++ b/metadata-ingestion/tests/integration/bigquery-usage/test_bigquery_usage.py
@@ -32,8 +32,8 @@ def test_bq_usage_config():
             table_pattern={"allow": ["test-regex", "test-regex-1"], "deny": []},
         )
     )
-    assert config.get_allow_pattern_string() == "test-regex|test-regex-1"
-    assert config.get_deny_pattern_string() == ""
+    assert config.get_table_allow_pattern_string() == "test-regex|test-regex-1"
+    assert config.get_table_deny_pattern_string() == ""
     assert (config.end_time - config.start_time) == timedelta(hours=1)
     assert config.projects == ["sample-bigquery-project-name-1234"]
 
@@ -69,7 +69,9 @@ def test_bq_usage_source(pytestconfig, tmp_path):
             PipelineContext(run_id="bq-usage-test"),
         )
         entries = list(
-            source._get_bigquery_log_entries(source._make_bigquery_clients())
+            source._get_bigquery_log_entries_via_gcp_logging(
+                source._make_bigquery_logging_clients()
+            )
         )
 
         entries = [entry._replace(logger=None) for entry in entries]

--- a/metadata-ingestion/tests/unit/test_great_expectations_action.py
+++ b/metadata-ingestion/tests/unit/test_great_expectations_action.py
@@ -156,11 +156,14 @@ def test_DataHubValidationAction_basic(
         data_context=ge_data_context, server_url=server_url
     )
 
-    assert datahub_action.run(
-        validation_result_suite_identifier=ge_validation_result_suite_id,
-        validation_result_suite=ge_validation_result_suite,
-        data_asset=ge_validator_sqlalchemy,
-    ) == {"datahub_notification_result": "DataHub notification succeeded"}
+    assert (
+        datahub_action.run(
+            validation_result_suite_identifier=ge_validation_result_suite_id,
+            validation_result_suite=ge_validation_result_suite,
+            data_asset=ge_validator_sqlalchemy,
+        )
+        == {"datahub_notification_result": "DataHub notification succeeded"}
+    )
 
     mock_emitter.assert_has_calls(
         [
@@ -259,11 +262,14 @@ def test_DataHubValidationAction_graceful_failure(
         data_context=ge_data_context, server_url=server_url
     )
 
-    assert datahub_action.run(
-        validation_result_suite_identifier=ge_validation_result_suite_id,
-        validation_result_suite=ge_validation_result_suite,
-        data_asset=ge_validator_sqlalchemy,
-    ) == {"datahub_notification_result": "DataHub notification failed"}
+    assert (
+        datahub_action.run(
+            validation_result_suite_identifier=ge_validation_result_suite_id,
+            validation_result_suite=ge_validation_result_suite,
+            data_asset=ge_validator_sqlalchemy,
+        )
+        == {"datahub_notification_result": "DataHub notification failed"}
+    )
 
 
 def test_DataHubValidationAction_not_supported(
@@ -279,8 +285,11 @@ def test_DataHubValidationAction_not_supported(
         data_context=ge_data_context, server_url=server_url
     )
 
-    assert datahub_action.run(
-        validation_result_suite_identifier=ge_validation_result_suite_id,
-        validation_result_suite=ge_validation_result_suite,
-        data_asset=ge_validator_pandas,
-    ) == {"datahub_notification_result": "none required"}
+    assert (
+        datahub_action.run(
+            validation_result_suite_identifier=ge_validation_result_suite_id,
+            validation_result_suite=ge_validation_result_suite,
+            data_asset=ge_validator_pandas,
+        )
+        == {"datahub_notification_result": "none required"}
+    )


### PR DESCRIPTION
Update bigquery-usage to ingest logs via a BigQuery log sink.

Currently only support v2 QueryEvents


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
