### PR TITLE
fix(search): handle commas in search queries in the UI

### DIFF
--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -14,7 +14,6 @@ import { useGetSearchResultsForMultipleQuery } from '../../graphql/search.genera
 import { SearchCfg } from '../../conf';
 import { ENTITY_FILTER_NAME } from './utils/constants';
 import { GetSearchResultsParams } from '../entity/shared/components/styled/search/types';
-import { decodeComma } from '../entity/shared/utils';
 
 type SearchPageParams = {
     type?: string;
@@ -29,7 +28,7 @@ export const SearchPage = () => {
 
     const entityRegistry = useEntityRegistry();
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
-    const query: string = decodeComma(params.query ? (params.query as string) : '');
+    const query: string = decodeURIComponent(params.query ? (params.query as string) : '');
     const activeType = entityRegistry.getTypeOrDefaultFromPathName(useParams<SearchPageParams>().type || '', undefined);
     const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
     const filters: Array<FacetFilterInput> = useFilters(params);

--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -14,6 +14,7 @@ import { useGetSearchResultsForMultipleQuery } from '../../graphql/search.genera
 import { SearchCfg } from '../../conf';
 import { ENTITY_FILTER_NAME } from './utils/constants';
 import { GetSearchResultsParams } from '../entity/shared/components/styled/search/types';
+import { decodeComma } from '../entity/shared/utils';
 
 type SearchPageParams = {
     type?: string;
@@ -28,7 +29,7 @@ export const SearchPage = () => {
 
     const entityRegistry = useEntityRegistry();
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
-    const query: string = params.query ? (params.query as string) : '';
+    const query: string = decodeComma(params.query ? (params.query as string) : '');
     const activeType = entityRegistry.getTypeOrDefaultFromPathName(useParams<SearchPageParams>().type || '', undefined);
     const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
     const filters: Array<FacetFilterInput> = useFilters(params);

--- a/datahub-web-react/src/app/search/utils/navigateToSearchUrl.ts
+++ b/datahub-web-react/src/app/search/utils/navigateToSearchUrl.ts
@@ -4,7 +4,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import filtersToQueryStringParams from './filtersToQueryStringParams';
 import { EntityType, FacetFilterInput } from '../../../types.generated';
 import { PageRoutes } from '../../../conf/Global';
-import { encodeComma } from '../../entity/shared/utils';
 
 export const navigateToSearchUrl = ({
     type: newType,
@@ -27,7 +26,7 @@ export const navigateToSearchUrl = ({
     const search = QueryString.stringify(
         {
             ...filtersToQueryStringParams(constructedFilters),
-            query: encodeComma(newQuery || ''),
+            query: encodeURIComponent(newQuery || ''),
             page: newPage,
         },
         { arrayFormat: 'comma' },
@@ -57,7 +56,7 @@ export const navigateToSearchLineageUrl = ({
     const search = QueryString.stringify(
         {
             ...filtersToQueryStringParams(constructedFilters),
-            query: encodeComma(newQuery || ''),
+            query: encodeURIComponent(newQuery || ''),
             page: newPage,
         },
         { arrayFormat: 'comma' },

--- a/datahub-web-react/src/app/search/utils/navigateToSearchUrl.ts
+++ b/datahub-web-react/src/app/search/utils/navigateToSearchUrl.ts
@@ -4,6 +4,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import filtersToQueryStringParams from './filtersToQueryStringParams';
 import { EntityType, FacetFilterInput } from '../../../types.generated';
 import { PageRoutes } from '../../../conf/Global';
+import { encodeComma } from '../../entity/shared/utils';
 
 export const navigateToSearchUrl = ({
     type: newType,
@@ -26,7 +27,7 @@ export const navigateToSearchUrl = ({
     const search = QueryString.stringify(
         {
             ...filtersToQueryStringParams(constructedFilters),
-            query: newQuery,
+            query: encodeComma(newQuery || ''),
             page: newPage,
         },
         { arrayFormat: 'comma' },
@@ -56,7 +57,7 @@ export const navigateToSearchLineageUrl = ({
     const search = QueryString.stringify(
         {
             ...filtersToQueryStringParams(constructedFilters),
-            query: newQuery,
+            query: encodeComma(newQuery || ''),
             page: newPage,
         },
         { arrayFormat: 'comma' },


### PR DESCRIPTION
Commas are special characters in our url params- they are used to separate array items. We need to escape them or our search query will be treated as an array

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.