### PR TITLE
fix(gms): Ensure Ordering by version when fetching next version

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -498,15 +498,19 @@ public class EbeanAspectDao {
     if (exp == null) {
       return result;
     }
+    // Ensure Ordering of Aspect version
+    exp.orderBy("version");
     List<EbeanAspectV2.PrimaryKey> dbResults = exp.endOr().findIds();
 
     for (EbeanAspectV2.PrimaryKey key: dbResults) {
+      log.debug("Reading from DB - Urn: {}, Aspect: {}, currVersion: {}", urn, key.getAspect(), key.getVersion());
       result.put(key.getAspect(), key.getVersion());
     }
     for (String aspectName: aspectNames) {
       long nextVal = 0L;
       if (result.containsKey(aspectName)) {
         nextVal = result.get(aspectName) + 1L;
+        log.debug("Setting nextVersion - Urn: {}, Aspect: {}, nextVersion: {}", urn, aspectName, nextVal);
       }
       result.put(aspectName, nextVal);
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -503,14 +503,12 @@ public class EbeanAspectDao {
     List<EbeanAspectV2.PrimaryKey> dbResults = exp.endOr().findIds();
 
     for (EbeanAspectV2.PrimaryKey key: dbResults) {
-      log.debug("Reading from DB - Urn: {}, Aspect: {}, currVersion: {}", urn, key.getAspect(), key.getVersion());
       result.put(key.getAspect(), key.getVersion());
     }
     for (String aspectName: aspectNames) {
       long nextVal = 0L;
       if (result.containsKey(aspectName)) {
         nextVal = result.get(aspectName) + 1L;
-        log.debug("Setting nextVersion - Urn: {}, Aspect: {}, nextVersion: {}", urn, aspectName, nextVal);
       }
       result.put(aspectName, nextVal);
     }


### PR DESCRIPTION

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

What was observed was in case of Postgres Connector for Ebean there seems to be an issue with the `Groupby` causing all aspect, version pair to be returned from the query.

One of the options that was discussed with @jjoyce0510 was to upgrade the ebean dependency from 11.33.3 to the latest versions. 

But, in any case to ensure ordering of the results from the Database added an `orderBy(version)` to resolve the issue in Postgres that we are facing now.

For Discussions in Slack - https://datahubspace.slack.com/archives/CUMUWQU66/p1650039418187819
 