### PR TITLE
feat(notebook): graphqul related logic change for notebook

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -43,6 +43,7 @@ import com.linkedin.datahub.graphql.generated.MLModelGroup;
 import com.linkedin.datahub.graphql.generated.MLModelProperties;
 import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
 import com.linkedin.datahub.graphql.generated.MLPrimaryKeyProperties;
+import com.linkedin.datahub.graphql.generated.Notebook;
 import com.linkedin.datahub.graphql.generated.Owner;
 import com.linkedin.datahub.graphql.generated.RecommendationContent;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResult;
@@ -72,7 +73,6 @@ import com.linkedin.datahub.graphql.resolvers.group.EntityCountsResolver;
 import com.linkedin.datahub.graphql.resolvers.group.ListGroupsResolver;
 import com.linkedin.datahub.graphql.resolvers.group.RemoveGroupMembersResolver;
 import com.linkedin.datahub.graphql.resolvers.group.RemoveGroupResolver;
-import com.linkedin.datahub.graphql.resolvers.user.UpdateUserStatusResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.CancelIngestionExecutionRequestResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.CreateIngestionExecutionRequestResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.GetIngestionExecutionRequestResolver;
@@ -123,6 +123,7 @@ import com.linkedin.datahub.graphql.resolvers.type.ResultsTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.type.TimeSeriesAspectInterfaceTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.user.ListUsersResolver;
 import com.linkedin.datahub.graphql.resolvers.user.RemoveUserResolver;
+import com.linkedin.datahub.graphql.resolvers.user.UpdateUserStatusResolver;
 import com.linkedin.datahub.graphql.types.BrowsableEntityType;
 import com.linkedin.datahub.graphql.types.EntityType;
 import com.linkedin.datahub.graphql.types.LoadableType;
@@ -135,6 +136,7 @@ import com.linkedin.datahub.graphql.types.container.ContainerType;
 import com.linkedin.datahub.graphql.types.corpgroup.CorpGroupType;
 import com.linkedin.datahub.graphql.types.corpuser.CorpUserType;
 import com.linkedin.datahub.graphql.types.dashboard.DashboardType;
+import com.linkedin.datahub.graphql.types.notebook.NotebookType;
 import com.linkedin.datahub.graphql.types.dataflow.DataFlowType;
 import com.linkedin.datahub.graphql.types.datajob.DataJobType;
 import com.linkedin.datahub.graphql.types.dataplatform.DataPlatformType;
@@ -179,15 +181,8 @@ import org.dataloader.BatchLoaderContextProvider;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderOptions;
 
