### PR TITLE
fix(ingestion): Fix presto_on_hive tests.

### DIFF
--- a/metadata-ingestion/tests/integration/presto-on-hive/test_presto_on_hive.py
+++ b/metadata-ingestion/tests/integration/presto-on-hive/test_presto_on_hive.py
@@ -1,15 +1,13 @@
 import re
 import subprocess
 import sys
+from typing import Dict
 
 import pytest
 import requests
 from freezegun import freeze_time
 
-from datahub.configuration.common import AllowDenyPattern
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.sink.file import FileSinkConfig
-from datahub.ingestion.source.sql.presto_on_hive import PrestoOnHiveConfig
 from tests.test_helpers import fs_helpers, mce_helpers
 from tests.test_helpers.docker_helpers import wait_for_port
 
@@ -66,24 +64,26 @@ def test_presto_on_hive_ingest(
         mce_out_file = "presto_on_hive_mces.json"
         events_file = tmp_path / mce_out_file
 
-        pipeline_config = {
+        pipeline_config: Dict = {
             "run_id": "presto-on-hive-test",
             "source": {
                 "type": data_platform,
-                "config": PrestoOnHiveConfig(
-                    host_port="localhost:5432",
-                    database="metastore",
-                    database_alias="hive",
-                    username="postgres",
-                    scheme="postgresql+psycopg2",
-                    include_views=True,
-                    include_tables=True,
-                    schema_pattern=AllowDenyPattern(allow=["^public"]),
-                ).dict(),
+                "config": {
+                    "host_port": "localhost:5432",
+                    "database": "metastore",
+                    "database_alias": "hive",
+                    "username": "postgres",
+                    "scheme": "postgresql+psycopg2",
+                    "include_views": True,
+                    "include_tables": True,
+                    "schema_pattern": {"allow": ["^public"]},
+                },
             },
             "sink": {
                 "type": "file",
-                "config": FileSinkConfig(filename=str(events_file)).dict(),
+                "config": {
+                    "filename": str(events_file),
+                },
             },
         }
 
@@ -120,25 +120,28 @@ def test_presto_on_hive_instance_ingest(
     platform = "presto-on-hive"
     mce_out_file = "presto_on_hive_instance_mces.json"
     events_file = tmp_path / mce_out_file
-    pipeline_config = {
-        "run_id": "presto-on-hive-instance-test",
+
+    pipeline_config: Dict = {
+        "run_id": "presto-on-hive-test-2",
         "source": {
             "type": data_platform,
-            "config": PrestoOnHiveConfig(
-                host_port="localhost:5432",
-                database="metastore",
-                database_alias="hive",
-                username="postgres",
-                scheme="postgresql+psycopg2",
-                include_views=True,
-                include_tables=True,
-                platform_instance="production_warehouse",
-                schema_pattern=AllowDenyPattern(allow=["^public"]),
-            ).dict(),
+            "config": {
+                "host_port": "localhost:5432",
+                "database": "metastore",
+                "database_alias": "hive",
+                "username": "postgres",
+                "scheme": "postgresql+psycopg2",
+                "include_views": True,
+                "include_tables": True,
+                "schema_pattern": {"allow": ["^public"]},
+                "platform_instance": "production_warehouse",
+            },
         },
         "sink": {
             "type": "file",
-            "config": FileSinkConfig(filename=str(events_file)).dict(),
+            "config": {
+                "filename": str(events_file),
+            },
         },
     }
 


### PR DESCRIPTION
Fix failing tests in test_presto_on_hive.

Root-cause: Since the `scheme` field of the config is now excluded, the way the test is building the pipeline config would drop the scheme in the dict() call causing the it to pickup the default value(`mysql+pymysql`), instead of what is being specified in the test(`postgresql+psycopg2`), which lead to an incorrect SQLAlchemyURL for the tests causing the test failures.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)