### PR TITLE
fix(lineage) Filter dataset -> dataset lineage edges if data is transformed

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -32,6 +32,7 @@ import { GetGlossaryTermDocument, GetGlossaryTermQuery } from './graphql/glossar
 import { GetEntityCountsDocument } from './graphql/app.generated';
 import { GetMeDocument } from './graphql/me.generated';
 import { ListRecommendationsDocument } from './graphql/recommendations.generated';
+import { FetchedEntity } from './app/lineage/types';
 
 const user1 = {
     username: 'sdas',
@@ -115,7 +116,7 @@ const dataPlatform = {
     },
 };
 
-const dataset1 = {
+export const dataset1 = {
     urn: 'urn:li:dataset:1',
     type: EntityType.Dataset,
     platform: {
@@ -208,7 +209,7 @@ const dataset1 = {
     deprecation: null,
 };
 
-const dataset2 = {
+export const dataset2 = {
     urn: 'urn:li:dataset:2',
     type: EntityType.Dataset,
     platform: {
@@ -231,6 +232,7 @@ const dataset2 = {
         name: 'Some Other Dataset',
         description: 'This is some other dataset, so who cares!',
         customProperties: [],
+        origin: 'PROD',
     },
     editableProperties: null,
     created: {
@@ -1055,8 +1057,8 @@ export const dataJob1 = {
     editableProperties: null,
     inputOutput: {
         __typename: 'DataJobInputOutput',
-        inputDatasets: [dataset3],
-        outputDatasets: [dataset3],
+        inputDatasets: [dataset5],
+        outputDatasets: [dataset6],
         inputDatajobs: [],
     },
     globalTags: {
@@ -1297,6 +1299,28 @@ export const mlModel = {
     status: null,
     deprecation: null,
 } as MlModel;
+
+export const dataset1FetchedEntity = {
+    urn: dataset1.urn,
+    name: dataset1.name,
+    type: dataset1.type,
+    upstreamChildren: [],
+    downstreamChildren: [
+        { type: EntityType.Dataset, entity: dataset2 },
+        { type: EntityType.DataJob, entity: dataJob1 },
+    ],
+} as FetchedEntity;
+
+export const dataset2FetchedEntity = {
+    urn: dataset2.urn,
+    name: 'test name',
+    type: dataset2.type,
+    upstreamChildren: [
+        { type: EntityType.Dataset, entity: dataset1 },
+        { type: EntityType.DataJob, entity: dataJob1 },
+    ],
+    downstreamChildren: [],
+} as FetchedEntity;
 
 export const mlModelGroup = {
     __typename: 'MLModelGroup',

--- a/datahub-web-react/src/app/lineage/__tests__/constructFetchedNode.test.tsx
+++ b/datahub-web-react/src/app/lineage/__tests__/constructFetchedNode.test.tsx
@@ -1,0 +1,70 @@
+import { dataset1, dataset2, dataJob1, dataset1FetchedEntity, dataset2FetchedEntity } from '../../../Mocks';
+import { EntityType } from '../../../types.generated';
+import { Direction, EntityAndType, FetchedEntity } from '../types';
+import { shouldIncludeChildEntity } from '../utils/constructFetchedNode';
+
+describe('shouldIncludeChildEntity', () => {
+    const parentChildren = [
+        { entity: dataset1, type: dataset1.type },
+        { entity: dataJob1, type: dataJob1.type },
+    ] as EntityAndType[];
+
+    it('should return false if parent and child are datasets and the child has a datajob child that belongs to the parent children', () => {
+        const shouldBeIncluded = shouldIncludeChildEntity(
+            Direction.Upstream,
+            parentChildren,
+            dataset1FetchedEntity,
+            dataset2FetchedEntity,
+        );
+
+        expect(shouldBeIncluded).toBe(false);
+    });
+
+    it('should return true if the datajob is not a child of the parent', () => {
+        const parentChild = [{ entity: dataset1, type: dataset1.type }] as EntityAndType[];
+        const shouldBeIncluded = shouldIncludeChildEntity(
+            Direction.Upstream,
+            parentChild,
+            dataset1FetchedEntity,
+            dataset2FetchedEntity,
+        );
+
+        expect(shouldBeIncluded).toBe(true);
+    });
+
+    it('should return true if either parent or child is not a dataset', () => {
+        const fetchedDatajobEntity = { ...dataset1FetchedEntity, type: EntityType.DataJob };
+        let shouldBeIncluded = shouldIncludeChildEntity(
+            Direction.Upstream,
+            parentChildren,
+            fetchedDatajobEntity,
+            dataset2FetchedEntity,
+        );
+        expect(shouldBeIncluded).toBe(true);
+
+        const fetchedDashboardEntity = { ...dataset2FetchedEntity, type: EntityType.Dashboard };
+        shouldBeIncluded = shouldIncludeChildEntity(
+            Direction.Upstream,
+            parentChildren,
+            dataset1FetchedEntity,
+            fetchedDashboardEntity,
+        );
+        expect(shouldBeIncluded).toBe(true);
+    });
+
+    it('should return true if the parent has a datajob child that is not a child of the dataset child', () => {
+        const updatedDataset1FetchedEntity = {
+            ...dataset1FetchedEntity,
+            downstreamChildren: [{ type: EntityType.Dataset, entity: dataset2 }],
+        } as FetchedEntity;
+
+        const shouldBeIncluded = shouldIncludeChildEntity(
+            Direction.Upstream,
+            parentChildren,
+            updatedDataset1FetchedEntity,
+            dataset2FetchedEntity,
+        );
+
+        expect(shouldBeIncluded).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/lineage/utils/constructTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructTree.ts
@@ -1,6 +1,6 @@
 import EntityRegistry from '../../entity/EntityRegistry';
 import { Direction, EntityAndType, FetchedEntities, NodeData } from '../types';
-import constructFetchedNode from './constructFetchedNode';
+import constructFetchedNode, { shouldIncludeChildEntity } from './constructFetchedNode';
 
 export default function constructTree(
     entityAndType: EntityAndType | null | undefined,
@@ -40,6 +40,10 @@ export default function constructTree(
             return constructFetchedNode(child.entity.urn, fetchedEntities, direction, constructedNodes, [
                 root.urn || '',
             ]);
+        })
+        ?.filter((child) => {
+            const childEntity = fetchedEntities[child?.urn || ''];
+            return shouldIncludeChildEntity(direction, children, childEntity, fetchedEntity);
         })
         ?.filter(Boolean) as Array<NodeData>;
     return root;


### PR DESCRIPTION
This is kind of a fix and kind of a feature request. Right now, if one dataset goes through a datajob like Airflow and then that produces another dataset, we show an edge connecting the two datasets as well as the edges going through the datajob. Instead, we don't want to show the edge between the two datasets but instead only have the edges before and after the datajob.

This PR takes care of that by creating a filter function that's used in `constructTree` (which constructs the whole tree and this filter function is used for the selected node) as well as in `constructFetchedNode` (where we add children to all the visible children branching off of the selected node).

Basically just check, before adding a node as a child of a parent, that if both nodes are datasets and the child has a datajob child that is also a child of the parent, don't add that dataset node as a child then.

This is my first time really digging into entities and a relatively complex lineage visualization - let me know if this approach is the cleanest and makes sense to all!

One example of how it looks now:
<img width="873" alt="image" src="https://user-images.githubusercontent.com/28656603/164545706-cf77afdd-c9a5-40b9-8b81-d3823b4ae14c.png">


How it looks with my change:
<img width="994" alt="image" src="https://user-images.githubusercontent.com/28656603/164545787-bb58fcc6-abc1-4a9e-ba15-2a40f338bcbf.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)