### PR TITLE
fix(azure_ad): silently discard other Azure AD object types (#4693)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
@@ -216,9 +216,8 @@ class AzureADSource(Source):
                         user_urn_to_group_membership,
                     )
                 else:
-                    raise ValueError(
-                        f"Unsupported @odata.type '{odata_type}' found in Azure group member"
-                    )
+                    # Unless told otherwise, we only care about users and groups.  Silently skip other object types.
+                    pass
 
     def _add_user_to_group_membership(
         self,

--- a/metadata-ingestion/tests/integration/azure_ad/azure_ad_nested_groups_members.json
+++ b/metadata-ingestion/tests/integration/azure_ad/azure_ad_nested_groups_members.json
@@ -82,4 +82,24 @@
         "theme": null,
         "visibility": null,
         "onPremisesProvisioningErrors": []
-    }]
+    },
+    {"@odata.type": "#microsoft.graph.orgContact",
+        "id": "00000000-0000-0000-9999-000000000000",
+        "deletedDateTime": null,
+        "companyName": null,
+        "department": null,
+        "displayName": null,
+        "proxyAddresses": [],
+        "givenName": null,
+        "imAddresses": [],
+        "jobTitle": null,
+        "mail": null,
+        "mailNickname": null,
+        "onPremisesLastSyncDateTime": null,
+        "onPremisesSyncEnabled": null,
+        "surname": null,
+        "addresses": [],
+        "onPremisesProvisioningErrors": [],
+        "phones": []
+    }
+]

--- a/metadata-ingestion/tests/integration/azure_ad/test_azure_ad.py
+++ b/metadata-ingestion/tests/integration/azure_ad/test_azure_ad.py
@@ -230,8 +230,8 @@ def load_test_resources(test_resources_dir):
     azure_ad_users_json_file = test_resources_dir / "azure_ad_users.json"
     azure_ad_groups_json_file = test_resources_dir / "azure_ad_groups.json"
     azure_ad_nested_group_json_file = test_resources_dir / "azure_ad_nested_group.json"
-    azure_ad_nested_groups_users_json_file = (
-        test_resources_dir / "azure_ad_nested_groups_users.json"
+    azure_ad_nested_groups_members_json_file = (
+        test_resources_dir / "azure_ad_nested_groups_members.json"
     )
 
     with azure_ad_users_json_file.open() as azure_ad_users_json:
@@ -243,7 +243,7 @@ def load_test_resources(test_resources_dir):
     with azure_ad_nested_group_json_file.open() as azure_ad_nested_group_json:
         reference_nested_group = json.loads(azure_ad_nested_group_json.read())
 
-    with azure_ad_nested_groups_users_json_file.open() as azure_ad_nested_groups_users_json:
+    with azure_ad_nested_groups_members_json_file.open() as azure_ad_nested_groups_users_json:
         reference_nested_groups_users = json.loads(
             azure_ad_nested_groups_users_json.read()
         )


### PR DESCRIPTION
Previous code was failing on AD object types other than user and group, now silently skipping those.  As for what Datahub is expecting from this source, probably only users and groups have value.

Unit test has been updated to make sure it is not failing anymore.

This PR is fixing issue #4693 .