### PR TITLE
fix(ingestion): dependencies - Downgrading typing-extension dependency to work with Airflow 2.0.2

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -23,7 +23,8 @@ def get_long_description():
 base_requirements = {
     # Compatability.
     "dataclasses>=0.6; python_version < '3.7'",
-    "typing_extensions>=3.10.0.2",
+    # Typing extension should be >=3.10.0.2 ideally but we can't restrict due to Airflow 2.0.2 dependency conflict
+    "typing_extensions>=3.7.4.3",
     "mypy_extensions>=0.4.3",
     # Actual dependencies.
     "typing-inspect",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -24,7 +24,8 @@ base_requirements = {
     # Compatability.
     "dataclasses>=0.6; python_version < '3.7'",
     # Typing extension should be >=3.10.0.2 ideally but we can't restrict due to Airflow 2.0.2 dependency conflict
-    "typing_extensions>=3.7.4.3",
+    "typing_extensions>=3.7.4.3 ;  python_version < '3.8'",
+    "typing_extensions>=3.10.0.2 ;  python_version >= '3.8'",
     "mypy_extensions>=0.4.3",
     # Actual dependencies.
     "typing-inspect",


### PR DESCRIPTION
Downgrading typing-extension dependency to work with Airflow 2.0.2

Normally we need typing-extension >=3.10.0.2 but it clashes with Airflow 2.0.2 and we have say we are fine with a lower version which is not true but typing only needs for compilation time (if we can say this at Python :))  and hoping who runs mypy and other typing check has actually a higher version.
This hack should solve the Airflow issue and until the user has >=3.10.0.2 on his machine it will be fine for the static checks as well.

```
The conflict is caused by:
    apache-airflow[cncf-kubernetes] 2.0.2 depends on typing-extensions>=3.7.4; python_version < "3.8"
    acryl-datahub 0.8.33 depends on typing-extensions>=3.10.0.2
    The user requested (constraint) typing-extensions==3.7.4.3
```


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)