### PR TITLE
fix(ingestion): add missing workunit ids

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -72,7 +72,6 @@ class DatahubRestSink(Sink):
         if isinstance(workunit, MetadataWorkUnit):
             mwu: MetadataWorkUnit = cast(MetadataWorkUnit, workunit)
             self.treat_errors_as_warnings = mwu.treat_errors_as_warnings
-        pass
 
     def handle_work_unit_end(self, workunit: WorkUnit) -> None:
         pass

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -302,6 +302,7 @@ class KafkaSource(StatefulIngestionSourceBase):
                 aspect=SubTypesClass(typeNames=["topic"]),
             ),
         )
+        self.report.report_workunit(subtype_wu)
         yield subtype_wu
 
         domain_urn: Optional[str] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -893,6 +893,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
                 id=f"{self.platform}-{lineage_mcpw.entityUrn}-{lineage_mcpw.aspectName}",
                 mcp=lineage_mcpw,
             )
+            self.report.report_workunit(lineage_wu)
             yield lineage_wu
 
         pk_constraints: dict = inspector.get_pk_constraint(table, schema)
@@ -927,6 +928,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
                 aspect=SubTypesClass(typeNames=["table"]),
             ),
         )
+        self.report.report_workunit(subtypes_aspect)
         yield subtypes_aspect
 
         yield from self._get_domain_wu(
@@ -1182,13 +1184,14 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
                 aspect=SubTypesClass(typeNames=["view"]),
             ),
         )
+        self.report.report_workunit(subtypes_aspect)
         yield subtypes_aspect
         if "view_definition" in properties:
             view_definition_string = properties["view_definition"]
             view_properties_aspect = ViewPropertiesClass(
                 materialized=False, viewLanguage="SQL", viewLogic=view_definition_string
             )
-            yield MetadataWorkUnit(
+            view_properties_wu = MetadataWorkUnit(
                 id=f"{view}-viewProperties",
                 mcp=MetadataChangeProposalWrapper(
                     entityType="dataset",
@@ -1198,6 +1201,8 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
                     aspect=view_properties_aspect,
                 ),
             )
+            self.report.report_workunit(view_properties_wu)
+            yield view_properties_wu
 
         yield from self._get_domain_wu(
             dataset_name=dataset_name,


### PR DESCRIPTION
Noticed this when running `kafka` source. Then checked the original PR https://github.com/datahub-project/datahub/pull/4496 by @shirshanka and noticed the same problem in `sql_common`. So fixed that too. Should help a bit during debugging.

As this is log in reporting tests are not applicable in my opinion.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
  - https://github.com/datahub-project/datahub/pull/4496
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)