### PR TITLE
fix(looker): Fix for Pydantic validation error for Looker TransportOptions on python 3.8

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -618,7 +618,7 @@ class LookerDashboardSource(Source):
             self.client,
             self.reporter,
             transport_options=self.source_config.transport_options.get_transport_options()
-            if self.source_config.transport_options
+            if self.source_config.transport_options is not None
             else None,
         )
         if looker_explore is not None:
@@ -703,7 +703,7 @@ class LookerDashboardSource(Source):
                     folder.id,
                     fields="name",
                     transport_options=self.source_config.transport_options.get_transport_options()
-                    if self.source_config.transport_options
+                    if self.source_config.transport_options is not None
                     else None,
                 )
             ]
@@ -742,7 +742,10 @@ class LookerDashboardSource(Source):
 
         dashboard_owner = (
             self.user_registry.get_by_id(
-                dashboard.user_id, self.source_config.transport_options
+                dashboard.user_id,
+                self.source_config.transport_options.get_transport_options()
+                if self.source_config.transport_options is not None
+                else None,
             )
             if self.source_config.extract_owners and dashboard.user_id is not None
             else None
@@ -792,7 +795,7 @@ class LookerDashboardSource(Source):
                 dashboard_id=dashboard_id,
                 fields=",".join(fields),
                 transport_options=self.source_config.transport_options.get_transport_options()
-                if self.source_config.transport_options
+                if self.source_config.transport_options is not None
                 else None,
             )
         except SDKError:
@@ -827,7 +830,7 @@ class LookerDashboardSource(Source):
         dashboards = self.client.all_dashboards(
             fields="id",
             transport_options=self.source_config.transport_options.get_transport_options()
-            if self.source_config.transport_options
+            if self.source_config.transport_options is not None
             else None,
         )
         deleted_dashboards = (
@@ -835,7 +838,7 @@ class LookerDashboardSource(Source):
                 fields="id",
                 deleted="true",
                 transport_options=self.source_config.transport_options.get_transport_options()
-                if self.source_config.transport_options
+                if self.source_config.transport_options is not None
                 else None,
             )
             if self.source_config.include_deleted

--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -94,7 +94,7 @@ class LookerAPI:
         try:
             self.client.me(
                 transport_options=config.transport_options.get_transport_options()
-                if config.transport_options
+                if config.transport_options is not None
                 else None
             )
         except SDKError as e:

