### PR TITLE
fix(policies): change order of operations for policies bootstrap step to update index after database

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestPoliciesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestPoliciesStep.java
@@ -67,11 +67,6 @@ public class IngestPoliciesStep implements BootstrapStep {
           String.format("Found malformed policies file, expected an Array but found %s", policiesObj.getNodeType()));
     }
 
-    // If search index for policies is empty, send MCLs for all policies to ingest policies into the search index
-    if (_entitySearchService.docCount(Constants.POLICY_ENTITY_NAME) == 0) {
-      updatePolicyIndex();
-    }
-
     // 2. For each JSON object, cast into a DataHub Policy Info object.
     for (final JsonNode policyObj : policiesObj) {
       final Urn urn = Urn.createFromString(policyObj.get("urn").asText());
@@ -98,6 +93,11 @@ public class IngestPoliciesStep implements BootstrapStep {
           log.info(String.format("Skipping ingestion of editable policy with urn %s", urn));
         }
       }
+    }
+    // If search index for policies is empty, update the policy index with the ingested policies from previous step.
+    // Directly update the ES index, does not produce MCLs
+    if (_entitySearchService.docCount(Constants.POLICY_ENTITY_NAME) == 0) {
+      updatePolicyIndex();
     }
     log.info("Successfully ingested default access policies.");
   }


### PR DESCRIPTION
Fixes issue where policies are not added to the index on a fresh install.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)