### PR TITLE
Deprecate an entity

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/AddDeprecatedDataModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/AddDeprecatedDataModal.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Button, DatePicker, Form, Input, message, Modal } from 'antd';
+import { useUpdateDeprecationMutation } from '../../../../../../graphql/mutations.generated';
+
+type Props = {
+    urn: string;
+    visible: boolean;
+    onClose: () => void;
+    refetch?: () => Promise<any>;
+};
+
+export const AddDeprecatedDataModal = ({ urn, visible, onClose, refetch }: Props) => {
+    const [updateDeprecation] = useUpdateDeprecationMutation();
+    const [form] = Form.useForm();
+
+    const handleClose = () => {
+        form.resetFields();
+        onClose();
+    };
+
+    const handleAdd = async (formData: any) => {
+        message.loading({ content: 'Updating...' });
+        try {
+            await updateDeprecation({
+                variables: {
+                    input: {
+                        urn,
+                        deprecated: true,
+                        note: formData.note,
+                        decommissionTime: formData.decommissionTime && formData.decommissionTime.unix(),
+                    },
+                },
+            });
+            message.destroy();
+            message.success({ content: 'Deprecation Updated', duration: 2 });
+        } catch (e: unknown) {
+            message.destroy();
+            if (e instanceof Error) {
+                message.error({ content: `Failed to update Deprecation: \n ${e.message || ''}`, duration: 2 });
+            }
+        }
+        refetch?.();
+        handleClose();
+    };
+
+    return (
+        <Modal
+            title="Add Deprecation Data"
+            visible={visible}
+            onCancel={handleClose}
+            keyboard
+            footer={
+                <>
+                    <Button onClick={handleClose} type="text">
+                        Cancel
+                    </Button>
+                    <Button form="addDeprecationForm" key="submit" htmlType="submit">
+                        Add
+                    </Button>
+                </>
+            }
+        >
+            <Form form={form} name="addDeprecationForm" onFinish={handleAdd} layout="vertical">
+                <Form.Item name="note" label="Note">
+                    <Input placeholder="Add Note" autoFocus />
+                </Form.Item>
+                <Form.Item name="decommissionTime" label="Decommission Time">
+                    <DatePicker showTime style={{ width: '100%' }} />
+                </Form.Item>
+            </Form>
+        </Modal>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/AddDeprecationDetailsModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/AddDeprecationDetailsModal.tsx
@@ -61,7 +61,7 @@ export const AddDeprecationDetailsModal = ({ urn, visible, onClose, refetch }: P
             }
         >
             <Form form={form} name="addDeprecationForm" onFinish={handleOk} layout="vertical">
-                <Form.Item name="note" label="Note">
+                <Form.Item name="note" label="Note" rules={[{ whitespace: true }, { min: 0, max: 100 }]}>
                     <Input placeholder="Add Note" autoFocus />
                 </Form.Item>
                 <Form.Item name="decommissionTime" label="Decommission Date">

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/AddDeprecationDetailsModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/AddDeprecationDetailsModal.tsx
@@ -9,7 +9,7 @@ type Props = {
     refetch?: () => Promise<any>;
 };
 
-export const AddDeprecatedDataModal = ({ urn, visible, onClose, refetch }: Props) => {
+export const AddDeprecationDetailsModal = ({ urn, visible, onClose, refetch }: Props) => {
     const [updateDeprecation] = useUpdateDeprecationMutation();
     const [form] = Form.useForm();
 
@@ -18,7 +18,7 @@ export const AddDeprecatedDataModal = ({ urn, visible, onClose, refetch }: Props
         onClose();
     };
 
-    const handleAdd = async (formData: any) => {
+    const handleOk = async (formData: any) => {
         message.loading({ content: 'Updating...' });
         try {
             await updateDeprecation({
@@ -45,7 +45,7 @@ export const AddDeprecatedDataModal = ({ urn, visible, onClose, refetch }: Props
 
     return (
         <Modal
-            title="Add Deprecation Data"
+            title="Add Deprecation Details"
             visible={visible}
             onCancel={handleClose}
             keyboard
@@ -55,17 +55,17 @@ export const AddDeprecatedDataModal = ({ urn, visible, onClose, refetch }: Props
                         Cancel
                     </Button>
                     <Button form="addDeprecationForm" key="submit" htmlType="submit">
-                        Add
+                        Ok
                     </Button>
                 </>
             }
         >
-            <Form form={form} name="addDeprecationForm" onFinish={handleAdd} layout="vertical">
+            <Form form={form} name="addDeprecationForm" onFinish={handleOk} layout="vertical">
                 <Form.Item name="note" label="Note">
                     <Input placeholder="Add Note" autoFocus />
                 </Form.Item>
-                <Form.Item name="decommissionTime" label="Decommission Time">
-                    <DatePicker showTime style={{ width: '100%' }} />
+                <Form.Item name="decommissionTime" label="Decommission Date">
+                    <DatePicker style={{ width: '100%' }} />
                 </Form.Item>
             </Form>
         </Modal>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -216,8 +216,8 @@ export const EntityHeader = () => {
     const lastEvaluatedAt = new Date();
     const lastEvaluatedTimeLocal =
         (lastEvaluatedAt &&
-            `Last evaluated on ${lastEvaluatedAt.toLocaleDateString()} at ${lastEvaluatedAt.toLocaleTimeString()} (${localeTimezone})`) ||
-        'No evaluations found';
+            `Scheduled to be decommissioned at ${lastEvaluatedAt.toLocaleDateString()} , ${lastEvaluatedAt.toLocaleTimeString()} (${localeTimezone})`) ||
+        'No decommissioned found';
     const lastEvaluatedTimeGMT = lastEvaluatedAt && lastEvaluatedAt.toUTCString();
 
     return (
@@ -268,9 +268,7 @@ export const EntityHeader = () => {
                             <Typography.Text type="secondary">
                                 {entityData?.deprecation?.decommissionTime === null ? (
                                     <Tooltip placement="right" title={lastEvaluatedTimeGMT}>
-                                        <LastEvaluatedAtLabel>
-                                            Scheduled to be decommissioned at {lastEvaluatedTimeLocal}
-                                        </LastEvaluatedAtLabel>
+                                        <LastEvaluatedAtLabel>{lastEvaluatedTimeLocal}</LastEvaluatedAtLabel>
                                     </Tooltip>
                                 ) : (
                                     'No Decommission Time'

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -141,6 +141,11 @@ const LastEvaluatedAtLabel = styled.div`
     color: ${ANTD_GRAY[7]};
 `;
 
+const Divider = styled.div`
+    border-top: 1px solid #f0f0f0;
+    padding-top: 5px;
+`;
+
 export const EntityHeader = () => {
     const { urn, entityType, entityData } = useEntityData();
     const [updateDeprecation] = useUpdateDeprecationMutation();
@@ -225,6 +230,9 @@ export const EntityHeader = () => {
         entityData?.deprecation?.decommissionTime &&
         moment.unix(entityData?.deprecation?.decommissionTime).utc().format('dddd, DD/MMM/YYYY HH:mm:ss z');
 
+    const hasDetails = entityData?.deprecation?.note !== '' || entityData?.deprecation?.decommissionTime !== null;
+    const isDividerNeeded = entityData?.deprecation?.note !== '' && entityData?.deprecation?.decommissionTime !== null;
+
     return (
         <>
             <HeaderContainer>
@@ -266,48 +274,38 @@ export const EntityHeader = () => {
                         <Link to={entityPath}>
                             <EntityTitle level={3}>{entityData?.name || ' '}</EntityTitle>
                         </Link>
-                        {entityData?.deprecation?.deprecated &&
-                            (entityData?.deprecation?.note !== '' ||
-                                entityData?.deprecation?.decommissionTime !== null) && (
-                                <Popover
-                                    overlayStyle={{ maxWidth: 240 }}
-                                    placement="right"
-                                    content={
+                        {entityData?.deprecation?.deprecated && (
+                            <Popover
+                                overlayStyle={{ maxWidth: 240 }}
+                                placement="right"
+                                content={
+                                    hasDetails ? (
                                         <>
                                             {entityData?.deprecation?.note !== '' && (
                                                 <Typography.Text>{entityData?.deprecation?.note}</Typography.Text>
                                             )}
+                                            {isDividerNeeded && <Divider />}
                                             {entityData?.deprecation?.decommissionTime !== null && (
                                                 <Typography.Text type="secondary">
                                                     <Tooltip placement="right" title={decommissionTimeGMT}>
-                                                        <LastEvaluatedAtLabel
-                                                            style={{
-                                                                borderTop: '1px solid #f0f0f0',
-                                                                paddingTop: '5px',
-                                                            }}
-                                                        >
+                                                        <LastEvaluatedAtLabel>
                                                             {decommissionTimeLocal}
                                                         </LastEvaluatedAtLabel>
                                                     </Tooltip>
                                                 </Typography.Text>
                                             )}
                                         </>
-                                    }
-                                >
-                                    <DeprecatedContainer>
-                                        <InfoCircleOutlined />
-                                        <DeprecatedText>Deprecated</DeprecatedText>
-                                    </DeprecatedContainer>
-                                </Popover>
-                            )}
-                        {entityData?.deprecation?.deprecated &&
-                            entityData?.deprecation?.decommissionTime === null &&
-                            entityData?.deprecation?.note === '' && (
+                                    ) : (
+                                        'No additional details'
+                                    )
+                                }
+                            >
                                 <DeprecatedContainer>
                                     <InfoCircleOutlined />
                                     <DeprecatedText>Deprecated</DeprecatedText>
                                 </DeprecatedContainer>
-                            )}
+                            </Popover>
+                        )}
                         {entityData?.health && (
                             <EntityHealthStatus
                                 status={entityData?.health.status}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -16,7 +16,7 @@ import analytics, { EventType, EntityActionType } from '../../../../../analytics
 import { EntityHealthStatus } from './EntityHealthStatus';
 import { useUpdateDeprecationMutation } from '../../../../../../graphql/mutations.generated';
 import { getLocaleTimezone } from '../../../../../shared/time/timeUtils';
-import { AddDeprecatedDataModal } from './AddDeprecatedDataModal';
+import { AddDeprecationDetailsModal } from './AddDeprecationDetailsModal';
 
 const LogoContainer = styled.span`
     margin-right: 10px;
@@ -144,7 +144,7 @@ const LastEvaluatedAtLabel = styled.div`
 export const EntityHeader = () => {
     const { urn, entityType, entityData } = useEntityData();
     const [updateDeprecation] = useUpdateDeprecationMutation();
-    const [showAddDeprecatedDataModal, setShowAddDeprecatedDataModal] = useState(false);
+    const [showAddDeprecationDetailsModal, setShowAddDeprecationDetailsModal] = useState(false);
     const refetch = useRefetch();
     const entityRegistry = useEntityRegistry();
     const [copiedUrn, setCopiedUrn] = useState(false);
@@ -201,7 +201,7 @@ export const EntityHeader = () => {
         <Menu>
             <Menu.Item key="0">
                 {!entityData?.deprecation?.deprecated ? (
-                    <MenuItem onClick={() => setShowAddDeprecatedDataModal(true)}>Mark as deprecated</MenuItem>
+                    <MenuItem onClick={() => setShowAddDeprecationDetailsModal(true)}>Mark as deprecated</MenuItem>
                 ) : (
                     <MenuItem onClick={() => handleUpdateDeprecation(false)}>Mark as un-deprecated</MenuItem>
                 )}
@@ -266,31 +266,48 @@ export const EntityHeader = () => {
                         <Link to={entityPath}>
                             <EntityTitle level={3}>{entityData?.name || ' '}</EntityTitle>
                         </Link>
-                        {entityData?.deprecation?.deprecated && entityData?.deprecation?.decommissionTime !== null && (
-                            <Popover
-                                overlayStyle={{ maxWidth: 240 }}
-                                placement="right"
-                                title={entityData?.deprecation?.note}
-                                content={
-                                    <Typography.Text type="secondary">
-                                        <Tooltip placement="right" title={decommissionTimeGMT}>
-                                            <LastEvaluatedAtLabel>{decommissionTimeLocal}</LastEvaluatedAtLabel>
-                                        </Tooltip>
-                                    </Typography.Text>
-                                }
-                            >
+                        {entityData?.deprecation?.deprecated &&
+                            (entityData?.deprecation?.note !== '' ||
+                                entityData?.deprecation?.decommissionTime !== null) && (
+                                <Popover
+                                    overlayStyle={{ maxWidth: 240 }}
+                                    placement="right"
+                                    content={
+                                        <>
+                                            {entityData?.deprecation?.note !== '' && (
+                                                <Typography.Text>{entityData?.deprecation?.note}</Typography.Text>
+                                            )}
+                                            {entityData?.deprecation?.decommissionTime !== null && (
+                                                <Typography.Text type="secondary">
+                                                    <Tooltip placement="right" title={decommissionTimeGMT}>
+                                                        <LastEvaluatedAtLabel
+                                                            style={{
+                                                                borderTop: '1px solid #f0f0f0',
+                                                                paddingTop: '5px',
+                                                            }}
+                                                        >
+                                                            {decommissionTimeLocal}
+                                                        </LastEvaluatedAtLabel>
+                                                    </Tooltip>
+                                                </Typography.Text>
+                                            )}
+                                        </>
+                                    }
+                                >
+                                    <DeprecatedContainer>
+                                        <InfoCircleOutlined />
+                                        <DeprecatedText>Deprecated</DeprecatedText>
+                                    </DeprecatedContainer>
+                                </Popover>
+                            )}
+                        {entityData?.deprecation?.deprecated &&
+                            entityData?.deprecation?.decommissionTime === null &&
+                            entityData?.deprecation?.note === '' && (
                                 <DeprecatedContainer>
                                     <InfoCircleOutlined />
                                     <DeprecatedText>Deprecated</DeprecatedText>
                                 </DeprecatedContainer>
-                            </Popover>
-                        )}
-                        {entityData?.deprecation?.deprecated && entityData?.deprecation?.decommissionTime === null && (
-                            <DeprecatedContainer>
-                                <InfoCircleOutlined />
-                                <DeprecatedText>Deprecated</DeprecatedText>
-                            </DeprecatedContainer>
-                        )}
+                            )}
                         {entityData?.health && (
                             <EntityHealthStatus
                                 status={entityData?.health.status}
@@ -317,11 +334,11 @@ export const EntityHeader = () => {
                     <MenuIcon />
                 </Dropdown>
             </HeaderContainer>
-            <AddDeprecatedDataModal
-                visible={showAddDeprecatedDataModal}
+            <AddDeprecationDetailsModal
+                visible={showAddDeprecationDetailsModal}
                 urn={urn}
                 onClose={() => {
-                    setShowAddDeprecatedDataModal(false);
+                    setShowAddDeprecationDetailsModal(false);
                 }}
                 refetch={refetch}
             />

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -257,9 +257,11 @@ export const EntityHeader = () => {
                     }}
                 />
             </Tooltip>
-            <Dropdown overlay={menu} trigger={['click']}>
-                <MenuIcon />
-            </Dropdown>
+            {!entityData?.deprecation?.deprecated && (
+                <Dropdown overlay={menu} trigger={['click']}>
+                    <MenuIcon />
+                </Dropdown>
+            )}
         </HeaderContainer>
     );
 };


### PR DESCRIPTION
Added a button to "deprecate" an entity from inside of the UI from the following entity profile page: dataset, chart, dashboard, data flow, data job, container, glossary term

![deprecate_entity](https://user-images.githubusercontent.com/86347578/162778437-44fb5b05-25ee-4ccc-b35a-25b0b50a03b5.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)