-import static com.linkedin.datahub.graphql.Constants.ANALYTICS_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.APP_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.AUTH_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.GMS_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.INGESTION_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.RECOMMENDATIONS_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.SEARCH_SCHEMA_FILE;
-import static com.linkedin.datahub.graphql.Constants.URN_FIELD_NAME;
-import static graphql.Scalars.GraphQLLong;
+import static com.linkedin.datahub.graphql.Constants.*;
+import static graphql.Scalars.*;
 
 /**
  * A {@link GraphQLEngine} configured to provide access to the entities and aspects on the the GMS graph.
@@ -230,6 +225,7 @@ public class GmsGraphQLEngine {
     private final UsageType usageType;
     private final ContainerType containerType;
     private final DomainType domainType;
+    private final NotebookType notebookType;
     private final AssertionType assertionType;
 
 
@@ -327,6 +323,7 @@ public class GmsGraphQLEngine {
         this.usageType = new UsageType(this.usageClient);
         this.containerType = new ContainerType(entityClient);
         this.domainType = new DomainType(entityClient);
+        this.notebookType = new NotebookType(entityClient);
         this.assertionType = new AssertionType(entityClient);
 
         // Init Lists
@@ -347,6 +344,7 @@ public class GmsGraphQLEngine {
             dataJobType,
             glossaryTermType,
             containerType,
+            notebookType,
             domainType,
             assertionType
         );
@@ -467,6 +465,7 @@ public class GmsGraphQLEngine {
         configureCorpUserResolvers(builder);
         configureCorpGroupResolvers(builder);
         configureDashboardResolvers(builder);
+        configureNotebookResolvers(builder);
         configureChartResolvers(builder);
         configureTypeResolvers(builder);
         configureTypeExtensions(builder);
@@ -557,6 +556,9 @@ public class GmsGraphQLEngine {
             .dataFetcher("dataset", new AuthenticatedResolver<>(
                     new LoadableTypeResolver<>(datasetType,
                             (env) -> env.getArgument(URN_FIELD_NAME))))
+            .dataFetcher("notebook", new AuthenticatedResolver<>(
+                    new LoadableTypeResolver<>(notebookType,
+                            (env) -> env.getArgument(URN_FIELD_NAME))))
             .dataFetcher("corpUser", new AuthenticatedResolver<>(
                     new LoadableTypeResolver<>(corpUserType,
                             (env) -> env.getArgument(URN_FIELD_NAME))))
@@ -639,6 +641,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("setTagColor", new SetTagColorResolver(entityClient, entityService))
             .dataFetcher("updateChart", new AuthenticatedResolver<>(new MutableTypeResolver<>(chartType)))
             .dataFetcher("updateDashboard", new AuthenticatedResolver<>(new MutableTypeResolver<>(dashboardType)))
+            .dataFetcher("updateNotebook", new AuthenticatedResolver<>(new MutableTypeResolver<>(notebookType)))
             .dataFetcher("updateDataJob", new AuthenticatedResolver<>(new MutableTypeResolver<>(dataJobType)))
             .dataFetcher("updateDataFlow", new AuthenticatedResolver<>(new MutableTypeResolver<>(dataFlowType)))
             .dataFetcher("updateCorpUserProperties", new MutableTypeResolver<>(corpUserType))
@@ -902,6 +905,26 @@ public class GmsGraphQLEngine {
             )
         );
     }
+
+  /**
+   * Configures resolvers responsible for resolving the {@link com.linkedin.datahub.graphql.generated.Notebook} type.
+   */
+  private void configureNotebookResolvers(final RuntimeWiring.Builder builder) {
+    builder.type("Notebook", typeWiring -> typeWiring
+        .dataFetcher("relationships", new AuthenticatedResolver<>(
+            new EntityRelationshipsResultResolver(graphClient)
+        ))
+        .dataFetcher("domain",
+            new LoadableTypeResolver<>(
+                domainType,
+                (env) -> {
+                  final Notebook notebook = env.getSource();
+                  return notebook.getDomain() != null ? notebook.getDomain().getUrn() : null;
+                }
+            )
+        )
+    );
+  }
 
     /**
      * Configures resolvers responsible for resolving the {@link com.linkedin.datahub.graphql.generated.Dashboard} type.

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -914,14 +914,13 @@ public class GmsGraphQLEngine {
         .dataFetcher("relationships", new AuthenticatedResolver<>(
             new EntityRelationshipsResultResolver(graphClient)
         ))
+        .dataFetcher("platform", new AuthenticatedResolver<>(
+                new LoadableTypeResolver<>(dataPlatformType,
+                        (env) -> ((Notebook) env.getSource()).getPlatform().getUrn()))
+        )
         .dataFetcher("domain",
-            new LoadableTypeResolver<>(
-                domainType,
-                (env) -> {
-                  final Notebook notebook = env.getSource();
-                  return notebook.getDomain() != null ? notebook.getDomain().getUrn() : null;
-                }
-            )
+            new LoadableTypeResolver<>(domainType,
+                (env) -> ((Notebook) env.getSource()).getDomain().getUrn())
         )
     );
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/EntityTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/EntityTypeMapper.java
@@ -31,6 +31,7 @@ public class EntityTypeMapper {
           .put(EntityType.MLPRIMARY_KEY, "mlPrimaryKey")
           .put(EntityType.CONTAINER, "container")
           .put(EntityType.DOMAIN, "domain")
+          .put(EntityType.NOTEBOOK, "notebook")
           .build();
 
   private static final Map<String, EntityType> ENTITY_NAME_TO_TYPE =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
@@ -15,6 +15,7 @@ import com.linkedin.identity.CorpGroupEditableInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.notebook.EditableNotebookProperties;
 import com.linkedin.schema.EditableSchemaFieldInfo;
 import com.linkedin.schema.EditableSchemaMetadata;
 import com.linkedin.tag.TagProperties;
@@ -117,15 +118,25 @@ public class DescriptionUtils {
       Urn actor,
       EntityService entityService
   ) {
-    GlossaryTermInfo glossaryTermInfo =
-        (GlossaryTermInfo) getAspectFromEntity(
-            resourceUrn.toString(), Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, entityService, null);
+    GlossaryTermInfo glossaryTermInfo = (GlossaryTermInfo) getAspectFromEntity(
+        resourceUrn.toString(), Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, entityService, null);
     if (glossaryTermInfo == null) {
       // If there are no properties for the term already, then we should throw since the properties model also requires a name.
       throw new IllegalArgumentException("Properties for this Glossary Term do not yet exist!");
     }
     glossaryTermInfo.setDefinition(newDescription); // We call description 'definition' for glossary terms. Not great, we know. :(
     persistAspect(resourceUrn, Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, glossaryTermInfo, actor, entityService);
+  }
+  
+  public static void updateNotebookDescription(
+      String newDescription,
+      Urn resourceUrn,
+      Urn actor,
+      EntityService entityService) {
+    EditableNotebookProperties notebookProperties = (EditableNotebookProperties) getAspectFromEntity(
+        resourceUrn.toString(), Constants.EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME, entityService, null);
+    notebookProperties.setDescription(newDescription);
+    persistAspect(resourceUrn, Constants.EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME, notebookProperties, actor, entityService);
   }
 
   public static Boolean validateFieldDescriptionInput(
@@ -181,6 +192,16 @@ public class DescriptionUtils {
   ) {
     if (!entityService.exists(corpUserUrn)) {
       throw new IllegalArgumentException(String.format("Failed to update %s. %s does not exist.", corpUserUrn, corpUserUrn));
+    }
+    return true;
+  }
+
+  public static Boolean validateNotebookInput(
+      Urn notebookUrn,
+      EntityService entityService) {
+    if (!entityService.exists(notebookUrn)) {
+      throw new IllegalArgumentException(
+          String.format("Failed to update %s. %s does not exist.", notebookUrn, notebookUrn));
     }
     return true;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateDescriptionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateDescriptionResolver.java
@@ -38,6 +38,8 @@ public class UpdateDescriptionResolver implements DataFetcher<CompletableFuture<
         return updateTagDescription(targetUrn, input, environment.getContext());
       case Constants.CORP_GROUP_ENTITY_NAME:
         return updateCorpGroupDescription(targetUrn, input, environment.getContext());
+      case Constants.NOTEBOOK_ENTITY_NAME:
+        return updateNotebookDescription(targetUrn, input, environment.getContext());
       default:
         throw new RuntimeException(
             String.format("Failed to update description. Unsupported resource type %s provided.", targetUrn));
@@ -181,6 +183,31 @@ public class UpdateDescriptionResolver implements DataFetcher<CompletableFuture<
       try {
         Urn actor = CorpuserUrn.createFromString(context.getActorUrn());
         DescriptionUtils.updateCorpGroupDescription(
+            input.getDescription(),
+            targetUrn,
+            actor,
+            _entityService);
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to perform update against input {}, {}", input.toString(), e.getMessage());
+        throw new RuntimeException(String.format("Failed to perform update against input %s", input.toString()), e);
+      }
+    });
+  }
+  
+  private CompletableFuture<Boolean> updateNotebookDescription(Urn targetUrn, DescriptionUpdateInput input,
+      QueryContext context) {
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (!DescriptionUtils.isAuthorizedToUpdateDescription(context, targetUrn)) {
+        throw new AuthorizationException(
+            "Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+      DescriptionUtils.validateNotebookInput(targetUrn, _entityService);
+
+      try {
+        Urn actor = CorpuserUrn.createFromString(context.getActorUrn());
+        DescriptionUtils.updateNotebookDescription(
             input.getDescription(),
             targetUrn,
             actor,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -27,7 +27,8 @@ public class SearchUtils {
           EntityType.CORP_USER,
           EntityType.CORP_GROUP,
           EntityType.CONTAINER,
-          EntityType.DOMAIN);
+          EntityType.DOMAIN,
+          EntityType.NOTEBOOK);
 
   /**
    * Entities that are part of autocomplete by default in Auto Complete Across Entities
@@ -45,5 +46,6 @@ public class SearchUtils {
           EntityType.GLOSSARY_TERM,
           EntityType.TAG,
           EntityType.CORP_USER,
-          EntityType.CORP_GROUP);
+          EntityType.CORP_GROUP,
+          EntityType.NOTEBOOK);
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/ChangeAuditStampsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/ChangeAuditStampsMapper.java
@@ -1,0 +1,25 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import com.linkedin.datahub.graphql.generated.ChangeAuditStamps;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+
+
+public class ChangeAuditStampsMapper implements ModelMapper<com.linkedin.common.ChangeAuditStamps, ChangeAuditStamps> {
+  public static final ChangeAuditStampsMapper INSTANCE = new ChangeAuditStampsMapper();
+
+  public static ChangeAuditStamps map(com.linkedin.common.ChangeAuditStamps input) {
+    return INSTANCE.apply(input);
+  }
+
+  @Override
+  public ChangeAuditStamps apply(com.linkedin.common.ChangeAuditStamps input) {
+    ChangeAuditStamps changeAuditStamps = new ChangeAuditStamps();
+    changeAuditStamps.setCreated(AuditStampMapper.map(input.getCreated()));
+    changeAuditStamps.setLastModified(AuditStampMapper.map(input.getLastModified()));
+    if (input.hasDeleted()) {
+      changeAuditStamps.setDeleted(AuditStampMapper.map(input.getDeleted()));
+    }
+
+    return changeAuditStamps;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
@@ -12,15 +12,16 @@ import com.linkedin.datahub.graphql.generated.DataJob;
 import com.linkedin.datahub.graphql.generated.DataPlatform;
 import com.linkedin.datahub.graphql.generated.Dataset;
 import com.linkedin.datahub.graphql.generated.Domain;
+import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.GlossaryTerm;
-import com.linkedin.datahub.graphql.generated.Entity;
-import com.linkedin.datahub.graphql.generated.Tag;
 import com.linkedin.datahub.graphql.generated.MLFeature;
 import com.linkedin.datahub.graphql.generated.MLFeatureTable;
-import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
 import com.linkedin.datahub.graphql.generated.MLModel;
 import com.linkedin.datahub.graphql.generated.MLModelGroup;
+import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
+import com.linkedin.datahub.graphql.generated.Notebook;
+import com.linkedin.datahub.graphql.generated.Tag;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import javax.annotation.Nonnull;
 
@@ -54,6 +55,11 @@ public class UrnToEntityMapper implements ModelMapper<com.linkedin.common.urn.Ur
       partialEntity = new Dashboard();
       ((Dashboard) partialEntity).setUrn(input.toString());
       ((Dashboard) partialEntity).setType(EntityType.DASHBOARD);
+    }
+    if (input.getEntityType().equals("notebook")) {
+      partialEntity = new Notebook();
+      ((Notebook) partialEntity).setUrn(input.toString());
+      ((Notebook) partialEntity).setType(EntityType.NOTEBOOK);
     }
     if (input.getEntityType().equals("dataJob")) {
       partialEntity = new DataJob();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/NotebookType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/NotebookType.java
@@ -1,0 +1,212 @@
+package com.linkedin.datahub.graphql.types.notebook;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.NotebookUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.authorization.ConjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.authorization.DisjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.BrowsePath;
+import com.linkedin.datahub.graphql.generated.BrowseResults;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.generated.Notebook;
+import com.linkedin.datahub.graphql.generated.NotebookUpdateInput;
+import com.linkedin.datahub.graphql.types.BrowsableEntityType;
+import com.linkedin.datahub.graphql.types.MutableType;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.mappers.BrowsePathsMapper;
+import com.linkedin.datahub.graphql.types.mappers.BrowseResultMapper;
+import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
+import com.linkedin.datahub.graphql.types.notebook.mappers.NotebookMapper;
+import com.linkedin.datahub.graphql.types.notebook.mappers.NotebookUpdateInputMapper;
+import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.metadata.browse.BrowseResult;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.execution.DataFetcherResult;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static com.linkedin.datahub.graphql.Constants.*;
+import static com.linkedin.metadata.Constants.*;
+
+public class NotebookType implements SearchableEntityType<Notebook>, BrowsableEntityType<Notebook>, MutableType<NotebookUpdateInput, Notebook> {
+  static final Set<String> ASPECTS_TO_RESOLVE = ImmutableSet.of(
+      NOTEBOOK_KEY_ASPECT_NAME,
+      NOTEBOOK_INFO_ASPECT_NAME,
+      NOTEBOOK_CONTENT_ASPECT_NAME,
+      EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME,
+      OWNERSHIP_ASPECT_NAME,
+      STATUS_ASPECT_NAME,
+      GLOBAL_TAGS_ASPECT_NAME,
+      GLOSSARY_TERMS_ASPECT_NAME,
+      INSTITUTIONAL_MEMORY_ASPECT_NAME,
+      DOMAINS_ASPECT_NAME,
+      SUB_TYPES_ASPECT_NAME);
+
+  private final EntityClient _entityClient;
+
+  public NotebookType(EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public SearchResults search(@Nonnull String query,
+      @Nullable List<FacetFilterInput> filters,
+      int start,
+      int count,
+      @Nonnull final QueryContext context) throws Exception {
+    // Put empty map here according to
+    // https://datahubspace.slack.com/archives/C029A3M079U/p1646288772126639
+    final Map<String, String> facetFilters = Collections.emptyMap();
+    final SearchResult searchResult = _entityClient.search(NOTEBOOK_ENTITY_NAME, query, facetFilters, start, count, context.getAuthentication());
+    return UrnSearchResultsMapper.map(searchResult);
+  }
+
+  @Override
+  public AutoCompleteResults autoComplete(@Nonnull String query,
+      @Nullable String field,
+      @Nullable List<FacetFilterInput> filters,
+      int limit,
+      @Nonnull final QueryContext context) throws Exception {
+    // Put empty map here according to
+    // https://datahubspace.slack.com/archives/C029A3M079U/p1646288772126639
+    final Map<String, String> facetFilters = Collections.emptyMap();
+    final AutoCompleteResult result = _entityClient.autoComplete(NOTEBOOK_ENTITY_NAME, query, facetFilters, limit, context.getAuthentication());
+    return AutoCompleteResultsMapper.map(result);
+  }
+
+  @Override
+  public BrowseResults browse(@Nonnull List<String> path, @Nullable List<FacetFilterInput> filters, int start,
+      int count, @Nonnull QueryContext context) throws Exception {
+    // Put empty map here according to
+    // https://datahubspace.slack.com/archives/C029A3M079U/p1646288772126639
+    final Map<String, String> facetFilters = Collections.emptyMap();
+
+    final String pathStr = path.size() > 0 ? BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path) : "";
+    final BrowseResult result = _entityClient.browse(NOTEBOOK_ENTITY_NAME, pathStr, facetFilters, start, count, context.getAuthentication());
+    return BrowseResultMapper.map(result);
+  }
+
+  @Override
+  public List<BrowsePath> browsePaths(@Nonnull String urn, @Nonnull QueryContext context) throws Exception {
+    final StringArray result = _entityClient.getBrowsePaths(NotebookUrn.createFromString(urn), context.getAuthentication());
+    return BrowsePathsMapper.map(result);
+  }
+
+  @Override
+  public EntityType type() {
+    return EntityType.NOTEBOOK;
+  }
+
+  @Override
+  public Class<Notebook> objectClass() {
+    return Notebook.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<Notebook>> batchLoad(@Nonnull List<String> urnStrs, @Nonnull QueryContext context)
+      throws Exception {
+    final List<Urn> urns = urnStrs.stream()
+        .map(UrnUtils::getUrn)
+        .collect(Collectors.toList());
+    try {
+      final Map<Urn, EntityResponse> notebookMap = _entityClient.batchGetV2(NOTEBOOK_ENTITY_NAME, new HashSet<>(urns),
+          ASPECTS_TO_RESOLVE, context.getAuthentication());
+
+      return urns.stream()
+          .map(urn -> notebookMap.getOrDefault(urn, null))
+          .map(entityResponse -> entityResponse == null
+              ? null
+              : DataFetcherResult.<Notebook>newResult()
+                  .data(NotebookMapper.map(entityResponse))
+                  .build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load Data Doc", e);
+    }
+  }
+
+  @Override
+  public Class<NotebookUpdateInput> inputClass() {
+    return NotebookUpdateInput.class;
+  }
+
+  @Override
+  public Notebook update(@Nonnull String urn, @Nonnull NotebookUpdateInput input, @Nonnull QueryContext context)
+      throws Exception {
+    if (!isAuthorized(urn, input, context)) {
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    }
+
+    CorpuserUrn actor = CorpuserUrn.createFromString(context.getAuthentication().getActor().toUrnStr());
+    Collection<MetadataChangeProposal> proposals = NotebookUpdateInputMapper.map(input, actor);
+    proposals.forEach(proposal -> proposal.setEntityUrn(UrnUtils.getUrn(urn)));
+
+    try {
+      _entityClient.batchIngestProposals(proposals, context.getAuthentication());
+    } catch (RemoteInvocationException e) {
+      throw new RuntimeException(String.format("Failed to write entity with urn %s", urn), e);
+    }
+
+    return load(urn, context).getData();
+  }
+
+  private boolean isAuthorized(@Nonnull String urn, @Nonnull NotebookUpdateInput update, @Nonnull QueryContext context) {
+    // Decide whether the current principal should be allowed to update the Dataset.
+    final DisjunctivePrivilegeGroup orPrivilegeGroups = getAuthorizedPrivileges(update);
+    return AuthorizationUtils.isAuthorized(
+        context.getAuthorizer(),
+        context.getAuthentication().getActor().toUrnStr(),
+        PoliciesConfig.NOTEBOOK_PRIVILEGES.getResourceType(),
+        urn,
+        orPrivilegeGroups);
+  }
+
+  private DisjunctivePrivilegeGroup getAuthorizedPrivileges(final NotebookUpdateInput updateInput) {
+
+    final ConjunctivePrivilegeGroup allPrivilegesGroup = new ConjunctivePrivilegeGroup(ImmutableList.of(
+      PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()
+    ));
+
+    List<String> specificPrivileges = new ArrayList<>();
+    if (updateInput.getOwnership() != null) {
+      specificPrivileges.add(PoliciesConfig.EDIT_ENTITY_OWNERS_PRIVILEGE.getType());
+    }
+    if (updateInput.getEditableProperties() != null) {
+      specificPrivileges.add(PoliciesConfig.EDIT_ENTITY_DOCS_PRIVILEGE.getType());
+    }
+    if (updateInput.getTags() != null) {
+      specificPrivileges.add(PoliciesConfig.EDIT_ENTITY_TAGS_PRIVILEGE.getType());
+    }
+    final ConjunctivePrivilegeGroup specificPrivilegeGroup = new ConjunctivePrivilegeGroup(specificPrivileges);
+
+    // If you either have all entity privileges, or have the specific privileges required, you are authorized.
+    return new DisjunctivePrivilegeGroup(ImmutableList.of(
+        allPrivilegesGroup,
+        specificPrivilegeGroup
+    ));
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/NotebookType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/NotebookType.java
@@ -64,7 +64,8 @@ public class NotebookType implements SearchableEntityType<Notebook>, BrowsableEn
       GLOSSARY_TERMS_ASPECT_NAME,
       INSTITUTIONAL_MEMORY_ASPECT_NAME,
       DOMAINS_ASPECT_NAME,
-      SUB_TYPES_ASPECT_NAME);
+      SUB_TYPES_ASPECT_NAME,
+      DATA_PLATFORM_INSTANCE_ASPECT_NAME);
 
   private final EntityClient _entityClient;
 
@@ -145,7 +146,7 @@ public class NotebookType implements SearchableEntityType<Notebook>, BrowsableEn
                   .build())
           .collect(Collectors.toList());
     } catch (Exception e) {
-      throw new RuntimeException("Failed to batch load Data Doc", e);
+      throw new RuntimeException("Failed to batch load Notebook", e);
     }
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java
@@ -1,0 +1,183 @@
+package com.linkedin.datahub.graphql.types.notebook.mappers;
+
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.Ownership;
+import com.linkedin.common.Status;
+import com.linkedin.common.SubTypes;
+import com.linkedin.common.GlossaryTerms;
+import com.linkedin.data.DataMap;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
+import com.linkedin.datahub.graphql.generated.ChartCell;
+import com.linkedin.datahub.graphql.generated.Domain;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.Notebook;
+import com.linkedin.datahub.graphql.generated.NotebookCell;
+import com.linkedin.datahub.graphql.generated.NotebookCellType;
+import com.linkedin.datahub.graphql.generated.NotebookContent;
+import com.linkedin.datahub.graphql.generated.NotebookEditableProperties;
+import com.linkedin.datahub.graphql.generated.NotebookInfo;
+import com.linkedin.datahub.graphql.generated.QueryCell;
+import com.linkedin.datahub.graphql.generated.TextCell;
+import com.linkedin.datahub.graphql.types.common.mappers.AuditStampMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.ChangeAuditStampsMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
+import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
+import com.linkedin.domain.Domains;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.key.NotebookKey;
+import com.linkedin.notebook.EditableNotebookProperties;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+import static com.linkedin.metadata.Constants.*;
+
+public class NotebookMapper implements ModelMapper<EntityResponse, Notebook> {
+  public static final NotebookMapper INSTANCE = new NotebookMapper();
+
+  public static Notebook map(EntityResponse response) {
+    return INSTANCE.apply(response);
+  }
+
+  @Override
+  public Notebook apply(EntityResponse response) {
+    final Notebook convertedNotebook = new Notebook();
+    convertedNotebook.setUrn(response.getUrn().toString());
+    convertedNotebook.setType(EntityType.NOTEBOOK);
+    EnvelopedAspectMap aspectMap = response.getAspects();
+    MappingHelper<Notebook> mappingHelper = new MappingHelper<>(aspectMap, convertedNotebook);
+    mappingHelper.mapToResult(NOTEBOOK_KEY_ASPECT_NAME, this::mapNotebookKey);
+    mappingHelper.mapToResult(NOTEBOOK_INFO_ASPECT_NAME, this::mapNotebookInfo);
+    mappingHelper.mapToResult(NOTEBOOK_CONTENT_ASPECT_NAME, this::mapNotebookContent);
+    mappingHelper.mapToResult(EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME, this::mapEditableNotebookProperties);
+    mappingHelper.mapToResult(OWNERSHIP_ASPECT_NAME, (notebook, dataMap) -> notebook.setOwnership(OwnershipMapper.map(new Ownership(dataMap))));
+    mappingHelper.mapToResult(STATUS_ASPECT_NAME, (notebook, dataMap) -> notebook.setStatus(StatusMapper.map(new Status(dataMap))));
+    mappingHelper.mapToResult(GLOBAL_TAGS_ASPECT_NAME, (notebook, dataMap) -> notebook.setTags(GlobalTagsMapper.map(new GlobalTags(dataMap))));
+    mappingHelper.mapToResult(INSTITUTIONAL_MEMORY_ASPECT_NAME, (notebook, dataMap) -> 
+      notebook.setInstitutionalMemory(InstitutionalMemoryMapper.map(new InstitutionalMemory(dataMap))));
+    mappingHelper.mapToResult(DOMAINS_ASPECT_NAME, this::mapDomains);
+    mappingHelper.mapToResult(SUB_TYPES_ASPECT_NAME, this::mapSubTypes);
+    mappingHelper.mapToResult(GLOSSARY_TERMS_ASPECT_NAME, (notebook, dataMap) -> 
+      notebook.setGlossaryTerms(GlossaryTermsMapper.map(new GlossaryTerms(dataMap))));
+    return mappingHelper.getResult();
+  }
+
+  private void mapSubTypes(Notebook notebook, DataMap dataMap) {
+    SubTypes pegasusSubTypes = new SubTypes(dataMap);
+    if (pegasusSubTypes.hasTypeNames()) {
+      com.linkedin.datahub.graphql.generated.SubTypes subTypes = new com.linkedin.datahub.graphql.generated.SubTypes();
+      subTypes.setTypeNames(pegasusSubTypes.getTypeNames().stream().collect(Collectors.toList()));
+      notebook.setSubTypes(subTypes);
+    }
+  }
+
+  private void mapNotebookKey(@Nonnull Notebook notebook, @Nonnull DataMap dataMap) {
+    final NotebookKey notebookKey = new NotebookKey(dataMap);
+    notebook.setNotebookId(notebookKey.getNotebookId());
+    notebook.setTool(notebookKey.getNotebookTool());
+  }
+
+  private void mapNotebookInfo(@Nonnull Notebook notebook, @Nonnull DataMap dataMap) {
+    final com.linkedin.notebook.NotebookInfo gmsNotebookInfo = new com.linkedin.notebook.NotebookInfo(dataMap);
+    final NotebookInfo notebookInfo = new NotebookInfo();
+    notebookInfo.setTitle(gmsNotebookInfo.getTitle());
+    notebookInfo.setChangeAuditStamps(ChangeAuditStampsMapper.map(gmsNotebookInfo.getChangeAuditStamps()));
+    notebookInfo.setDescription(gmsNotebookInfo.getDescription());
+
+    if (gmsNotebookInfo.hasExternalUrl()) {
+      notebookInfo.setExternalUrl(gmsNotebookInfo.getExternalUrl().toString());
+    }
+
+    if (gmsNotebookInfo.hasCustomProperties()) {
+      notebookInfo.setCustomProperties(StringMapMapper.map(gmsNotebookInfo.getCustomProperties()));
+    }
+    notebook.setInfo(notebookInfo);
+  }
+
+  private void mapNotebookContent(@Nonnull Notebook notebook, @Nonnull DataMap dataMap) {
+    com.linkedin.notebook.NotebookContent pegasusNotebookContent = new com.linkedin.notebook.NotebookContent(dataMap);
+    NotebookContent notebookContent = new NotebookContent();
+    notebookContent.setCells(mapNotebookCells(pegasusNotebookContent.getCells()));
+    notebook.setContent(notebookContent);
+  }
+
+  private List<NotebookCell> mapNotebookCells(com.linkedin.notebook.NotebookCellArray pegasusCells) {
+    return pegasusCells.stream()
+        .map(pegasusCell -> {
+          NotebookCell notebookCell = new NotebookCell();
+          NotebookCellType cellType = NotebookCellType.valueOf(pegasusCell.getType().toString());
+          notebookCell.setType(cellType);
+          switch (cellType) {
+            case CHART_CELL:
+              notebookCell.setChartCell(mapChartCell(pegasusCell.getChartCell()));
+              break;
+            case TEXT_CELL:
+              notebookCell.setTextCell(mapTextCell(pegasusCell.getTextCell()));
+              break;
+            case QUERY_CELL:
+              notebookCell.setQueryChell(mapQueryCell(pegasusCell.getQueryCell()));
+              break;
+            default:
+              throw new DataHubGraphQLException(String.format("Un-supported NotebookCellType: %s", cellType),
+                  DataHubGraphQLErrorCode.SERVER_ERROR);
+          }
+          return notebookCell;
+        })
+        .collect(Collectors.toList());
+  }
+
+  private ChartCell mapChartCell(com.linkedin.notebook.ChartCell pegasusChartCell) {
+    ChartCell chartCell = new ChartCell();
+    chartCell.setCellId(pegasusChartCell.getCellId());
+    chartCell.setCellTitle(pegasusChartCell.getCellTitle());
+    chartCell.setChangeAuditStamps(ChangeAuditStampsMapper.map(pegasusChartCell.getChangeAuditStamps()));
+    return chartCell;
+  }
+
+  private TextCell mapTextCell(com.linkedin.notebook.TextCell pegasusTextCell) {
+    TextCell textCell = new TextCell();
+    textCell.setCellId(pegasusTextCell.getCellId());
+    textCell.setCellTitle(pegasusTextCell.getCellTitle());
+    textCell.setChangeAuditStamps(ChangeAuditStampsMapper.map(pegasusTextCell.getChangeAuditStamps()));
+    textCell.setText(pegasusTextCell.getText());
+    return textCell;
+  }
+
+  private QueryCell mapQueryCell(com.linkedin.notebook.QueryCell pegasusQueryCell) {
+    QueryCell queryCell = new QueryCell();
+    queryCell.setCellId(pegasusQueryCell.getCellId());
+    queryCell.setCellTitle(pegasusQueryCell.getCellTitle());
+    queryCell.setChangeAuditStamps(ChangeAuditStampsMapper.map(pegasusQueryCell.getChangeAuditStamps()));
+    queryCell.setRawQuery(pegasusQueryCell.getRawQuery());
+    if (pegasusQueryCell.hasLastExecuted()) {
+      queryCell.setLastExecuted(AuditStampMapper.map(pegasusQueryCell.getLastExecuted()));
+    }
+    return queryCell;
+  }
+
+  private void mapEditableNotebookProperties(@Nonnull Notebook notebook, @Nonnull DataMap dataMap) {
+    final EditableNotebookProperties editableNotebookProperties = new EditableNotebookProperties(dataMap);
+    final NotebookEditableProperties notebookEditableProperties = new NotebookEditableProperties();
+    notebookEditableProperties.setDescription(editableNotebookProperties.getDescription());
+    notebook.setEditableProperties(notebookEditableProperties);
+  }
+
+  private void mapDomains(@Nonnull Notebook notebook, @Nonnull DataMap dataMap) {
+    final Domains domains = new Domains(dataMap);
+    // Currently we only take the first domain if it exists.
+    if (domains.getDomains().size() > 0) {
+      notebook.setDomain(Domain.builder()
+          .setType(EntityType.DOMAIN)
+          .setUrn(domains.getDomains().get(0).toString()).build());
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java
@@ -70,7 +70,7 @@ public class NotebookMapper implements ModelMapper<EntityResponse, Notebook> {
     mappingHelper.mapToResult(SUB_TYPES_ASPECT_NAME, this::mapSubTypes);
     mappingHelper.mapToResult(GLOSSARY_TERMS_ASPECT_NAME, (notebook, dataMap) -> 
       notebook.setGlossaryTerms(GlossaryTermsMapper.map(new GlossaryTerms(dataMap))));
-    mappingHelper.mapToResult(DATA_PLATFORM_INSTANCE_ASPECT_NAME, this::mapDataPlatformInstance) ;
+    mappingHelper.mapToResult(DATA_PLATFORM_INSTANCE_ASPECT_NAME, this::mapDataPlatformInstance);
     return mappingHelper.getResult();
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookMapper.java
@@ -1,15 +1,17 @@
 package com.linkedin.datahub.graphql.types.notebook.mappers;
 
+import com.linkedin.common.DataPlatformInstance;
 import com.linkedin.common.GlobalTags;
+import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.InstitutionalMemory;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.Status;
 import com.linkedin.common.SubTypes;
-import com.linkedin.common.GlossaryTerms;
 import com.linkedin.data.DataMap;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.ChartCell;
+import com.linkedin.datahub.graphql.generated.DataPlatform;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.Notebook;
@@ -68,7 +70,17 @@ public class NotebookMapper implements ModelMapper<EntityResponse, Notebook> {
     mappingHelper.mapToResult(SUB_TYPES_ASPECT_NAME, this::mapSubTypes);
     mappingHelper.mapToResult(GLOSSARY_TERMS_ASPECT_NAME, (notebook, dataMap) -> 
       notebook.setGlossaryTerms(GlossaryTermsMapper.map(new GlossaryTerms(dataMap))));
+    mappingHelper.mapToResult(DATA_PLATFORM_INSTANCE_ASPECT_NAME, this::mapDataPlatformInstance) ;
     return mappingHelper.getResult();
+  }
+
+  private void mapDataPlatformInstance(Notebook notebook, DataMap dataMap) {
+    DataPlatformInstance dataPlatformInstance = new DataPlatformInstance(dataMap);
+    notebook.setPlatform(DataPlatform
+        .builder()
+        .setType(EntityType.DATA_PLATFORM)
+        .setUrn(dataPlatformInstance.getPlatform().toString())
+        .build());
   }
 
   private void mapSubTypes(Notebook notebook, DataMap dataMap) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookUpdateInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/mappers/NotebookUpdateInputMapper.java
@@ -1,0 +1,67 @@
+package com.linkedin.datahub.graphql.types.notebook.mappers;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.dashboard.EditableDashboardProperties;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.generated.NotebookUpdateInput;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipUpdateMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.util.UpdateMappingHelper;
+import com.linkedin.datahub.graphql.types.mappers.InputModelMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.TagAssociationUpdateMapper;
+import com.linkedin.mxe.MetadataChangeProposal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+import static com.linkedin.metadata.Constants.*;
+
+
+public class NotebookUpdateInputMapper implements InputModelMapper<NotebookUpdateInput, Collection<MetadataChangeProposal>,
+    Urn> {
+
+  public static final NotebookUpdateInputMapper INSTANCE = new NotebookUpdateInputMapper();
+
+  public static Collection<MetadataChangeProposal> map(@Nonnull final NotebookUpdateInput notebookUpdateInput,
+      @Nonnull final Urn actor) {
+    return INSTANCE.apply(notebookUpdateInput, actor);
+  }
+
+  @Override
+  public Collection<MetadataChangeProposal> apply(NotebookUpdateInput input, Urn actor) {
+    final Collection<MetadataChangeProposal> proposals = new ArrayList<>(3);
+    final UpdateMappingHelper updateMappingHelper = new UpdateMappingHelper(NOTEBOOK_ENTITY_NAME);
+    final AuditStamp auditStamp = new AuditStamp();
+    auditStamp.setActor(actor, SetMode.IGNORE_NULL);
+    auditStamp.setTime(System.currentTimeMillis());
+
+    if (input.getOwnership() != null) {
+      proposals.add(updateMappingHelper.aspectToProposal(OwnershipUpdateMapper.map(input.getOwnership(), actor),
+          OWNERSHIP_ASPECT_NAME));
+    }
+
+    if (input.getTags() != null) {
+      final GlobalTags globalTags = new GlobalTags();
+      globalTags.setTags(new TagAssociationArray(input.getTags().getTags().stream()
+          .map(TagAssociationUpdateMapper::map)
+          .collect(Collectors.toList())));
+      proposals.add(updateMappingHelper.aspectToProposal(globalTags, GLOBAL_TAGS_ASPECT_NAME));
+    }
+
+    if (input.getEditableProperties() != null) {
+      final EditableDashboardProperties editableDashboardProperties = new EditableDashboardProperties();
+      editableDashboardProperties.setDescription(input.getEditableProperties().getDescription());
+      if (!editableDashboardProperties.hasCreated()) {
+        editableDashboardProperties.setCreated(auditStamp);
+      }
+      editableDashboardProperties.setLastModified(auditStamp);
+      proposals.add(updateMappingHelper.aspectToProposal(editableDashboardProperties,
+          EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME));
+    }
+
+    return proposals;
+  }
+}

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -3343,6 +3343,11 @@ type Notebook implements Entity {
     The structured glossary terms associated with the notebook
     """
     glossaryTerms: GlossaryTerms
+
+    """
+    Standardized platform.
+    """
+    platform: DataPlatform!
 }
 
 """
@@ -3352,7 +3357,7 @@ type NotebookContent {
     """
     The content of a Notebook which is composed by a list of NotebookCell
     """
-    cells: [NotebookCell]!
+    cells: [NotebookCell!]!
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -35,6 +35,11 @@ type Query {
     dashboard(urn: String!): Dashboard
 
     """
+    Fetch a Notebook by primary key (urn)
+    """
+    notebook(urn: String!): Notebook
+
+    """
     Fetch a Chart by primary key (urn)
     """
     chart(urn: String!): Chart
@@ -144,6 +149,11 @@ type Mutation {
     Update the metadata about a particular Dashboard
     """
     updateDashboard(urn: String!, input: DashboardUpdateInput!): Dashboard
+
+    """
+    Update the metadata about a particular Notebook
+    """
+    updateNotebook(urn: String!, input: NotebookUpdateInput!): Notebook
 
     """
     Update the metadata about a particular Data Flow (Pipeline)
@@ -351,6 +361,11 @@ enum EntityType {
     The Dashboard Entity
     """
     DASHBOARD
+
+    """
+    The Notebook Entity
+    """
+    NOTEBOOK
 
     """
     The Chart Entity
@@ -1947,6 +1962,17 @@ type DashboardEditableProperties {
 }
 
 """
+Notebook properties that are editable via the UI This represents logical metadata,
+as opposed to technical metadata
+"""
+type NotebookEditableProperties {
+    """
+    Description of the Notebook
+    """
+    description: String
+}
+
+"""
 Data Job properties that are editable via the UI This represents logical metadata,
 as opposed to technical metadata
 """
@@ -2881,7 +2907,7 @@ input ChartUpdateInput {
 }
 
 """
-Arguments provided to update a Chart Entity
+Arguments provided to update a Dashboard Entity
 """
 input DashboardUpdateInput {
     """
@@ -2904,6 +2930,26 @@ input DashboardUpdateInput {
     Update to editable properties
     """
     editableProperties: DashboardEditablePropertiesUpdate
+}
+
+"""
+Arguments provided to update a Notebook Entity
+"""
+input NotebookUpdateInput {
+    """
+    Update to ownership
+    """
+    ownership: OwnershipUpdate
+
+    """
+    Update to tags
+    """
+    tags: GlobalTagsUpdate
+
+    """
+    Update to editable properties
+    """
+    editableProperties: NotebookEditablePropertiesUpdate
 }
 
 """
@@ -3045,6 +3091,16 @@ Update to writable Chart fields
 input ChartEditablePropertiesUpdate {
     """
     Writable description aka documentation for a Chart
+    """
+    description: String!
+}
+
+"""
+Update to writable Notebook fields
+"""
+input NotebookEditablePropertiesUpdate {
+    """
+    Writable description aka documentation for a Notebook
     """
     description: String!
 }
@@ -3207,6 +3263,237 @@ input InstitutionalMemoryMetadataUpdate {
     The time at which this metadata was created
     """
     createdAt: Long
+}
+
+"""
+A Notebook Metadata Entity
+"""
+type Notebook implements Entity {
+    """
+    The primary key of the Notebook
+    """
+    urn: String!
+
+    """
+    A standard Entity Type
+    """
+    type: EntityType!
+
+    """
+    The Notebook tool name
+    """
+    tool: String!
+
+    """
+    An id unique within the Notebook tool
+    """
+    notebookId: String!
+
+    """
+    Additional read only information about the Notebook
+    """
+    info: NotebookInfo
+
+    """
+    Additional read write properties about the Notebook
+    """
+    editableProperties: NotebookEditableProperties
+
+    """
+    Ownership metadata of the Notebook
+    """
+    ownership: Ownership
+
+    """
+    Status metadata of the Notebook
+    """
+    status: Status
+
+    """
+    The content of this Notebook
+    """
+    content: NotebookContent!
+
+    """
+    The tags associated with the Notebook
+    """
+    tags: GlobalTags
+
+    """
+    References to internal resources related to the Notebook
+    """
+    institutionalMemory: InstitutionalMemory
+
+    """
+    The Domain associated with the Notebook
+    """
+    domain: Domain
+
+    """
+    Edges extending from this entity
+    """
+    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+
+    """
+    Sub Types that this entity implements
+    """
+    subTypes: SubTypes
+
+    """
+    The structured glossary terms associated with the notebook
+    """
+    glossaryTerms: GlossaryTerms
+}
+
+"""
+The actual content in a Notebook
+"""
+type NotebookContent {
+    """
+    The content of a Notebook which is composed by a list of NotebookCell
+    """
+    cells: [NotebookCell]!
+}
+
+"""
+The Union of every NotebookCell
+"""
+type NotebookCell {
+    """
+    The chart cell content. The will be non-null only when all other cell field is null.
+    """
+    chartCell: ChartCell
+
+    """
+    The text cell content. The will be non-null only when all other cell field is null.
+    """
+    textCell: TextCell
+
+    """
+    The query cell content. The will be non-null only when all other cell field is null.
+    """
+    queryChell: QueryCell
+
+    """
+    The type of this Notebook cell
+    """
+    type: NotebookCellType!
+}
+
+"""
+The type for a NotebookCell
+"""
+enum NotebookCellType {
+    """
+    TEXT Notebook cell type. The cell context is text only.
+    """
+    TEXT_CELL,
+
+    """
+    QUERY Notebook cell type. The cell context is query only.
+    """
+    QUERY_CELL,
+
+    """
+    CHART Notebook cell type. The cell content is chart only.
+    """
+    CHART_CELL
+}
+
+"""
+A Notebook cell which contains text as content
+"""
+type TextCell {
+
+    """
+    Title of the cell
+    """
+    cellTitle: String!
+
+    """
+    Unique id for the cell.
+    """
+    cellId: String!
+
+    """
+    Captures information about who created/last modified/deleted this TextCell and when
+    """
+    changeAuditStamps: ChangeAuditStamps
+
+    """
+    The actual text in a TextCell in a Notebook
+    """
+    text: String!
+}
+
+"""
+A Notebook cell which contains Query as content
+"""
+type QueryCell {
+    """
+    Title of the cell
+    """
+    cellTitle: String!
+
+    """
+    Unique id for the cell.
+    """
+    cellId: String!
+
+    """
+    Captures information about who created/last modified/deleted this TextCell and when
+    """
+    changeAuditStamps: ChangeAuditStamps
+
+    """
+    Raw query to explain some specific logic in a Notebook
+    """
+    rawQuery: String!
+
+    """
+    Captures information about who last executed this query cell and when
+    """
+    lastExecuted: AuditStamp
+}
+
+"""
+A Notebook cell which contains chart as content
+"""
+type ChartCell {
+    """
+    Title of the cell
+    """
+    cellTitle: String!
+
+    """
+    Unique id for the cell.
+    """
+    cellId: String!
+
+    """
+    Captures information about who created/last modified/deleted this TextCell and when
+    """
+    changeAuditStamps: ChangeAuditStamps
+}
+
+"""
+Captures information about who created/last modified/deleted the entity and when
+"""
+type ChangeAuditStamps {
+    """
+    An AuditStamp corresponding to the creation
+    """
+    created: AuditStamp!
+
+    """
+    An AuditStamp corresponding to the modification
+    """
+    lastModified: AuditStamp!
+
+    """
+    An optional AuditStamp corresponding to the deletion
+    """
+    deleted: AuditStamp
 }
 
 """
@@ -3374,6 +3661,36 @@ type DashboardInfo {
     An optional AuditStamp corresponding to the deletion of this dashboard
     """
     deleted: AuditStamp
+}
+
+"""
+Additional read only information about a Notebook
+"""
+type NotebookInfo {
+    """
+    Display of the Notebook
+    """
+    title: String
+
+    """
+    Description of the Notebook
+    """
+    description: String
+
+    """
+    Native platform URL of the Notebook
+    """
+    externalUrl: String
+
+    """
+    A list of platform specific metadata tuples
+    """
+    customProperties: [StringMapEntry!]
+
+    """
+    Captures information about who created/last modified/deleted this Notebook and when
+    """
+    changeAuditStamps: ChangeAuditStamps
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/notebook/NotebookTypeTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/notebook/NotebookTypeTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.ChangeAuditStamps;
+import com.linkedin.common.DataPlatformInstance;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTermAssociation;
 import com.linkedin.common.GlossaryTermAssociationArray;
@@ -23,6 +24,7 @@ import com.linkedin.common.TagAssociation;
 import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.url.Url;
+import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.GlossaryTermUrn;
 import com.linkedin.common.urn.NotebookUrn;
 import com.linkedin.common.urn.TagUrn;
@@ -92,6 +94,9 @@ public class NotebookTypeTest {
 
   private static final SubTypes SUB_TYPES = new SubTypes().setTypeNames(new StringArray(ImmutableList.of("DataDoc")));
 
+  private static final DataPlatformInstance DATA_PLATFORM_INSTANCE = new DataPlatformInstance()
+      .setPlatform(new DataPlatformUrn("test_platform"));
+
   private static final NotebookInfo NOTEBOOK_INFO = new NotebookInfo()
       .setTitle("title")
       .setExternalUrl(new Url("https://querybook.com/notebook/123"))
@@ -158,6 +163,8 @@ public class NotebookTypeTest {
         Constants.GLOSSARY_TERMS_ASPECT_NAME,
         new EnvelopedAspect().setValue(new Aspect(TEST_GLOSSARY_TERMS.data()))
     );
+    notebookAspects.put(Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(DATA_PLATFORM_INSTANCE.data())));
 
     Urn notebookUrn = new NotebookUrn("querybook", "123");
     Urn dummyNotebookUrn = new NotebookUrn("querybook", "dummy");
@@ -214,9 +221,9 @@ public class NotebookTypeTest {
     assertEquals(notebook.getTags().getTags().get(0).getTag().getUrn(),
         GLOBAL_TAGS.getTags().get(0).getTag().toString());
     assertEquals(notebook.getSubTypes().getTypeNames(), SUB_TYPES.getTypeNames().stream().collect(Collectors.toList()));
-    assertEquals(
-        notebook.getGlossaryTerms().getTerms().get(0).getTerm().getUrn(),
+    assertEquals(notebook.getGlossaryTerms().getTerms().get(0).getTerm().getUrn(),
         TEST_GLOSSARY_TERMS.getTerms().get(0).getUrn().toString());
+    assertEquals(notebook.getPlatform().getUrn(), DATA_PLATFORM_INSTANCE.getPlatform().toString());
 
     // Assert second element is null.
     assertNull(result.get(1));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/notebook/NotebookTypeTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/notebook/NotebookTypeTest.java
@@ -1,0 +1,241 @@
+package com.linkedin.datahub.graphql.types.notebook;
+
+import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.ChangeAuditStamps;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.GlossaryTermAssociation;
+import com.linkedin.common.GlossaryTermAssociationArray;
+import com.linkedin.common.GlossaryTerms;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.InstitutionalMemoryMetadata;
+import com.linkedin.common.InstitutionalMemoryMetadataArray;
+import com.linkedin.common.Owner;
+import com.linkedin.common.OwnerArray;
+import com.linkedin.common.Ownership;
+import com.linkedin.common.OwnershipType;
+import com.linkedin.common.Status;
+import com.linkedin.common.SubTypes;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.url.Url;
+import com.linkedin.common.urn.GlossaryTermUrn;
+import com.linkedin.common.urn.NotebookUrn;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.notebook.NotebookCell;
+import com.linkedin.notebook.NotebookCellArray;
+import com.linkedin.notebook.NotebookCellType;
+import com.linkedin.notebook.NotebookContent;
+import com.linkedin.notebook.NotebookInfo;
+import com.linkedin.notebook.EditableNotebookProperties;
+import com.linkedin.notebook.TextCell;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Notebook;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.types.container.ContainerType;
+import com.linkedin.domain.Domains;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.NotebookKey;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.execution.DataFetcherResult;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class NotebookTypeTest {
+  private static final String TEST_NOTEBOOK = "urn:li:notebook:(querybook,123)";
+  private static final NotebookKey NOTEBOOK_KEY = new NotebookKey()
+      .setNotebookId("123")
+      .setNotebookTool("querybook");
+  private static final NotebookContent NOTEBOOK_CONTENT = new NotebookContent()
+      .setCells(new NotebookCellArray(ImmutableList.of(new NotebookCell()
+          .setType(NotebookCellType.TEXT_CELL)
+          .setTextCell(new TextCell()
+              .setCellId("1234")
+              .setCellTitle("test cell")
+              .setText("test text")
+              .setChangeAuditStamps(new ChangeAuditStamps())))));
+  private static final EditableNotebookProperties TEST_EDITABLE_DESCRIPTION = new EditableNotebookProperties()
+      .setDescription("test editable description");
+  private static final Ownership OWNERSHIP = new Ownership()
+      .setOwners(
+          new OwnerArray(ImmutableList.of(
+              new Owner()
+                  .setType(OwnershipType.DATAOWNER)
+                  .setOwner(Urn.createFromTuple("corpuser", "test")))));
+  private static final InstitutionalMemory INSTITUTIONAL_MEMORY = new InstitutionalMemory()
+      .setElements(
+          new InstitutionalMemoryMetadataArray(ImmutableList.of(
+              new InstitutionalMemoryMetadata()
+                  .setUrl(new Url("https://www.test.com"))
+                  .setDescription("test description")
+                  .setCreateStamp(new AuditStamp().setTime(0L).setActor(Urn.createFromTuple("corpuser", "test"))))));
+
+  private static final SubTypes SUB_TYPES = new SubTypes().setTypeNames(new StringArray(ImmutableList.of("DataDoc")));
+
+  private static final NotebookInfo NOTEBOOK_INFO = new NotebookInfo()
+      .setTitle("title")
+      .setExternalUrl(new Url("https://querybook.com/notebook/123"))
+      .setChangeAuditStamps(new ChangeAuditStamps())
+      .setDescription("test doc");
+
+  private static final Status STATUS = new Status()
+      .setRemoved(false);
+
+  private static final Domains DOMAINS = new Domains()
+      .setDomains(new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:domain:123"))));
+  private static final GlobalTags GLOBAL_TAGS = new GlobalTags()
+      .setTags(new TagAssociationArray(ImmutableList.of(new TagAssociation().setTag(new TagUrn("test")))));
+  private static final GlossaryTerms TEST_GLOSSARY_TERMS = new GlossaryTerms()
+      .setTerms(new GlossaryTermAssociationArray(ImmutableList.of(new GlossaryTermAssociation().setUrn(new GlossaryTermUrn("term")))));
+
+  @Test
+  public void testBatchLoad() throws Exception {
+
+    EntityClient client = Mockito.mock(EntityClient.class);
+
+    Map<String, EnvelopedAspect> notebookAspects = new HashMap<>();
+    notebookAspects.put(
+        Constants.NOTEBOOK_KEY_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(NOTEBOOK_KEY.data()))
+    );
+    notebookAspects.put(
+        Constants.NOTEBOOK_INFO_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(NOTEBOOK_INFO.data()))
+    );
+    notebookAspects.put(
+        Constants.NOTEBOOK_CONTENT_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(NOTEBOOK_CONTENT.data()))
+    );
+    notebookAspects.put(
+        Constants.EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(TEST_EDITABLE_DESCRIPTION.data()))
+    );
+    notebookAspects.put(
+        Constants.OWNERSHIP_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(OWNERSHIP.data()))
+    );
+    notebookAspects.put(
+        Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(INSTITUTIONAL_MEMORY.data()))
+    );
+    notebookAspects.put(
+        Constants.STATUS_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(STATUS.data()))
+    );
+    notebookAspects.put(
+        Constants.GLOBAL_TAGS_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(GLOBAL_TAGS.data()))
+    );
+    notebookAspects.put(
+        Constants.DOMAINS_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(DOMAINS.data()))
+    );
+    notebookAspects.put(
+        Constants.SUB_TYPES_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(SUB_TYPES.data()))
+    );
+    notebookAspects.put(
+        Constants.GLOSSARY_TERMS_ASPECT_NAME,
+        new EnvelopedAspect().setValue(new Aspect(TEST_GLOSSARY_TERMS.data()))
+    );
+
+    Urn notebookUrn = new NotebookUrn("querybook", "123");
+    Urn dummyNotebookUrn = new NotebookUrn("querybook", "dummy");
+    Mockito.when(client.batchGetV2(
+        Mockito.eq(Constants.NOTEBOOK_ENTITY_NAME),
+        Mockito.eq(new HashSet<>(ImmutableSet.of(notebookUrn, dummyNotebookUrn))),
+        Mockito.eq(NotebookType.ASPECTS_TO_RESOLVE),
+        Mockito.any(Authentication.class)))
+        .thenReturn(ImmutableMap.of(
+            notebookUrn,
+            new EntityResponse()
+                .setEntityName(Constants.NOTEBOOK_ENTITY_NAME)
+                .setUrn(notebookUrn)
+                .setAspects(new EnvelopedAspectMap(notebookAspects))));
+
+    NotebookType type = new NotebookType(client);
+
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    List<DataFetcherResult<Notebook>>
+        result = type.batchLoad(ImmutableList.of(TEST_NOTEBOOK, dummyNotebookUrn.toString()), mockContext);
+
+    // Verify response
+    Mockito.verify(client, Mockito.times(1)).batchGetV2(
+        Mockito.eq(Constants.NOTEBOOK_ENTITY_NAME),
+        Mockito.eq(ImmutableSet.of(notebookUrn, dummyNotebookUrn)),
+        Mockito.eq(NotebookType.ASPECTS_TO_RESOLVE),
+        Mockito.any(Authentication.class)
+    );
+
+    assertEquals(result.size(), 2);
+
+    System.out.println(result.get(0).getData());
+
+    Notebook notebook = result.get(0).getData();
+    assertEquals(notebook.getContent().getCells().size(), NOTEBOOK_CONTENT.getCells().size());
+    assertEquals(notebook.getContent().getCells().get(0).getType().toString(),
+        NOTEBOOK_CONTENT.getCells().get(0).getType().toString());
+    assertEquals(notebook.getContent().getCells().get(0).getTextCell().getCellId(),
+        NOTEBOOK_CONTENT.getCells().get(0).getTextCell().getCellId());
+    assertEquals(notebook.getContent().getCells().get(0).getTextCell().getCellTitle(),
+        NOTEBOOK_CONTENT.getCells().get(0).getTextCell().getCellTitle());
+    assertEquals(notebook.getContent().getCells().get(0).getTextCell().getText(),
+        NOTEBOOK_CONTENT.getCells().get(0).getTextCell().getText());
+    assertEquals(notebook.getInfo().getDescription(), NOTEBOOK_INFO.getDescription());
+    assertEquals(notebook.getInfo().getExternalUrl(), NOTEBOOK_INFO.getExternalUrl().toString());
+    assertEquals(notebook.getTool(), NOTEBOOK_KEY.getNotebookTool());
+    assertEquals(notebook.getNotebookId(), NOTEBOOK_KEY.getNotebookId());
+    assertEquals(notebook.getUrn(), TEST_NOTEBOOK);
+    assertEquals(notebook.getType(), EntityType.NOTEBOOK);
+    assertEquals(notebook.getOwnership().getOwners().size(), 1);
+    assertEquals(notebook.getInstitutionalMemory().getElements().size(), 1);
+    assertEquals(notebook.getEditableProperties().getDescription(), TEST_EDITABLE_DESCRIPTION.getDescription());
+    assertEquals(notebook.getTags().getTags().get(0).getTag().getUrn(),
+        GLOBAL_TAGS.getTags().get(0).getTag().toString());
+    assertEquals(notebook.getSubTypes().getTypeNames(), SUB_TYPES.getTypeNames().stream().collect(Collectors.toList()));
+    assertEquals(
+        notebook.getGlossaryTerms().getTerms().get(0).getTerm().getUrn(),
+        TEST_GLOSSARY_TERMS.getTerms().get(0).getUrn().toString());
+
+    // Assert second element is null.
+    assertNull(result.get(1));
+  }
+
+  @Test
+  public void testBatchLoadClientException() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.doThrow(RemoteInvocationException.class).when(mockClient).batchGetV2(
+        Mockito.anyString(),
+        Mockito.anySet(),
+        Mockito.anySet(),
+        Mockito.any(Authentication.class));
+    ContainerType type = new ContainerType(mockClient);
+
+    // Execute Batch load
+    QueryContext context = Mockito.mock(QueryContext.class);
+    Mockito.when(context.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    assertThrows(RuntimeException.class, () -> type.batchLoad(ImmutableList.of(TEST_NOTEBOOK),
+        context));
+  }
+}

--- a/li-utils/src/main/javaPegasus/com/linkedin/common/urn/NotebookUrn.java
+++ b/li-utils/src/main/javaPegasus/com/linkedin/common/urn/NotebookUrn.java
@@ -1,0 +1,71 @@
+package com.linkedin.common.urn;
+
+import com.linkedin.data.template.Custom;
+import com.linkedin.data.template.DirectCoercer;
+import com.linkedin.data.template.TemplateOutputCastException;
+import java.net.URISyntaxException;
+
+
+public class NotebookUrn extends Urn {
+  public static final String ENTITY_TYPE = "notebook";
+
+  private final String _notebookTool;
+  private final String _notebookId;
+
+  public NotebookUrn(String notebookTool, String notebookId) {
+    super(ENTITY_TYPE, TupleKey.create(notebookTool, notebookId));
+    this._notebookTool = notebookTool;
+    this._notebookId = notebookId;
+  }
+
+  public String getNotebookToolEntity() {
+    return _notebookTool;
+  }
+
+  public String getNotebookIdEntity() {
+    return _notebookId;
+  }
+
+  public static NotebookUrn createFromString(String rawUrn) throws URISyntaxException {
+    return createFromUrn(Urn.createFromString(rawUrn));
+  }
+
+  public static NotebookUrn createFromUrn(Urn urn) throws URISyntaxException {
+    if (!"li".equals(urn.getNamespace())) {
+      throw new URISyntaxException(urn.toString(), "Urn namespace type should be 'li'.");
+    } else if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Urn entity type should be 'notebook'.");
+    } else {
+      TupleKey key = urn.getEntityKey();
+      if (key.size() != 2) {
+        throw new URISyntaxException(urn.toString(), "Invalid number of keys.");
+      } else {
+        try {
+          return new NotebookUrn((String) key.getAs(0, String.class), (String) key.getAs(1, String.class));
+        } catch (Exception e) {
+          throw new URISyntaxException(urn.toString(), "Invalid URN Parameter: '" + e.getMessage());
+        }
+      }
+    }
+  }
+
+  public static NotebookUrn deserialize(String rawUrn) throws URISyntaxException {
+    return createFromString(rawUrn);
+  }
+
+  static {
+    Custom.registerCoercer(new DirectCoercer<NotebookUrn>() {
+      public Object coerceInput(NotebookUrn object) throws ClassCastException {
+        return object.toString();
+      }
+
+      public NotebookUrn coerceOutput(Object object) throws TemplateOutputCastException {
+        try {
+          return NotebookUrn.createFromString((String) object);
+        } catch (URISyntaxException e) {
+          throw new TemplateOutputCastException("Invalid URN syntax: " + e.getMessage(), e);
+        }
+      }
+    }, NotebookUrn.class);
+  }
+}

--- a/li-utils/src/main/pegasus/com/linkedin/common/NotebookUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/NotebookUrn.pdl
@@ -1,0 +1,30 @@
+namespace com.linkedin.common
+
+/**
+ * Standardized Notebook identifier
+ */
+@java.class = "com.linkedin.common.urn.NotebookUrn"
+@validate.`com.linkedin.common.validator.TypedUrnValidator` = {
+  "accessible" : true,
+  "owningTeam" : "urn:li:internalTeam:datahub",
+  "entityType" : "notebook",
+  "constructable" : true,
+  "namespace" : "li",
+  "name" : "Notebook",
+  "doc" : "Standardized Notebook identifier",
+  "owners" : [ "urn:li:corpuser:fbar", "urn:li:corpuser:bfoo" ],
+  "fields" : [ {
+    "name" : "notebookTool",
+    "doc" : "The name of the Notebook tool such as querybook etc.",
+    "type" : "string",
+    "maxLength" : 20
+  },
+  {
+    "name" : "notebookId",
+    "doc" : "Unique id for the Notebook. This id should be globally unique for a Notebook tool even when there are multiple deployments of it. As an example, Notebook URL could be used here for querybook such as 'querybook.com/notebook/773'",
+    "type" : "string",
+    "maxLength" : 200
+  }],
+  "maxLength" : 240
+}
+typeref NotebookUrn = string

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
   public static final String INGESTION_SOURCE_ENTITY_NAME = "dataHubIngestionSource";
   public static final String SECRETS_ENTITY_NAME = "dataHubSecret";
   public static final String EXECUTION_REQUEST_ENTITY_NAME = "dataHubExecutionRequest";
