### PR TITLE
fix(usage): pull usage from environment source rather than args

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/UsageTypeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/UsageTypeResolver.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.load;
 
 import com.linkedin.datahub.graphql.UsageStatsKey;
 
+import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.types.LoadableType;
 import com.linkedin.pegasus2avro.usage.UsageQueryResult;
 import com.linkedin.usage.UsageTimeRange;
@@ -27,7 +28,7 @@ public class UsageTypeResolver implements DataFetcher<CompletableFuture<UsageQue
     public CompletableFuture<UsageQueryResult> get(DataFetchingEnvironment environment) {
         final DataLoader<UsageStatsKey, UsageQueryResult> loader = environment.getDataLoaderRegistry().getDataLoader("UsageQueryResult");
 
-        String resource = environment.getArgument("resource");
+        final String resource = ((Entity) environment.getSource()).getUrn();
         UsageTimeRange duration = UsageTimeRange.valueOf(environment.getArgument("range"));
 
         UsageStatsKey key = new UsageStatsKey(resource, duration);

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -769,7 +769,7 @@ type Dataset implements EntityWithRelationships & Entity {
     """
     Statistics about how this Dataset is used
     """
-    usageStats(resource: String!, range: TimeRange): UsageQueryResult
+    usageStats(range: TimeRange): UsageQueryResult
 
     """
     Profile Stats resource that retrieves the events in a previous unit of time in descending order

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -64,7 +64,7 @@ query getDataset($urn: String!) {
         container {
             ...entityContainer
         }
-        usageStats(resource: $urn, range: MONTH) {
+        usageStats(range: MONTH) {
             buckets {
                 bucket
                 duration


### PR DESCRIPTION
The argument was unnecessary since we always already have the parent urn in the environment.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)