### PR TITLE
fix(search) Fixes a UI issue so results and filters are always separated

### DIFF
--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -174,88 +174,95 @@ export const SearchResults = ({
     return (
         <>
             {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
-            <SearchBody>
-                <FiltersContainer>
-                    <FiltersHeader>Filter</FiltersHeader>
-                    <SearchFilterContainer>
-                        <SearchFilters
-                            loading={loading}
-                            facets={filters || []}
-                            selectedFilters={selectedFilters}
-                            onFilterSelect={onFilterSelect}
-                        />
-                    </SearchFilterContainer>
-                </FiltersContainer>
-                <ResultContainer>
-                    <PaginationInfoContainer>
-                        <Typography.Paragraph>
-                            Showing{' '}
-                            <b>
-                                {lastResultIndex > 0 ? (page - 1) * pageSize + 1 : 0} - {lastResultIndex}
-                            </b>{' '}
-                            of <b>{totalResults}</b> results
-                        </Typography.Paragraph>
-                        <SearchMenuContainer>
-                            <SearchExtendedMenu
-                                callSearchOnVariables={callSearchOnVariables}
-                                entityFilters={entityFilters}
-                                filters={filtersWithoutEntities}
-                                query={query}
+            <div>
+                <SearchBody>
+                    <FiltersContainer>
+                        <FiltersHeader>Filter</FiltersHeader>
+                        <SearchFilterContainer>
+                            <SearchFilters
+                                loading={loading}
+                                facets={filters || []}
+                                selectedFilters={selectedFilters}
+                                onFilterSelect={onFilterSelect}
                             />
-                        </SearchMenuContainer>
-                    </PaginationInfoContainer>
-                    {!loading && (
-                        <>
-                            <ResultList<React.FC<ListProps<SearchResult>>>
-                                dataSource={searchResponse?.searchResults}
-                                split={false}
-                                locale={{
-                                    emptyText: (
-                                        <NoDataContainer>
-                                            <Empty
-                                                style={{ fontSize: 18, color: ANTD_GRAY[8] }}
-                                                description={`No results found for "${query}"`}
-                                            />
-                                            <Button
-                                                onClick={() => navigateToSearchUrl({ query: '*', page: 0, history })}
-                                            >
-                                                <RocketOutlined /> Explore your metadata
-                                            </Button>
-                                        </NoDataContainer>
-                                    ),
-                                }}
-                                renderItem={(item, index) => (
-                                    <>
-                                        <List.Item style={{ padding: 0 }} onClick={() => onResultClick(item, index)}>
-                                            {entityRegistry.renderSearchResult(item.entity.type, item)}
-                                        </List.Item>
-                                        <ThinDivider />
-                                    </>
-                                )}
-                            />
-                            <PaginationControlContainer>
-                                <Pagination
-                                    current={page}
-                                    pageSize={SearchCfg.RESULTS_PER_PAGE}
-                                    total={totalResults}
-                                    showLessItems
-                                    onChange={onChangePage}
-                                    showSizeChanger={false}
+                        </SearchFilterContainer>
+                    </FiltersContainer>
+                    <ResultContainer>
+                        <PaginationInfoContainer>
+                            <Typography.Paragraph>
+                                Showing{' '}
+                                <b>
+                                    {lastResultIndex > 0 ? (page - 1) * pageSize + 1 : 0} - {lastResultIndex}
+                                </b>{' '}
+                                of <b>{totalResults}</b> results
+                            </Typography.Paragraph>
+                            <SearchMenuContainer>
+                                <SearchExtendedMenu
+                                    callSearchOnVariables={callSearchOnVariables}
+                                    entityFilters={entityFilters}
+                                    filters={filtersWithoutEntities}
+                                    query={query}
                                 />
-                            </PaginationControlContainer>
-                            {authenticatedUserUrn && (
-                                <SearchResultsRecommendationsContainer>
-                                    <SearchResultsRecommendations
-                                        userUrn={authenticatedUserUrn}
-                                        query={query}
-                                        filters={selectedFilters}
+                            </SearchMenuContainer>
+                        </PaginationInfoContainer>
+                        {!loading && (
+                            <>
+                                <ResultList<React.FC<ListProps<SearchResult>>>
+                                    dataSource={searchResponse?.searchResults}
+                                    split={false}
+                                    locale={{
+                                        emptyText: (
+                                            <NoDataContainer>
+                                                <Empty
+                                                    style={{ fontSize: 18, color: ANTD_GRAY[8] }}
+                                                    description={`No results found for "${query}"`}
+                                                />
+                                                <Button
+                                                    onClick={() =>
+                                                        navigateToSearchUrl({ query: '*', page: 0, history })
+                                                    }
+                                                >
+                                                    <RocketOutlined /> Explore your metadata
+                                                </Button>
+                                            </NoDataContainer>
+                                        ),
+                                    }}
+                                    renderItem={(item, index) => (
+                                        <>
+                                            <List.Item
+                                                style={{ padding: 0 }}
+                                                onClick={() => onResultClick(item, index)}
+                                            >
+                                                {entityRegistry.renderSearchResult(item.entity.type, item)}
+                                            </List.Item>
+                                            <ThinDivider />
+                                        </>
+                                    )}
+                                />
+                                <PaginationControlContainer>
+                                    <Pagination
+                                        current={page}
+                                        pageSize={SearchCfg.RESULTS_PER_PAGE}
+                                        total={totalResults}
+                                        showLessItems
+                                        onChange={onChangePage}
+                                        showSizeChanger={false}
                                     />
-                                </SearchResultsRecommendationsContainer>
-                            )}
-                        </>
-                    )}
-                </ResultContainer>
-            </SearchBody>
+                                </PaginationControlContainer>
+                                {authenticatedUserUrn && (
+                                    <SearchResultsRecommendationsContainer>
+                                        <SearchResultsRecommendations
+                                            userUrn={authenticatedUserUrn}
+                                            query={query}
+                                            filters={selectedFilters}
+                                        />
+                                    </SearchResultsRecommendationsContainer>
+                                )}
+                            </>
+                        )}
+                    </ResultContainer>
+                </SearchBody>
+            </div>
         </>
     );
 };


### PR DESCRIPTION
Always display the separator between filters and search results by adding a separating div so content can always grow to its full amount.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)