### PR TITLE
fix(ui): Fixing privilege option display bug

### DIFF
--- a/datahub-web-react/src/app/policy/PoliciesPage.tsx
+++ b/datahub-web-react/src/app/policy/PoliciesPage.tsx
@@ -179,22 +179,27 @@ export const PoliciesPage = () => {
     };
 
     const getPrivilegeNames = (policy: Omit<Policy, 'urn'>) => {
-        let privilegeOptions: PrivilegeOptionType[] = [];
+        let privileges: PrivilegeOptionType[] = [];
         if (policy?.type === PolicyType.Platform) {
-            privilegeOptions = platformPrivileges.map((platformPrivilege) => {
-                return { type: platformPrivilege.type, name: platformPrivilege.displayName };
-            });
+            privileges = platformPrivileges
+                .filter((platformPrivilege) => policy.privileges.includes(platformPrivilege.type))
+                .map((platformPrivilege) => {
+                    return { type: platformPrivilege.type, name: platformPrivilege.displayName };
+                });
         } else {
             const privilegeData = resourcePrivileges.filter(
                 (resourcePrivilege) => resourcePrivilege.resourceType === policy?.resources?.type,
             );
-            privilegeOptions =
-                privilegeData &&
-                privilegeData[0]?.privileges.map((b) => {
-                    return { type: b.type, name: b.displayName };
-                });
+            privileges =
+                (privilegeData.length > 0 &&
+                    privilegeData[0]?.privileges
+                        .filter((resourcePrivilege) => policy.privileges.includes(resourcePrivilege.type))
+                        .map((b) => {
+                            return { type: b.type, name: b.displayName };
+                        })) ||
+                [];
         }
-        return privilegeOptions;
+        return privileges;
     };
 
     const onViewPolicy = (policy: Policy) => {


### PR DESCRIPTION
**Summary**
During the Policies Page redesign, a bug was introduced that causes the privileges granted by a policy to appear incorrectly on the "details" modal that shows when you click the policy. This is a display-only bug and did not affect actual policy enforcement. 

This PR addresses this issue. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
