### PR TITLE
refactor(deps): Bump jackson-databind 2.13.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,9 +76,9 @@ project.ext.externalDependency = [
     'httpClient': 'org.apache.httpcomponents:httpclient:4.5.9',
     'httpAsyncClient': 'org.apache.httpcomponents:httpasyncclient:4.1.5',
     'iStackCommons': 'com.sun.istack:istack-commons-runtime:4.0.1',
-    'jacksonCore': 'com.fasterxml.jackson.core:jackson-core:2.9.10',
-    'jacksonDataBind': 'com.fasterxml.jackson.core:jackson-databind:2.9.10.7',
-    'jacksonDataFormatYaml': 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.10',
+    'jacksonCore': 'com.fasterxml.jackson.core:jackson-core:2.13.2',
+    'jacksonDataBind': 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2',
+    'jacksonDataFormatYaml': 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2',
     'javatuples': 'org.javatuples:javatuples:1.2',
     'javaxInject' : 'javax.inject:javax.inject:1',
     'javaxValidation' : 'javax.validation:validation-api:2.0.1.Final',
@@ -190,6 +190,7 @@ subprojects {
         implementation('org.apache.commons:commons-compress:1.21')
         implementation('org.apache.velocity:velocity-engine-core:2.3')
         implementation('org.hibernate:hibernate-validator:6.0.20.Final')
+        implementation('com.fasterxml.jackson.core:jackson-databind:2.13.2.2')
       }
     }
 

--- a/metadata-integration/java/datahub-client/scripts/check_jar.sh
+++ b/metadata-integration/java/datahub-client/scripts/check_jar.sh
@@ -22,6 +22,7 @@ jar -tvf $jarFile |\
       grep -v "java-header-style.xml" |\
       grep -v "xml-header-style.xml" |\
       grep -v "license.header" |\
+      grep -v "module-info.class" |\
       grep -v "client.properties"
 
 if [ $? -ne 0 ]; then

--- a/metadata-integration/java/spark-lineage/build.gradle
+++ b/metadata-integration/java/spark-lineage/build.gradle
@@ -142,7 +142,7 @@ shadowJar {
         })
 
   }
-
+  relocate 'com.fasterxml.jackson', 'datahub.shaded.jackson'
   relocate 'org.apache.http','datahub.spark2.shaded.http'
   relocate 'org.apache.commons.codec', 'datahub.spark2.shaded.o.a.c.codec'
   relocate 'org.apache.commons.compress', 'datahub.spark2.shaded.o.a.c.compress'

--- a/metadata-integration/java/spark-lineage/scripts/check_jar.sh
+++ b/metadata-integration/java/spark-lineage/scripts/check_jar.sh
@@ -23,6 +23,7 @@ jar -tvf $jarFile |\
       grep -v "java-header-style.xml" |\
       grep -v "xml-header-style.xml" |\
       grep -v "license.header" |\
+      grep -v "module-info.class" |\
       grep -v "client.properties"
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
# Summary

Constraining jackson-databind library to 2.13.2.2 to ensure that this vulnerability is addressed: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518  

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)