### PR TITLE
Added Relative Routing on the Users & Groups screen

### DIFF
--- a/datahub-web-react/src/app/identity/ManageIdentitiesPage.tsx
+++ b/datahub-web-react/src/app/identity/ManageIdentitiesPage.tsx
@@ -1,7 +1,8 @@
-import { Tabs, Typography } from 'antd';
-import React, { useState } from 'react';
+import React from 'react';
+import { Typography } from 'antd';
 import styled from 'styled-components';
 import { SearchablePage } from '../search/SearchablePage';
+import { RoutedTabs } from '../shared/RoutedTabs';
 import { GroupList } from './group/GroupList';
 import { UserList } from './user/UserList';
 
@@ -21,34 +22,49 @@ const PageTitle = styled(Typography.Title)`
     }
 `;
 
-const StyledTabs = styled(Tabs)`
-    &&& .ant-tabs-nav {
-        margin-bottom: 0;
-        padding-left: 28px;
+const Content = styled.div`
+    color: #262626;
+    height: calc(100vh - 60px);
+
+    &&& .ant-tabs > .ant-tabs-nav .ant-tabs-nav-wrap {
+        padding-left: 15px;
     }
 `;
-
-const Tab = styled(Tabs.TabPane)`
-    font-size: 14px;
-    line-height: 22px;
-`;
-
-const ListContainer = styled.div``;
 
 enum TabType {
     Users = 'Users',
     Groups = 'Groups',
 }
+const ENABLED_TAB_TYPES = [TabType.Users, TabType.Groups];
 
 export const ManageIdentitiesPage = () => {
     /**
      * Determines which view should be visible: users or groups list.
      */
-    const [selectedTab, setSelectedTab] = useState<TabType>(TabType.Users);
 
-    const onClickTab = (newTab: string) => {
-        setSelectedTab(TabType[newTab]);
+    const getTabs = () => {
+        return [
+            {
+                name: TabType.Users,
+                path: TabType.Users.toLocaleLowerCase(),
+                content: <UserList />,
+                display: {
+                    enabled: () => true,
+                },
+            },
+            {
+                name: TabType.Groups,
+                path: TabType.Groups.toLocaleLowerCase(),
+                content: <GroupList />,
+                display: {
+                    enabled: () => true,
+                },
+            },
+        ].filter((tab) => ENABLED_TAB_TYPES.includes(tab.name));
     };
+
+    const defaultTabPath = getTabs() && getTabs()?.length > 0 ? getTabs()[0].path : '';
+    const onTabChange = () => null;
 
     return (
         <SearchablePage>
@@ -59,11 +75,9 @@ export const ManageIdentitiesPage = () => {
                         View your DataHub users & groups. Take administrative actions.
                     </Typography.Paragraph>
                 </PageHeaderContainer>
-                <StyledTabs activeKey={selectedTab} size="large" onTabClick={(tab: string) => onClickTab(tab)}>
-                    <Tab key={TabType.Users} tab={TabType.Users} />
-                    <Tab key={TabType.Groups} tab={TabType.Groups} />
-                </StyledTabs>
-                <ListContainer>{selectedTab === TabType.Users ? <UserList /> : <GroupList />}</ListContainer>
+                <Content>
+                    <RoutedTabs defaultPath={defaultTabPath} tabs={getTabs()} onTabChange={onTabChange} />
+                </Content>
             </PageContainer>
         </SearchablePage>
     );

--- a/datahub-web-react/src/app/identity/ManageIdentitiesPage.tsx
+++ b/datahub-web-react/src/app/identity/ManageIdentitiesPage.tsx
@@ -23,6 +23,9 @@ const PageTitle = styled(Typography.Title)`
 `;
 
 const Content = styled.div`
+    &&& .ant-tabs-nav {
+        margin: 0;
+    }
     color: #262626;
     height: calc(100vh - 60px);
 

--- a/datahub-web-react/src/app/shared/RoutedTabs.tsx
+++ b/datahub-web-react/src/app/shared/RoutedTabs.tsx
@@ -3,14 +3,6 @@ import { Route, Switch, useRouteMatch, useLocation } from 'react-router-dom';
 import { Redirect, useHistory } from 'react-router';
 import { Tabs } from 'antd';
 import { TabsProps } from 'antd/lib/tabs';
-import styled from 'styled-components';
-
-const StyledTabs = styled(Tabs)`
-    &&& .ant-tabs-nav {
-        margin-bottom: 0;
-        padding-left: 28px;
-    }
-`;
 
 const { TabPane } = Tabs;
 
@@ -42,7 +34,7 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
     const activePath = subRoutes.includes(providedPath) ? providedPath : defaultPath.replace('/', '');
     return (
         <div>
-            <StyledTabs
+            <Tabs
                 defaultActiveKey={activePath}
                 activeKey={activePath}
                 size="large"
@@ -55,7 +47,7 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
                         <TabPane tab={tab.name} key={tab.path.replace('/', '')} disabled={!tab.display?.enabled()} />
                     );
                 })}
-            </StyledTabs>
+            </Tabs>
             <Switch>
                 <Route exact path={path}>
                     <Redirect to={`${pathname}${pathname.endsWith('/') ? '' : '/'}${defaultPath}`} />

--- a/datahub-web-react/src/app/shared/RoutedTabs.tsx
+++ b/datahub-web-react/src/app/shared/RoutedTabs.tsx
@@ -3,6 +3,14 @@ import { Route, Switch, useRouteMatch, useLocation } from 'react-router-dom';
 import { Redirect, useHistory } from 'react-router';
 import { Tabs } from 'antd';
 import { TabsProps } from 'antd/lib/tabs';
+import styled from 'styled-components';
+
+const StyledTabs = styled(Tabs)`
+    &&& .ant-tabs-nav {
+        margin-bottom: 0;
+        padding-left: 28px;
+    }
+`;
 
 const { TabPane } = Tabs;
 
@@ -34,7 +42,7 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
     const activePath = subRoutes.includes(providedPath) ? providedPath : defaultPath.replace('/', '');
     return (
         <div>
-            <Tabs
+            <StyledTabs
                 defaultActiveKey={activePath}
                 activeKey={activePath}
                 size="large"
@@ -47,7 +55,7 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
                         <TabPane tab={tab.name} key={tab.path.replace('/', '')} disabled={!tab.display?.enabled()} />
                     );
                 })}
-            </Tabs>
+            </StyledTabs>
             <Switch>
                 <Route exact path={path}>
                     <Redirect to={`${pathname}${pathname.endsWith('/') ? '' : '/'}${defaultPath}`} />


### PR DESCRIPTION
Worked on the relative Routing on the Users & Groups screen
- /identities/users (DEFAULT)
- /identities/groups

![relative_path_user_screen](https://user-images.githubusercontent.com/86347578/163239971-dbcdec06-73a1-492d-9d56-af609344d38a.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)