### PR TITLE
feat(autocomplete): show fully qualified name in autocomplete

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DatabaseFilled, DatabaseOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
-import { Dataset, EntityType, OwnershipType, SearchResult } from '../../../types.generated';
+import { Dataset, DatasetProperties, EntityType, OwnershipType, SearchResult } from '../../../types.generated';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { Preview } from './preview/Preview';
 import { FIELDS_TO_HIGHLIGHT } from './search/highlights';
@@ -211,10 +211,15 @@ export class DatasetEntity implements Entity<Dataset> {
     getOverridePropertiesFromEntity = (dataset?: Dataset | null): GenericEntityProperties => {
         // if dataset has subTypes filled out, pick the most specific subtype and return it
         const subTypes = dataset?.subTypes;
+        const extendedProperties: DatasetProperties | undefined | null = dataset?.properties && {
+            ...dataset?.properties,
+            qualifiedName: dataset?.properties?.qualifiedName || dataset?.name,
+        };
         return {
             name: dataset?.properties?.name || dataset?.name,
             externalUrl: dataset?.properties?.externalUrl,
             entityTypeOverride: subTypes ? capitalizeFirstLetter(subTypes.typeNames?.[0]) : '',
+            properties: extendedProperties,
         };
     };
 

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -49,9 +49,10 @@ export type EntitySidebarSection = {
 export type GenericEntityProperties = {
     urn?: string;
     name?: Maybe<string>;
-    properties?: {
-        description?: string;
-    };
+    properties?: Maybe<{
+        description?: Maybe<string>;
+        qualifiedName?: Maybe<string>;
+    }>;
     globalTags?: Maybe<GlobalTags>;
     glossaryTerms?: Maybe<GlossaryTerms>;
     ownership?: Maybe<Ownership>;

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -111,7 +111,10 @@ const renderEntitySuggestion = (query: string, entity: Entity, registry: EntityR
     const genericEntityProps = registry.getGenericEntityProperties(entity.type, entity);
     const platformName = genericEntityProps?.platform?.properties?.displayName || genericEntityProps?.platform?.name;
     const platformLogoUrl = genericEntityProps?.platform?.properties?.logoUrl;
-    const displayName = registry.getDisplayName(entity.type, entity);
+    const displayName =
+        genericEntityProps?.properties?.qualifiedName ||
+        genericEntityProps?.name ||
+        registry.getDisplayName(entity.type, entity);
     const icon =
         (platformLogoUrl && <PreviewImage preview={false} src={platformLogoUrl} alt={platformName || ''} />) ||
         registry.getIcon(entity.type, 12, IconStyleType.ACCENT);

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -38,6 +38,7 @@ fragment searchResultFields on Entity {
         properties {
             name
             description
+            qualifiedName
             customProperties {
                 key
                 value


### PR DESCRIPTION
Defaults fqn to `name` if fqn is unavailable, rather than displayname.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)