### PR TITLE
fix(doc): try to fix broken link

### DIFF
--- a/metadata-models/docs/entities/dataset.md
+++ b/metadata-models/docs/entities/dataset.md
@@ -36,7 +36,7 @@ Taking a simple nested schema as described below:
 }
 ```
 - v1 field path: `address.zipcode`
-- v2 field path: `[version=2.0].[type=struct].address.[type=string].zipcode"`. More examples and a formal specification of a v2 fieldPath can be found [here](docs/advanced/field-path-spec-v2/). 
+- v2 field path: `[version=2.0].[type=struct].address.[type=string].zipcode"`. More examples and a formal specification of a v2 fieldPath can be found [here](docs/advanced/field-path-spec-v2.md).
 
 Understanding field paths is important, because they are the identifiers through which tags, terms, documentation on fields are expressed. Besides the type and name of the field, schemas also contain descriptions attached to the individual fields, as well as information about primary and foreign keys.
 


### PR DESCRIPTION
Try to fix a broken link, it currently points to https://github.com/datahub-project/datahub/blob/master/docs/generated/metamodel/entities/docs/advanced/field-path-spec-v2/ which does not exist. I'm not sure this works.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.