### PR TITLE
feat(snowflake): stop querying when no mix/max dates for usage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -425,6 +425,12 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
         logger.info("Checking usage date ranges")
         self._check_usage_date_ranges(engine)
 
+        if (
+            self.report.min_access_history_time is None
+            or self.report.max_access_history_time is None
+        ):
+            return
+
         logger.info("Getting usage history")
         with PerfTimer() as timer:
             query = self._make_usage_query()


### PR DESCRIPTION
Currently we continue querying even if there is no usage data. We should stop early

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
