### PR TITLE
refactor(authorization): Add authorizedActor function to Authorizer interface

### DIFF
--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizedActors.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/AuthorizedActors.java
@@ -1,0 +1,17 @@
+package com.datahub.authorization;
+
+import com.linkedin.common.urn.Urn;
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+
+@Value
+@Builder
+public class AuthorizedActors {
+  String privilege;
+  List<Urn> users;
+  List<Urn> groups;
+  boolean allUsers;
+  boolean allGroups;
+}

--- a/metadata-service/auth-api/src/main/java/com/datahub/authorization/Authorizer.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authorization/Authorizer.java
@@ -1,6 +1,7 @@
 package com.datahub.authorization;
 
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 
@@ -20,4 +21,12 @@ public interface Authorizer {
    * Authorizes an action based on the actor, the resource, & required privileges.
    */
   AuthorizationResult authorize(AuthorizationRequest request);
+
+  /**
+   * Retrieves the current list of actors authorized to for a particular privilege against
+   * an optional resource
+   */
+  AuthorizedActors authorizedActors(
+      final String privilege,
+      final Optional<ResourceSpec> resourceSpec);
 }

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/AuthorizerChain.java
@@ -1,6 +1,8 @@
 package com.datahub.authorization;
 
 import com.linkedin.common.urn.Urn;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -84,26 +86,26 @@ public class AuthorizerChain implements Authorizer {
       return original;
     }
 
+    boolean isAllUsers = original.isAllUsers() || other.isAllUsers();
     List<Urn> mergedUsers;
-    if (original.isAllUsers()) {
-      // If original enabled for all users, take the other's users
-      mergedUsers = other.getUsers();
-    } else if (other.isAllUsers()) {
-      mergedUsers = original.getUsers();
+    if (isAllUsers) {
+      // If enabled for all users, no need to check users
+      mergedUsers = Collections.emptyList();
     } else {
-      Set<Urn> otherUsers = new HashSet<>(other.getUsers());
-      mergedUsers = original.getUsers().stream().filter(otherUsers::contains).collect(Collectors.toList());
+      Set<Urn> users = new HashSet<>(original.getUsers());
+      users.addAll(other.getUsers());
+      mergedUsers = new ArrayList<>(users);
     }
 
+    boolean isAllGroups = original.isAllGroups() || other.isAllGroups();
     List<Urn> mergedGroups;
-    if (original.isAllGroups()) {
-      // If original enabled for all users, take the other's users
-      mergedGroups = other.getGroups();
-    } else if (other.isAllUsers()) {
-      mergedGroups = original.getGroups();
+    if (isAllGroups) {
+      // If enabled for all users, no need to check users
+      mergedGroups = Collections.emptyList();
     } else {
-      Set<Urn> otherGroups = new HashSet<>(other.getGroups());
-      mergedGroups = original.getGroups().stream().filter(otherGroups::contains).collect(Collectors.toList());
+      Set<Urn> groups = new HashSet<>(original.getGroups());
+      groups.addAll(other.getGroups());
+      mergedGroups = new ArrayList<>(groups);
     }
 
     return AuthorizedActors.builder()

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -131,7 +131,7 @@ public class DataHubAuthorizer implements Authorizer {
    */
   public AuthorizedActors authorizedActors(
       final String privilege,
-      final Optional<ResourceSpec> resourceSpec) throws RuntimeException {
+      final Optional<ResourceSpec> resourceSpec) {
     // Step 1: Find policies granting the privilege.
     final List<DataHubPolicyInfo> policiesToEvaluate = _policyCache.getOrDefault(privilege, new ArrayList<>());
 
@@ -309,44 +309,4 @@ public class DataHubAuthorizer implements Authorizer {
         .map(Owner::getOwner)
         .collect(Collectors.toList());
   }
-
-  /**
-   * Class used to represent all users authorized to perform a particular privilege.
-   */
-  public static class AuthorizedActors {
-    final String _privilege;
-    final List<Urn> _users;
-    final List<Urn> _groups;
-    final Boolean _allUsers;
-    final Boolean _allGroups;
-
-    public AuthorizedActors(final String privilege, final List<Urn> users, final List<Urn> groups, final Boolean allUsers, final Boolean allGroups) {
-      _privilege = privilege;
-      _users = users;
-      _groups = groups;
-      _allUsers = allUsers;
-      _allGroups = allGroups;
-    }
-
-    public String getPrivilege() {
-      return _privilege;
-    }
-
-    public List<Urn> getUsers() {
-      return _users;
-    }
-
-    public List<Urn> getGroups() {
-      return _groups;
-    }
-
-    public Boolean allUsers() {
-      return _allUsers;
-    }
-
-    public Boolean allGroups() {
-      return _allGroups;
-    }
-  }
-
 }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -209,12 +209,12 @@ public class DataHubAuthorizerTest {
 
   @Test
   public void testAuthorizedActorsActivePolicy() throws Exception {
-    final DataHubAuthorizer.AuthorizedActors actors =
+    final AuthorizedActors actors =
         _dataHubAuthorizer.authorizedActors("EDIT_ENTITY_TAGS", // Should be inside the active policy.
             Optional.of(new ResourceSpec("dataset", "urn:li:dataset:1")));
 
-    assertTrue(actors.allUsers());
-    assertTrue(actors.allGroups());
+    assertTrue(actors.isAllUsers());
+    assertTrue(actors.isAllGroups());
 
     assertEquals(new HashSet<>(actors.getUsers()), ImmutableSet.of(
         Urn.createFromString("urn:li:corpuser:user1"),


### PR DESCRIPTION
This function fetches all actors that have been granted the input privilege. 

Implement a merging logic of authorized actors in the AuthorizationChain, where we get the greatest common denominator of all actors. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)