+  public static final String NOTEBOOK_ENTITY_NAME = "notebook";
 
 
   /**
@@ -90,6 +91,12 @@ public class Constants {
   public static final String DASHBOARD_KEY_ASPECT_NAME = "dashboardKey";
   public static final String DASHBOARD_INFO_ASPECT_NAME = "dashboardInfo";
   public static final String EDITABLE_DASHBOARD_PROPERTIES_ASPECT_NAME = "editableDashboardProperties";
+
+  // Notebook
+  public static final String NOTEBOOK_KEY_ASPECT_NAME = "notebookKey";
+  public static final String NOTEBOOK_INFO_ASPECT_NAME = "notebookInfo";
+  public static final String NOTEBOOK_CONTENT_ASPECT_NAME = "notebookContent";
+  public static final String EDITABLE_NOTEBOOK_PROPERTIES_ASPECT_NAME = "editableNotebookProperties";
 
   // DataFlow
   public static final String DATA_FLOW_KEY_ASPECT_NAME = "dataFlowKey";

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -205,6 +205,14 @@ public class PoliciesConfig {
       COMMON_ENTITY_PRIVILEGES
   );
 
+  // Data Doc Privileges
+  public static final ResourcePrivileges NOTEBOOK_PRIVILEGES = ResourcePrivileges.of(
+      "notebook",
+      "Notebook",
+      "Notebook indexed by DataHub",
+      COMMON_ENTITY_PRIVILEGES
+  );
+
   // Data Flow Privileges
   public static final ResourcePrivileges DATA_FLOW_PRIVILEGES = ResourcePrivileges.of(
       "dataFlow",
@@ -293,7 +301,8 @@ public class PoliciesConfig {
       DOMAIN_PRIVILEGES,
       GLOSSARY_TERM_PRIVILEGES,
       CORP_GROUP_PRIVILEGES,
-      CORP_USER_PRIVILEGES
+      CORP_USER_PRIVILEGES,
+      NOTEBOOK_PRIVILEGES
   );
 
   @Data


### PR DESCRIPTION
This PR contains the GraphQL related logic for Notebook data entity. 

Please refer to https://github.com/datahub-project/datahub/pull/4237 for more info about Notebook entity

Main changes in this PR:
1. GraphQL schema change in entity.graphql  file
2. new EntityType and Mappers in src/main/java/com/linkedin/datahub/graphql/types/notebook folder
3. necessary changes to hook notebook entity
4. Register NotebookUrn in li-utils module

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
