### PR TITLE
fix(build): increase memory to stop gradle daemon from disappearing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=false
 
-org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 # Increase retries to 5 (from default of 3) and increase interval from 125ms to 1s.
 org.gradle.internal.repository.max.retries=5

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=false
 
-# Increase gradle JVM memory to 2GB to allow tests to run locally
-#org.gradle.jvmargs=-Xmx2000m
+org.gradle.jvmargs=-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # Increase retries to 5 (from default of 3) and increase interval from 125ms to 1s.
 org.gradle.internal.repository.max.retries=5


### PR DESCRIPTION
Taken from https://medium.com/@wasyl/make-your-gradle-builds-fast-again-ea323ce6a435

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
