### PR TITLE
fix(doc): Change to forward slash-separated strings, as in the example

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/common/BrowsePaths.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/BrowsePaths.pdl
@@ -10,7 +10,7 @@ record BrowsePaths {
   /**
    * A list of valid browse paths for the entity.
    *
-   * Browse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'
+   * Browse paths are expected to be forward slash-separated strings. For example: 'prod/snowflake/datasetName'
    */
   @Searchable = {
     "/*": {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -512,7 +512,7 @@
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'",
+      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be forward slash-separated strings. For example: 'prod/snowflake/datasetName'",
       "Searchable" : {
         "/*" : {
           "fieldName" : "browsePaths",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -325,7 +325,7 @@
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'",
+      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be forward slash-separated strings. For example: 'prod/snowflake/datasetName'",
       "Searchable" : {
         "/*" : {
           "fieldName" : "browsePaths",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -272,7 +272,7 @@
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'",
+      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be forward slash-separated strings. For example: 'prod/snowflake/datasetName'",
       "Searchable" : {
         "/*" : {
           "fieldName" : "browsePaths",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -325,7 +325,7 @@
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'",
+      "doc" : "A list of valid browse paths for the entity.\n\nBrowse paths are expected to be forward slash-separated strings. For example: 'prod/snowflake/datasetName'",
       "Searchable" : {
         "/*" : {
           "fieldName" : "browsePaths",

--- a/test-models/src/main/pegasus/com/datahub/test/BrowsePaths.pdl
+++ b/test-models/src/main/pegasus/com/datahub/test/BrowsePaths.pdl
@@ -10,7 +10,7 @@ record BrowsePaths {
   /**
    * A list of valid browse paths for the entity.
    *
-   * Browse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'
+   * Browse paths are expected to be forward slash-separated strings. For example: 'prod/snowflake/datasetName'
    */
   @Searchable = {
     "/*": {


### PR DESCRIPTION
The doc was a bit confusing, mentioning "backslash-separated strings" when the example is using forward slash. The example seems correct to me so changing the description to use "forward slash". 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
