### PR TITLE
fix(ml models): re-enabling ml tabs

### DIFF
--- a/datahub-web-react/src/app/entity/mlFeatureTable/profile/MLFeatureTableProfile.tsx
+++ b/datahub-web-react/src/app/entity/mlFeatureTable/profile/MLFeatureTableProfile.tsx
@@ -44,11 +44,19 @@ export const MLFeatureTableProfile = ({ urn }: { urn: string }): JSX.Element => 
                 name: TabType.Features,
                 path: TabType.Features.toLowerCase(),
                 content: <MlFeatureTableFeatures features={features} />,
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
             {
                 name: TabType.Sources,
                 path: TabType.Sources.toLowerCase(),
                 content: <SourcesView features={features} />,
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
             {
                 name: TabType.Ownership,
@@ -59,6 +67,10 @@ export const MLFeatureTableProfile = ({ urn }: { urn: string }): JSX.Element => 
                         lastModifiedAt={(ownership && ownership.lastModified?.time) || 0}
                     />
                 ),
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
         ];
     };

--- a/datahub-web-react/src/app/entity/mlModel/profile/MLModelProfile.tsx
+++ b/datahub-web-react/src/app/entity/mlModel/profile/MLModelProfile.tsx
@@ -41,16 +41,28 @@ export const MLModelProfile = ({ urn }: { urn: string }): JSX.Element => {
                 name: TabType.Summary,
                 path: TabType.Summary.toLowerCase(),
                 content: <MLModelSummary model={model} />,
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
             {
                 name: TabType.Groups,
                 path: TabType.Groups.toLowerCase(),
                 content: <MLModelGroupsTab model={model} />,
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
             {
                 name: TabType.CustomProperties,
                 path: TabType.CustomProperties.toLowerCase(),
                 content: <Properties properties={model?.properties?.customProperties || EMPTY_ARR} />,
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
             // {
             //     name: TabType.Deployments,
@@ -66,6 +78,10 @@ export const MLModelProfile = ({ urn }: { urn: string }): JSX.Element => {
                         lastModifiedAt={model?.ownership?.lastModified?.time || 0}
                     />
                 ),
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
         ];
     };

--- a/datahub-web-react/src/app/entity/mlModelGroup/profile/MLModelGroupProfile.tsx
+++ b/datahub-web-react/src/app/entity/mlModelGroup/profile/MLModelGroupProfile.tsx
@@ -38,6 +38,10 @@ export const MLModelGroupProfile = ({ urn }: { urn: string }): JSX.Element => {
                         models={group?.['incoming']?.relationships?.map((relationship) => relationship.entity) || []}
                     />
                 ),
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
             {
                 name: TabType.Ownership,
@@ -48,6 +52,10 @@ export const MLModelGroupProfile = ({ urn }: { urn: string }): JSX.Element => {
                         lastModifiedAt={group?.ownership?.lastModified?.time || 0}
                     />
                 ),
+                display: {
+                    visible: (_, _1) => true,
+                    enabled: (_, _1) => true,
+                },
             },
         ];
     };


### PR DESCRIPTION
When we migrated the legacy ml pages to use the shared RoutedTabs component, they did not also receive the `display` methods. The long term fix is to bring the ml model pages onto the new entity page framework, but this will re-enable the tabs for the time being.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
