### PR TITLE
fix(docs): add grant statements for redshift-ingestion

### DIFF
--- a/metadata-ingestion/source_docs/redshift.md
+++ b/metadata-ingestion/source_docs/redshift.md
@@ -16,6 +16,8 @@ This source needs to access system tables that require extra permissions.
 To grant these permissions, please alter your datahub Redshift user the following way:
 ```sql
 ALTER USER datahub_user WITH SYSLOG ACCESS UNRESTRICTED;
+GRANT SELECT ON pg_catalog.svv_table_info to datahub_user;
+GRANT SELECT ON pg_catalog.svl_user_info to datahub_user;
 ```
 :::note
 


### PR DESCRIPTION
Redshift ingestion sources throw a permission denied error for the tables added in the PR docs. 

To recreate this issue:
1. Create a user on redshift with no data access.
2. Run - ALTER USER datahub_user WITH SYSLOG ACCESS UNRESTRICTED;
3. Ingest data using cli

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.