### PR TITLE
[DO NOT MERGE] feat(spring): Upgrade spring version to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,15 @@ buildscript {
   ext.junitJupiterVersion = '5.6.1'
   ext.pegasusVersion = '29.22.16'
   ext.mavenVersion = '3.6.3'
+  ext.springVersion = '5.3.18'
+  ext.springBootVersion = '2.5.12'
   apply from: './repositories.gradle'
   buildscript.repositories.addAll(project.repositories)
   dependencies {
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
     classpath 'com.github.node-gradle:gradle-node-plugin:2.2.4'
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.8.1'
-    classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.4.RELEASE'
+    classpath 'org.springframework.boot:spring-boot-gradle-plugin:' + springBootVersion
     classpath('com.github.jengelman.gradle.plugins:shadow:5.2.0') {
       exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     }
@@ -119,20 +121,20 @@ project.ext.externalDependency = [
     'shiroCore': 'org.apache.shiro:shiro-core:1.8.0',
     'sparkSql' : 'org.apache.spark:spark-sql_2.11:2.4.8',
     'sparkHive' : 'org.apache.spark:spark-hive_2.11:2.4.8',
-    'springBeans': 'org.springframework:spring-beans:5.2.3.RELEASE',
-    'springContext': 'org.springframework:spring-context:5.2.3.RELEASE',
-    'springCore': 'org.springframework:spring-core:5.2.3.RELEASE',
+    'springBeans': "org.springframework:spring-beans:$springVersion",
+    'springContext': "org.springframework:spring-context:$springVersion",
+    'springCore': "org.springframework:spring-core:$springVersion",
     'springDocUI': 'org.springdoc:springdoc-openapi-ui:1.6.6',
-    'springJdbc': 'org.springframework:spring-jdbc:5.2.3.RELEASE',
-    'springWeb': 'org.springframework:spring-web:5.2.3.RELEASE',
-    'springWebMVC': 'org.springframework:spring-webmvc:5.2.3.RELEASE',
-    'springBoot': 'org.springframework.boot:spring-boot:2.1.14.RELEASE',
-    'springBootAutoconfigure': 'org.springframework.boot:spring-boot-autoconfigure:2.1.4.RELEASE',
-    'springBootStarterWeb': 'org.springframework.boot:spring-boot-starter-web:2.1.4.RELEASE',
-    'springBootStarterJetty': 'org.springframework.boot:spring-boot-starter-jetty:2.1.4.RELEASE',
-    'springBootStarterCache': 'org.springframework.boot:spring-boot-starter-cache:2.1.4.RELEASE',
-    'springKafka': 'org.springframework.kafka:spring-kafka:2.2.14.RELEASE',
-    'springActuator': 'org.springframework.boot:spring-boot-starter-actuator:2.1.4.RELEASE',
+    'springJdbc': "org.springframework:spring-jdbc:$springVersion",
+    'springWeb': "org.springframework:spring-web:$springVersion",
+    'springWebMVC': "org.springframework:spring-webmvc:$springVersion",
+    'springBoot': "org.springframework.boot:spring-boot:$springBootVersion",
+    'springBootAutoconfigure': "org.springframework.boot:spring-boot-autoconfigure:$springBootVersion",
+    'springBootStarterWeb': "org.springframework.boot:spring-boot-starter-web:$springBootVersion",
+    'springBootStarterJetty': "org.springframework.boot:spring-boot-starter-jetty:$springBootVersion",
+    'springBootStarterCache': "org.springframework.boot:spring-boot-starter-cache:$springBootVersion",
+    'springKafka': 'org.springframework.kafka:spring-kafka:2.7.12',
+    'springActuator': "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion",
     'swaggerAnnotations': 'io.swagger.core.v3:swagger-annotations:2.1.12',
     'testng': 'org.testng:testng:7.3.0',
     'testContainers': 'org.testcontainers:testcontainers:1.15.3',

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCliApplication.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCliApplication.java
@@ -2,13 +2,13 @@ package com.linkedin.datahub.upgrade;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@SpringBootApplication(exclude = {RestClientAutoConfiguration.class}, scanBasePackages = {"com.linkedin.gms.factory",
-    "com.linkedin.datahub.upgrade.config"})
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class}, scanBasePackages = {
+    "com.linkedin.gms.factory", "com.linkedin.datahub.upgrade.config"})
 public class UpgradeCliApplication {
   public static void main(String[] args) {
     new SpringApplicationBuilder(UpgradeCliApplication.class, UpgradeCli.class).web(WebApplicationType.NONE).run(args);

--- a/metadata-ingestion-examples/kafka-etl/src/main/java/com/linkedin/metadata/examples/kafka/KafkaEtlApplication.java
+++ b/metadata-ingestion-examples/kafka-etl/src/main/java/com/linkedin/metadata/examples/kafka/KafkaEtlApplication.java
@@ -2,12 +2,12 @@ package com.linkedin.metadata.examples.kafka;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@SpringBootApplication(exclude = {RestClientAutoConfiguration.class}, scanBasePackages = {
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class}, scanBasePackages = {
     "com.linkedin.metadata.examples.configs", "com.linkedin.metadata.examples.kafka"})
 public class KafkaEtlApplication {
   public static void main(String[] args) {

--- a/metadata-ingestion-examples/mce-cli/src/main/java/com/linkedin/metadata/examples/cli/MceCliApplication.java
+++ b/metadata-ingestion-examples/mce-cli/src/main/java/com/linkedin/metadata/examples/cli/MceCliApplication.java
@@ -2,12 +2,12 @@ package com.linkedin.metadata.examples.cli;
 
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@SpringBootApplication(exclude = {RestClientAutoConfiguration.class}, scanBasePackages = {
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class}, scanBasePackages = {
     "com.linkedin.metadata.examples.configs", "com.linkedin.metadata.examples.cli"})
 public class MceCliApplication {
   public static void main(String[] args) {

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MaeConsumerApplication.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MaeConsumerApplication.java
@@ -2,10 +2,10 @@ package com.linkedin.metadata.kafka;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@SpringBootApplication(exclude = {RestClientAutoConfiguration.class})
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 public class MaeConsumerApplication {
 
   public static void main(String[] args) {

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceConsumerApplication.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceConsumerApplication.java
@@ -2,11 +2,11 @@ package com.linkedin.metadata.kafka;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration;
 
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@SpringBootApplication(exclude = {RestClientAutoConfiguration.class})
+@SpringBootApplication(exclude = {ElasticsearchRestClientAutoConfiguration.class})
 public class MceConsumerApplication {
 
   public static void main(String[] args) {


### PR DESCRIPTION
Spring with JDK9+ has a critical vulnerability https://tanzu.vmware.com/security/cve-2022-22965
Although we are not impacted since we use JDK8, we want to still upgrade to the version without vulnerabilities to make sure we are not exposed to vulnerabilities when upgrading jdk version in the near future. 
Followed https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement to upgrade spring and dependencies. 

Testing whether everything just works after the upgrade. 
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.