### PR TITLE
(fix): Update path generated when creating LookML URL

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -2,6 +2,7 @@ import glob
 import importlib
 import itertools
 import logging
+import os
 import pathlib
 import re
 import sys
@@ -924,7 +925,7 @@ class LookMLSource(Source):
     def _get_custom_properties(self, looker_view: LookerView) -> DatasetPropertiesClass:
         file_path = str(pathlib.Path(looker_view.absolute_file_path).resolve()).replace(
             str(self.source_config.base_folder.resolve()), ""
-        )
+        ).lstrip(os.sep)
 
         custom_properties = {
             "looker.file.content": looker_view.raw_file_content[

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -923,9 +923,11 @@ class LookMLSource(Source):
             return None
 
     def _get_custom_properties(self, looker_view: LookerView) -> DatasetPropertiesClass:
-        file_path = str(pathlib.Path(looker_view.absolute_file_path).resolve()).replace(
-            str(self.source_config.base_folder.resolve()), ""
-        ).lstrip(os.sep)
+        file_path = (
+            str(pathlib.Path(looker_view.absolute_file_path).resolve())
+            .replace(str(self.source_config.base_folder.resolve()), "")
+            .lstrip(os.sep)
+        )
 
         custom_properties = {
             "looker.file.content": looker_view.raw_file_content[

--- a/metadata-ingestion/tests/integration/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/lookml/expected_output.json
@@ -186,7 +186,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_view",
@@ -410,7 +410,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_derived_view",
@@ -508,7 +508,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "include_able_view",
@@ -587,7 +587,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "looker_events",
@@ -720,7 +720,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "extending_looker_events",
@@ -799,7 +799,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "autodetect_sql_name_based_on_view_name",
@@ -878,7 +878,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "test_include_external_view",
@@ -1045,7 +1045,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "fragment_derived_view",
@@ -1127,7 +1127,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "customer_facts",

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
@@ -186,7 +186,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_view",
@@ -410,7 +410,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_derived_view",
@@ -508,7 +508,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "include_able_view",
@@ -587,7 +587,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "looker_events",
@@ -720,7 +720,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "extending_looker_events",
@@ -799,7 +799,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "autodetect_sql_name_based_on_view_name",
@@ -878,7 +878,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "test_include_external_view",
@@ -1045,7 +1045,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "fragment_derived_view",
@@ -1127,7 +1127,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "customer_facts",

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
@@ -186,7 +186,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_view",
@@ -410,7 +410,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_derived_view",
@@ -508,7 +508,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "include_able_view",
@@ -587,7 +587,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "looker_events",
@@ -720,7 +720,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "extending_looker_events",
@@ -799,7 +799,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "autodetect_sql_name_based_on_view_name",
@@ -878,7 +878,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "test_include_external_view",
@@ -1045,7 +1045,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "fragment_derived_view",
@@ -1127,7 +1127,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "customer_facts",

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
@@ -170,7 +170,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_view",
@@ -378,7 +378,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_derived_view",
@@ -476,7 +476,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "include_able_view",
@@ -555,7 +555,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "looker_events",
@@ -688,7 +688,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "extending_looker_events",
@@ -767,7 +767,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "autodetect_sql_name_based_on_view_name",
@@ -846,7 +846,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "test_include_external_view",
@@ -909,7 +909,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "fragment_derived_view",
@@ -991,7 +991,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "customer_facts",

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
@@ -186,7 +186,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_view",
@@ -410,7 +410,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_derived_view",
@@ -508,7 +508,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "include_able_view",
@@ -587,7 +587,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "looker_events",
@@ -720,7 +720,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "extending_looker_events",
@@ -799,7 +799,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "autodetect_sql_name_based_on_view_name",
@@ -878,7 +878,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "test_include_external_view",
@@ -1045,7 +1045,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "fragment_derived_view",
@@ -1127,7 +1127,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "customer_facts",

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_platform_instance.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_platform_instance.json
@@ -186,7 +186,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_view",
@@ -410,7 +410,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "my_derived_view",
@@ -508,7 +508,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "include_able_view",
@@ -587,7 +587,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "looker_events",
@@ -720,7 +720,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "extending_looker_events",
@@ -799,7 +799,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "autodetect_sql_name_based_on_view_name",
@@ -878,7 +878,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "test_include_external_view",
@@ -1045,7 +1045,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "fragment_derived_view",
@@ -1127,7 +1127,7 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,
                         "name": "customer_facts",

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
@@ -186,9 +186,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/foo.view.lkml"
+                            "looker.file.path": "foo.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//foo.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml",
                         "name": "my_view",
                         "qualifiedName": null,
                         "description": null,
@@ -410,9 +410,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
-                            "looker.file.path": "/bar.view.lkml"
+                            "looker.file.path": "bar.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//bar.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/bar.view.lkml",
                         "name": "my_derived_view",
                         "qualifiedName": null,
                         "description": null,
@@ -508,9 +508,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
-                            "looker.file.path": "/included_view_file.view.lkml"
+                            "looker.file.path": "included_view_file.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//included_view_file.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/included_view_file.view.lkml",
                         "name": "include_able_view",
                         "qualifiedName": null,
                         "description": null,
@@ -587,9 +587,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//view_declarations.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
                         "name": "looker_events",
                         "qualifiedName": null,
                         "description": null,
@@ -720,9 +720,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//view_declarations.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
                         "name": "extending_looker_events",
                         "qualifiedName": null,
                         "description": null,
@@ -799,9 +799,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//view_declarations.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
                         "name": "autodetect_sql_name_based_on_view_name",
                         "qualifiedName": null,
                         "description": null,
@@ -878,9 +878,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
-                            "looker.file.path": "/view_declarations.view.lkml"
+                            "looker.file.path": "view_declarations.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//view_declarations.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
                         "name": "test_include_external_view",
                         "qualifiedName": null,
                         "description": null,
@@ -1045,9 +1045,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
-                            "looker.file.path": "/nested/fragment_derived.view.lkml"
+                            "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//nested/fragment_derived.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/nested/fragment_derived.view.lkml",
                         "name": "fragment_derived_view",
                         "qualifiedName": null,
                         "description": null,
@@ -1127,9 +1127,9 @@
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
-                            "looker.file.path": "/liquid.view.lkml"
+                            "looker.file.path": "liquid.view.lkml"
                         },
-                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master//liquid.view.lkml",
+                        "externalUrl": "https://github.com/datahub/looker-demo/blob/master/liquid.view.lkml",
                         "name": "customer_facts",
                         "qualifiedName": null,
                         "description": null,


### PR DESCRIPTION
Pathlib by default removes the leading `/`, which leads to a trailing `/` being present in file_path after striping repo path.

The trailing `/` eventually causes the looker url to be incorrect.

I.e.:
`base_url//file_path`
to 
`base_url/file_path`

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.