### PR TITLE
fix(ui): Users and Groups UI bug fixes

### DIFF
--- a/datahub-web-react/src/app/entity/group/GroupInfoSideBar.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupInfoSideBar.tsx
@@ -1,4 +1,4 @@
-import { Divider, message, Space, Button, Typography } from 'antd';
+import { Divider, message, Space, Button, Typography, Row, Col } from 'antd';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { EditOutlined, MailOutlined, SlackOutlined } from '@ant-design/icons';
@@ -48,20 +48,21 @@ const TITLES = {
     editGroup: 'Edit Group',
 };
 
-const GroupNameHeader = styled.div`
+const GroupNameHeader = styled(Row)`
     font-size: 20px;
     line-height: 28px;
     color: #262626;
     margin: 16px 16px 8px 8px;
     display: flex;
     align-items: center;
-    justify-content: left;
+    justify-content: center;
     min-height: 100px;
 `;
 
 const GroupName = styled.div`
-    margin-left: 12px;
     max-width: 260px;
+    word-wrap: break-word;
+    width: 140px;
 `;
 
 /**
@@ -120,14 +121,18 @@ export default function GroupInfoSidebar({ sideBarData, refetch }: Props) {
             <SideBar>
                 <SideBarSubSection className={canEditGroup ? '' : 'fullView'}>
                     <GroupNameHeader>
-                        <CustomAvatar
-                            useDefaultAvatar={false}
-                            size={64}
-                            photoUrl={photoUrl}
-                            name={avatarName}
-                            style={AVATAR_STYLE}
-                        />
-                        <GroupName>{name}</GroupName>
+                        <Col>
+                            <CustomAvatar
+                                useDefaultAvatar={false}
+                                size={64}
+                                photoUrl={photoUrl}
+                                name={avatarName}
+                                style={AVATAR_STYLE}
+                            />
+                        </Col>
+                        <Col>
+                            <GroupName>{name}</GroupName>
+                        </Col>
                     </GroupNameHeader>
                     <Divider className="divider-infoSection" />
                     <SocialDetails>

--- a/datahub-web-react/src/app/entity/group/GroupMembersSideBarSection.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupMembersSideBarSection.tsx
@@ -1,4 +1,4 @@
-import { Tag } from 'antd';
+import { Tag, Tooltip } from 'antd';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -53,7 +53,11 @@ export default function GroupMembersSideBarSection({ total, relationships, onSee
                                         photoUrl={user.editableProperties?.pictureLink || undefined}
                                         useDefaultAvatar={false}
                                     />
-                                    {name}
+                                    {name.length > 15 ? (
+                                        <Tooltip title={name}>{`${name.substring(0, 15)}..`}</Tooltip>
+                                    ) : (
+                                        <span>{name}</span>
+                                    )}
                                 </Link>
                             </MemberTag>
                         );

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
@@ -50,7 +50,6 @@ type SelectedActor = {
 };
 
 export const AddOwnerModal = ({ urn, type, visible, hideOwnerType, defaultOwnerType, onClose, refetch }: Props) => {
-    console.log('defaultOwnerType', defaultOwnerType);
     const entityRegistry = useEntityRegistry();
     const [selectedActor, setSelectedActor] = useState<SelectedActor | undefined>(undefined);
     const [selectedOwnerType, setSelectedOwnerType] = useState<OwnershipType>(defaultOwnerType || OwnershipType.None);

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Form, message, Modal, Select, Tag, Typography } from 'antd';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { useAddOwnerMutation } from '../../../../../../../graphql/mutations.generated';
@@ -50,6 +50,7 @@ type SelectedActor = {
 };
 
 export const AddOwnerModal = ({ urn, type, visible, hideOwnerType, defaultOwnerType, onClose, refetch }: Props) => {
+    console.log('defaultOwnerType', defaultOwnerType);
     const entityRegistry = useEntityRegistry();
     const [selectedActor, setSelectedActor] = useState<SelectedActor | undefined>(undefined);
     const [selectedOwnerType, setSelectedOwnerType] = useState<OwnershipType>(defaultOwnerType || OwnershipType.None);
@@ -189,6 +190,12 @@ export const AddOwnerModal = ({ urn, type, visible, hideOwnerType, defaultOwnerT
     const selectValue = (selectedActor && [selectedActor.displayName]) || [];
     const ownershipTypes = OWNERSHIP_DISPLAY_TYPES;
 
+    useEffect(() => {
+        if (ownershipTypes) {
+            setSelectedOwnerType(ownershipTypes[0].type);
+        }
+    }, [ownershipTypes]);
+
     // Handle the Enter press
     // TODO: Allow user to be selected prior to executed the save.
     // useEnterKeyListener({
@@ -240,7 +247,11 @@ export const AddOwnerModal = ({ urn, type, visible, hideOwnerType, defaultOwnerT
                     <Form.Item label={<Typography.Text strong>Type</Typography.Text>}>
                         <Typography.Paragraph>Choose an owner type</Typography.Paragraph>
                         <Form.Item name="type">
-                            <Select value={selectedOwnerType} onChange={onSelectOwnerType}>
+                            <Select
+                                defaultValue={selectedOwnerType}
+                                value={selectedOwnerType}
+                                onChange={onSelectOwnerType}
+                            >
                                 {ownershipTypes.map((ownerType) => (
                                     <Select.Option key={ownerType.type} value={ownerType.type}>
                                         <Typography.Text>{ownerType.name}</Typography.Text>


### PR DESCRIPTION

## Checklist
- Groups side bar title and member section css fixes 
<img width="294" alt="Screenshot 2022-04-25 at 8 02 59 PM" src="https://user-images.githubusercontent.com/29713365/165159404-5bb5a014-f53a-48f1-8c13-c182cee8ec3c.png">
<img width="317" alt="Screenshot 2022-04-25 at 8 00 43 PM" src="https://user-images.githubusercontent.com/29713365/165159526-38dee909-46b8-4cbb-8789-3855d32b7b10.png">


- Groups side bar- member section tags css breaking, fixed with the character limit and full name will be shown on hover of tag(if the name is long, else only shown the original tag).

- Add owner modal -> When user opens the add owner modal, the value added by default type selected with the first value.
<img width="666" alt="Screenshot 2022-04-25 at 8 04 11 PM" src="https://user-images.githubusercontent.com/29713365/165159554-c4253fe4-21b9-438e-961d-915984063e36.png">

@jjoyce0510 @chriscollins3456 

