### PR TITLE
fix(ingest) bigquery: Moving bigquery temporary credential deletion to atexit

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -1,3 +1,4 @@
+import atexit
 import collections
 import datetime
 import functools
@@ -8,7 +9,6 @@ import textwrap
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 from unittest.mock import patch
-import atexit
 
 # This import verifies that the dependencies are available.
 import sqlalchemy_bigquery

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -8,6 +8,7 @@ import textwrap
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 from unittest.mock import patch
+import atexit
 
 # This import verifies that the dependencies are available.
 import sqlalchemy_bigquery
@@ -240,6 +241,15 @@ class BigQueryPartitionColumn:
     partition_id: str
 
 
+# We can't use close as it is not called if the ingestion is not successful
+def cleanup(config: BigQueryConfig) -> None:
+    if config._credentials_path is not None:
+        logger.debug(
+            f"Deleting temporary credential file at {config._credentials_path}"
+        )
+        os.unlink(config._credentials_path)
+
+
 class BigQuerySource(SQLAlchemySource):
     def __init__(self, config, ctx):
         super().__init__(config, ctx, "bigquery")
@@ -248,6 +258,7 @@ class BigQuerySource(SQLAlchemySource):
         self.report: BigQueryReport = BigQueryReport()
         self.lineage_metadata: Optional[Dict[str, Set[str]]] = None
         self.maximum_shard_ids: Dict[str, str] = dict()
+        atexit.register(cleanup, config)
 
     def get_db_name(self, inspector: Inspector = None) -> str:
         if self.config.project_id:
@@ -906,11 +917,3 @@ WHERE
         for wu in container_workunits:
             self.report.report_workunit(wu)
             yield wu
-
-    # We can't use close as it is not called if the ingestion is not successful
-    def __del__(self):
-        if self.config._credentials_path is not None:
-            logger.debug(
-                f"Deleting temporary credential file at {self.config._credentials_path}"
-            )
-            os.unlink(self.config._credentials_path)


### PR DESCRIPTION
Moving bigquery temporary credential deletion to atexit vs __del__ because it is more reliable and deterministic.
Recently with __del__ it threw an error because the logging object was None as it seemed to be cleaned up when the method was called.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)