### PR TITLE
feat(search): Only reindex if the mappings for an existing field changed

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -86,7 +86,8 @@ public class ESIndexBuilder {
       return;
     }
 
-    // If there are no updates to settings, and there are only pure additions to mappings (no updates to existing fields), there is no need to reindex. Just update mappings
+    // If there are no updates to settings, and there are only pure additions to mappings (no updates to existing fields),
+    // there is no need to reindex. Just update mappings
     if (isSettingsEqual && isPureAddition(mappingsDiff)) {
       log.info("New fields have been added to index {}. Updating index in place", indexName);
       PutMappingRequest request = new PutMappingRequest(indexName).source(mappings);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -27,10 +27,12 @@ import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.PutMappingRequest;
 import org.elasticsearch.client.tasks.TaskSubmissionResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.ReindexRequest;
+
 
 @Slf4j
 @RequiredArgsConstructor
@@ -68,21 +70,32 @@ public class ESIndexBuilder {
         .get()
         .getSourceAsMap();
 
-    MapDifference<String, Object> mappingsDiff = Maps.difference(mappings, oldMappings);
+    MapDifference<String, Object> mappingsDiff = Maps.difference((Map<String, Object>) oldMappings.get("properties"),
+        (Map<String, Object>) mappings.get("properties"));
 
     Settings oldSettings = searchClient.indices()
         .getSettings(new GetSettingsRequest().indices(indexName), RequestOptions.DEFAULT)
         .getIndexToSettings()
         .valuesIt()
         .next();
+    boolean isSettingsEqual = equals(finalSettings, oldSettings);
 
-    // If there are no updates to mappings, return
-    if (mappingsDiff.areEqual() && equals(finalSettings, oldSettings)) {
+    // If there are no updates to mappings and settings, return
+    if (mappingsDiff.areEqual() && isSettingsEqual) {
       log.info("No updates to index {}", indexName);
       return;
     }
 
-    if (!mappingsDiff.areEqual()) {
+    // If there are no updates to settings, and there are only pure additions to mappings (no updates to existing fields), there is no need to reindex. Just update mappings
+    if (isSettingsEqual && isPureAddition(mappingsDiff)) {
+      log.info("New fields have been added to index {}. Updating index in place", indexName);
+      PutMappingRequest request = new PutMappingRequest(indexName).source(mappings);
+      searchClient.indices().putMapping(request, RequestOptions.DEFAULT);
+      log.info("Updated index {} with new mappings", indexName);
+      return;
+    }
+
+    if (!mappingsDiff.entriesDiffering().isEmpty()) {
       log.info("There's diff between new mappings (left) and old mappings (right): {}", mappingsDiff.toString());
     } else {
       log.info("There's an update to settings");
@@ -92,7 +105,8 @@ public class ESIndexBuilder {
     createIndex(tempIndexName, mappings, finalSettings);
     try {
       TaskSubmissionResponse reindexTask;
-      reindexTask = searchClient.submitReindexTask(new ReindexRequest().setSourceIndices(indexName).setDestIndex(tempIndexName),
+      reindexTask =
+          searchClient.submitReindexTask(new ReindexRequest().setSourceIndices(indexName).setDestIndex(tempIndexName),
               RequestOptions.DEFAULT);
 
       // wait up to 5 minutes for the task to complete
@@ -105,18 +119,21 @@ public class ESIndexBuilder {
         ListTasksRequest request = new ListTasksRequest();
         ListTasksResponse tasks = searchClient.tasks().list(request, RequestOptions.DEFAULT);
         if (tasks.getTasks().stream().noneMatch(task -> task.getTaskId().toString().equals(reindexTask.getTask()))) {
-          log.info("Reindexing {} to {} task has completed, will now check if reindex was successful", indexName, tempIndexName);
+          log.info("Reindexing {} to {} task has completed, will now check if reindex was successful", indexName,
+              tempIndexName);
           reindexTaskCompleted = true;
           break;
         }
         try {
           Thread.sleep(5000);
         } catch (InterruptedException e) {
-          log.info("Trouble sleeping while reindexing {} to {}: Exception {}. Retrying...", indexName, tempIndexName, e.toString());
+          log.info("Trouble sleeping while reindexing {} to {}: Exception {}. Retrying...", indexName, tempIndexName,
+              e.toString());
         }
       }
       if (!reindexTaskCompleted) {
-        throw new RuntimeException(String.format("Reindex from %s to %s failed-- task exceeded 60 minute limit", indexName, tempIndexName));
+        throw new RuntimeException(
+            String.format("Reindex from %s to %s failed-- task exceeded 60 minute limit", indexName, tempIndexName));
       }
     } catch (Exception e) {
       log.info("Failed to reindex {} to {}: Exception {}", indexName, tempIndexName, e.toString());
@@ -187,6 +204,11 @@ public class ESIndexBuilder {
     log.info("Created index {}", indexName);
   }
 
+  private boolean isPureAddition(MapDifference<String, Object> mapDifference) {
+    return !mapDifference.areEqual() && mapDifference.entriesDiffering().isEmpty()
+        && !mapDifference.entriesOnlyOnRight().isEmpty();
+  }
+
   private boolean equals(Map<String, Object> newSettings, Settings oldSettings) {
     if (!newSettings.containsKey("index")) {
       return true;
@@ -212,6 +234,11 @@ public class ESIndexBuilder {
     }
 
     for (String key : newSettings.keySet()) {
+      // Skip urn stop filter, as adding new entities will cause this filter to change
+      // No need to reindex every time a new entity is added
+      if (key.equals("urn_stop_filter")) {
+        continue;
+      }
       if (newSettings.get(key) instanceof Map) {
         if (!equalsGroup((Map<String, Object>) newSettings.get(key), oldSettings.getByPrefix(key + "."))) {
           return false;


### PR DESCRIPTION
Currently, everytime mappings or settings for a given entity updates, we reindex the whole search index. This has led to us reindexing huge indices every time a new searchable field has been added to the model. This is very unnecessary.

There have been two sources of diffs
a) a new searchable field causes mappings diff
b) a new entity causes changes in urn stop filters (which adds the list of entities to the list of stop words to remove when indexing urns)

This PR aims to make sure we do not reindex on the above two cases. Reindex will only happen when a mappings for an existing field needs to change. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)