### PR TITLE
feat(snowflake-usage): allow setting custom usage query in config

### DIFF
--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -280,6 +280,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `user_email_pattern.deny`       |          |                                                                     | List of regex patterns for user emails to exclude from usage.                    |
 | `user_email_pattern.ignoreCase` |          | `True`                                                              | Whether to ignore case sensitivity during pattern matching.                      |
 | `format_sql_queries`            |          | `False`                                                             | Whether to format sql queries                                                    |
+| `usage_custom_sql_template` |          |                                                                         | A custom SQL statement template which replaces the default `SNOWFLAKE_USAGE_SQL_TEMPLATE` (see source code for details).                      |
 
 :::caution
 

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -273,7 +273,8 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
     def _make_usage_query(self) -> str:
         start_time = int(self.config.start_time.timestamp() * 1000)
         end_time = int(self.config.end_time.timestamp() * 1000)
-        return SNOWFLAKE_USAGE_SQL_TEMPLATE.format(
+        usage_sql_template = self.config.usage_custom_sql_template.strip() or SNOWFLAKE_USAGE_SQL_TEMPLATE
+        return usage_sql_template.format(
             start_time_millis=start_time,
             end_time_millis=end_time,
         )

--- a/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
@@ -37,6 +37,7 @@ class SnowflakeUsageConfig(
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     apply_view_usage_to_tables: bool = False
     stateful_ingestion: Optional[SnowflakeStatefulIngestionConfig] = None
+    usage_custom_sql_template: Optional[str]
 
     def get_sql_alchemy_url(self):
         return super().get_sql_alchemy_url(


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.


## Motivation

The hard-coded `SNOWFLAKE_USAGE_SQL_TEMPLATE` has some drawbacks:

* `user_email_pattern.deny` apparently leads to empty Top-N query lists if the denied users make up most of the top queries. This is very common, e.g. for technical dbt users which run hundreds of tests.
* Technical proxy users which sometimes are used for user impersonation cannot be resolved to the email addresses of the impersonated users.

Therefore we were looking for a way to override the built-in query template.


## Implementation

* Create a new config option for the `snowflake-usage` source which allows for overriding the SQL template.
This option is called `usage_custom_sql_template`.
* Use the query defined in this config option, if present. Otherwise fallback to the built-in `SNOWFLAKE_USAGE_SQL_TEMPLATE`
* Add minimal documentation only, as it would be tricky to describe the whole `SNOWFLAKE_USAGE_SQL_TEMPLATE` query's columns and variables.

## Testing

Add a `usage_custom_sql_template` key-value pair to the `snowflake-usage` `config` block.

Example with a custom query which serves our individual needs:

```yaml
source:
  type: snowflake-usage
  config:
    # Coordinates
    host_port: redacted
    warehouse: redacted

    # Credentials
    username: redacted
    password: redacted
    role: redacted

    # Options
    top_n_queries: 25
    email_domain: redacted

    usage_custom_sql_template: >
      select
          access_history.query_start_time,
          query_history.query_text,
          query_history.query_type,
          query_history.rows_inserted,
          query_history.rows_updated,
          query_history.rows_deleted,
          access_history.base_objects_accessed,
          access_history.direct_objects_accessed,
          access_history.user_name,
          users.first_name,
          users.last_name,
          users.display_name,
          lower(coalesce(users.email,cfg_users.login_name)) as email,
          query_history.role_name
      from snowflake.account_usage.access_history as access_history
      left join snowflake.account_usage.query_history as query_history
          ON access_history.query_id = query_history.query_id
      left join snowflake.account_usage.users as users
          ON access_history.user_name = users.name
      left join eh_account.sys_config.users as cfg_users
        on  query_history.role_name = cfg_users.user_role -- matching the user_roles
        and upper(access_history.user_name) like '%_PROXY' -- respect only proxy users   
      where
        lower(coalesce(users.email,cfg_users.login_name)) like '%@%'
        and query_start_time >= to_timestamp_ltz({start_time_millis}, 3)
        and query_start_time < to_timestamp_ltz({end_time_millis}, 3)
      order by
        query_start_time desc
      ;
```

## Final words

I am not sure how to _automatically_ test this feature and if tests would be needed here.
I would be grateful if I could get some guidance so we could get this PR accepted.