### PR TITLE
feat(ui): Adding GraphQL queries to fetch entity deprecation status

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1392,7 +1392,7 @@ type Container implements Entity {
     domain: Domain
 
     """
-    The deprecation status of the dashboard
+    The deprecation status of the container
     """
     deprecation: Deprecation
 

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -205,6 +205,7 @@ const dataset1 = {
     downstream: null,
     health: null,
     assertions: null,
+    deprecation: null,
 };
 
 const dataset2 = {
@@ -283,6 +284,7 @@ const dataset2 = {
     health: null,
     assertions: null,
     status: null,
+    deprecation: null,
 };
 
 export const dataset3 = {
@@ -789,6 +791,7 @@ const glossaryTerm1 = {
         sourceRef: 'sourceRef',
         sourceURI: 'sourceURI',
     },
+    deprecation: null,
 } as GlossaryTerm;
 
 const glossaryTerm2 = {
@@ -831,6 +834,7 @@ const glossaryTerm2 = {
         ],
         __typename: 'GlossaryTermProperties',
     },
+    deprecation: null,
     isRealtedTerms: {
         start: 0,
         count: 0,
@@ -922,6 +926,7 @@ const glossaryTerm3 = {
         ],
         __typename: 'GlossaryRelatedTerms',
     },
+    deprecation: null,
     __typename: 'GlossaryTerm',
 } as GlossaryTerm;
 
@@ -1010,6 +1015,7 @@ export const dataFlow1 = {
         ...dataPlatform,
     },
     domain: null,
+    deprecation: null,
 } as DataFlow;
 
 export const dataJob1 = {
@@ -1086,6 +1092,7 @@ export const dataJob1 = {
     },
     domain: null,
     status: null,
+    deprecation: null,
 } as DataJob;
 
 export const dataJob2 = {
@@ -1147,6 +1154,7 @@ export const dataJob2 = {
     domain: null,
     upstream: null,
     downstream: null,
+    deprecation: null,
 } as DataJob;
 
 export const dataJob3 = {
@@ -1209,6 +1217,7 @@ export const dataJob3 = {
     upstream: null,
     downstream: null,
     status: null,
+    deprecation: null,
 } as DataJob;
 
 export const mlModel = {
@@ -1284,6 +1293,7 @@ export const mlModel = {
     upstream: null,
     downstream: null,
     status: null,
+    deprecation: null,
 } as MlModel;
 
 export const mlModelGroup = {
@@ -1347,6 +1357,7 @@ export const mlModelGroup = {
     upstream: null,
     downstream: null,
     status: null,
+    deprecation: null,
 } as MlModelGroup;
 
 export const recommendationModules = [

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -24,6 +24,7 @@ import {
     Container,
     Health,
     Status,
+    Deprecation,
 } from '../../../types.generated';
 import { FetchedEntity } from '../../lineage/types';
 
@@ -73,6 +74,7 @@ export type GenericEntityProperties = {
     container?: Maybe<Container>;
     health?: Maybe<Health>;
     status?: Maybe<Status>;
+    deprecation?: Maybe<Deprecation>;
 };
 
 export type GenericEntityUpdate = {

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -47,6 +47,9 @@ query getChart($urn: String!) {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
         inputs: relationships(input: { types: ["Consumes"], direction: OUTGOING, start: 0, count: 100 }) {
             ...fullRelationshipResults
         }

--- a/datahub-web-react/src/graphql/container.graphql
+++ b/datahub-web-react/src/graphql/container.graphql
@@ -39,5 +39,8 @@ query getContainer($urn: String!) {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -38,6 +38,9 @@ fragment dataFlowFields on DataFlow {
     status {
         removed
     }
+    deprecation {
+        ...deprecationFields
+    }
 }
 
 query getDataFlow($urn: String!) {
@@ -79,6 +82,9 @@ query getDataFlow($urn: String!) {
                         }
                         glossaryTerms {
                             ...glossaryTerms
+                        }
+                        deprecation {
+                            ...deprecationFields
                         }
                     }
                 }

--- a/datahub-web-react/src/graphql/dataJob.graphql
+++ b/datahub-web-react/src/graphql/dataJob.graphql
@@ -28,6 +28,9 @@ query getDataJob($urn: String!) {
         status {
             removed
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -23,6 +23,13 @@ fragment glossaryTerms on GlossaryTerms {
     }
 }
 
+fragment deprecationFields on Deprecation {
+    actor
+    deprecated
+    note
+    decommissionTime
+}
+
 fragment ownershipFields on Ownership {
     owners {
         owner {
@@ -171,12 +178,6 @@ fragment nonRecursiveDatasetFields on Dataset {
             }
         }
     }
-    deprecation {
-        actor
-        deprecated
-        note
-        decommissionTime
-    }
     globalTags {
         ...globalTagsFields
     }
@@ -191,6 +192,9 @@ fragment nonRecursiveDatasetFields on Dataset {
     }
     container {
         ...entityContainer
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 
@@ -222,6 +226,9 @@ fragment nonRecursiveDataFlowFields on DataFlow {
     domain {
         ...entityDomain
     }
+    deprecation {
+        ...deprecationFields
+    }
 }
 
 fragment nonRecursiveDataJobFields on DataJob {
@@ -240,6 +247,9 @@ fragment nonRecursiveDataJobFields on DataJob {
     }
     domain {
         ...entityDomain
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 
@@ -287,6 +297,9 @@ fragment dataJobFields on DataJob {
     }
     domain {
         ...entityDomain
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 
@@ -336,6 +349,9 @@ fragment dashboardFields on Dashboard {
     status {
         removed
     }
+    deprecation {
+        ...deprecationFields
+    }
 }
 
 fragment nonRecursiveMLFeature on MLFeature {
@@ -372,6 +388,9 @@ fragment nonRecursiveMLFeature on MLFeature {
     }
     status {
         removed
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 
@@ -410,6 +429,9 @@ fragment nonRecursiveMLPrimaryKey on MLPrimaryKey {
     status {
         removed
     }
+    deprecation {
+        ...deprecationFields
+    }
 }
 
 fragment nonRecursiveMLFeatureTable on MLFeatureTable {
@@ -437,6 +459,9 @@ fragment nonRecursiveMLFeatureTable on MLFeatureTable {
     }
     status {
         removed
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 
@@ -553,6 +578,9 @@ fragment nonRecursiveMLModel on MLModel {
     status {
         removed
     }
+    deprecation {
+        ...deprecationFields
+    }
 }
 
 fragment nonRecursiveMLModelGroupFields on MLModelGroup {
@@ -569,6 +597,9 @@ fragment nonRecursiveMLModelGroupFields on MLModelGroup {
     }
     status {
         removed
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 
@@ -619,6 +650,9 @@ fragment entityContainer on Container {
     }
     subTypes {
         typeNames
+    }
+    deprecation {
+        ...deprecationFields
     }
 }
 

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -49,5 +49,8 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
         schemaMetadata(version: 0) {
             ...schemaMetadataFields
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/mutations.graphql
+++ b/datahub-web-react/src/graphql/mutations.graphql
@@ -45,3 +45,7 @@ mutation unsetDomain($entityUrn: String!) {
 mutation setTagColor($urn: String!, $colorHex: String!) {
     setTagColor(urn: $urn, colorHex: $colorHex)
 }
+
+mutation updateDeprecation($input: UpdateDeprecationInput!) {
+    updateDeprecation(input: $input)
+}

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -35,6 +35,9 @@ fragment entityPreview on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on CorpUser {
         username
@@ -94,6 +97,9 @@ fragment entityPreview on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on Chart {
         urn
@@ -128,6 +134,9 @@ fragment entityPreview on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on DataFlow {
         urn
@@ -158,6 +167,9 @@ fragment entityPreview on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on DataJob {
         urn
@@ -185,6 +197,9 @@ fragment entityPreview on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on GlossaryTerm {
         name
@@ -200,6 +215,9 @@ fragment entityPreview on Entity {
                 key
                 value
             }
+        }
+        deprecation {
+            ...deprecationFields
         }
     }
     ... on MLFeatureTable {
@@ -222,6 +240,9 @@ fragment entityPreview on Entity {
         platform {
             ...platformFields
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on MLModel {
         name
@@ -233,6 +254,9 @@ fragment entityPreview on Entity {
         platform {
             ...platformFields
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on MLModelGroup {
         name
@@ -243,6 +267,9 @@ fragment entityPreview on Entity {
         }
         platform {
             ...platformFields
+        }
+        deprecation {
+            ...deprecationFields
         }
     }
     ... on Tag {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -61,6 +61,9 @@ fragment searchResultFields on Entity {
         container {
             ...entityContainer
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on CorpUser {
         username
@@ -133,6 +136,9 @@ fragment searchResultFields on Entity {
         container {
             ...entityContainer
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on Chart {
         urn
@@ -170,6 +176,9 @@ fragment searchResultFields on Entity {
         container {
             ...entityContainer
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on DataFlow {
         urn
@@ -200,6 +209,9 @@ fragment searchResultFields on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on DataJob {
         urn
@@ -227,6 +239,9 @@ fragment searchResultFields on Entity {
         domain {
             ...entityDomain
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on GlossaryTerm {
         name
@@ -242,6 +257,9 @@ fragment searchResultFields on Entity {
                 key
                 value
             }
+        }
+        deprecation {
+            ...deprecationFields
         }
     }
     ... on Domain {
@@ -287,6 +305,9 @@ fragment searchResultFields on Entity {
         container {
             ...entityContainer
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on MLFeatureTable {
         urn
@@ -308,6 +329,9 @@ fragment searchResultFields on Entity {
         platform {
             ...platformFields
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on MLModel {
         name
@@ -319,6 +343,9 @@ fragment searchResultFields on Entity {
         platform {
             ...platformFields
         }
+        deprecation {
+            ...deprecationFields
+        }
     }
     ... on MLModelGroup {
         name
@@ -329,6 +356,9 @@ fragment searchResultFields on Entity {
         }
         platform {
             ...platformFields
+        }
+        deprecation {
+            ...deprecationFields
         }
     }
     ... on Tag {


### PR DESCRIPTION
- GraphQL queries for fetching deprecation status for each entity type inside the UI. Next: displaying it!


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)