### PR TITLE
feat(metadata-service): Supporting a configurable Authorizer Chain 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql;
 
 import com.datahub.authentication.token.TokenService;
+import com.datahub.authorization.AuthorizationConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.datahub.graphql.analytics.resolver.AnalyticsChartTypeResolver;
 import com.linkedin.datahub.graphql.analytics.resolver.GetChartsResolver;
@@ -207,6 +208,7 @@ public class GmsGraphQLEngine {
     private final TimeseriesAspectService timeseriesAspectService;
 
     private final IngestionConfiguration ingestionConfiguration;
+    private final AuthorizationConfiguration authorizationConfiguration;
 
     private final DatasetType datasetType;
     private final CorpUserType corpUserType;
@@ -271,6 +273,7 @@ public class GmsGraphQLEngine {
             null,
             null,
             null,
+            null,
             false);
     }
 
@@ -286,6 +289,7 @@ public class GmsGraphQLEngine {
         final EntityRegistry entityRegistry,
         final SecretService secretService,
         final IngestionConfiguration ingestionConfiguration,
+        final AuthorizationConfiguration authorizationConfiguration,
         final GitVersion gitVersion,
         final boolean supportsImpactAnalysis
         ) {
@@ -305,6 +309,7 @@ public class GmsGraphQLEngine {
         this.timeseriesAspectService = timeseriesAspectService;
 
         this.ingestionConfiguration = Objects.requireNonNull(ingestionConfiguration);
+        this.authorizationConfiguration = Objects.requireNonNull(authorizationConfiguration);
 
         this.datasetType = new DatasetType(entityClient);
         this.corpUserType = new CorpUserType(entityClient);
@@ -537,7 +542,9 @@ public class GmsGraphQLEngine {
     private void configureQueryResolvers(final RuntimeWiring.Builder builder) {
         builder.type("Query", typeWiring -> typeWiring
             .dataFetcher("appConfig",
-                new AppConfigResolver(gitVersion, analyticsService != null, this.ingestionConfiguration,
+                new AppConfigResolver(gitVersion, analyticsService != null,
+                    this.ingestionConfiguration,
+                    this.authorizationConfiguration,
                     supportsImpactAnalysis))
             .dataFetcher("me", new AuthenticatedResolver<>(
                     new MeResolver(this.entityClient)))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -1,7 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.config;
 
 import com.datahub.authorization.AuthorizationConfiguration;
-import com.datahub.authorization.Authorizer;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AnalyticsConfig;
 import com.linkedin.datahub.graphql.generated.AppConfig;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.config;
 
+import com.datahub.authorization.AuthorizationConfiguration;
 import com.datahub.authorization.Authorizer;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AnalyticsConfig;
@@ -27,16 +28,19 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
   private final GitVersion _gitVersion;
   private final boolean _isAnalyticsEnabled;
   private final IngestionConfiguration _ingestionConfiguration;
+  private final AuthorizationConfiguration _authorizationConfiguration;
   private final boolean _supportsImpactAnalysis;
 
   public AppConfigResolver(
       final GitVersion gitVersion,
       final boolean isAnalyticsEnabled,
       final IngestionConfiguration ingestionConfiguration,
+      final AuthorizationConfiguration authorizationConfiguration,
       final boolean supportsImpactAnalysis) {
     _gitVersion = gitVersion;
     _isAnalyticsEnabled = isAnalyticsEnabled;
     _ingestionConfiguration = ingestionConfiguration;
+    _authorizationConfiguration = authorizationConfiguration;
     _supportsImpactAnalysis = supportsImpactAnalysis;
   }
 
@@ -57,9 +61,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
     analyticsConfig.setEnabled(_isAnalyticsEnabled);
 
     final PoliciesConfig policiesConfig = new PoliciesConfig();
-
-    boolean policiesEnabled = Authorizer.AuthorizationMode.DEFAULT.equals(context.getAuthorizer().mode());
-    policiesConfig.setEnabled(policiesEnabled);
+    policiesConfig.setEnabled(_authorizationConfiguration.getDefaultAuthorizer().isEnabled());
 
     policiesConfig.setPlatformPrivileges(com.linkedin.metadata.authorization.PoliciesConfig.PLATFORM_PRIVILEGES
         .stream()

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/DeletePolicyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/DeletePolicyResolver.java
@@ -1,6 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.policy;
 
-import com.datahub.authorization.DataHubAuthorizer;
+import com.datahub.authorization.AuthorizerChain;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
@@ -30,8 +30,8 @@ public class DeletePolicyResolver implements DataFetcher<CompletableFuture<Strin
       return CompletableFuture.supplyAsync(() -> {
         try {
           _entityClient.deleteEntity(urn, context.getAuthentication());
-          if (context.getAuthorizer() instanceof DataHubAuthorizer) {
-            ((DataHubAuthorizer) context.getAuthorizer()).invalidateCache();
+          if (context.getAuthorizer() instanceof AuthorizerChain) {
+            ((AuthorizerChain) context.getAuthorizer()).getDefaultAuthorizer().invalidateCache();
           }
           return policyUrn;
         } catch (Exception e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/DeletePolicyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/DeletePolicyResolver.java
@@ -1,6 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.policy;
 
-import com.datahub.authorization.AuthorizationManager;
+import com.datahub.authorization.DataHubAuthorizer;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
@@ -30,8 +30,8 @@ public class DeletePolicyResolver implements DataFetcher<CompletableFuture<Strin
       return CompletableFuture.supplyAsync(() -> {
         try {
           _entityClient.deleteEntity(urn, context.getAuthentication());
-          if (context.getAuthorizer() instanceof AuthorizationManager) {
-            ((AuthorizationManager) context.getAuthorizer()).invalidateCache();
+          if (context.getAuthorizer() instanceof DataHubAuthorizer) {
+            ((DataHubAuthorizer) context.getAuthorizer()).invalidateCache();
           }
           return policyUrn;
         } catch (Exception e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolver.java
@@ -1,6 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.policy;
 
-import com.datahub.authorization.AuthorizationManager;
+import com.datahub.authorization.DataHubAuthorizer;
 import com.datahub.authorization.ResourceSpec;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
@@ -35,9 +35,9 @@ public class GetGrantedPrivilegesResolver implements DataFetcher<CompletableFutu
     final Optional<ResourceSpec> resourceSpec = Optional.ofNullable(input.getResourceSpec())
         .map(spec -> new ResourceSpec(EntityTypeMapper.getName(spec.getResourceType()), spec.getResourceUrn()));
 
-    if (context.getAuthorizer() instanceof AuthorizationManager) {
-      AuthorizationManager authorizationManager = (AuthorizationManager) context.getAuthorizer();
-      List<String> privileges = authorizationManager.getGrantedPrivileges(actor, resourceSpec);
+    if (context.getAuthorizer() instanceof DataHubAuthorizer) {
+      DataHubAuthorizer dataHubAuthorizer = (DataHubAuthorizer) context.getAuthorizer();
+      List<String> privileges = dataHubAuthorizer.getGrantedPrivileges(actor, resourceSpec);
       return CompletableFuture.supplyAsync(() -> Privileges.builder()
           .setPrivileges(privileges)
           .build());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/GetGrantedPrivilegesResolver.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.policy;
 
+import com.datahub.authorization.AuthorizerChain;
 import com.datahub.authorization.DataHubAuthorizer;
 import com.datahub.authorization.ResourceSpec;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -35,8 +36,8 @@ public class GetGrantedPrivilegesResolver implements DataFetcher<CompletableFutu
     final Optional<ResourceSpec> resourceSpec = Optional.ofNullable(input.getResourceSpec())
         .map(spec -> new ResourceSpec(EntityTypeMapper.getName(spec.getResourceType()), spec.getResourceUrn()));
 
-    if (context.getAuthorizer() instanceof DataHubAuthorizer) {
-      DataHubAuthorizer dataHubAuthorizer = (DataHubAuthorizer) context.getAuthorizer();
+    if (context.getAuthorizer() instanceof AuthorizerChain) {
+      DataHubAuthorizer dataHubAuthorizer = ((AuthorizerChain) context.getAuthorizer()).getDefaultAuthorizer();
       List<String> privileges = dataHubAuthorizer.getGrantedPrivileges(actor, resourceSpec);
       return CompletableFuture.supplyAsync(() -> Privileges.builder()
           .setPrivileges(privileges)

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/UpsertPolicyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/UpsertPolicyResolver.java
@@ -1,6 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.policy;
 
-import com.datahub.authorization.AuthorizationManager;
+import com.datahub.authorization.DataHubAuthorizer;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
@@ -69,8 +69,8 @@ public class UpsertPolicyResolver implements DataFetcher<CompletableFuture<Strin
         try {
           // TODO: We should also provide SystemMetadata.
           String urn = _entityClient.ingestProposal(proposal, context.getAuthentication());
-          if (context.getAuthorizer() instanceof AuthorizationManager) {
-            ((AuthorizationManager) context.getAuthorizer()).invalidateCache();
+          if (context.getAuthorizer() instanceof DataHubAuthorizer) {
+            ((DataHubAuthorizer) context.getAuthorizer()).invalidateCache();
           }
           return urn;
         } catch (Exception e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/UpsertPolicyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/UpsertPolicyResolver.java
@@ -1,6 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.policy;
 
-import com.datahub.authorization.DataHubAuthorizer;
+import com.datahub.authorization.AuthorizerChain;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
@@ -69,8 +69,8 @@ public class UpsertPolicyResolver implements DataFetcher<CompletableFuture<Strin
         try {
           // TODO: We should also provide SystemMetadata.
           String urn = _entityClient.ingestProposal(proposal, context.getAuthentication());
-          if (context.getAuthorizer() instanceof DataHubAuthorizer) {
-            ((DataHubAuthorizer) context.getAuthorizer()).invalidateCache();
+          if (context.getAuthorizer() instanceof AuthorizerChain) {
+            ((AuthorizerChain) context.getAuthorizer()).getDefaultAuthorizer().invalidateCache();
           }
           return urn;
         } catch (Exception e) {

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationConfiguration.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationConfiguration.java
@@ -1,0 +1,19 @@
+package com.datahub.authorization;
+
+import java.util.List;
+import lombok.Data;
+
+/**
+ * POJO representing the "authentication" configuration block in application.yml.
+ */
+@Data
+public class AuthorizationConfiguration {
+  /**
+   * Configuration for the default DataHub Policies-based authorizer.
+   */
+  private DefaultAuthorizerConfiguration defaultAuthorizer;
+  /**
+   * List of configurations for {@link Authorizer}s to be registered
+   */
+  private List<AuthorizerConfiguration> authorizers;
+}

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationRequest.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationRequest.java
@@ -4,9 +4,22 @@ import java.util.Optional;
 import lombok.Value;
 
 
+/**
+ * A request to authorize a user for a specific privilege.
+ */
 @Value
 public class AuthorizationRequest {
+  /**
+   * The urn of the actor (corpuser) making the request.
+   */
   String actorUrn;
+  /**
+   * The privilege that the user is requesting
+   */
   String privilege;
+  /**
+   * The resource that the user is requesting for, if applicable. If the privilege is a platform privilege
+   * this optional will be empty.
+   */
   Optional<ResourceSpec> resourceSpec;
 }

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationResult.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationResult.java
@@ -31,10 +31,13 @@ public class AuthorizationResult {
     DENY
   }
 
+  /**
+   * The decision - whether to allow or deny the request.
+   */
   Type type;
 
   /**
-   * Optional: The DataHub policy that granted the privilege.
+   * Optional message associated with the decision. Useful for debugging.
    */
-  Optional<DataHubPolicyInfo> policy;
+  String message;
 }

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationResult.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationResult.java
@@ -1,7 +1,5 @@
 package com.datahub.authorization;
 
-import com.linkedin.policy.DataHubPolicyInfo;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationResult.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizationResult.java
@@ -6,17 +6,35 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 
 
+/**
+ * A result returned after requesting authorization for a particular privilege.
+ */
 @Data
 @AllArgsConstructor
 public class AuthorizationResult {
+  /**
+   * The original authorization request
+   */
   AuthorizationRequest request;
 
-  Optional<DataHubPolicyInfo> policy;
+  /**
+   * The result type. Allow or deny the authorization request for the actor.
+   */
+  public enum Type {
+    /**
+     * Allow the request - the requested actor is privileged.
+     */
+    ALLOW,
+    /**
+     * Deny the request - the requested actor is not privileged.
+     */
+    DENY
+  }
 
   Type type;
 
-  public enum Type {
-    ALLOW,
-    DENY
-  }
+  /**
+   * Optional: The DataHub policy that granted the privilege.
+   */
+  Optional<DataHubPolicyInfo> policy;
 }

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/Authorizer.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/Authorizer.java
@@ -1,26 +1,23 @@
 package com.datahub.authorization;
 
-public interface Authorizer {
+import java.util.Map;
+import javax.annotation.Nonnull;
 
-  enum AuthorizationMode {
-    /**
-     * Default mode simply means that authorization is enforced, with a DENY result returned
-     */
-    DEFAULT,
-    /**
-     * Allow all means that the AuthorizationManager will allow all actions. This is used as an override to disable the
-     * policies feature.
-     */
-    ALLOW_ALL
-  }
+
+/**
+ * An Authorizer is responsible for determining whether an actor should be granted a specific privilege.
+ */
+public interface Authorizer {
+  /**
+   * Initialize the Authorizer. Invoked once at boot time.
+   *
+   * @param authorizerConfig config provided to the authenticator derived from the Metadata Service YAML config. This
+   *                         config comes from the "authorization.authorizers.config" configuration.
+   */
+  void init(@Nonnull final Map<String, Object> authorizerConfig);
 
   /**
    * Authorizes an action based on the actor, the resource, & required privileges.
    */
   AuthorizationResult authorize(AuthorizationRequest request);
-
-  /**
-   * Returns the mode the Authorizer is operating in.
-   */
-  AuthorizationMode mode();
 }

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -1,0 +1,4 @@
+package com.datahub.authorization;
+
+public class AuthorizerChain {
+}

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -1,4 +1,0 @@
-package com.datahub.authorization;
-
-public class AuthorizerChain {
-}

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizerConfiguration.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizerConfiguration.java
@@ -1,0 +1,20 @@
+package com.datahub.authorization;
+
+import java.util.Map;
+import lombok.Data;
+
+
+/**
+ * POJO representing {@link Authorizer} configurations provided in the application.yml.
+ */
+@Data
+public class AuthorizerConfiguration {
+  /**
+   * A fully-qualified class name for the {@link Authorizer} implementation to be registered.
+   */
+  private String type;
+  /**
+   * A set of authorizer-specific configurations passed through during "init" of the authorizer.
+   */
+  private Map<String, Object> configs;
+}

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/DefaultAuthorizerConfiguration.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/DefaultAuthorizerConfiguration.java
@@ -1,0 +1,15 @@
+package com.datahub.authorization;
+
+import lombok.Data;
+
+@Data
+public class DefaultAuthorizerConfiguration {
+  /**
+   * Whether authorization via DataHub policies is enabled.
+   */
+  private boolean enabled;
+  /**
+   * The duration between policies cache refreshes.
+   */
+  private int cacheRefreshIntervalSecs;
+}

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/ResourceSpec.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/ResourceSpec.java
@@ -4,11 +4,20 @@ import javax.annotation.Nonnull;
 import lombok.Value;
 
 
+/**
+ * Details about a specific resource being acted upon. Resource types currently supported
+ * can be found inside of {@link PoliciesConfig}.
+ */
 @Value
 public class ResourceSpec {
+  /**
+   * The resource type. Most often, this corresponds to the entity type. (dataset, chart, dashboard, corpGroup, etc).
+   */
   @Nonnull
   String type;
-
+  /**
+   * The resource identity. Most often, this corresponds to the raw entity urn. (urn:li:corpGroup:groupId)
+   */
   @Nonnull
   String resource;
 }

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -37,7 +37,7 @@ public class AuthorizerChain implements Authorizer {
     Objects.requireNonNull(request);
     for (final Authorizer authorizer : this.authorizers) {
       try {
-        log.debug(String.format("Executing Authorizer with class name %s", authorizer.getClass().getCanonicalName()));
+        log.debug("Executing Authorizer with class name {}", authorizer.getClass().getCanonicalName());
         AuthorizationResult result = authorizer.authorize(request);
         if (AuthorizationResult.Type.ALLOW.equals(result.type)) {
           // Authorization was successful - Short circuit
@@ -46,9 +46,9 @@ public class AuthorizerChain implements Authorizer {
           log.debug("Received DENY result from Authorizer with class name {}. message: {}", authorizer.getClass().getCanonicalName(), result.getMessage());
         }
       } catch (Exception e) {
-        log.debug(String.format(
-            "Caught exception while attempting to authorize request using Authorizer %s. Skipping authorizer.",
-            authorizer.getClass().getCanonicalName()), e);
+        log.error(
+            "Caught exception while attempting to authorize request using Authorizer {}. Skipping authorizer.",
+            authorizer.getClass().getCanonicalName(), e);
       }
     }
     // Return failed Authorization result.

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -1,0 +1,68 @@
+package com.datahub.authorization;
+
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.AuthorizationException;
+
+
+/**
+ * A configurable chain of {@link Authorizer}s executed in series to attempt to authenticate an inbound request.
+ *
+ * Individual {@link Authorizer}s are registered with the chain using {@link #register(Authorizer)}.
+ * The chain can be executed by invoking {@link #authorize(AuthorizationRequest)}.
+ */
+@Slf4j
+public class AuthorizerChain implements Authorizer {
+
+  private final List<Authorizer> authorizers;
+
+  public AuthorizerChain(final List<Authorizer> authorizers) {
+    this.authorizers = Objects.requireNonNull(authorizers);
+  }
+
+  /**
+   * Registers a new {@link Authorizer} at the end of the authorizer chain.
+   *
+   * @param authorizer the authorizer to register
+   */
+  public void register(@Nonnull final Authorizer authorizer) {
+    Objects.requireNonNull(authorizer);
+    authorizers.add(authorizer);
+  }
+
+  @Override
+  public void init(@Nonnull Map<String, Object> authorizerConfig) {
+    // pass.
+  }
+
+  /**
+   * Executes a set of {@link Authorizer}s and returns the first successful authentication result.
+   *
+   * Returns an instance of {@link AuthorizationResult}.
+   */
+  @Nullable
+  public AuthorizationResult authorize(@Nonnull final AuthorizationRequest request) throws AuthorizationException {
+    Objects.requireNonNull(request);
+    for (final Authorizer authorizer : this.authorizers) {
+      try {
+        log.debug(String.format("Executing Authorizer with class name %s", authorizer.getClass().getCanonicalName()));
+        AuthorizationResult result = authorizer.authorize(request);
+        if (AuthorizationResult.Type.ALLOW.equals(result.type)) {
+          // Authorization was successful - Short circuit
+          return result;
+        }
+      } catch (Exception e) {
+        log.debug(String.format(
+            "Caught exception while attempting to authorize request using Authorizer %s. Skipping authorizer.",
+            authorizer.getClass().getCanonicalName()), e);
+      }
+    }
+    // Return failed Authorization result.
+    return new AuthorizationResult(request, AuthorizationResult.Type.DENY, Optional.empty());
+  }
+}

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -96,7 +96,7 @@ public class DataHubAuthorizer implements Authorizer {
 
     // 0. Short circuit: If the action is being performed by the system (root), always allow it.
     if (isSystemRequest(request, this._systemAuthentication)) {
-      return new AuthorizationResult(request, AuthorizationResult.Type.ALLOW, Optional.empty());
+      return new AuthorizationResult(request, AuthorizationResult.Type.ALLOW, null);
     }
 
     Optional<ResolvedResourceSpec> resolvedResourceSpec = request.getResourceSpec().map(_resourceSpecResolver::resolve);
@@ -108,10 +108,11 @@ public class DataHubAuthorizer implements Authorizer {
     for (DataHubPolicyInfo policy : policiesToEvaluate) {
       if (isRequestGranted(policy, request, resolvedResourceSpec)) {
         // Short circuit if policy has granted privileges to this actor.
-        return new AuthorizationResult(request, AuthorizationResult.Type.ALLOW, Optional.of(policy));
+        return new AuthorizationResult(request, AuthorizationResult.Type.ALLOW,
+            String.format("Granted by policy with type: %s", policy.getType()));
       }
     }
-    return new AuthorizationResult(request, AuthorizationResult.Type.DENY,  Optional.empty());
+    return new AuthorizationResult(request, AuthorizationResult.Type.DENY,  null);
   }
 
   public List<String> getGrantedPrivileges(final String actorUrn, final Optional<ResourceSpec> resourceSpec) {

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.metadata.Constants.CORP_GROUP_ENTITY_NAME;
@@ -34,14 +35,27 @@ import static com.linkedin.metadata.Constants.POLICY_ENTITY_NAME;
 
 /**
  * The Authorizer is a singleton class responsible for authorizing
- * operations on the DataHub platform.
+ * operations on the DataHub platform via DataHub Policies.
  *
  * Currently, the authorizer is implemented as a spring-instantiated Singleton
  * which manages its own thread-pool used for resolving policy predicates.
  */
 // TODO: Decouple this from all Rest.li objects if possible.
 @Slf4j
-public class AuthorizationManager implements Authorizer {
+public class DataHubAuthorizer implements Authorizer {
+
+  public enum AuthorizationMode {
+    /**
+     * Default mode simply means that authorization is enforced, with a DENY result returned
+     */
+    DEFAULT,
+    /**
+     * Allow all means that the AuthorizationManager will allow all actions. This is used as an override to disable the
+     * policies feature.
+     */
+    ALLOW_ALL
+  }
+
 
   // Credentials used to make / authorize requests as the internal system actor.
   private final Authentication _systemAuthentication;
@@ -59,7 +73,7 @@ public class AuthorizationManager implements Authorizer {
 
   public static final String ALL = "ALL";
 
-  public AuthorizationManager(
+  public DataHubAuthorizer(
       final Authentication systemAuthentication,
       final EntityClient entityClient,
       final int delayIntervalSeconds,
@@ -73,11 +87,16 @@ public class AuthorizationManager implements Authorizer {
     _policyEngine = new PolicyEngine(systemAuthentication, entityClient);
   }
 
+  @Override
+  public void init(@Nonnull Map<String, Object> authorizerConfig) {
+    // Pass. No static config.
+  }
+
   public AuthorizationResult authorize(final AuthorizationRequest request) {
 
     // 0. Short circuit: If the action is being performed by the system (root), always allow it.
     if (isSystemRequest(request, this._systemAuthentication)) {
-      return new AuthorizationResult(request, Optional.empty(), AuthorizationResult.Type.ALLOW);
+      return new AuthorizationResult(request, AuthorizationResult.Type.ALLOW, Optional.empty());
     }
 
     Optional<ResolvedResourceSpec> resolvedResourceSpec = request.getResourceSpec().map(_resourceSpecResolver::resolve);
@@ -89,10 +108,10 @@ public class AuthorizationManager implements Authorizer {
     for (DataHubPolicyInfo policy : policiesToEvaluate) {
       if (isRequestGranted(policy, request, resolvedResourceSpec)) {
         // Short circuit if policy has granted privileges to this actor.
-        return new AuthorizationResult(request, Optional.of(policy), AuthorizationResult.Type.ALLOW);
+        return new AuthorizationResult(request, AuthorizationResult.Type.ALLOW, Optional.of(policy));
       }
     }
-    return new AuthorizationResult(request, Optional.empty(), AuthorizationResult.Type.DENY);
+    return new AuthorizationResult(request, AuthorizationResult.Type.DENY,  Optional.empty());
   }
 
   public List<String> getGrantedPrivileges(final String actorUrn, final Optional<ResourceSpec> resourceSpec) {
@@ -154,7 +173,6 @@ public class AuthorizationManager implements Authorizer {
     _refreshExecutorService.execute(_policyRefreshRunnable);
   }
 
-  @Override
   public AuthorizationMode mode() {
     return _mode;
   }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -45,12 +45,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 
-public class AuthorizationManagerTest {
+public class DataHubAuthorizerTest {
 
   public static final String DATAHUB_SYSTEM_CLIENT_ID = "__datahub_system";
 
   private EntityClient _entityClient;
-  private AuthorizationManager _authorizationManager;
+  private DataHubAuthorizer _dataHubAuthorizer;
 
   @BeforeMethod
   public void setupTest() throws Exception {
@@ -100,14 +100,14 @@ public class AuthorizationManagerTest {
         ""
     );
 
-    _authorizationManager = new AuthorizationManager(
+    _dataHubAuthorizer = new DataHubAuthorizer(
         systemAuthentication,
         _entityClient,
         10,
         10,
         Authorizer.AuthorizationMode.DEFAULT
     );
-    _authorizationManager.invalidateCache();
+    _dataHubAuthorizer.invalidateCache();
     Thread.sleep(500); // Sleep so the runnable can execute. (not ideal)
   }
 
@@ -124,7 +124,7 @@ public class AuthorizationManagerTest {
         Optional.of(resourceSpec)
     );
 
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
   }
 
   @Test
@@ -138,7 +138,7 @@ public class AuthorizationManagerTest {
         Optional.of(resourceSpec)
       );
 
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
   }
 
   @Test
@@ -153,13 +153,13 @@ public class AuthorizationManagerTest {
         Optional.of(resourceSpec)
     );
 
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.DENY);
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.DENY);
   }
 
   @Test
   public void testAllowAllMode() throws Exception {
 
-    _authorizationManager.setMode(Authorizer.AuthorizationMode.ALLOW_ALL);
+    _dataHubAuthorizer.setMode(DataHubAuthorizer.AuthorizationMode.ALLOW_ALL);
 
     ResourceSpec resourceSpec = new ResourceSpec("dataset", "urn:li:dataset:test");
 
@@ -170,7 +170,7 @@ public class AuthorizationManagerTest {
         Optional.of(resourceSpec)
     );
 
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
   }
 
   @Test
@@ -185,7 +185,7 @@ public class AuthorizationManagerTest {
         Optional.of(resourceSpec)
     );
 
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
 
     // Now init the mocks to return 0 policies.
     final ListUrnsResult emptyUrnsResult = new ListUrnsResult();
@@ -201,16 +201,16 @@ public class AuthorizationManagerTest {
     );
 
     // Invalidate Cache.
-    _authorizationManager.invalidateCache();
+    _dataHubAuthorizer.invalidateCache();
     Thread.sleep(500); // Sleep so the runnable can execute. (not ideal)
     // Now verify that invalidating the cache updates the policies by running the same authorization request.
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.DENY);
+    assertEquals(_dataHubAuthorizer.authorize(request).getType(), AuthorizationResult.Type.DENY);
   }
 
   @Test
   public void testAuthorizedActorsActivePolicy() throws Exception {
-    final AuthorizationManager.AuthorizedActors actors =
-        _authorizationManager.authorizedActors("EDIT_ENTITY_TAGS", // Should be inside the active policy.
+    final DataHubAuthorizer.AuthorizedActors actors =
+        _dataHubAuthorizer.authorizedActors("EDIT_ENTITY_TAGS", // Should be inside the active policy.
             Optional.of(new ResourceSpec("dataset", "urn:li:dataset:1")));
 
     assertTrue(actors.allUsers());

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -105,7 +105,7 @@ public class DataHubAuthorizerTest {
         _entityClient,
         10,
         10,
-        Authorizer.AuthorizationMode.DEFAULT
+        DataHubAuthorizer.AuthorizationMode.DEFAULT
     );
     _dataHubAuthorizer.invalidateCache();
     Thread.sleep(500); // Sleep so the runnable can execute. (not ideal)

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/AuthorizerChainFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/AuthorizerChainFactory.java
@@ -1,0 +1,83 @@
+package com.linkedin.gms.factory.auth;
+
+import com.datahub.authorization.AuthorizerConfiguration;
+import com.datahub.authorization.DataHubAuthorizer;
+import com.datahub.authorization.Authorizer;
+import com.datahub.authorization.AuthorizerChain;
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.Scope;
+
+@Slf4j
+@Configuration
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+@Import({DataHubAuthorizerFactory.class})
+public class AuthorizerChainFactory {
+
+  @Autowired
+  private ConfigurationProvider configurationProvider;
+
+  @Autowired
+  @Qualifier("dataHubAuthorizer")
+  private DataHubAuthorizer _dataHubAuthorizer;
+
+  @Bean(name = "authorizerChain")
+  @Scope("singleton")
+  @Nonnull
+  protected AuthorizerChain getInstance() {
+    // Extract + initialize customer authorizers from application configs.
+    final List<Authorizer> authorizers = new ArrayList<>(initCustomAuthorizers());
+    // Add the DataHub core policies-based Authorizer - this one should always be enabled.
+    authorizers.add(this._dataHubAuthorizer);
+    return new AuthorizerChain(authorizers);
+  }
+
+  private List<Authorizer> initCustomAuthorizers() {
+    final List<Authorizer> customAuthorizers = new ArrayList<>();
+
+    if (this.configurationProvider.getAuthorization().getAuthorizers() != null) {
+
+      final List<AuthorizerConfiguration> authorizerConfigurations =
+          this.configurationProvider.getAuthorization().getAuthorizers();
+
+      for (AuthorizerConfiguration authorizer : authorizerConfigurations) {
+        final String type = authorizer.getType();
+        final Map<String, Object> configs =
+            authorizer.getConfigs() != null ? authorizer.getConfigs() : Collections.emptyMap();
+
+        log.debug(String.format("Found configs for notification sink of type %s: %s ", type, configs));
+
+        // Instantiate the Authorizer
+        Class<? extends Authorizer> clazz = null;
+        try {
+          clazz = (Class<? extends Authorizer>) Class.forName(type);
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException(
+              String.format("Failed to find custom Authorizer class with name %s on the classpath.", type));
+        }
+
+        // Else construct an instance of the class, each class should have an empty constructor.
+        try {
+          final Authorizer authorizerInstance = clazz.newInstance();
+          authorizerInstance.init(configs);
+          customAuthorizers.add(authorizerInstance);
+        } catch (Exception e) {
+          throw new RuntimeException(String.format("Failed to instantiate custom Authorizer with class name %s", clazz.getCanonicalName()), e);
+        }
+      }
+    }
+    return customAuthorizers;
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubAuthorizerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubAuthorizerFactory.java
@@ -1,7 +1,7 @@
 package com.linkedin.gms.factory.auth;
 
 import com.datahub.authentication.Authentication;
-import com.datahub.authorization.AuthorizationManager;
+import com.datahub.authorization.DataHubAuthorizer;
 import com.linkedin.entity.client.JavaEntityClient;
 import com.linkedin.gms.factory.entity.RestliEntityClientFactory;
 import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Scope;
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
 @Import({RestliEntityClientFactory.class})
-public class AuthorizationManagerFactory {
+public class DataHubAuthorizerFactory {
 
   @Autowired
   @Qualifier("systemAuthentication")
@@ -29,21 +29,21 @@ public class AuthorizationManagerFactory {
   @Qualifier("javaEntityClient")
   private JavaEntityClient entityClient;
 
-  @Value("${authorizationManager.cacheRefreshIntervalSecs}")
+  @Value("${authorization.defaultAuthorizer.cacheRefreshIntervalSecs}")
   private Integer policyCacheRefreshIntervalSeconds;
 
-  @Value("${authorizationManager.enabled:true}")
+  @Value("${authorization.defaultAuthorizer..enabled:true}")
   private Boolean policiesEnabled;
 
-  @Bean(name = "authorizationManager")
+  @Bean(name = "dataHubAuthorizer")
   @Scope("singleton")
   @Nonnull
-  protected AuthorizationManager getInstance() {
+  protected DataHubAuthorizer getInstance() {
 
-    final AuthorizationManager.AuthorizationMode mode = policiesEnabled ? AuthorizationManager.AuthorizationMode.DEFAULT
-        : AuthorizationManager.AuthorizationMode.ALLOW_ALL;
+    final DataHubAuthorizer.AuthorizationMode mode = policiesEnabled ? DataHubAuthorizer.AuthorizationMode.DEFAULT
+        : DataHubAuthorizer.AuthorizationMode.ALLOW_ALL;
 
-    return new AuthorizationManager(systemAuthentication, entityClient, 10,
+    return new DataHubAuthorizer(systemAuthentication, entityClient, 10,
         policyCacheRefreshIntervalSeconds, mode);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/config/ConfigurationProvider.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/config/ConfigurationProvider.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.config;
 
 import com.datahub.authentication.AuthenticationConfiguration;
+import com.datahub.authorization.AuthorizationConfiguration;
 import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
 import lombok.Data;
@@ -18,6 +19,10 @@ public class ConfigurationProvider {
    * Authentication related configs
    */
   private AuthenticationConfiguration authentication;
+  /**
+   * Authentication related configs
+   */
+  private AuthorizationConfiguration authorization;
   /**
    * Ingestion related configs
    */

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -111,6 +111,7 @@ public class GraphQLEngineFactory {
           _entityRegistry,
           _secretService,
           _configProvider.getIngestion(),
+          _configProvider.getAuthorization(),
           _gitVersion,
           _graphService.supportsMultiHop()
           ).builder().build();
@@ -127,6 +128,7 @@ public class GraphQLEngineFactory {
         _entityRegistry,
         _secretService,
         _configProvider.getIngestion(),
+        _configProvider.getAuthorization(),
         _gitVersion,
         _graphService.supportsMultiHop()
     ).builder().build();

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -24,6 +24,20 @@ authentication:
   # The max duration of a UI session in milliseconds. Defaults to 1 day.
   sessionTokenDurationMs: ${SESSION_TOKEN_DURATION_MS:86400000}
 
+# Authorization-related configurations.
+authorization:
+
+  # Configurations for the default DataHub policies-based authorizer.
+  defaultAuthorizer:
+    enabled: ${AUTH_POLICIES_ENABLED:true}
+    cacheRefreshIntervalSecs: ${POLICY_CACHE_REFRESH_INTERVAL_SECONDS:120}
+
+  # Optional: A set of custom authorizers, serving in addition to the default DataHub policies-based authorizer.
+  authorizers:
+  # - type: com.datahub.authorization.authorizer.CustomAuthorizer
+  #   configs:
+  #     config1: value1
+
 ingestion:
   enabled: ${UI_INGESTION_ENABLED:true}
   defaultCliVersion: '${UI_INGESTION_DEFAULT_CLI_VERSION:0.8.26.6}'
@@ -63,10 +77,6 @@ searchService:
 configEntityRegistry:
   # TODO: Change to read from resources on classpath.
   path: ${ENTITY_REGISTRY_CONFIG_PATH:../../metadata-models/src/main/resources/entity-registry.yml}
-
-authorizationManager:
-  enabled: ${AUTH_POLICIES_ENABLED:true}
-  cacheRefreshIntervalSecs: ${POLICY_CACHE_REFRESH_INTERVAL_SECONDS:120}
 
 platformAnalytics:
   enabled: ${ANALYTICS_ENABLED:true}

--- a/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
+++ b/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
@@ -3,7 +3,6 @@ package com.datahub.graphql;
 import com.datahub.authentication.AuthenticationContext;
 import com.datahub.authentication.Authentication;
 import com.datahub.authorization.AuthorizerChain;
-import com.datahub.authorization.DataHubAuthorizer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
+++ b/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
@@ -2,6 +2,7 @@ package com.datahub.graphql;
 
 import com.datahub.authentication.AuthenticationContext;
 import com.datahub.authentication.Authentication;
+import com.datahub.authorization.AuthorizerChain;
 import com.datahub.authorization.DataHubAuthorizer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -36,7 +37,7 @@ public class GraphQLController {
   GraphQLEngine _engine;
 
   @Inject
-  DataHubAuthorizer _authManager;
+  AuthorizerChain _authorizerChain;
 
   @PostMapping(value = "/graphql", produces = "application/json;charset=utf-8")
   CompletableFuture<ResponseEntity<String>> postGraphQL(HttpEntity<String> httpEntity) {
@@ -80,7 +81,7 @@ public class GraphQLController {
     SpringQueryContext context = new SpringQueryContext(
         true,
         authentication,
-        _authManager);
+        _authorizerChain);
 
     return CompletableFuture.supplyAsync(() -> {
       /*

--- a/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
+++ b/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
@@ -2,7 +2,7 @@ package com.datahub.graphql;
 
 import com.datahub.authentication.AuthenticationContext;
 import com.datahub.authentication.Authentication;
-import com.datahub.authorization.AuthorizationManager;
+import com.datahub.authorization.DataHubAuthorizer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -36,7 +36,7 @@ public class GraphQLController {
   GraphQLEngine _engine;
 
   @Inject
-  AuthorizationManager _authManager;
+  DataHubAuthorizer _authManager;
 
   @PostMapping(value = "/graphql", produces = "application/json;charset=utf-8")
   CompletableFuture<ResponseEntity<String>> postGraphQL(HttpEntity<String> httpEntity) {


### PR DESCRIPTION
**Summary**

In this PR, we introduce support for a configurable Authorizer chain in the metadata service. This allows people to write their own implementation of the Authorizer interface and plug it in so that requests to perform specific actions can be authorized on DataHub using custom approaches. 

**Changes**
- Adding a custom AuthorizerChain component, which internally nests the default DataHub Authorizer as a fixed Authorizer. 
- Supporting configuration of custom Authorizer components inside of application.yml 


**Status**
WIP

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.