### PR TITLE
feat(gms): Expose kafka listener concurrency as a GMS setting

### DIFF
--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -61,3 +61,6 @@ UI_INGESTION_DEFAULT_CLI_VERSION=0.8.26.6
 
 # Encryption of DataHub Secrets
 # SECRET_SERVICE_ENCRYPTION_KEY=<your-AES-encryption-key>
+
+# Uncomment to increase concurrency across Kafka consumers
+# KAFKA_LISTENER_CONCURRENCY=2

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
@@ -38,6 +38,9 @@ public class KafkaEventConsumerFactory {
   @Value("${kafka.schemaRegistry.type}")
   private String schemaRegistryType;
 
+  @Value("${kafka.listener.concurrency:1}")
+  private Integer kafkaListenerConcurrency;
+
   @Autowired
   @Lazy
   @Qualifier("kafkaSchemaRegistry")
@@ -78,6 +81,7 @@ public class KafkaEventConsumerFactory {
     ConcurrentKafkaListenerContainerFactory<String, GenericRecord> factory =
         new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(props));
+    factory.setConcurrency(this.kafkaListenerConcurrency);
 
     log.info("Event-based KafkaListenerContainerFactory built successfully");
 

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -118,6 +118,8 @@ elasticsearch:
 
 # TODO: Kafka topic convention
 kafka:
+  listener:
+    concurrency: ${KAFKA_LISTENER_CONCURRENCY:1}
   bootstrapServers: ${KAFKA_BOOTSTRAP_SERVER:http://localhost:9092}
   schemaRegistry:
     type: ${SCHEMA_REGISTRY_TYPE:KAFKA} # KAFKA or AWS_GLUE


### PR DESCRIPTION
**Summary**
This change exposes the Kafka Listener concurrency for configuration inside the GMS + MAE consumer pods. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
