### PR TITLE
fix(velocity): prevent velocity 1.7 from coming through and use 2.3

### DIFF
--- a/metadata-events/mxe-avro-1.7/build.gradle
+++ b/metadata-events/mxe-avro-1.7/build.gradle
@@ -7,7 +7,9 @@ apply plugin: 'java'
 
 dependencies {
   compile externalDependency.avro_1_7
-  compile externalDependency.avroCompiler_1_7
+  compile(externalDependency.avroCompiler_1_7) {
+    exclude group: 'org.apache.velocity', module: 'velocity'
+  }
   constraints {
     implementation('commons-collections:commons-collections:3.2.2') {
       because 'Vulnerability Issue'

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -18,7 +18,8 @@ dependencies {
   compile spec.product.pegasus.generator
 
   compile externalDependency.dgraph4j exclude group: 'com.google.guava', module: 'guava'
-  compile externalDependency.lombok
+  compileOnly externalDependency.lombok
+  implementation externalDependency.commonsCollections
   compile externalDependency.datastaxOssNativeProtocol
   compile externalDependency.datastaxOssCore
   compile externalDependency.datastaxOssQueryBuilder


### PR DESCRIPTION
Upgrades Velocity to remove vulnerabilities CVE-2020-13936 & CVE-2020-13959