### PR TITLE
minor fix(metadata-ingestion): Add new schemas to python codegen

### DIFF
--- a/metadata-ingestion/scripts/codegen.sh
+++ b/metadata-ingestion/scripts/codegen.sh
@@ -6,7 +6,7 @@ OUTDIR=./src/datahub/metadata
 # Note: this assumes that datahub has already been built with `./gradlew build`.
 DATAHUB_ROOT=..
 SCHEMAS_ROOT="$DATAHUB_ROOT/metadata-events/mxe-schemas/src/renamed/avro/com/linkedin"
-FILES="$SCHEMAS_ROOT/mxe/MetadataChangeEvent.avsc $SCHEMAS_ROOT/mxe/MetadataChangeProposal.avsc $SCHEMAS_ROOT/usage/UsageAggregation.avsc"
+FILES="$SCHEMAS_ROOT/mxe/MetadataChangeEvent.avsc $SCHEMAS_ROOT/mxe/MetadataChangeProposal.avsc $SCHEMAS_ROOT/usage/UsageAggregation.avsc $SCHEMAS_ROOT/mxe/MetadataChangeLog.avsc $SCHEMAS_ROOT/mxe/PlatformEvent.avsc $SCHEMAS_ROOT/platform/event/v1/EntityChangeEvent.avsc"
 # Since we depend on jq, check if jq is installed
 if ! which jq > /dev/null; then
    echo "jq is not installed. Please install jq and rerun (https://stedolan.github.io/jq/)"

--- a/metadata-models/src/main/pegasus/com/linkedin/mxe/MetadataChangeProposal.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/mxe/MetadataChangeProposal.pdl
@@ -37,7 +37,7 @@ record MetadataChangeProposal {
   /**
    * Aspect of the entity being written to
    * Not filling this out implies that the writer wants to affect the entire entity
-   * Note: This is only valid for CREATE and DELETE operations.
+   * Note: This is only valid for CREATE, UPSERT, and DELETE operations.
    **/
   aspectName: optional string
 


### PR DESCRIPTION
Adding a few new AVSC schemas to python code gen so they are published. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)