### PR TITLE
fix(docs): Fixing outdated control-center doc on policies.md

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -122,8 +122,8 @@ Supported fields are as follows
 
 ## Managing Policies
 
-Policies can be managed under the `/policies` page, or accessed inside the Control Center, a slide-out menu
-appearing on the left side of the DataHub UI. The `Policies` tab will only be visible to those users having the `MANAGE_POLICIES` privilege.
+Policies can be managed under the `/policies` page, or accessed via the top navigation bar. The `Policies` tab will only 
+be visible to those users having the `Manage Policies` privilege.
 
 Out of the box, DataHub is deployed with a set of pre-baked Policies. The set of default policies are created at deploy 
 time and can be found inside the `policies.json` file within `metadata-service/war/src/main/resources/boot`. This set of policies serves the 


### PR DESCRIPTION
**Summary**
Fixing an outdated doc which refers to the slide out control-center menu (replaced by top nav). 


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)