### PR TITLE
fix(ingest): add fix to tableau connector when table has None fields

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -247,8 +247,11 @@ class TableauSource(Source):
 
         for table in datasource.get("upstreamTables", []):
             # skip upstream tables when there is no column info when retrieving embedded datasource
+            # and when table name is None
             # Schema details for these will be taken care in self.emit_custom_sql_ds()
             if not is_custom_sql and not table.get("columns"):
+                continue
+            elif table["name"] is None:
                 continue
 
             schema = self._get_schema(table.get("schema", ""), upstream_db)


### PR DESCRIPTION
## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

Co-authored-by: Ludmila Ferreira <ludmila.ferreira@elo7.com>

Hello!

We are using Datahub for ingesting metadata from Tableau. We were facing an issue when ingesting some Tableau data sources. The execution was crashing in the middle when data was coming with `None` fields, as shown in the following stack trace: 


```
File "/usr/local/lib/python3.8/site-packages/datahub/ingestion/source/tableau.py", line 570, in emit_datasource
    upstream_tables = self._create_upstream_table_lineage(datasource, project)
File "/usr/local/lib/python3.8/site-packages/datahub/ingestion/source/tableau.py", line 257, in _create_upstream_table_lineage
    table_urn = make_table_urn(
File "/usr/local/lib/python3.8/site-packages/datahub/ingestion/source/tableau_common.py", line 379, in make_table_urn
    final_name = full_name.replace("[", "").replace("]", "")

AttributeError: 'NoneType' object has no attribute 'replace'
```


This happens when table object has this structure:
```
{'id': '1ca95eea-fab3-643b-110e-e91af4b0ea74', 'name': None, 'schema': None, 'fullName': None, 'connectionType': None, 'description': None, 'columns': [{'name': None, 'remoteType': 'WSTR'}, {'name': None, 'remoteType': 'I8'}, {'name': None, 'remoteType': 'DATE'}, {'name': None, 'remoteType': 'DATE'}, {'name': None, 'remoteType': 'R8'}, {'name': None, 'remoteType': 'I8'}, {'name': None, 'remoteType': 'R8'}, {'name': None, 'remoteType': 'I8'}]}
```

This fix is to treat scenarios like this one mentioned above.

Thanks a lot!


