### PR TITLE
Revert "fix(timelineCli): fix naming for timeline cli (#4729)"

### DIFF
--- a/metadata-ingestion/src/datahub/cli/timeline_cli.py
+++ b/metadata-ingestion/src/datahub/cli/timeline_cli.py
@@ -204,8 +204,8 @@ def timeline(
             if change_txn["changeEvents"] is not None:
                 for change_event in change_txn["changeEvents"]:
                     element_string = (
-                        f"({pretty_id(change_event.get('modifier'))})"
-                        if change_event.get("modifier")
+                        f"({pretty_id(change_event.get('elementId'))})"
+                        if change_event.get("elementId")
                         else ""
                     )
                     event_change_color: str = (
@@ -213,9 +213,9 @@ def timeline(
                         if change_event.get("semVerChange") == "MINOR"
                         else "red"
                     )
-                    target_string = pretty_id(change_event.get("entityUrn") or "")
+                    target_string = pretty_id(change_event.get("target") or "")
                     print(
-                        f"\t{colored(change_event['operation'],event_change_color)} {change_event.get('category')} {target_string} {element_string}: {change_event['description']}"
+                        f"\t{colored(change_event['changeType'],event_change_color)} {change_event.get('category')} {target_string} {element_string}: {change_event['description']}"
                     )
     else:
         click.echo(


### PR DESCRIPTION
This reverts commit 7bcc2d9f62a7513b8bd8bc74d6eea0c85f07e245 due to server-compatibility concerns. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)