### PR TITLE
fix(ui): search filter entity ui update

### DIFF
--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -33,7 +33,7 @@ const PlatformInfo = styled.div`
 `;
 
 const TitleContainer = styled.div`
-    margin-bottom: 0px;
+    margin-bottom: 5px;
     line-height: 30px;
 `;
 

--- a/datahub-web-react/src/app/search/SearchFilter.tsx
+++ b/datahub-web-react/src/app/search/SearchFilter.tsx
@@ -17,6 +17,19 @@ type Props = {
     onFilterSelect: (selected: boolean, field: string, value: string) => void;
 };
 
+const SearchFilterWrapper = styled.div`
+    padding: 0 25px 15px 25px;
+`;
+
+const Title = styled.div`
+    font-weight: bold;
+    margin-bottom: 10px;
+`;
+
+const CheckBox = styled(Checkbox)`
+    margin: 5px 0;
+`;
+
 const ExpandButton = styled(Button)`
     &&& {
         padding: 4px;
@@ -30,19 +43,16 @@ export const SearchFilter = ({ facet, selectedFilters, onFilterSelect }: Props) 
         FILTERS_TO_TRUNCATE.indexOf(facet.field) > -1 && facet.aggregations.length > TRUNCATED_FILTER_LENGTH;
 
     return (
-        // TODO(gabe-lyons): fix up styes to use styled-components
-        <div key={facet.field} style={{ padding: '0px 25px 15px 25px' }}>
-            <div style={{ fontWeight: 'bold', marginBottom: '10px' }}>{facet?.displayName}</div>
+        <SearchFilterWrapper key={facet.field}>
+            <Title>{facet?.displayName}</Title>
             {facet.aggregations.map((aggregation, i) => {
                 if (i >= TRUNCATED_FILTER_LENGTH && !expanded && shouldTruncate) {
                     return null;
                 }
                 return (
                     <span key={`${facet.field}-${aggregation.value}`}>
-                        <Checkbox
+                        <CheckBox
                             data-testid={`facet-${facet.field}-${aggregation.value}`}
-                            // TODO(gabe-lyons): fix up styling to use styled-components
-                            style={{ margin: '5px 0px' }}
                             checked={
                                 selectedFilters.find(
                                     (f) => f.field === facet.field && f.value === aggregation.value,
@@ -53,7 +63,7 @@ export const SearchFilter = ({ facet, selectedFilters, onFilterSelect }: Props) 
                             }
                         >
                             <SearchFilterLabel field={facet.field} aggregation={aggregation} />
-                        </Checkbox>
+                        </CheckBox>
                         <br />
                     </span>
                 );
@@ -63,6 +73,6 @@ export const SearchFilter = ({ facet, selectedFilters, onFilterSelect }: Props) 
                     {expanded ? '- Less' : '+ More'}
                 </ExpandButton>
             )}
-        </div>
+        </SearchFilterWrapper>
     );
 };

--- a/datahub-web-react/src/app/search/utils/constants.ts
+++ b/datahub-web-react/src/app/search/utils/constants.ts
@@ -8,6 +8,8 @@ export const GLOSSARY_FILTER_NAME = 'glossaryTerms';
 export const CONTAINER_FILTER_NAME = 'container';
 export const DOMAINS_FILTER_NAME = 'domains';
 export const OWNERS_FILTER_NAME = 'owners';
+export const TYPE_FILTER_NAME = 'typeNames';
+export const PLATFORM_FILTER_NAME = 'platform';
 
 export const FILTERS_TO_TRUNCATE = [
     TAG_FILTER_NAME,
@@ -15,5 +17,8 @@ export const FILTERS_TO_TRUNCATE = [
     CONTAINER_FILTER_NAME,
     DOMAINS_FILTER_NAME,
     OWNERS_FILTER_NAME,
+    ENTITY_FILTER_NAME,
+    TYPE_FILTER_NAME,
+    PLATFORM_FILTER_NAME,
 ];
 export const TRUNCATED_FILTER_LENGTH = 5;


### PR DESCRIPTION

## Checklist
- Search filter ui update, added the '+ more' for Types, Sub types and Platform.
<img width="262" alt="Screenshot 2022-05-06 at 10 26 21 PM" src="https://user-images.githubusercontent.com/29713365/167214076-2f136242-0554-4deb-84db-f8d4fd8c4061.png">

- SearchFitler.tsx -> styled component added
- Entity Card -> added the space  between the title and description
<img width="453" alt="Screenshot 2022-05-06 at 10 22 59 PM" src="https://user-images.githubusercontent.com/29713365/167214106-4b062098-5006-4819-9e44-2e4a65f83d56.png">

@chriscollins3456 @jjoyce0510 

