### PR TITLE
fix(ingest): lookml - add view definitions for all views

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -9,6 +9,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 ### Potential Downtime
 
 ### Deprecations
+  - #4875 Lookml view file contents will no longer be populated in custom_properties, instead view definitions will be always available in the View Definitions tab.
 
 ### Other notable Changes
 

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -2,7 +2,6 @@ import glob
 import importlib
 import itertools
 import logging
-import os
 import pathlib
 import re
 import sys

--- a/metadata-ingestion/tests/integration/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/lookml/expected_output.json
@@ -185,7 +185,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
@@ -409,7 +408,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
@@ -507,7 +505,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
@@ -539,6 +536,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -586,7 +602,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -618,6 +633,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -719,7 +753,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -751,6 +784,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -798,7 +850,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -830,6 +881,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -877,7 +947,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -909,6 +978,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -979,6 +1067,25 @@
                         },
                         "fields": [
                             {
+                                "fieldPath": "aliased_platform",
+                                "jsonPath": null,
+                                "nullable": false,
+                                "description": "",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NullType": {}
+                                    }
+                                },
+                                "nativeDataType": "unknown",
+                                "recursive": false,
+                                "globalTags": {
+                                    "tags": []
+                                },
+                                "glossaryTerms": null,
+                                "isPartOfKey": false,
+                                "jsonProps": null
+                            },
+                            {
                                 "fieldPath": "country",
                                 "jsonPath": null,
                                 "nullable": false,
@@ -1015,25 +1122,6 @@
                                 "glossaryTerms": null,
                                 "isPartOfKey": false,
                                 "jsonProps": null
-                            },
-                            {
-                                "fieldPath": "aliased_platform",
-                                "jsonPath": null,
-                                "nullable": false,
-                                "description": "",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NullType": {}
-                                    }
-                                },
-                                "nativeDataType": "unknown",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": []
-                                },
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": [],
@@ -1044,7 +1132,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
@@ -1126,7 +1213,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
@@ -185,7 +185,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
@@ -409,7 +408,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
@@ -507,7 +505,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
@@ -539,6 +536,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -586,7 +602,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -618,6 +633,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -719,7 +753,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -751,6 +784,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -798,7 +850,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -830,6 +881,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -877,7 +947,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -909,6 +978,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -998,7 +1086,7 @@
                                 "jsonProps": null
                             },
                             {
-                                "fieldPath": "country",
+                                "fieldPath": "aliased_platform",
                                 "jsonPath": null,
                                 "nullable": false,
                                 "description": "",
@@ -1017,7 +1105,7 @@
                                 "jsonProps": null
                             },
                             {
-                                "fieldPath": "aliased_platform",
+                                "fieldPath": "country",
                                 "jsonPath": null,
                                 "nullable": false,
                                 "description": "",
@@ -1044,7 +1132,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
@@ -1126,7 +1213,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
@@ -185,7 +185,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
@@ -409,7 +408,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
@@ -507,7 +505,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
@@ -539,6 +536,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -586,7 +602,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -618,6 +633,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -719,7 +753,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -751,6 +784,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -798,7 +850,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -830,6 +881,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -877,7 +947,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -909,6 +978,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -979,6 +1067,25 @@
                         },
                         "fields": [
                             {
+                                "fieldPath": "country",
+                                "jsonPath": null,
+                                "nullable": false,
+                                "description": "",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NullType": {}
+                                    }
+                                },
+                                "nativeDataType": "unknown",
+                                "recursive": false,
+                                "globalTags": {
+                                    "tags": []
+                                },
+                                "glossaryTerms": null,
+                                "isPartOfKey": false,
+                                "jsonProps": null
+                            },
+                            {
                                 "fieldPath": "date",
                                 "jsonPath": null,
                                 "nullable": false,
@@ -1015,25 +1122,6 @@
                                 "glossaryTerms": null,
                                 "isPartOfKey": false,
                                 "jsonProps": null
-                            },
-                            {
-                                "fieldPath": "country",
-                                "jsonPath": null,
-                                "nullable": false,
-                                "description": "",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NullType": {}
-                                    }
-                                },
-                                "nativeDataType": "unknown",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": []
-                                },
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": [],
@@ -1044,7 +1132,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
@@ -1126,7 +1213,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
@@ -169,7 +169,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
@@ -377,7 +376,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
@@ -475,7 +473,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
@@ -507,6 +504,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -554,7 +570,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -586,6 +601,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -687,7 +721,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -719,6 +752,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -766,7 +818,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -798,6 +849,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -845,7 +915,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -889,6 +958,25 @@
 },
 {
     "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.fragment_derived_view,PROD)",
@@ -908,7 +996,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
@@ -990,7 +1077,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
@@ -185,7 +185,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
@@ -409,7 +408,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
@@ -507,7 +505,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
@@ -539,6 +536,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -586,7 +602,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -618,6 +633,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -719,7 +753,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -751,6 +784,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -798,7 +850,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -830,6 +881,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -877,7 +947,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -909,6 +978,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -979,25 +1067,6 @@
                         },
                         "fields": [
                             {
-                                "fieldPath": "aliased_platform",
-                                "jsonPath": null,
-                                "nullable": false,
-                                "description": "",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NullType": {}
-                                    }
-                                },
-                                "nativeDataType": "unknown",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": []
-                                },
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "jsonProps": null
-                            },
-                            {
                                 "fieldPath": "country",
                                 "jsonPath": null,
                                 "nullable": false,
@@ -1034,6 +1103,25 @@
                                 "glossaryTerms": null,
                                 "isPartOfKey": false,
                                 "jsonProps": null
+                            },
+                            {
+                                "fieldPath": "aliased_platform",
+                                "jsonPath": null,
+                                "nullable": false,
+                                "description": "",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NullType": {}
+                                    }
+                                },
+                                "nativeDataType": "unknown",
+                                "recursive": false,
+                                "globalTags": {
+                                    "tags": []
+                                },
+                                "glossaryTerms": null,
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": [],
@@ -1044,7 +1132,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
@@ -1126,7 +1213,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_platform_instance.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_platform_instance.json
@@ -185,7 +185,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": null,
@@ -409,7 +408,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": null,
@@ -507,7 +505,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": null,
@@ -539,6 +536,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -586,7 +602,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -618,6 +633,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -719,7 +753,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -751,6 +784,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -798,7 +850,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -830,6 +881,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -877,7 +947,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": null,
@@ -909,6 +978,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -979,25 +1067,6 @@
                         },
                         "fields": [
                             {
-                                "fieldPath": "aliased_platform",
-                                "jsonPath": null,
-                                "nullable": false,
-                                "description": "",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NullType": {}
-                                    }
-                                },
-                                "nativeDataType": "unknown",
-                                "recursive": false,
-                                "globalTags": {
-                                    "tags": []
-                                },
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "jsonProps": null
-                            },
-                            {
                                 "fieldPath": "date",
                                 "jsonPath": null,
                                 "nullable": false,
@@ -1034,6 +1103,25 @@
                                 "glossaryTerms": null,
                                 "isPartOfKey": false,
                                 "jsonProps": null
+                            },
+                            {
+                                "fieldPath": "aliased_platform",
+                                "jsonPath": null,
+                                "nullable": false,
+                                "description": "",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NullType": {}
+                                    }
+                                },
+                                "nativeDataType": "unknown",
+                                "recursive": false,
+                                "globalTags": {
+                                    "tags": []
+                                },
+                                "glossaryTerms": null,
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": [],
@@ -1044,7 +1132,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": null,
@@ -1126,7 +1213,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": null,

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
@@ -185,7 +185,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_view {\n  derived_table: {\n    sql:\n        SELECT\n          is_latest,\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          my_table ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension: is_latest {\n    type: yesno\n    description: \"Is latest data\"\n    sql: ${TABLE}.is_latest ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "foo.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/foo.view.lkml",
@@ -409,7 +408,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: my_derived_view {\n  derived_table: {\n    sql:\n        SELECT\n          country,\n          city,\n          timestamp,\n          measurement\n        FROM\n          ${my_view.SQL_TABLE_NAME} AS my_view ;;\n  }\n\n  dimension: country {\n    type: string\n    description: \"The country\"\n    sql: ${TABLE}.country ;;\n  }\n\n  dimension: city {\n    type: string\n    description: \"City\"\n    sql: ${TABLE}.city ;;\n  }\n\n  dimension_group: timestamp {\n    group_label: \"Timestamp\"\n    type: time\n    description: \"Timestamp of measurement\"\n    sql: ${TABLE}.timestamp ;;\n    timeframes: [hour, date, week, day_of_week]\n  }\n\n  measure: average_measurement {\n    group_label: \"Measurement\"\n    type: average\n    description: \"My measurement\"\n    sql: ${TABLE}.measurement ;;\n  }\n\n}\n",
                             "looker.file.path": "bar.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/bar.view.lkml",
@@ -507,7 +505,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: include_able_view {\n  sql_table_name: looker_schema.include_able ;;\n}\n",
                             "looker.file.path": "included_view_file.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/included_view_file.view.lkml",
@@ -539,6 +536,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.include_able_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"view: include_able_view {\\n  sql_table_name: looker_schema.include_able ;;\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -586,7 +602,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
@@ -618,6 +633,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -719,7 +753,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
@@ -751,6 +784,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.extending_looker_events,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -798,7 +850,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
@@ -830,6 +881,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.autodetect_sql_name_based_on_view_name,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -877,7 +947,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "include: \"/included_view_file.view\"\n\nview: looker_events {\n  sql_table_name: looker_schema.events ;;\n}\n\nview: extending_looker_events {\n  extends: [looker_events]\n\n  measure: additional_measure {\n    type: count\n  }\n}\n\nview: autodetect_sql_name_based_on_view_name {}\n\nview: test_include_external_view {\n  extends: [include_able_view]\n}\n",
                             "looker.file.path": "view_declarations.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/view_declarations.view.lkml",
@@ -909,6 +978,25 @@
     "aspectName": "subTypes",
     "aspect": {
         "value": "{\"typeNames\": [\"view\"]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "lookml-test",
+        "registryName": null,
+        "registryVersion": null,
+        "properties": null
+    }
+},
+{
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.test_include_external_view,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "value": "{\"materialized\": false, \"viewLogic\": \"include: \\\"/included_view_file.view\\\"\\n\\nview: looker_events {\\n  sql_table_name: looker_schema.events ;;\\n}\\n\\nview: extending_looker_events {\\n  extends: [looker_events]\\n\\n  measure: additional_measure {\\n    type: count\\n  }\\n}\\n\\nview: autodetect_sql_name_based_on_view_name {}\\n\\nview: test_include_external_view {\\n  extends: [include_able_view]\\n}\\n\", \"viewLanguage\": \"lookml\"}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -979,7 +1067,7 @@
                         },
                         "fields": [
                             {
-                                "fieldPath": "country",
+                                "fieldPath": "date",
                                 "jsonPath": null,
                                 "nullable": false,
                                 "description": "",
@@ -1017,7 +1105,7 @@
                                 "jsonProps": null
                             },
                             {
-                                "fieldPath": "date",
+                                "fieldPath": "country",
                                 "jsonPath": null,
                                 "nullable": false,
                                 "description": "",
@@ -1044,7 +1132,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: fragment_derived_view \n{ derived_table: \n  { \n    sql: date DATE encode ZSTD, \n         platform VARCHAR(20) encode ZSTD AS aliased_platform, \n         country VARCHAR(20) encode ZSTD\n         ;; \n  } \n}\n",
                             "looker.file.path": "nested/fragment_derived.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/nested/fragment_derived.view.lkml",
@@ -1126,7 +1213,6 @@
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "looker.file.content": "view: customer_facts {\n  derived_table: {\nsql:\n      SELECT\n        customer_id,\n        SUM(sale_price) AS lifetime_spend\n      FROM\n        order\n      WHERE\n        {% condition order_region %} order.region {% endcondition %}\n      GROUP BY 1\n    ;;\n    }\n}\n",
                             "looker.file.path": "liquid.view.lkml"
                         },
                         "externalUrl": "https://github.com/datahub/looker-demo/blob/master/liquid.view.lkml",


### PR DESCRIPTION
Previously, we were only populating view definitions for derived tables in looker views. 
This PR:
1. expands this to all views (lookml / sql views)
2. removes the population of custom_properties with file contents to avoid duplicate information being stored
3. adds a config variable to control the number of characters from the view file that are stored in the view definition

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)