### PR TITLE
fix(graphql): Adding PRE FabricType to GraphQL

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1300,6 +1300,12 @@ enum FabricType {
     Designates early integration fabrics
     """
     EI
+
+    """
+    Designates pre-production fabrics
+    """
+    PRE
+
     """
     Designates staging fabrics
     """


### PR DESCRIPTION
We missed the PRE fabric type in GraphQL, adding it here! 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.