### PR TITLE
feat(GraphQL): Add data platform query to GraphQL API

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -588,6 +588,9 @@ public class GmsGraphQLEngine {
             .dataFetcher("domain",
                 new LoadableTypeResolver<>(domainType,
                     (env) -> env.getArgument(URN_FIELD_NAME)))
+            .dataFetcher("dataPlatform",
+                new LoadableTypeResolver<>(dataPlatformType,
+                    (env) -> env.getArgument(URN_FIELD_NAME)))
             .dataFetcher("mlFeatureTable", new AuthenticatedResolver<>(
                     new LoadableTypeResolver<>(mlFeatureTableType,
                             (env) -> env.getArgument(URN_FIELD_NAME))))

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -15,6 +15,11 @@ Coming soon listEntity queries for listing all entities of a given type
 """
 type Query {
     """
+    Fetch a Data Platform by primary key (urn)
+    """
+    dataPlatform(urn: String!): DataPlatform
+
+    """
     Fetch a CorpUser, representing a DataHub platform user, by primary key (urn)
     """
     corpUser(urn: String!): CorpUser

--- a/datahub-web-react/src/graphql/dataPlatform.graphql
+++ b/datahub-web-react/src/graphql/dataPlatform.graphql
@@ -1,0 +1,5 @@
+query getDataPlatform($urn: String!) {
+    dataPlatform(urn: $urn) {
+        ...platformFields
+    }
+}


### PR DESCRIPTION
Adding simple "get data platform by urn" query to GraphQL API. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.