### PR TITLE
fix(kafka): Stop overriding kafka registry props with empty values

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
@@ -67,12 +67,10 @@ public class DataHubKafkaProducerFactory {
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, schemaRegistryConfig.getSerializer().getName());
 
     // Override KafkaProperties with SchemaRegistryConfig only for non-empty values
-    for (Map.Entry<String, Object> e : schemaRegistryConfig.getProperties().entrySet()) {
-      Object v = e.getValue();
-      if (v != null && !v.toString().isEmpty()) {
-        props.put(e.getKey(), v);
-      }
-    }
+    schemaRegistryConfig.getProperties().entrySet()
+      .stream()
+      .filter(entry -> entry.getValue() != null && !entry.toString().isEmpty())
+      .forEach(entry -> props.put(entry.getKey(), entry.getValue())); 
 
     return new KafkaProducer<>(props);
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
@@ -65,7 +65,14 @@ public class DataHubKafkaProducerFactory {
     Map<String, Object> props = properties.buildProducerProperties();
 
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, schemaRegistryConfig.getSerializer().getName());
-    props.putAll(schemaRegistryConfig.getProperties());
+
+    // Override KafkaProperties with SchemaRegistryConfig only for non-empty values
+    for (Map.Entry<String, Object> e : schemaRegistryConfig.getProperties().entrySet()) {
+      Object v = e.getValue();
+      if (v != null && !v.toString().isEmpty()) {
+        props.put(e.getKey(), v);
+      }
+    }
 
     return new KafkaProducer<>(props);
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/DataHubKafkaProducerFactory.java
@@ -69,7 +69,7 @@ public class DataHubKafkaProducerFactory {
     // Override KafkaProperties with SchemaRegistryConfig only for non-empty values
     schemaRegistryConfig.getProperties().entrySet()
       .stream()
-      .filter(entry -> entry.getValue() != null && !entry.toString().isEmpty())
+      .filter(entry -> entry.getValue() != null && !entry.getValue().toString().isEmpty())
       .forEach(entry -> props.put(entry.getKey(), entry.getValue())); 
 
     return new KafkaProducer<>(props);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
@@ -76,7 +76,14 @@ public class KafkaEventConsumerFactory {
 
     consumerProps.setValueDeserializer(schemaRegistryConfig.getDeserializer());
     Map<String, Object> props = properties.buildConsumerProperties();
-    props.putAll(schemaRegistryConfig.getProperties());
+
+    // Override KafkaProperties with SchemaRegistryConfig only for non-empty values
+    for (Map.Entry<String, Object> e : schemaRegistryConfig.getProperties().entrySet()) {
+      Object v = e.getValue();
+      if (v != null && !v.toString().isEmpty()) {
+        props.put(e.getKey(), v);
+      }
+    }
 
     ConcurrentKafkaListenerContainerFactory<String, GenericRecord> factory =
         new ConcurrentKafkaListenerContainerFactory<>();

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
@@ -78,12 +78,10 @@ public class KafkaEventConsumerFactory {
     Map<String, Object> props = properties.buildConsumerProperties();
 
     // Override KafkaProperties with SchemaRegistryConfig only for non-empty values
-    for (Map.Entry<String, Object> e : schemaRegistryConfig.getProperties().entrySet()) {
-      Object v = e.getValue();
-      if (v != null && !v.toString().isEmpty()) {
-        props.put(e.getKey(), v);
-      }
-    }
+    schemaRegistryConfig.getProperties().entrySet()
+      .stream()
+      .filter(entry -> entry.getValue() != null && !entry.toString().isEmpty())
+      .forEach(entry -> props.put(entry.getKey(), entry.getValue())); 
 
     ConcurrentKafkaListenerContainerFactory<String, GenericRecord> factory =
         new ConcurrentKafkaListenerContainerFactory<>();

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/KafkaEventConsumerFactory.java
@@ -80,7 +80,7 @@ public class KafkaEventConsumerFactory {
     // Override KafkaProperties with SchemaRegistryConfig only for non-empty values
     schemaRegistryConfig.getProperties().entrySet()
       .stream()
-      .filter(entry -> entry.getValue() != null && !entry.toString().isEmpty())
+      .filter(entry -> entry.getValue() != null && !entry.getValue().toString().isEmpty())
       .forEach(entry -> props.put(entry.getKey(), entry.getValue())); 
 
     ConcurrentKafkaListenerContainerFactory<String, GenericRecord> factory =


### PR DESCRIPTION
This fixes an issue where registry SSL properties as described in https://datahubproject.io/docs/how/kafka-config/#schema-registry were being overwritten by empty ones for MCE and MAE consumers.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.