### PR TITLE
fix: Update GroupProfile to read from properties over deprecated info aspect

### DIFF
--- a/datahub-web-react/src/app/entity/group/GroupProfile.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupProfile.tsx
@@ -89,11 +89,20 @@ export default function GroupProfile() {
     // Side bar data
     const sideBarData = {
         photoUrl: undefined,
-        avatarName: data?.corpGroup?.properties?.displayName || data?.corpGroup?.name || data?.corpGroup?.info?.displayName || undefined,
-        name: data?.corpGroup?.properties?.displayName || data?.corpGroup?.name || data?.corpGroup?.info?.displayName || undefined,
+        avatarName:
+            data?.corpGroup?.properties?.displayName ||
+            data?.corpGroup?.name ||
+            data?.corpGroup?.info?.displayName ||
+            undefined,
+        name:
+            data?.corpGroup?.properties?.displayName ||
+            data?.corpGroup?.name ||
+            data?.corpGroup?.info?.displayName ||
+            undefined,
         email: data?.corpGroup?.editableProperties?.email || data?.corpGroup?.properties?.email || undefined,
         slack: data?.corpGroup?.editableProperties?.slack || undefined,
-        aboutText: data?.corpGroup?.editableProperties?.description || data?.corpGroup?.properties?.description || undefined,
+        aboutText:
+            data?.corpGroup?.editableProperties?.description || data?.corpGroup?.properties?.description || undefined,
         groupMemberRelationships: groupMemberRelationships as EntityRelationshipsResult,
         groupOwnerShip: data?.corpGroup?.ownership as Ownership,
         urn,

--- a/datahub-web-react/src/app/entity/group/GroupProfile.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupProfile.tsx
@@ -89,11 +89,11 @@ export default function GroupProfile() {
     // Side bar data
     const sideBarData = {
         photoUrl: undefined,
-        avatarName: data?.corpGroup?.info?.displayName || data?.corpGroup?.name,
-        name: data?.corpGroup?.info?.displayName || data?.corpGroup?.name || undefined,
-        email: data?.corpGroup?.editableProperties?.email || undefined,
+        avatarName: data?.corpGroup?.properties?.displayName || data?.corpGroup?.name || data?.corpGroup?.info?.displayName || undefined,
+        name: data?.corpGroup?.properties?.displayName || data?.corpGroup?.name || data?.corpGroup?.info?.displayName || undefined,
+        email: data?.corpGroup?.editableProperties?.email || data?.corpGroup?.properties?.email || undefined,
         slack: data?.corpGroup?.editableProperties?.slack || undefined,
-        aboutText: data?.corpGroup?.editableProperties?.description || undefined,
+        aboutText: data?.corpGroup?.editableProperties?.description || data?.corpGroup?.properties?.description || undefined,
         groupMemberRelationships: groupMemberRelationships as EntityRelationshipsResult,
         groupOwnerShip: data?.corpGroup?.ownership as Ownership,
         urn,

--- a/datahub-web-react/src/graphql/group.graphql
+++ b/datahub-web-react/src/graphql/group.graphql
@@ -13,6 +13,11 @@ query getGroup($urn: String!, $membersCount: Int!) {
             slack
             email
         }
+        properties {
+            displayName
+            description
+            email
+        }
         ownership {
             ...ownershipFields
         }


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
