### PR TITLE
feat(graphQL): support versioned aspect queries for timeline aspects

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/AspectResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/AspectResolver.java
@@ -17,11 +17,21 @@ import org.dataloader.DataLoader;
  *
  */
 public class AspectResolver implements DataFetcher<CompletableFuture<Aspect>> {
+    private final String fieldNameOverride;
+
+    public AspectResolver() {
+        fieldNameOverride = null;
+    }
+
+    public AspectResolver(String fieldNameOverride) {
+        this.fieldNameOverride = fieldNameOverride;
+    }
+
     @Override
     public CompletableFuture<Aspect> get(DataFetchingEnvironment environment) {
         final DataLoader<VersionedAspectKey, Aspect> loader = environment.getDataLoaderRegistry().getDataLoader("Aspect");
-        final String fieldName = environment.getField().getName();
-        final Long version = environment.getArgument("version");
+        final String fieldName = fieldNameOverride != null ? fieldNameOverride : environment.getField().getName();
+        final Long version = environment.containsArgument("version") ? environment.getArgument("version") : 0L;
         final String urn = ((Entity) environment.getSource()).getUrn();
         return loader.load(new VersionedAspectKey(urn, fieldName, version));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/aspect/AspectMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/aspect/AspectMapper.java
@@ -1,26 +1,106 @@
 package com.linkedin.datahub.graphql.types.aspect;
 
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.GlossaryTerms;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.Ownership;
+import com.linkedin.datahub.graphql.VersionedAspectKey;
 import com.linkedin.datahub.graphql.generated.Aspect;
+import com.linkedin.datahub.graphql.generated.DatasetEditableProperties;
+import com.linkedin.datahub.graphql.generated.FabricType;
+import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
+import com.linkedin.datahub.graphql.types.dataset.mappers.EditableSchemaMetadataMapper;
 import com.linkedin.datahub.graphql.types.dataset.mappers.SchemaMetadataMapper;
+import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
+import com.linkedin.dataset.DatasetProperties;
+import com.linkedin.dataset.EditableDatasetProperties;
+import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
-import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.DatasetKey;
+import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.schema.EditableSchemaMetadata;
+import com.linkedin.util.Pair;
 import javax.annotation.Nonnull;
 
+import static com.linkedin.metadata.Constants.*;
 
-public class AspectMapper implements ModelMapper<EnvelopedAspect, Aspect> {
+
+public class AspectMapper implements ModelMapper<Pair<VersionedAspectKey, EntityResponse>, Aspect> {
 
   public static final AspectMapper INSTANCE = new AspectMapper();
 
-  public static Aspect map(@Nonnull final EnvelopedAspect aspect) {
-    return INSTANCE.apply(aspect);
+  public static Aspect map(@Nonnull final Pair<VersionedAspectKey, EntityResponse> responsePair) {
+    return INSTANCE.apply(responsePair);
   }
 
   @Override
-  public Aspect apply(@Nonnull final EnvelopedAspect aspect) {
-    if (Constants.SCHEMA_METADATA_ASPECT_NAME.equals(aspect.getName())) {
-      return SchemaMetadataMapper.map(aspect);
+  public Aspect apply(@Nonnull final Pair<VersionedAspectKey, EntityResponse> responsePair) {
+    EntityResponse response = responsePair.getSecond();
+    EnvelopedAspect aspect = response.getAspects().get(responsePair.getFirst().getAspectName());
+    switch (aspect.getName()) {
+      case SCHEMA_METADATA_ASPECT_NAME:
+        return SchemaMetadataMapper.map(aspect);
+      case GLOBAL_TAGS_ASPECT_NAME:
+        com.linkedin.datahub.graphql.generated.GlobalTags globalTags = GlobalTagsMapper
+            .map(new GlobalTags(aspect.getValue().data()));
+        globalTags.setVersion(aspect.getVersion());
+        return globalTags;
+      case GLOSSARY_TERMS_ASPECT_NAME:
+        com.linkedin.datahub.graphql.generated.GlossaryTerms glossaryTerms = GlossaryTermsMapper
+            .map(new GlossaryTerms(aspect.getValue().data()));
+        glossaryTerms.setVersion(aspect.getVersion());
+        return glossaryTerms;
+      case DATASET_PROPERTIES_ASPECT_NAME:
+        return mapDatasetProperties(response, aspect);
+      case EDITABLE_DATASET_PROPERTIES_ASPECT_NAME:
+        DatasetEditableProperties datasetEditableProperties = new DatasetEditableProperties();
+        EditableDatasetProperties editableDatasetProperties = new EditableDatasetProperties(aspect.getValue().data());
+        datasetEditableProperties.setDescription(editableDatasetProperties.getDescription());
+        datasetEditableProperties.setVersion(aspect.getVersion());
+        return datasetEditableProperties;
+      case EDITABLE_SCHEMA_METADATA_ASPECT_NAME:
+        com.linkedin.datahub.graphql.generated.EditableSchemaMetadata editableSchemaMetadata = EditableSchemaMetadataMapper
+            .map(new EditableSchemaMetadata(aspect.getValue().data()));
+        editableSchemaMetadata.setVersion(aspect.getVersion());
+        return editableSchemaMetadata;
+      case INSTITUTIONAL_MEMORY_ASPECT_NAME:
+        com.linkedin.datahub.graphql.generated.InstitutionalMemory institutionalMemory = InstitutionalMemoryMapper
+            .map(new InstitutionalMemory(aspect.getValue().data()));
+        institutionalMemory.setVersion(aspect.getVersion());
+        return institutionalMemory;
+      case OWNERSHIP_ASPECT_NAME:
+        com.linkedin.datahub.graphql.generated.Ownership ownership = OwnershipMapper
+            .map(new Ownership(aspect.getValue().data()));
+        ownership.setVersion(aspect.getVersion());
+        return ownership;
+      default:
+        return null;
     }
-    return null;
+  }
+
+  private com.linkedin.datahub.graphql.generated.DatasetProperties mapDatasetProperties(EntityResponse response,
+      EnvelopedAspect aspect) {
+    DatasetKey datasetKey = (DatasetKey) EntityKeyUtils.convertUrnToEntityKey(response.getUrn(),
+        new DatasetKey().schema());
+    DatasetProperties datasetProperties = new DatasetProperties(aspect.getValue().data());
+    com.linkedin.datahub.graphql.generated.DatasetProperties graphQlProperties =
+        new com.linkedin.datahub.graphql.generated.DatasetProperties();
+    graphQlProperties.setOrigin(FabricType.valueOf(datasetKey.getOrigin().toString()));
+    graphQlProperties.setDescription(datasetProperties.getDescription());
+    if (datasetProperties.getExternalUrl() != null) {
+      graphQlProperties.setExternalUrl(datasetProperties.getExternalUrl().toString());
+    }
+    graphQlProperties.setCustomProperties(StringMapMapper.map(datasetProperties.getCustomProperties()));
+    if (datasetProperties.getName() != null) {
+      graphQlProperties.setName(datasetProperties.getName());
+    } else {
+      graphQlProperties.setName(datasetKey.getName());
+    }
+    graphQlProperties.setQualifiedName(datasetProperties.getQualifiedName());
+    return graphQlProperties;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -1,37 +1,24 @@
 package com.linkedin.datahub.graphql.types.dataset.mappers;
 
 import com.linkedin.common.Deprecation;
-import com.linkedin.common.GlobalTags;
-import com.linkedin.common.GlossaryTerms;
-import com.linkedin.common.InstitutionalMemory;
-import com.linkedin.common.Ownership;
 import com.linkedin.common.Status;
 import com.linkedin.data.DataMap;
 import com.linkedin.datahub.graphql.generated.Container;
 import com.linkedin.datahub.graphql.generated.DataPlatform;
 import com.linkedin.datahub.graphql.generated.Dataset;
-import com.linkedin.datahub.graphql.generated.DatasetEditableProperties;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FabricType;
 import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
-import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
-import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
-import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
-import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
-import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
 import com.linkedin.dataset.DatasetDeprecation;
-import com.linkedin.dataset.DatasetProperties;
-import com.linkedin.dataset.EditableDatasetProperties;
 import com.linkedin.dataset.ViewProperties;
 import com.linkedin.domain.Domains;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.metadata.key.DatasetKey;
-import com.linkedin.schema.EditableSchemaMetadata;
 import com.linkedin.schema.SchemaMetadata;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -62,24 +49,13 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
         EnvelopedAspectMap aspectMap = entityResponse.getAspects();
         MappingHelper<Dataset> mappingHelper = new MappingHelper<>(aspectMap, result);
         mappingHelper.mapToResult(DATASET_KEY_ASPECT_NAME, this::mapDatasetKey);
-        mappingHelper.mapToResult(DATASET_PROPERTIES_ASPECT_NAME, this::mapDatasetProperties);
         mappingHelper.mapToResult(DATASET_DEPRECATION_ASPECT_NAME, (dataset, dataMap) ->
             dataset.setDeprecation(DatasetDeprecationMapper.map(new DatasetDeprecation(dataMap))));
         mappingHelper.mapToResult(SCHEMA_METADATA_ASPECT_NAME, (dataset, dataMap) ->
             dataset.setSchema(SchemaMapper.map(new SchemaMetadata(dataMap))));
-        mappingHelper.mapToResult(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME, this::mapEditableDatasetProperties);
         mappingHelper.mapToResult(VIEW_PROPERTIES_ASPECT_NAME, this::mapViewProperties);
-        mappingHelper.mapToResult(INSTITUTIONAL_MEMORY_ASPECT_NAME, (dataset, dataMap) ->
-            dataset.setInstitutionalMemory(InstitutionalMemoryMapper.map(new InstitutionalMemory(dataMap))));
-        mappingHelper.mapToResult(OWNERSHIP_ASPECT_NAME, (dataset, dataMap) ->
-            dataset.setOwnership(OwnershipMapper.map(new Ownership(dataMap))));
         mappingHelper.mapToResult(STATUS_ASPECT_NAME, (dataset, dataMap) ->
             dataset.setStatus(StatusMapper.map(new Status(dataMap))));
-        mappingHelper.mapToResult(GLOBAL_TAGS_ASPECT_NAME, this::mapGlobalTags);
-        mappingHelper.mapToResult(EDITABLE_SCHEMA_METADATA_ASPECT_NAME, (dataset, dataMap) ->
-            dataset.setEditableSchemaMetadata(EditableSchemaMetadataMapper.map(new EditableSchemaMetadata(dataMap))));
-        mappingHelper.mapToResult(GLOSSARY_TERMS_ASPECT_NAME, (dataset, dataMap) ->
-            dataset.setGlossaryTerms(GlossaryTermsMapper.map(new GlossaryTerms(dataMap))));
         mappingHelper.mapToResult(CONTAINER_ASPECT_NAME, this::mapContainers);
         mappingHelper.mapToResult(DOMAINS_ASPECT_NAME, this::mapDomains);
         mappingHelper.mapToResult(DEPRECATION_ASPECT_NAME, (dataset, dataMap) ->
@@ -97,37 +73,6 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
             .setUrn(gmsKey.getPlatform().toString()).build());
     }
 
-    private void mapDatasetProperties(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
-        final DatasetProperties gmsProperties = new DatasetProperties(dataMap);
-        final com.linkedin.datahub.graphql.generated.DatasetProperties properties =
-            new com.linkedin.datahub.graphql.generated.DatasetProperties();
-        properties.setDescription(gmsProperties.getDescription());
-        dataset.setDescription(gmsProperties.getDescription());
-        properties.setOrigin(dataset.getOrigin());
-        if (gmsProperties.getExternalUrl() != null) {
-            properties.setExternalUrl(gmsProperties.getExternalUrl().toString());
-        }
-        properties.setCustomProperties(StringMapMapper.map(gmsProperties.getCustomProperties()));
-        if (gmsProperties.getName() != null) {
-            properties.setName(gmsProperties.getName());
-        } else {
-            properties.setName(dataset.getName());
-        }
-        properties.setQualifiedName(gmsProperties.getQualifiedName());
-        dataset.setProperties(properties);
-        dataset.setDescription(properties.getDescription());
-        if (gmsProperties.getUri() != null) {
-            dataset.setUri(gmsProperties.getUri().toString());
-        }
-    }
-
-    private void mapEditableDatasetProperties(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
-        final EditableDatasetProperties editableDatasetProperties = new EditableDatasetProperties(dataMap);
-        final DatasetEditableProperties editableProperties = new DatasetEditableProperties();
-        editableProperties.setDescription(editableDatasetProperties.getDescription());
-        dataset.setEditableProperties(editableProperties);
-    }
-
     private void mapViewProperties(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
         final ViewProperties properties = new ViewProperties(dataMap);
         final com.linkedin.datahub.graphql.generated.ViewProperties graphqlProperties =
@@ -136,12 +81,6 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
         graphqlProperties.setLanguage(properties.getViewLanguage());
         graphqlProperties.setLogic(properties.getViewLogic());
         dataset.setViewProperties(graphqlProperties);
-    }
-
-    private void mapGlobalTags(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
-        com.linkedin.datahub.graphql.generated.GlobalTags globalTags = GlobalTagsMapper.map(new GlobalTags(dataMap));
-        dataset.setGlobalTags(globalTags);
-        dataset.setTags(globalTags);
     }
 
     private void mapContainers(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -704,17 +704,17 @@ type Dataset implements EntityWithRelationships & Entity {
     """
     An additional set of read only properties
     """
-    properties: DatasetProperties
+    properties(version: Long): DatasetProperties
 
     """
     An additional set of of read write properties
     """
-    editableProperties: DatasetEditableProperties
+    editableProperties(version: Long): DatasetEditableProperties
 
     """
     Ownership metadata of the dataset
     """
-    ownership: Ownership
+    ownership(version: Long): Ownership
 
     """
     The deprecation status of the dataset
@@ -724,7 +724,7 @@ type Dataset implements EntityWithRelationships & Entity {
     """
     References to internal resources related to the dataset
     """
-    institutionalMemory: InstitutionalMemory
+    institutionalMemory(version: Long): InstitutionalMemory
 
     """
     Schema metadata of the dataset, available by version number
@@ -734,7 +734,7 @@ type Dataset implements EntityWithRelationships & Entity {
     """
     Editable schema metadata of the dataset
     """
-    editableSchemaMetadata: EditableSchemaMetadata
+    editableSchemaMetadata(version: Long): EditableSchemaMetadata
 
     """
     Status of the Dataset
@@ -744,12 +744,12 @@ type Dataset implements EntityWithRelationships & Entity {
     """
     Tags used for searching dataset
     """
-    tags: GlobalTags
+    tags(version: Long): GlobalTags
 
     """
     The structured glossary terms associated with the dataset
     """
-    glossaryTerms: GlossaryTerms
+    glossaryTerms(version: Long): GlossaryTerms
 
     """
     The Domain associated with the Dataset
@@ -833,7 +833,7 @@ type Dataset implements EntityWithRelationships & Entity {
     Deprecated, use tags field instead
     The structured tags associated with the dataset
     """
-    globalTags: GlobalTags @deprecated
+    globalTags(version: Long): GlobalTags @deprecated
 
     """
     Sub Types that this entity implements
@@ -907,7 +907,12 @@ type AspectRenderSpec {
 """
 Additional read only properties about a Dataset
 """
-type DatasetProperties {
+type DatasetProperties implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
 
     """
     The name of the dataset used in display
@@ -1520,7 +1525,13 @@ type DatasetDeprecation {
 """
 Institutional memory metadata, meaning internal links and pointers related to an Entity
 """
-type InstitutionalMemory {
+type InstitutionalMemory implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
+
     """
     List of records that represent the institutional memory or internal documentation of an entity
     """
@@ -1815,7 +1826,13 @@ type SchemaField {
 """
 Information about schema metadata that is editable via the UI
 """
-type EditableSchemaMetadata {
+type EditableSchemaMetadata implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
+
     """
     Editable schema field metadata
     """
@@ -1948,7 +1965,13 @@ type ViewProperties {
 Dataset properties that are editable via the UI This represents logical metadata,
 as opposed to technical metadata
 """
-type DatasetEditableProperties {
+type DatasetEditableProperties implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
+
     """
     Description of the Dataset
     """
@@ -2749,7 +2772,13 @@ type Owner {
 """
 Ownership information about a Metadata Entity
 """
-type Ownership {
+type Ownership implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
+
     """
     List of owners of the entity
     """
@@ -2860,7 +2889,13 @@ type TagAssociation {
 """
 Tags attached to a particular Metadata Entity
 """
-type GlobalTags {
+type GlobalTags implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
+
     """
     The set of tags attached to the Metadata Entity
     """
@@ -2877,8 +2912,14 @@ type VersionTag {
 """
 Glossary Terms attached to a particular Metadata Entity
 """
-type GlossaryTerms {
-     """
+type GlossaryTerms implements Aspect {
+    """
+    The logical version of the schema metadata, where zero represents the latest version
+    with otherwise monotonic ordering starting at one
+    """
+    version: Long
+
+    """
      The set of glossary terms attached to the Metadata Entity
      """
     terms: [GlossaryTermAssociation!]

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -213,7 +213,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 platformName={data.platform.properties?.displayName || data.platform.name}
                 platformLogo={data.platform.properties?.logoUrl}
                 owners={data.ownership?.owners}
-                globalTags={data.globalTags}
+                globalTags={data.tags}
                 glossaryTerms={data.glossaryTerms}
                 domain={data.domain}
                 container={data.container}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -179,6 +179,29 @@ public abstract class EntityService {
   }
 
   /**
+   * Retrieves the versioned aspects for the given set of urns as dynamic aspect objects
+   * (Without having to define union objects)
+   *
+   * @param entityName name of the entity to fetch
+   * @param urn urn to fetch
+   * @param aspectName aspect to fetch
+   * @param version version to fetch
+   * @return a map of {@link Urn} to {@link Entity} object
+   */
+  @Nullable
+  public EntityResponse getEntityVersionedAspectV2(
+      @Nonnull final String entityName,
+      @Nonnull final Urn urn,
+      @Nonnull final String aspectName,
+      final long version) {
+    EnvelopedAspect aspect = getEnvelopedAspect(entityName, urn, aspectName, version);
+    if (aspect == null) {
+      return null;
+    }
+    return toEntityResponse(urn, Collections.singletonList(aspect));
+  }
+
+  /**
    * Retrieves the latest aspects for the given set of urns as a list of enveloped aspects
    *
    * @param entityName name of the entity to fetch
@@ -217,7 +240,7 @@ public abstract class EntityService {
       @Nonnull final String entityName,
       @Nonnull final Urn urn,
       @Nonnull final String aspectName,
-      long version) throws Exception;
+      long version);
 
   /**
    * Retrieves an {@link VersionedAspect}, or null if one cannot be found.

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -9,6 +9,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.Status;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.data.template.JacksonDataTemplateCodec;
@@ -245,7 +246,7 @@ public class EbeanEntityService extends EntityService {
       @Nonnull String entityName,
       @Nonnull Urn urn,
       @Nonnull String aspectName,
-      long version) throws Exception {
+      long version) {
     log.debug(String.format("Invoked getEnvelopedAspect with entityName: %s, urn: %s, aspectName: %s, version: %s",
         entityName,
         urn,
@@ -705,7 +706,7 @@ public class EbeanEntityService extends EntityService {
     return result;
   }
 
-  private Map<EbeanAspectV2.PrimaryKey, EnvelopedAspect> getEnvelopedAspects(final Set<EbeanAspectV2.PrimaryKey> dbKeys) throws URISyntaxException {
+  private Map<EbeanAspectV2.PrimaryKey, EnvelopedAspect> getEnvelopedAspects(final Set<EbeanAspectV2.PrimaryKey> dbKeys) {
     final Map<EbeanAspectV2.PrimaryKey, EnvelopedAspect> result = new HashMap<>();
     final Map<EbeanAspectV2.PrimaryKey, EbeanAspectV2> dbEntries = _entityDao.batchGet(dbKeys);
 
@@ -726,7 +727,7 @@ public class EbeanEntityService extends EntityService {
       envelopedAspect.setVersion(currAspectEntry.getKey().getVersion());
       envelopedAspect.setValue(aspect);
       envelopedAspect.setCreated(new AuditStamp()
-          .setActor(Urn.createFromString(currAspectEntry.getCreatedBy()))
+          .setActor(UrnUtils.getUrn(currAspectEntry.getCreatedBy()))
           .setTime(currAspectEntry.getCreatedOn().getTime())
       );
       result.put(currKey, envelopedAspect);

--- a/metadata-service/restli-api/src/main/idl/com.linkedin.entity.entitiesV2.restspec.json
+++ b/metadata-service/restli-api/src/main/idl/com.linkedin.entity.entitiesV2.restspec.json
@@ -26,6 +26,23 @@
         "optional" : true
       } ]
     } ],
+    "actions" : [ {
+      "name" : "getVersionedEntity",
+      "parameters" : [ {
+        "name" : "entityType",
+        "type" : "string"
+      }, {
+        "name" : "urn",
+        "type" : "string"
+      }, {
+        "name" : "aspect",
+        "type" : "string"
+      }, {
+        "name" : "version",
+        "type" : "long"
+      } ],
+      "returns" : "com.linkedin.entity.EntityResponse"
+    } ],
     "entity" : {
       "path" : "/entitiesV2/{entitiesV2Id}"
     }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesV2.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesV2.snapshot.json
@@ -127,6 +127,23 @@
           "optional" : true
         } ]
       } ],
+      "actions" : [ {
+        "name" : "getVersionedEntity",
+        "parameters" : [ {
+          "name" : "entityType",
+          "type" : "string"
+        }, {
+          "name" : "urn",
+          "type" : "string"
+        }, {
+          "name" : "aspect",
+          "type" : "string"
+        }, {
+          "name" : "version",
+          "type" : "long"
+        } ],
+        "returns" : "com.linkedin.entity.EntityResponse"
+      } ],
       "entity" : {
         "path" : "/entitiesV2/{entitiesV2Id}"
       }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -274,6 +274,12 @@ public interface EntityClient {
       @Nonnull Long version, @Nonnull Class<T> aspectClass, @Nonnull Authentication authentication)
       throws RemoteInvocationException;
 
+  EntityResponse getVersionedEntity(@Nonnull final String entityName,
+      @Nonnull final Urn urn,
+      @Nonnull final String aspectName,
+      long version,
+      @Nonnull Authentication authentication) throws RemoteInvocationException;
+
   @Deprecated
   public DataMap getRawAspect(@Nonnull String urn, @Nonnull String aspect, @Nonnull Long version,
       @Nonnull Authentication authentication) throws RemoteInvocationException;

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -349,6 +349,15 @@ public class JavaEntityClient implements EntityClient {
         return _entityService.getVersionedAspect(Urn.createFromString(urn), aspect, version);
     }
 
+    @Override
+    public EntityResponse getVersionedEntity(@Nonnull final String entityName,
+        @Nonnull final Urn urn,
+        @Nonnull final String aspectName,
+        long version,
+        @Nonnull Authentication authentication) throws RemoteInvocationException {
+        return _entityService.getEntityVersionedAspectV2(entityName, urn, aspectName, version);
+    }
+
     @SneakyThrows
     @Override
     public VersionedAspect getAspectOrNull(@Nonnull String urn, @Nonnull String aspect, @Nonnull Long version,

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -28,6 +28,7 @@ import com.linkedin.entity.EntitiesDoSearchRequestBuilder;
 import com.linkedin.entity.EntitiesDoSetWritableRequestBuilder;
 import com.linkedin.entity.EntitiesRequestBuilders;
 import com.linkedin.entity.EntitiesV2BatchGetRequestBuilder;
+import com.linkedin.entity.EntitiesV2DoGetVersionedEntityRequestBuilder;
 import com.linkedin.entity.EntitiesV2GetRequestBuilder;
 import com.linkedin.entity.EntitiesV2RequestBuilders;
 import com.linkedin.entity.Entity;
@@ -587,6 +588,29 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     }
 
     return Optional.empty();
+  }
+
+  @Override
+  public EntityResponse getVersionedEntity(@Nonnull final String entityName,
+      @Nonnull final Urn urn,
+      @Nonnull final String aspectName,
+      long version,
+      @Nonnull Authentication authentication) throws RemoteInvocationException {
+    EntitiesV2DoGetVersionedEntityRequestBuilder requestBuilder =
+        ENTITIES_V2_REQUEST_BUILDERS.actionGetVersionedEntity().urnParam(urn.toString())
+            .aspectParam(aspectName).versionParam(version);
+
+    try {
+      return sendClientRequest(requestBuilder, authentication).getEntity();
+    } catch (RestLiResponseException e) {
+      if (e.getStatus() == 404) {
+        log.debug("Could not find aspect {} for entity {}", aspectName, urn);
+        return null;
+      } else {
+        // re-throw other exceptions
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   @SneakyThrows

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/restli/RestliConstants.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/restli/RestliConstants.java
@@ -34,4 +34,7 @@ public final class RestliConstants {
   public static final String PARAM_URNS = "urns";
   public static final String PARAM_MODE = "mode";
   public static final String PARAM_DIRECTION = "direction";
+  public static final String PARAM_ENTITY_TYPE = "entityType";
+  public static final String PARAM_ASPECT = "aspect";
+  public static final String PARAM_VERSION = "version";
 }

--- a/smoke-test/test_resources/timeline/test_timeline_all.sh
+++ b/smoke-test/test_resources/timeline/test_timeline_all.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+datahub delete --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --hard --force
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a institutionalMemory -d newdocumentation.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a institutionalMemory -d newdocumentationv2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a institutionalMemory -d newdocumentationv3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category documentation --start 10daysago --end 2682397800000 $1
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a editableDatasetProperties -d neweditableproperties.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a editableDatasetProperties -d neweditablepropertiesv2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a editableDatasetProperties -d neweditablepropertiesv3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category documentation --start 10daysago --end 2682397800000 $1
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a editableSchemaMetadata -d neweditableschemametadata.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a editableSchemaMetadata -d neweditableschemametadatav2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a editableSchemaMetadata -d neweditableschemametadatav3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category documentation --start 10daysago --end 2682397800000 $1
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a glossaryTerms -d newglossary.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a glossaryTerms -d newglossaryv2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a glossaryTerms -d newglossaryv3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category glossary_term --start 10daysago --end 2682397800000 $1
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a ownership -d newownership.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a ownership -d newownershipv2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a ownership -d newownershipv3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category ownership --start 10daysago --end 2682397800000
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a ownership -d ../ownership_v1.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a ownership -d ../ownership_v2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a ownership -d ../ownership_v3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category ownership --start 10daysago --end 2682397800000
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a datasetProperties -d newproperties.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a datasetProperties -d newpropertiesv2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a datasetProperties -d newpropertiesv3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category documentation --start 10daysago --end 2682397800000 $1
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a schemaMetadata -d newschema.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a schemaMetadata -d newschemav2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a schemaMetadata -d newschemav3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category technical_schema --start 10daysago --end 2682397800000 $1
+
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a globalTags -d newtags.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a globalTags -d newtagsv2.json
+datahub put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" -a globalTags -d newtagsv3.json
+datahub timeline --urn "urn:li:dataset:(urn:li:dataPlatform:hive,testTimelineDataset,PROD)" --category tag --start 10daysago --end 2682397800000 $1


### PR DESCRIPTION
Fixes versioned querying for SchemaMetadata and updates the query for Dataset to support versioning for all aspects returned for the Timeline API. This is supporting work for the Schema Version History UI.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable) - N/A
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same. - N/A
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md) - N/A