### PR TITLE
fix(scrolling) Fixes scrolling and weird heights for embeddedListSearch across entities

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedEntity.tsx
@@ -6,8 +6,7 @@ import { EmbeddedListSearch } from '../../shared/components/styled/search/Embedd
 import { useEntityData } from '../../shared/EntityContext';
 
 const GroupAssetsWrapper = styled(Row)`
-    height: calc(100vh - 245px);
-    overflow: auto;
+    height: 100%;
 `;
 
 export default function GlossaryRelatedEntity() {

--- a/datahub-web-react/src/app/entity/group/GroupAssets.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupAssets.tsx
@@ -4,7 +4,6 @@ import { EmbeddedListSearch } from '../shared/components/styled/search/EmbeddedL
 
 const GroupAssetsWrapper = styled.div`
     height: calc(100vh - 114px);
-    overflow: auto;
 `;
 
 type Props = {

--- a/datahub-web-react/src/app/entity/shared/components/styled/TabToolbar.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/TabToolbar.tsx
@@ -10,4 +10,5 @@ export default styled.div`
     border-bottom: 1px solid ${ANTD_GRAY[4.5]};
     padding: 7px 16px;
     box-shadow: 0px 2px 6px 0px #0000000d;
+    flex: 0 0 auto;
 `;

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -17,8 +17,9 @@ import { useGetSearchResultsForMultipleQuery } from '../../../../../../graphql/s
 import { GetSearchResultsParams, SearchResultsInterface } from './types';
 
 const Container = styled.div`
-    overflow: scroll;
-    height: 120;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 `;
 
 // this extracts the response from useGetSearchResultsForMultipleQuery into a common interface other search endpoints can also produce

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -10,6 +10,8 @@ import { ReactComponent as LoadingSvg } from '../../../../../../images/datahub-l
 const SearchBody = styled.div`
     display: flex;
     flex-direction: row;
+    flex: 1 1 auto;
+    overflow-y: hidden;
 `;
 
 const PaginationInfo = styled(Typography.Text)`
@@ -17,7 +19,9 @@ const PaginationInfo = styled(Typography.Text)`
 `;
 
 const FiltersContainer = styled.div`
-    display: block;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
     max-width: 260px;
     min-width: 260px;
     border-right: 1px solid;
@@ -26,7 +30,9 @@ const FiltersContainer = styled.div`
 
 const ResultContainer = styled.div`
     flex: 1;
-    margin-bottom: 20px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
 `;
 
 const PaginationInfoContainer = styled.div`
@@ -42,6 +48,7 @@ const PaginationInfoContainer = styled.div`
 const FiltersHeader = styled.div`
     font-size: 14px;
     font-weight: 600;
+    flex: 0 0 auto;
 
     padding-left: 20px;
     padding-right: 20px;
@@ -61,6 +68,8 @@ const StyledPagination = styled(Pagination)`
 
 const SearchFilterContainer = styled.div`
     padding-top: 10px;
+    flex: 1 1 auto;
+    overflow: hidden;
 `;
 
 const LoadingText = styled.div`
@@ -73,6 +82,7 @@ const LoadingContainer = styled.div`
     padding-bottom: 40px;
     width: 100%;
     text-align: center;
+    flex: 1;
 `;
 
 interface Props {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -68,8 +68,21 @@ const HeaderAndTabsFlex = styled.div`
     max-height: 100%;
     overflow: hidden;
     min-height: 0;
+    overflow-y: auto;
+
+    &::-webkit-scrollbar {
+        height: 12px;
+        width: 2px;
+        background: #f2f2f2;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: #cccccc;
+        -webkit-border-radius: 1ex;
+        -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75);
+    }
 `;
 const Sidebar = styled.div`
+    max-height: 100%;
     overflow: auto;
     flex-basis: 30%;
     padding-left: 20px;
@@ -83,6 +96,8 @@ const Header = styled.div`
 `;
 
 const TabContent = styled.div`
+    display: flex;
+    flex-direction: column;
     flex: 1;
     overflow: auto;
 `;

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/EntitySidebar.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/EntitySidebar.tsx
@@ -13,6 +13,16 @@ const ContentContainer = styled.div`
         padding-top: 20px;
         margin-bottom: 20px;
     }
+    &::-webkit-scrollbar {
+        height: 12px;
+        width: 2px;
+        background: #f2f2f2;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: #cccccc;
+        -webkit-border-radius: 1ex;
+        -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75);
+    }
 `;
 
 type Props = {

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ImpactAnalysis.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ImpactAnalysis.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import * as QueryString from 'query-string';
 import { useLocation } from 'react-router';
+import styled from 'styled-components';
 
 import { useSearchAcrossLineageQuery } from '../../../../../graphql/search.generated';
 import { EntityType, FacetFilterInput, LineageDirection } from '../../../../../types.generated';
@@ -10,6 +11,10 @@ import { SearchCfg } from '../../../../../conf';
 import analytics, { EventType } from '../../../../analytics';
 import { EmbeddedListSearch } from '../../components/styled/search/EmbeddedListSearch';
 import generateUseSearchResultsViaRelationshipHook from './generateUseSearchResultsViaRelationshipHook';
+
+const ImpactAnalysisWrapper = styled.div`
+    flex: 1;
+`;
 
 type Props = {
     urn: string;
@@ -54,13 +59,13 @@ export const ImpactAnalysis = ({ urn }: Props) => {
     }, [query, data, loading]);
 
     return (
-        <div>
+        <ImpactAnalysisWrapper>
             <EmbeddedListSearch
                 useGetSearchResults={generateUseSearchResultsViaRelationshipHook({
                     urn,
                     direction: LineageDirection.Downstream,
                 })}
             />
-        </div>
+        </ImpactAnalysisWrapper>
     );
 };

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -10,6 +10,7 @@ import { capitalizeFirstLetter } from '../../../shared/textUtil';
 const StyledList = styled(List)`
     margin-top: -1px;
     box-shadow: ${(props) => props.theme.styles['box-shadow']};
+    flex: 1;
     .ant-list-items > .ant-list-item {
         padding-right: 0px;
         padding-left: 0px;
@@ -23,6 +24,16 @@ const StyledList = styled(List)`
         border-bottom: none;
         padding-bottom: 0px;
         padding-top: 15px;
+    }
+    &::-webkit-scrollbar {
+        height: 12px;
+        width: 5px;
+        background: #f2f2f2;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: #cccccc;
+        -webkit-border-radius: 1ex;
+        -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75);
     }
 ` as typeof List;
 

--- a/datahub-web-react/src/app/search/SearchFilters.tsx
+++ b/datahub-web-react/src/app/search/SearchFilters.tsx
@@ -1,7 +1,24 @@
 import * as React from 'react';
+import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { FacetMetadata } from '../../types.generated';
 import { SearchFilter } from './SearchFilter';
+
+export const SearchFilterWrapper = styled.div`
+    max-height: 100%;
+    overflow: auto;
+
+    &::-webkit-scrollbar {
+        height: 12px;
+        width: 1px;
+        background: #f2f2f2;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: #cccccc;
+        -webkit-border-radius: 1ex;
+        -webkit-box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.75);
+    }
+`;
 
 interface Props {
     facets: Array<FacetMetadata>;
@@ -46,7 +63,7 @@ export const SearchFilters = ({ facets, selectedFilters, onFilterSelect, loading
     };
 
     return (
-        <>
+        <SearchFilterWrapper>
             {cachedProps.facets.map((facet) => (
                 <SearchFilter
                     key={`${facet.displayName}-${facet.field}`}
@@ -55,6 +72,6 @@ export const SearchFilters = ({ facets, selectedFilters, onFilterSelect, loading
                     onFilterSelect={onFilterSelectAndSetCache}
                 />
             ))}
-        </>
+        </SearchFilterWrapper>
     );
 };

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -16,6 +16,7 @@ const styles = {
         marginTop: 60,
         display: 'flex',
         flexDirection: 'column' as const,
+        maxHeight: 'calc(100vh - 60px)',
     },
 };
 


### PR DESCRIPTION
Took over work from @ShubhamThakre to work on making `embeddedListSearch` have better scroll behavior - specifically we want the pagination footer to always be at the bottom (even if there's not enough content to push it there) and we want scroll to be inside of it.

There was a few other scroll-related css changes as well.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)