### PR TITLE
fix(tableau): avoid duplicate schema in URNs for upstream tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -272,11 +272,15 @@ class TableauSource(Source):
                     table.get("connectionType", ""), table.get("id", "")
                 )
             )
-            schema = self._get_schema(
-                schema, upstream_db, full_name
-            )
+            schema = self._get_schema(schema, upstream_db, full_name)
             # if the schema is included within the table name we omit it
-            if schema and table_name and full_name and table_name == full_name and schema in table_name:
+            if (
+                schema
+                and table_name
+                and full_name
+                and table_name == full_name
+                and schema in table_name
+            ):
                 schema = ""
             table_urn = make_table_urn(
                 self.config.env,


### PR DESCRIPTION
## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

I've found that the URN of the redshift upstream tables have the schema duplicated. I tried the ingestion after [this PR](https://github.com/datahub-project/datahub/pull/4609) hoping it would be fixed but we still have the same issue.

Turns out that the upstream tables name and full name both contain already the schema, so we are duplicating it. With this PR we check if there is a schema, the name and the full name are equal and the schema is already contained within the name.