### PR TITLE
fix(rollback) Removes status & key aspects from affected aspects count during rollback

### DIFF
--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/BatchIngestionRunResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/BatchIngestionRunResource.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.resources.entity;
 
 import com.codahale.metrics.MetricRegistry;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.RollbackRunResult;
@@ -109,7 +110,8 @@ public class BatchIngestionRunResource extends CollectionResourceTaskTemplate<St
         final List<AspectRowSummary> affectedAspectsList = keyAspects.stream()
                 .map((AspectRowSummary urn) -> _systemMetadataService.findByUrn(urn.getUrn(), false))
                 .flatMap(List::stream)
-                .filter(row -> !row.getRunId().equals(runId))
+                .filter(row -> !row.getRunId().equals(runId) && !row.isKeyAspect()
+                        && !row.getAspectName().equals(Constants.STATUS_ASPECT_NAME))
                 .collect(Collectors.toList());
 
         long affectedAspects = affectedAspectsList.size();
@@ -171,7 +173,8 @@ public class BatchIngestionRunResource extends CollectionResourceTaskTemplate<St
       final List<AspectRowSummary> affectedAspectsList = keyAspects.stream()
               .map((AspectRowSummary urn) -> _systemMetadataService.findByUrn(urn.getUrn(), false))
               .flatMap(List::stream)
-              .filter(row -> !row.getRunId().equals(runId))
+              .filter(row -> !row.getRunId().equals(runId) && !row.isKeyAspect()
+                      && !row.getAspectName().equals(Constants.STATUS_ASPECT_NAME))
               .collect(Collectors.toList());
 
       long affectedAspects = affectedAspectsList.size();


### PR DESCRIPTION
Rollback affected entities computation was incorrectly considering key aspects & status aspects as affected entities.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.