### PR TITLE
fix(docs): fix the metadata service auth documentation and frontend clarifications

### DIFF
--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -174,7 +174,6 @@ datahub-frontend:
   extraEnvs:
     - name: METADATA_SERVICE_AUTH_ENABLED
       value: "true"
-
 ```
 
 

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -186,7 +186,7 @@ datahub-datahub-frontend   <none>   demo.datahubproject.io   k8s-default-datahub
 
 Note down the elb address in the address column. Add the DNS CNAME record to the host domain pointing the host-name (
 from above) to the elb address. DNS updates generally take a few minutes to an hour. Once that is done, you should be
-able to access datahub-frontend through the host-name. In case the frontend is not loading well try setting a specific version in the field tag for the repository.
+able to access datahub-frontend through the host-name.
 
 ## Use AWS managed services for the storage layer
 

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -162,7 +162,7 @@ You need to request a certificate in the AWS Certificate Manager by following th
 the ARN of the new certificate. You also need to replace host-name with the hostname of choice like
 demo.datahubproject.io.
 
-To have the metadata [authentication service](https://datahubproject.io/docs/introducing-metadata-service-authentication/#configuring-metadata-service-authentication) enable and use [API tokens](https://datahubproject.io/docs/introducing-metadata-service-authentication/#generating-personal-access-tokens) from the UI you will need to set the configuration in the values.yaml for the `gms` and the `frontend` deployments. This could be done by enabling `metadata_service_authentication`:
+To have the metadata [authentication service](https://datahubproject.io/docs/introducing-metadata-service-authentication/#configuring-metadata-service-authentication) enable and use [API tokens](https://datahubproject.io/docs/introducing-metadata-service-authentication/#generating-personal-access-tokens) from the UI you will need to set the configuration in the values.yaml for the `gms` and the `frontend` deployments. This could be done by enabling the `metadata_service_authentication`:
 
 ```
 datahub:

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -162,6 +162,22 @@ You need to request a certificate in the AWS Certificate Manager by following th
 the ARN of the new certificate. You also need to replace host-name with the hostname of choice like
 demo.datahubproject.io.
 
+To have the metadata [authentication service](https://datahubproject.io/docs/introducing-metadata-service-authentication/#configuring-metadata-service-authentication) enable and use [API tokens](https://datahubproject.io/docs/introducing-metadata-service-authentication/#generating-personal-access-tokens) from the UI you will need to set the configuration in the values.yaml for the `gms` and the `frontend` deployments. For example, using extraEnvs:
+
+```
+datahub-gms:
+  extraEnvs:
+    - name: METADATA_SERVICE_AUTH_ENABLED
+      value: "true"
+
+datahub-frontend:
+  extraEnvs:
+    - name: METADATA_SERVICE_AUTH_ENABLED
+      value: "true"
+
+```
+
+
 After updating the yaml file, run the following to apply the updates.
 
 ```
@@ -178,7 +194,7 @@ datahub-datahub-frontend   <none>   demo.datahubproject.io   k8s-default-datahub
 
 Note down the elb address in the address column. Add the DNS CNAME record to the host domain pointing the host-name (
 from above) to the elb address. DNS updates generally take a few minutes to an hour. Once that is done, you should be
-able to access datahub-frontend through the host-name.
+able to access datahub-frontend through the host-name. In case the frontend is not loading well try setting a specific version in the field tag for the repository.
 
 ## Use AWS managed services for the storage layer
 

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -162,20 +162,13 @@ You need to request a certificate in the AWS Certificate Manager by following th
 the ARN of the new certificate. You also need to replace host-name with the hostname of choice like
 demo.datahubproject.io.
 
-To have the metadata [authentication service](https://datahubproject.io/docs/introducing-metadata-service-authentication/#configuring-metadata-service-authentication) enable and use [API tokens](https://datahubproject.io/docs/introducing-metadata-service-authentication/#generating-personal-access-tokens) from the UI you will need to set the configuration in the values.yaml for the `gms` and the `frontend` deployments. For example, using extraEnvs:
+To have the metadata [authentication service](https://datahubproject.io/docs/introducing-metadata-service-authentication/#configuring-metadata-service-authentication) enable and use [API tokens](https://datahubproject.io/docs/introducing-metadata-service-authentication/#generating-personal-access-tokens) from the UI you will need to set the configuration in the values.yaml for the `gms` and the `frontend` deployments. This could be done by enabling `metadata_service_authentication`:
 
 ```
-datahub-gms:
-  extraEnvs:
-    - name: METADATA_SERVICE_AUTH_ENABLED
-      value: "true"
-
-datahub-frontend:
-  extraEnvs:
-    - name: METADATA_SERVICE_AUTH_ENABLED
-      value: "true"
+datahub:
+  metadata_service_authentication:
+    enabled: true
 ```
-
 
 After updating the yaml file, run the following to apply the updates.
 


### PR DESCRIPTION
Adding documentation in the main regarding how to enable auth for the metadata services and some clarifications regarding the frontend service. This would make the installation easier and the documentation centralized in the main guide.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)