### PR TITLE
fix(ingest): fwk - datahub_api should be initialized by datahub-rest …

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -88,7 +88,7 @@ class PipelineConfig(ConfigModel):
         cls, v: Optional[DatahubClientConfig], values: Dict[str, Any], **kwargs: Any
     ) -> Optional[DatahubClientConfig]:
         if v is None:
-            if "sink" in values and "type" in values["sink"]:
+            if "sink" in values and hasattr(values["sink"], "type"):
                 sink_type = values["sink"].type
                 if sink_type == "datahub-rest":
                     sink_config = values["sink"].config


### PR DESCRIPTION
…sink config

#4718 introduced a bug where `datahub-api` is not initialized even if the `datahub-rest` sink has been configured. 
This unfortunately makes sources and transformers that require a datahub-graph (e.g. `dbt`) to complain and exit on startup.  

This PR fixes the issue and adds a few tests to ensure that we don't run into this issue again.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)