### PR TITLE
fix(ui): Show deprecate button only for specific entity pages. 

### DIFF
--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -69,6 +69,7 @@ export class ChartEntity implements Entity<Chart> {
             useEntityQuery={useGetChartQuery}
             useUpdateQuery={useUpdateChartMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Documentation',

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -72,6 +72,7 @@ export class DashboardEntity implements Entity<Dashboard> {
             useEntityQuery={useGetDashboardQuery}
             useUpdateQuery={useUpdateDashboardMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Documentation',

--- a/datahub-web-react/src/app/entity/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataFlow/DataFlowEntity.tsx
@@ -62,6 +62,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
             useEntityQuery={useGetDataFlowQuery}
             useUpdateQuery={useUpdateDataFlowMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Documentation',

--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -64,6 +64,7 @@ export class DataJobEntity implements Entity<DataJob> {
             useEntityQuery={useGetDataJobQuery}
             useUpdateQuery={useUpdateDataJobMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Documentation',

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -83,6 +83,7 @@ export class DatasetEntity implements Entity<Dataset> {
             useEntityQuery={useGetDatasetQuery}
             useUpdateQuery={useUpdateDatasetMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Schema',

--- a/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
@@ -60,6 +60,7 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                 urn={urn}
                 entityType={EntityType.GlossaryTerm}
                 useEntityQuery={useGetGlossaryTermQuery as any}
+                showDeprecateOption
                 tabs={[
                     {
                         name: 'Related Entities',

--- a/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
@@ -68,6 +68,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
             entityType={EntityType.Mlfeature}
             useEntityQuery={useGetMlFeatureQuery}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Feature Tables',

--- a/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -65,6 +65,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
             entityType={EntityType.MlfeatureTable}
             useEntityQuery={useGetMlFeatureTableQuery}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Features',

--- a/datahub-web-react/src/app/entity/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlModel/MLModelEntity.tsx
@@ -67,6 +67,7 @@ export class MLModelEntity implements Entity<MlModel> {
             entityType={EntityType.Mlmodel}
             useEntityQuery={useGetMlModelQuery}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Summary',

--- a/datahub-web-react/src/app/entity/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlModelGroup/MLModelGroupEntity.tsx
@@ -64,6 +64,7 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
             entityType={EntityType.MlmodelGroup}
             useEntityQuery={useGetMlModelGroupQuery}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
+            showDeprecateOption
             tabs={[
                 {
                     name: 'Models',

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -43,6 +43,7 @@ type Props<T, U> = {
     getOverrideProperties: (T) => GenericEntityProperties;
     tabs: EntityTab[];
     sidebarSections: EntitySidebarSection[];
+    showDeprecateOption?: boolean;
 };
 
 const ContentContainer = styled.div`
@@ -114,6 +115,7 @@ export const EntityProfile = <T, U>({
     getOverrideProperties,
     tabs,
     sidebarSections,
+    showDeprecateOption,
 }: Props<T, U>): JSX.Element => {
     const isLineageMode = useIsLineageMode();
     const entityRegistry = useEntityRegistry();
@@ -202,7 +204,7 @@ export const EntityProfile = <T, U>({
                     )}
                     {!loading && (
                         <>
-                            <EntityHeader />
+                            <EntityHeader showDeprecateOption={showDeprecateOption} />
                             <Divider />
                             <EntitySidebar sidebarSections={sideBarSectionsWithDefaults} />
                         </>
@@ -260,7 +262,7 @@ export const EntityProfile = <T, U>({
                             <HeaderAndTabs>
                                 <HeaderAndTabsFlex>
                                     <Header>
-                                        <EntityHeader />
+                                        <EntityHeader showDeprecateOption={showDeprecateOption} />
                                         <EntityTabs
                                             tabs={[...tabsWithDefaults, ...autoRenderTabs]}
                                             selectedTab={routedTab}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -146,7 +146,11 @@ const Divider = styled.div`
     padding-top: 5px;
 `;
 
-export const EntityHeader = () => {
+type Props = {
+    showDeprecateOption?: boolean;
+};
+
+export const EntityHeader = ({ showDeprecateOption }: Props) => {
     const { urn, entityType, entityData } = useEntityData();
     const [updateDeprecation] = useUpdateDeprecationMutation();
     const [showAddDeprecationDetailsModal, setShowAddDeprecationDetailsModal] = useState(false);
@@ -202,18 +206,6 @@ export const EntityHeader = () => {
         refetch?.();
     };
 
-    const menu = (
-        <Menu>
-            <Menu.Item key="0">
-                {!entityData?.deprecation?.deprecated ? (
-                    <MenuItem onClick={() => setShowAddDeprecationDetailsModal(true)}>Mark as deprecated</MenuItem>
-                ) : (
-                    <MenuItem onClick={() => handleUpdateDeprecation(false)}>Mark as un-deprecated</MenuItem>
-                )}
-            </Menu.Item>
-        </Menu>
-    );
-
     /**
      * Deprecation Decommission Timestamp
      */
@@ -232,6 +224,7 @@ export const EntityHeader = () => {
 
     const hasDetails = entityData?.deprecation?.note !== '' || entityData?.deprecation?.decommissionTime !== null;
     const isDividerNeeded = entityData?.deprecation?.note !== '' && entityData?.deprecation?.decommissionTime !== null;
+    const showAdditionalOptions = showDeprecateOption;
 
     return (
         <>
@@ -328,9 +321,28 @@ export const EntityHeader = () => {
                         }}
                     />
                 </Tooltip>
-                <Dropdown overlay={menu} trigger={['click']}>
-                    <MenuIcon />
-                </Dropdown>
+                {showAdditionalOptions && (
+                    <Dropdown
+                        overlay={
+                            <Menu>
+                                <Menu.Item key="0">
+                                    {!entityData?.deprecation?.deprecated ? (
+                                        <MenuItem onClick={() => setShowAddDeprecationDetailsModal(true)}>
+                                            Mark as deprecated
+                                        </MenuItem>
+                                    ) : (
+                                        <MenuItem onClick={() => handleUpdateDeprecation(false)}>
+                                            Mark as un-deprecated
+                                        </MenuItem>
+                                    )}
+                                </Menu.Item>
+                            </Menu>
+                        }
+                        trigger={['click']}
+                    >
+                        <MenuIcon />
+                    </Dropdown>
+                )}
             </HeaderContainer>
             <AddDeprecationDetailsModal
                 visible={showAddDeprecationDetailsModal}


### PR DESCRIPTION
**Summary**
In this PR, we limit the newly added "Deprecate" button to specific entity pages, including:

- Datasets, dashboards, charts, data jobs, data flows, glossary terms, and the ML related entities.

Previously, this button was shown on every entity profile. Only certain entities support deprecation, so this was a bug!

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)