### PR TITLE
feat(ml): show custom properties for MLFeatureTable in UI

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureTablePropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureTablePropertiesMapper.java
@@ -42,7 +42,9 @@ public class MLFeatureTablePropertiesMapper implements ModelMapper<com.linkedin.
                 .collect(Collectors.toList()));
         }
 
-        result.setCustomProperties(StringMapMapper.map(mlFeatureTableProperties.getCustomProperties()));
+        if (mlFeatureTableProperties.hasCustomProperties()){
+            result.setCustomProperties(StringMapMapper.map(mlFeatureTableProperties.getCustomProperties()));
+        }
 
         return result;
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureTablePropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureTablePropertiesMapper.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.graphql.types.mlmodel.mappers;
 import com.linkedin.datahub.graphql.generated.MLFeature;
 import com.linkedin.datahub.graphql.generated.MLFeatureTableProperties;
 import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
+import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import lombok.NonNull;
 
@@ -40,6 +41,8 @@ public class MLFeatureTablePropertiesMapper implements ModelMapper<com.linkedin.
                 })
                 .collect(Collectors.toList()));
         }
+
+        result.setCustomProperties(StringMapMapper.map(mlFeatureTableProperties.getCustomProperties()));
 
         return result;
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureTablePropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLFeatureTablePropertiesMapper.java
@@ -42,7 +42,7 @@ public class MLFeatureTablePropertiesMapper implements ModelMapper<com.linkedin.
                 .collect(Collectors.toList()));
         }
 
-        if (mlFeatureTableProperties.hasCustomProperties()){
+        if (mlFeatureTableProperties.hasCustomProperties()) {
             result.setCustomProperties(StringMapMapper.map(mlFeatureTableProperties.getCustomProperties()));
         }
 

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -6945,6 +6945,8 @@ description: String
     mlFeatures: [MLFeature]
 
     mlPrimaryKeys: [MLPrimaryKey]
+
+    customProperties: [StringMapEntry!]
 }
 
 type HyperParameterMap {

--- a/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -14,6 +14,7 @@ import { SidebarTagsSection } from '../shared/containers/profile/sidebar/Sidebar
 import MlFeatureTableFeatures from './profile/features/MlFeatureTableFeatures';
 import Sources from './profile/Sources';
 import { DocumentationTab } from '../shared/tabs/Documentation/DocumentationTab';
+import { PropertiesTab } from '../shared/tabs/Properties/PropertiesTab';
 
 /**
  * Definition of the DataHub MLFeatureTable entity.
@@ -73,6 +74,10 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                 {
                     name: 'Sources',
                     component: Sources,
+                },
+                {
+                    name: 'Properties',
+                    component: PropertiesTab,
                 },
                 {
                     name: 'Documentation',

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -498,6 +498,10 @@ fragment nonRecursiveMLFeatureTable on MLFeatureTable {
         mlPrimaryKeys {
             ...nonRecursiveMLPrimaryKey
         }
+        customProperties {
+            key
+            value
+        }
     }
     ownership {
         ...ownershipFields

--- a/smoke-test/tests/cypress/cypress/integration/ml/feature_table.js
+++ b/smoke-test/tests/cypress/cypress/integration/ml/feature_table.js
@@ -18,6 +18,14 @@ describe('features', () => {
       // feature & primary key sources are visible
       cy.contains('SampleCypressHdfsDataset');
       cy.contains('SampleCypressKafkaDataset');
+
+      // navigate to properties
+      cy.contains('Properties').click();
+
+      // custom properties are visible
+      cy.contains('status');
+      cy.contains('Created');
+
     });
 
     it('can visit feature page', () => {


### PR DESCRIPTION
Adds the properties tab to MLFeatureTable, which is quite handy to add custom metadata that does not fit with the actual model.

<img width="689" alt="image" src="https://user-images.githubusercontent.com/3258096/164243723-af57ef57-1227-4140-9d62-25014524567d.png">


## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)