### PR TITLE
fix(lineage): Fix lineage entity drawer height UI bug

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -17,6 +17,8 @@ import { EntityType } from '../../types.generated';
 import { capitalizeFirstLetter } from '../shared/textUtil';
 import { ANTD_GRAY } from '../entity/shared/constants';
 
+const DEFAULT_DISTANCE_FROM_TOP = 106;
+
 const LoadingMessage = styled(Message)`
     margin-top: 10%;
 `;
@@ -26,10 +28,10 @@ const FooterButtonGroup = styled.div`
     margin: 12px 0;
 `;
 
-const EntityDrawer = styled(Drawer)`
-    top: 106px;
+const EntityDrawer = styled(Drawer)<{ distanceFromTop: number }>`
+    top: ${(props) => props.distanceFromTop}px;
     z-index: 1;
-    height: calc(100vh - 106px);
+    height: calc(100vh - ${(props) => props.distanceFromTop}px);
     .ant-drawer-content-wrapper {
         border-right: 1px solid ${ANTD_GRAY[4.5]};
         box-shadow: none !important;
@@ -61,6 +63,8 @@ export default function LineageExplorer({ urn, type }: Props) {
     const [isDrawerVisible, setIsDrawVisible] = useState(false);
     const [selectedEntity, setSelectedEntity] = useState<EntitySelectParams | undefined>(undefined);
     const [asyncEntities, setAsyncEntities] = useState<FetchedEntities>({});
+
+    const drawerRef: React.MutableRefObject<HTMLDivElement | null> = useRef(null);
 
     const maybeAddAsyncLoadedEntity = useCallback(
         (entityAndType: EntityAndType) => {
@@ -99,6 +103,9 @@ export default function LineageExplorer({ urn, type }: Props) {
         return <Alert type="error" message={error?.message || 'Entity failed to load'} />;
     }
 
+    const drawerDistanceFromTop =
+        drawerRef && drawerRef.current ? drawerRef.current.offsetTop : DEFAULT_DISTANCE_FROM_TOP;
+
     return (
         <>
             {loading && <LoadingMessage type="loading" content="Loading..." />}
@@ -123,7 +130,9 @@ export default function LineageExplorer({ urn, type }: Props) {
                     />
                 </div>
             )}
+            <div ref={drawerRef} />
             <EntityDrawer
+                distanceFromTop={drawerDistanceFromTop}
                 placement="left"
                 closable={false}
                 onClose={handleClose}


### PR DESCRIPTION
When the width of a screen is small or an entity has enough path crumbs so that the browse path in the entity profile nav bar is wide enough to push content in this nav bar onto a second line, this second line gets covered up by the `EntityDrawer` that pops out from the left.

Since the `EntityDrawer` is an abolsutely positioned element and there's no easy way to contain it within its parent, we have to set the distance from the top of the page. In order to make this more dynamic for varying heights of `EntityProfileNavBar` I'm setting an empty div above the drawer and a ref on that div to get the `offsetTop` of it so we know how far to push down the drawer.

Here's the issue before the fix:
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/28656603/164085851-d5583e14-93d8-4e4c-bb57-0f98da48a0a4.png">

Here it is after the fix:
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/28656603/164085511-71a5c4eb-0c33-49b5-839f-cb3a811fcbc0.png">

And it still looks good when it's only on one line:
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/28656603/164086111-28c13627-43cf-49a9-9284-95933e47f4a6.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)