### PR TITLE
feat(ebeans): Add metrics to track connection pool

### DIFF
--- a/metadata-service/factories/build.gradle
+++ b/metadata-service/factories/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'java'
 
 dependencies {
   compile project(':metadata-io')
+  compile project(':metadata-utils')
   compile project(':metadata-service:auth-impl')
   compile project(':datahub-graphql-core')
   compile project(':metadata-service:restli-servlet-impl')

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java
@@ -7,7 +7,6 @@ import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourcePoolListener;
 import java.sql.Connection;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java
@@ -46,6 +46,9 @@ public class LocalEbeanServerConfigFactory {
   @Value("${ebean.leakTimeMinutes:15}")
   private Integer ebeanLeakTimeMinutes;
 
+  @Value("${ebean.waitTimeoutMillis:1000}")
+  private Integer ebeanWaitTimeoutMillis;
+
   @Value("${ebean.autoCreateDdl:false}")
   private Boolean ebeanAutoCreate;
 
@@ -75,6 +78,7 @@ public class LocalEbeanServerConfigFactory {
     dataSourceConfig.setMaxInactiveTimeSecs(ebeanMaxInactiveTimeSecs);
     dataSourceConfig.setMaxAgeMinutes(ebeanMaxAgeMinutes);
     dataSourceConfig.setLeakTimeMinutes(ebeanLeakTimeMinutes);
+    dataSourceConfig.setWaitTimeoutMillis(ebeanWaitTimeoutMillis);
     dataSourceConfig.setListener(getListenerToTrackCounts(dataSourceType));
     return dataSourceConfig;
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java
@@ -49,9 +49,6 @@ public class LocalEbeanServerConfigFactory {
   @Value("${ebean.autoCreateDdl:false}")
   private Boolean ebeanAutoCreate;
 
-  @Value("${ebean.readOnlyUrl:}")
-  private String ebeanReadOnlyDatasourceUrl;
-
   private DataSourcePoolListener getListenerToTrackCounts(String metricName) {
     final String counterName = "ebeans_connection_pool_size_" + metricName;
     return new DataSourcePoolListener() {
@@ -87,12 +84,6 @@ public class LocalEbeanServerConfigFactory {
     ServerConfig serverConfig = new ServerConfig();
     serverConfig.setName("gmsEbeanServiceConfig");
     serverConfig.setDataSourceConfig(buildDataSourceConfig(ebeanDatasourceUrl, "main"));
-
-    if (!StringUtils.isEmpty(ebeanReadOnlyDatasourceUrl)) {
-      serverConfig.setReadOnlyDataSourceConfig(buildDataSourceConfig(ebeanReadOnlyDatasourceUrl, "read_only"));
-      serverConfig.setAutoReadOnlyDataSource(true);
-    }
-
     serverConfig.setDdlGenerate(ebeanAutoCreate);
     serverConfig.setDdlRun(ebeanAutoCreate);
     return serverConfig;

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -97,6 +97,7 @@ ebean:
   maxInactiveTimeSeconds: ${EBEAN_MAX_INACTIVE_TIME_IN_SECS:120}
   maxAgeMinutes: ${EBEAN_MAX_AGE_MINUTES:120}
   leakTimeMinutes: ${EBEAN_LEAK_TIME_MINUTES:15}
+  waitTimeoutMillis: ${EBEAN_WAIT_TIMEOUT_MILLIS:1000}
   autoCreateDdl: ${EBEAN_AUTOCREATE:false}
 
 cassandra:

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -91,6 +91,7 @@ ebean:
   username: ${EBEAN_DATASOURCE_USERNAME:datahub}
   password: ${EBEAN_DATASOURCE_PASSWORD:datahub}
   url: ${EBEAN_DATASOURCE_URL:jdbc:mysql://localhost:3306/datahub} # JDBC URL
+  readOnlyUrl: ${EBEAN_READ_ONLY_DATASOURCE_URL:}
   driver: ${EBEAN_DATASOURCE_DRIVER:com.mysql.jdbc.Driver} # JDBC Driver
   minConnections: ${EBEAN_MIN_CONNECTIONS:2}
   maxConnections: ${EBEAN_MAX_CONNECTIONS:50}

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -91,7 +91,6 @@ ebean:
   username: ${EBEAN_DATASOURCE_USERNAME:datahub}
   password: ${EBEAN_DATASOURCE_PASSWORD:datahub}
   url: ${EBEAN_DATASOURCE_URL:jdbc:mysql://localhost:3306/datahub} # JDBC URL
-  readOnlyUrl: ${EBEAN_READ_ONLY_DATASOURCE_URL:}
   driver: ${EBEAN_DATASOURCE_DRIVER:com.mysql.jdbc.Driver} # JDBC Driver
   minConnections: ${EBEAN_MIN_CONNECTIONS:2}
   maxConnections: ${EBEAN_MAX_CONNECTIONS:50}


### PR DESCRIPTION
We've seen various scaling issues lately due to the number of open connections to the local DB. First, add metrics to track the number of open connections.

<img width="563" alt="Screen Shot 2022-04-26 at 4 30 08 PM" src="https://user-images.githubusercontent.com/896177/165409246-762e3b2d-a69c-4459-b0ff-b1b80fee309b.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)