--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -63,11 +63,19 @@ from datahub.metadata.schema_classes import (
 logger = logging.getLogger(__name__)
 
 
+class TransportOptionsConfig(ConfigModel):
+    timeout: int
+    headers: MutableMapping[str, str]
+
+    def get_transport_options(self) -> TransportOptions:
+        return TransportOptions(timeout=self.timeout, headers=self.headers)
+
+
 class LookerAPIConfig(ConfigModel):
     client_id: str
     client_secret: str
     base_url: str
-    transport_options: Optional[TransportOptions]
+    transport_options: Optional[TransportOptionsConfig]
 
 
 class LookerAPI:
@@ -84,7 +92,11 @@ class LookerAPI:
         # try authenticating current user to check connectivity
         # (since it's possible to initialize an invalid client without any complaints)
         try:
-            self.client.me(transport_options=config.transport_options)
+            self.client.me(
+                transport_options=config.transport_options.get_transport_options()
+                if config.transport_options
+                else None
+            )
         except SDKError as e:
             raise ConfigurationError(
                 "Failed to initialize Looker client. Please check your configuration."
@@ -605,7 +617,9 @@ class LookerDashboardSource(Source):
             explore,
             self.client,
             self.reporter,
-            self.source_config.transport_options,
+            transport_options=self.source_config.transport_options.get_transport_options()
+            if self.source_config.transport_options
+            else None,
         )
         if looker_explore is not None:
             events = (
@@ -688,7 +702,9 @@ class LookerDashboardSource(Source):
                 for ancestor in client.folder_ancestors(
                     folder.id,
                     fields="name",
-                    transport_options=self.source_config.transport_options,
+                    transport_options=self.source_config.transport_options.get_transport_options()
+                    if self.source_config.transport_options
+                    else None,
                 )
             ]
             self.folder_path_cache[folder.id] = "/".join(ancestors + [folder.name])
@@ -775,7 +791,9 @@ class LookerDashboardSource(Source):
             dashboard_object = self.client.dashboard(
                 dashboard_id=dashboard_id,
                 fields=",".join(fields),
-                transport_options=self.source_config.transport_options,
+                transport_options=self.source_config.transport_options.get_transport_options()
+                if self.source_config.transport_options
+                else None,
             )
         except SDKError:
             # A looker dashboard could be deleted in between the list and the get
@@ -807,13 +825,18 @@ class LookerDashboardSource(Source):
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         dashboards = self.client.all_dashboards(
-            fields="id", transport_options=self.source_config.transport_options
+            fields="id",
+            transport_options=self.source_config.transport_options.get_transport_options()
+            if self.source_config.transport_options
+            else None,
         )
         deleted_dashboards = (
             self.client.search_dashboards(
                 fields="id",
                 deleted="true",
-                transport_options=self.source_config.transport_options,
+                transport_options=self.source_config.transport_options.get_transport_options()
+                if self.source_config.transport_options
+                else None,
             )
             if self.source_config.include_deleted
             else []

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
 
 import pydantic
 from looker_sdk.error import SDKError
-from looker_sdk.rtl.transport import TransportOptions
 from looker_sdk.sdk.api31.methods import Looker31SDK
 from looker_sdk.sdk.api31.models import DBConnection
 from pydantic import root_validator, validator
@@ -46,7 +45,11 @@ from datahub.configuration.common import AllowDenyPattern, ConfigurationError
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.ingestion.source.looker import LookerAPI, LookerAPIConfig
+from datahub.ingestion.source.looker import (
+    LookerAPI,
+    LookerAPIConfig,
+    TransportOptionsConfig,
+)
 from datahub.metadata.com.linkedin.pegasus2avro.common import BrowsePaths, Status
 from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
     DatasetLineageTypeClass,
@@ -145,7 +148,7 @@ class LookMLSourceConfig(LookerCommonConfig):
     sql_parser: str = "datahub.utilities.sql_parser.DefaultSQLParser"
     api: Optional[LookerAPIConfig]
     project_name: Optional[str]
-    transport_options: Optional[TransportOptions]
+    transport_options: Optional[TransportOptionsConfig]
 
     @validator("platform_instance")
     def platform_instance_not_supported(cls, v: str) -> str:
@@ -1014,7 +1017,9 @@ class LookMLSource(Source):
             model = self.looker_client.lookml_model(
                 model_name,
                 "project_name",
-                transport_options=self.source_config.transport_options,
+                transport_options=self.source_config.transport_options.get_transport_options()
+                if self.source_config.transport_options
+                else None,
             )
             assert (
                 model.project_name is not None

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -1018,7 +1018,7 @@ class LookMLSource(Source):
                 model_name,
                 "project_name",
                 transport_options=self.source_config.transport_options.get_transport_options()
-                if self.source_config.transport_options
+                if self.source_config.transport_options is not None
                 else None,
             )
             assert (


### PR DESCRIPTION
Fix for pydantic validation error for Looker TransportOptions on python 3.8

Previously we used TransportOptions directly in our configs which used typing.TypedDict on python 3.8 and this caused Pydantic validation to fail.

This is how it looked like on python 3.8
```
============================================================================================= short test summary info ==============================================================================================
FAILED tests/integration/looker/test_looker.py::test_looker_ingest - TypeError: You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2. Without it, there is no way to di...
FAILED tests/integration/looker/test_looker.py::test_looker_ingest_joins - TypeError: You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2. Without it, there is no way...
FAILED tests/integration/looker/test_looker.py::test_looker_ingest_unaliased_joins - TypeError: You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2. Without it, there...
FAILED tests/integration/looker/test_looker.py::test_looker_ingest_allow_pattern - TypeError: You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2. Without it, there I...
```

This is how it looks with the fix:
```
tests/integration/looker/test_looker.py::test_looker_ingest PASSED                                                                                                                                           [ 25%]
tests/integration/looker/test_looker.py::test_looker_ingest_joins PASSED                                                                                                                                     [ 50%]
tests/integration/looker/test_looker.py::test_looker_ingest_unaliased_joins PASSED                                                                                                                           [ 75%]
tests/integration/looker/test_looker.py::test_looker_ingest_allow_pattern PASSED                                                                                                                             [100%]
```

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)