### PR TITLE
fix(ingestion): ElasticSearch when no properties from elastic_mappings, gracefully continue

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -155,10 +155,10 @@ class ElasticToSchemaFieldConverter:
         converter = cls()
         properties = elastic_mappings.get("properties")
         if not properties:
-            return []
             logger.warning(
                 f"Missing 'properties' in elastic search mappings={json.dumps(elastic_mappings)}!"
             )
+            return []
         yield from converter._get_schema_fields(properties)
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from hashlib import md5
-from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Type
 
 from elasticsearch import Elasticsearch
 from pydantic import validator
@@ -151,14 +151,14 @@ class ElasticToSchemaFieldConverter:
     @classmethod
     def get_schema_fields(
         cls, elastic_mappings: Dict[str, Any]
-    ) -> Union[Generator[SchemaField, None, None], List]:
+    ) -> Generator[SchemaField, None, None]:
         converter = cls()
         properties = elastic_mappings.get("properties")
         if not properties:
             logger.warning(
                 f"Missing 'properties' in elastic search mappings={json.dumps(elastic_mappings)}!"
             )
-            return []
+            return
         yield from converter._get_schema_fields(properties)
 
 

--- a/metadata-ingestion/tests/unit/test_elasticsearch_source.py
+++ b/metadata-ingestion/tests/unit/test_elasticsearch_source.py
@@ -2437,6 +2437,11 @@ def test_elastic_search_schema_conversion(
     assret_field_paths_match(actual_fields, expected_field_paths)
 
 
+def test_no_properties_in_mappings_schema() -> None:
+    fields = list(ElasticToSchemaFieldConverter.get_schema_fields({}))
+    assert fields == []
+
+
 def test_host_port_parsing() -> None:
     """ensure we handle different styles of host_port specifications correctly"""
     examples = [


### PR DESCRIPTION
When there's no properties (schema) from the index, it raises ValueError.
However, it's usual that we can have empty schema index.
This PR makes the pipeline gracefully continue when there's an index with no schema.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)