### PR TITLE
fix: urlencode slash in urns too

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -3,7 +3,6 @@ import logging
 import os.path
 import sys
 import typing
-import urllib.parse
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
@@ -55,6 +54,7 @@ from datahub.metadata.schema_classes import (
     UpstreamLineageClass,
     ViewPropertiesClass,
 )
+from datahub.utilities.urns.urn import Urn
 
 log = logging.getLogger(__name__)
 
@@ -448,7 +448,7 @@ def batch_get_ids(
     url = gms_host + endpoint
     ids_to_get = []
     for id in ids:
-        ids_to_get.append(urllib.parse.quote(id, safe=""))
+        ids_to_get.append(Urn.url_encode(id))
 
     response = session.get(
         f"{url}?ids=List({','.join(ids_to_get)})",
@@ -482,7 +482,7 @@ def get_outgoing_relationships(urn: str, types: List[str]) -> Iterable[Dict]:
 
 def get_relationships(urn: str, types: List[str], direction: str) -> Iterable[Dict]:
     session, gms_host = get_session_and_host()
-    encoded_urn = urllib.parse.quote(urn, safe="")
+    encoded_urn: str = Urn.url_encode(urn)
     types_param_string = "List(" + ",".join(types) + ")"
     endpoint: str = f"{gms_host}/relationships?urn={encoded_urn}&direction={direction}&types={types_param_string}"
     response: Response = session.get(endpoint)
@@ -515,7 +515,7 @@ def get_entity(
         # we assume the urn is already encoded
         encoded_urn: str = urn
     elif urn.startswith("urn:"):
-        encoded_urn = urllib.parse.quote(urn, safe="")
+        encoded_urn = Urn.url_encode(urn)
     else:
         raise Exception(
             f"urn {urn} does not seem to be a valid raw (starts with urn:) or encoded urn (starts with urn%3A)"

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -448,7 +448,7 @@ def batch_get_ids(
     url = gms_host + endpoint
     ids_to_get = []
     for id in ids:
-        ids_to_get.append(urllib.parse.quote(id))
+        ids_to_get.append(urllib.parse.quote(id, safe=""))
 
     response = session.get(
         f"{url}?ids=List({','.join(ids_to_get)})",
@@ -515,7 +515,7 @@ def get_entity(
         # we assume the urn is already encoded
         encoded_urn: str = urn
     elif urn.startswith("urn:"):
-        encoded_urn = urllib.parse.quote(urn)
+        encoded_urn = urllib.parse.quote(urn, safe="")
     else:
         raise Exception(
             f"urn {urn} does not seem to be a valid raw (starts with urn:) or encoded urn (starts with urn%3A)"

--- a/metadata-ingestion/src/datahub/cli/timeline_cli.py
+++ b/metadata-ingestion/src/datahub/cli/timeline_cli.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import time
-import urllib.parse
 from datetime import datetime
 from typing import Any, List, Optional
 
@@ -13,6 +12,7 @@ from termcolor import colored
 import datahub.cli.cli_utils
 from datahub.emitter.mce_builder import dataset_urn_to_key, schema_field_urn_to_key
 from datahub.telemetry import telemetry
+from datahub.utilities.urns.urn import Urn
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ def get_timeline(
         # we assume the urn is already encoded
         encoded_urn: str = urn
     elif urn.startswith("urn:"):
-        encoded_urn = urllib.parse.quote(urn, safe="")
+        encoded_urn = Urn.url_encode(urn)
     else:
         raise Exception(
             f"urn {urn} does not seem to be a valid raw (starts with urn:) or encoded urn (starts with urn%3A)"

--- a/metadata-ingestion/src/datahub/cli/timeline_cli.py
+++ b/metadata-ingestion/src/datahub/cli/timeline_cli.py
@@ -74,7 +74,7 @@ def get_timeline(
         # we assume the urn is already encoded
         encoded_urn: str = urn
     elif urn.startswith("urn:"):
-        encoded_urn = urllib.parse.quote(urn)
+        encoded_urn = urllib.parse.quote(urn, safe="")
     else:
         raise Exception(
             f"urn {urn} does not seem to be a valid raw (starts with urn:) or encoded urn (starts with urn%3A)"

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -126,7 +126,7 @@ class DataHubGraph(DatahubRestEmitter):
         :rtype: Optional[Aspect]
         :raises HttpError: if the HTTP response is not a 200 or a 404
         """
-        url = f"{self._gms_server}/aspects/{urllib.parse.quote(entity_urn)}?aspect={aspect}&version=0"
+        url = f"""{self._gms_server}/aspects/{urllib.parse.quote(entity_urn, safe="")}?aspect={aspect}&version=0"""
         response = self._session.get(url)
         if response.status_code == 404:
             # not found

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import urllib.parse
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Optional, Type
 
@@ -18,6 +17,7 @@ from datahub.metadata.schema_classes import (
     GlossaryTermsClass,
     OwnershipClass,
 )
+from datahub.utilities.urns.urn import Urn
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +126,7 @@ class DataHubGraph(DatahubRestEmitter):
         :rtype: Optional[Aspect]
         :raises HttpError: if the HTTP response is not a 200 or a 404
         """
-        url = f"""{self._gms_server}/aspects/{urllib.parse.quote(entity_urn, safe="")}?aspect={aspect}&version=0"""
+        url: str = f"{self._gms_server}/aspects/{Urn.url_encode(entity_urn)}?aspect={aspect}&version=0"
         response = self._session.get(url)
         if response.status_code == 404:
             # not found

--- a/metadata-ingestion/src/datahub/utilities/urns/urn.py
+++ b/metadata-ingestion/src/datahub/utilities/urns/urn.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from typing import List
 
 from datahub.utilities.urns.error import InvalidUrnError
@@ -73,6 +74,11 @@ class Urn:
 
         cls._validate_entity_type(parts[2])
         cls._validate_entity_id(cls._get_entity_id_from_str(parts[3]))
+
+    @staticmethod
+    def url_encode(urn: str) -> str:
+        # safe='' encodes '/' as '%2F'
+        return urllib.parse.quote(urn, safe="")
 
     def get_type(self) -> str:
         return self._entity_type

--- a/metadata-ingestion/tests/unit/test_urn.py
+++ b/metadata-ingestion/tests/unit/test_urn.py
@@ -22,6 +22,15 @@ class TestUrn(unittest.TestCase):
         assert urn.get_type() == "dataset"
         assert urn.__str__() == "urn:li:dataset:(urn:li:dataPlatform:abc,def,prod)"
 
+    def test_url_encode_urn(self) -> None:
+        urn_with_slash: Urn = Urn.create_from_string(
+            "urn:li:dataset:(urn:li:dataPlatform:abc, def/ghi, prod)"
+        )
+        assert (
+            Urn.url_encode(str(urn_with_slash))
+            == "urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Aabc%2Cdef%2Fghi%2Cprod%29"
+        )
+
     def test_invalid_urn(self) -> None:
         with self.assertRaises(InvalidUrnError):
             Urn.create_from_string("urn:li:abc")


### PR DESCRIPTION
Urns for datasources with datasetNameDelimiter: "/" was not encoded
correctly, resulting in REST calls not returning any data when querying
with the urn.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
