### PR TITLE
Specify `mysql` platform in Docker Quickstart to support Apple Silicon

### DIFF
--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -137,6 +137,7 @@ services:
     - MYSQL_ROOT_PASSWORD=datahub
     hostname: mysql
     image: mysql:5.7
+    platform: linux/x86_64
     ports:
     - 3306:3306
     volumes:


### PR DESCRIPTION
Fixes #2416.

To run `docker-compose-without-neo4j.quickstart.yml` on Apple Silicon
hardware, it's required to specify the platform for the MySQL service as
`linux/x86_64`.

NOTE: we need to confirm that this does not impact users with `x86_64` machines.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)