### PR TITLE
fix(ui ingest): Unschedule all sources on ingestion source refresh, fix delete not being enforced

### DIFF
--- a/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
+++ b/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -88,7 +89,8 @@ public class IngestionScheduler {
     final BatchRefreshSchedulesRunnable batchRefreshSchedulesRunnable = new BatchRefreshSchedulesRunnable(
         _systemAuthentication,
         _entityClient,
-        this::scheduleNextIngestionSourceExecution);
+        this::scheduleNextIngestionSourceExecution,
+        this::unscheduleAll);
 
     // Schedule a recurring batch-reload task.
     _sharedExecutorService.scheduleAtFixedRate(
@@ -100,11 +102,23 @@ public class IngestionScheduler {
    * Removes the next scheduled execution of a particular ingestion source, if it exists.
    */
   public void unscheduleNextIngestionSourceExecution(final Urn ingestionSourceUrn) {
+    log.info("Unscheduling ingestion source with urn {}", ingestionSourceUrn);
     // Deleting an ingestion source schedule. Un-schedule the next execution.
     ScheduledFuture<?> future = _nextIngestionSourceExecutionCache.get(ingestionSourceUrn);
     if (future != null) {
-      future.cancel(true);
+      future.cancel(false); // Do not interrupt running processes
       _nextIngestionSourceExecutionCache.remove(ingestionSourceUrn);
+    }
+  }
+
+  /**
+   * Un-schedule all ingestion sources that are scheduled for execution. This is performed on refresh of ingestion sources.
+   */
+  public void unscheduleAll() {
+    // Deleting an ingestion source schedule. Un-schedule the next execution.
+    Set<Urn> scheduledSources = new HashSet<>(_nextIngestionSourceExecutionCache.keySet()); // Create copy to avoid concurrent mod.
+    for (Urn urn : scheduledSources) {
+      unscheduleNextIngestionSourceExecution(urn);
     }
   }
 
@@ -173,14 +187,17 @@ public class IngestionScheduler {
     private final Authentication _systemAuthentication;
     private final EntityClient _entityClient;
     private final BiConsumer<Urn, DataHubIngestionSourceInfo> _scheduleNextIngestionSourceExecution;
+    private final Runnable _unscheduleAll;
 
     public BatchRefreshSchedulesRunnable(
         @Nonnull final Authentication systemAuthentication,
         @Nonnull final EntityClient entityClient,
-        @Nonnull final BiConsumer<Urn, DataHubIngestionSourceInfo> scheduleNextIngestionSourceExecution) {
+        @Nonnull final BiConsumer<Urn, DataHubIngestionSourceInfo> scheduleNextIngestionSourceExecution,
+        @Nonnull final Runnable unscheduleAll) {
       _systemAuthentication = Objects.requireNonNull(systemAuthentication);
       _entityClient = Objects.requireNonNull(entityClient);
       _scheduleNextIngestionSourceExecution = Objects.requireNonNull(scheduleNextIngestionSourceExecution);
+      _unscheduleAll = unscheduleAll;
     }
 
     @Override
@@ -212,6 +229,11 @@ public class IngestionScheduler {
 
             // 3. Reschedule ingestion sources based on the fetched schedules (inside "info")
             log.debug("Received batch of Ingestion Source Info aspects. Attempting to re-schedule execution requests.");
+
+            // First unschedule all currently scheduled runs (to make sure consistency is maintained)
+            _unscheduleAll.run();
+
+            // Then schedule the next ingestion runs
             scheduleNextIngestionRuns(new ArrayList<>(ingestionSources.values()));
 
             total = ingestionSourceUrns.getTotal();

--- a/ingestion-scheduler/src/test/java/com/datahub/metadata/ingestion/IngestionSchedulerTest.java
+++ b/ingestion-scheduler/src/test/java/com/datahub/metadata/ingestion/IngestionSchedulerTest.java
@@ -232,4 +232,35 @@ public class IngestionSchedulerTest {
     ScheduledFuture<?> future = _ingestionScheduler._nextIngestionSourceExecutionCache.get(urn);
     Assert.assertTrue(future.getDelay(TimeUnit.SECONDS) < 60); // Next execution must always be less than a minute away.
   }
+
+  @Test
+  public void testUnscheduleAll() throws Exception {
+    assertEquals(_ingestionScheduler._nextIngestionSourceExecutionCache.size(), 1);
+
+    final Urn urn = Urn.createFromString("urn:li:dataHubIngestionSourceUrn:3");
+    final DataHubIngestionSourceInfo newInfo = new DataHubIngestionSourceInfo();
+    newInfo.setSchedule(new DataHubIngestionSourceSchedule().setInterval("* * * * *").setTimezone("UTC")); // Run every monday
+    newInfo.setType("redshift");
+    newInfo.setName("My Redshift Source 2");
+    newInfo.setConfig(new DataHubIngestionSourceConfig()
+        .setExecutorId("default")
+        .setRecipe("{ type }")
+        .setVersion("0.8.18")
+    );
+    _ingestionScheduler.scheduleNextIngestionSourceExecution(urn, newInfo);
+
+    assertEquals(_ingestionScheduler._nextIngestionSourceExecutionCache.size(), 2);
+
+    // Get reference to schedules futures
+    ScheduledFuture<?> future = _ingestionScheduler._nextIngestionSourceExecutionCache.get(urn);
+
+    // Unschedule all
+    _ingestionScheduler.unscheduleAll();
+
+    // Ensure that the cache is empty
+    Assert.assertTrue(_ingestionScheduler._nextIngestionSourceExecutionCache.isEmpty());
+
+    // And that the future is cancelled
+    Assert.assertTrue(future.isCancelled());
+  }
 }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -68,6 +68,9 @@ public class MetadataChangeLogProcessor {
       return;
     }
 
+    log.info("Invoked MCL Processor with event {}", event.toString());
+
+
     log.debug("Invoking MCL hooks for urn: {}, key: {}", event.getEntityUrn(), event.getEntityKeyAspect());
 
     // Here - plug in additional "custom processor hooks"

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -68,9 +68,6 @@ public class MetadataChangeLogProcessor {
       return;
     }
 
-    log.info("Invoked MCL Processor with event {}", event.toString());
-
-
     log.debug("Invoking MCL hooks for urn: {}, key: {}", event.getEntityUrn(), event.getEntityKeyAspect());
 
     // Here - plug in additional "custom processor hooks"

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
@@ -75,7 +75,7 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
    * of an Ingestion Source Info aspect, which in turn contains the schedule associated with the source.
    */
   private boolean isEligibleForProcessing(final MetadataChangeLog event) {
-    return isIngestionSourceUpdate(event) || isIngestionSourceDelete(event);
+    return isIngestionSourceUpdate(event) || isIngestionSourceDeleted(event);
   }
 
   private boolean isIngestionSourceUpdate(final MetadataChangeLog event) {
@@ -85,7 +85,7 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
         || ChangeType.DELETE.equals(event.getChangeType()));
   }
 
-  private boolean isIngestionSourceDelete(final MetadataChangeLog event) {
+  private boolean isIngestionSourceDeleted(final MetadataChangeLog event) {
     return Constants.INGESTION_SOURCE_KEY_ASPECT_NAME.equals(event.getAspectName())
         && ChangeType.DELETE.equals(event.getChangeType());
   }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
@@ -51,6 +51,7 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
 
   @Override
   public void invoke(@Nonnull MetadataChangeLog event) {
+
     if (isEligibleForProcessing(event)) {
 
       log.info("Received {} to Ingestion Source. Rescheduling the source (if applicable). urn: {}, key: {}.",
@@ -75,10 +76,19 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
    * of an Ingestion Source Info aspect, which in turn contains the schedule associated with the source.
    */
   private boolean isEligibleForProcessing(final MetadataChangeLog event) {
+    return isIngestionSourceUpdate(event) || isIngestionSourceDelete(event);
+  }
+
+  private boolean isIngestionSourceUpdate(final MetadataChangeLog event) {
     return Constants.INGESTION_INFO_ASPECT_NAME.equals(event.getAspectName())
-        && (ChangeType.DELETE.equals(event.getChangeType())
-        || ChangeType.UPSERT.equals(event.getChangeType())
-        || ChangeType.CREATE.equals(event.getChangeType()));
+        && (ChangeType.UPSERT.equals(event.getChangeType())
+        || ChangeType.CREATE.equals(event.getChangeType())
+        || ChangeType.DELETE.equals(event.getChangeType()));
+  }
+
+  private boolean isIngestionSourceDelete(final MetadataChangeLog event) {
+    return Constants.INGESTION_SOURCE_KEY_ASPECT_NAME.equals(event.getAspectName())
+        && ChangeType.DELETE.equals(event.getChangeType());
   }
 
   /**

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHook.java
@@ -51,7 +51,6 @@ public class IngestionSchedulerHook implements MetadataChangeLogHook {
 
   @Override
   public void invoke(@Nonnull MetadataChangeLog event) {
-
     if (isEligibleForProcessing(event)) {
 
       log.info("Received {} to Ingestion Source. Rescheduling the source (if applicable). urn: {}, key: {}.",

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/ingestion/IngestionSchedulerHookTest.java
@@ -51,7 +51,18 @@ public class IngestionSchedulerHookTest {
   }
 
   @Test
-  public void testInvokeDelete() throws Exception {
+  public void testInvokeDeleteKeyAspect() throws Exception {
+    MetadataChangeLog event2 = new MetadataChangeLog();
+    event2.setEntityType(INGESTION_SOURCE_ENTITY_NAME);
+    event2.setAspectName(INGESTION_SOURCE_KEY_ASPECT_NAME);
+    event2.setChangeType(ChangeType.DELETE);
+    event2.setEntityUrn(Urn.createFromString("urn:li:dataHubIngestionSourceUrn:0"));
+    _ingestionSchedulerHook.invoke(event2);
+    Mockito.verify(_ingestionSchedulerHook.scheduler(), Mockito.times(1)).unscheduleNextIngestionSourceExecution(Mockito.any());
+  }
+
+  @Test
+  public void testInvokeDeleteInfoAspect() throws Exception {
     MetadataChangeLog event2 = new MetadataChangeLog();
     event2.setEntityType(INGESTION_SOURCE_ENTITY_NAME);
     event2.setAspectName(INGESTION_INFO_ASPECT_NAME);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/ingestion/IngestionSchedulerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/ingestion/IngestionSchedulerFactory.java
@@ -32,10 +32,10 @@ public class IngestionSchedulerFactory {
   @Autowired
   private ConfigurationProvider _configProvider;
 
-  @Value("${ingestion.scheduler.delayIntervalSeconds:30}")
+  @Value("${ingestion.scheduler.delayIntervalSeconds:45}") // Boot up ingestion source cache after waiting 45 seconds for startup.
   private Integer _delayIntervalSeconds;
 
-  @Value("${ingestion.scheduler.refreshIntervalSeconds:86400}")
+  @Value("${ingestion.scheduler.refreshIntervalSeconds:43200}") // By default, refresh ingestion sources 2 times per day.
   private Integer _refreshIntervalSeconds;
 
   @Bean(name = "ingestionScheduler")

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -179,6 +179,7 @@ public class Constants {
   public static final String ASSERTION_RUN_EVENT_STATUS_COMPLETE = "COMPLETE";
 
   // DataHub Ingestion Source
+  public static final String INGESTION_SOURCE_KEY_ASPECT_NAME = "dataHubIngestionSourceKey";
   public static final String INGESTION_INFO_ASPECT_NAME = "dataHubIngestionSourceInfo";
 
   // DataHub Secret


### PR DESCRIPTION
**Summary** 
For UI ingestion we periodically refresh all of the scheduled ingestion sources to make sure schedules are all up to date. Previously, doing this only updated the schedules that were explicitly found in the DB. The result is that if an ingestion source failed to clear previously (e.g. missed message) then it will continue to run indefinitely. 

Additionally, this fixes a bug where Deletes are failing to reflect immediately due to a bad assumption on a deleted aspect coming through to the Ingestion Scheduler. This PR makes the ingestion scheduler hook more amenable to entity-level deletes. 

This change unschedules all ingestion sources when we refetch them periodically. It also increases the default refresh freq to 2x per day. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)