### PR TITLE
updated the URL to connect to the database

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -156,9 +156,9 @@ def make_sqlalchemy_uri(
 ) -> str:
     url = f"{scheme}://"
     if username is not None:
-        url += f"{quote_plus(username)}"
+        url += f"{quote_plus(username)}:"
         if password is not None:
-            url += f":{quote_plus(password)}"
+            url += f"{quote_plus(password)}"
         url += "@"
     if at is not None:
         url += f"{at}"


### PR DESCRIPTION
I updated the URL to connect to the database. When I use a Clickhouse database with no password and only the default user default, I cannot connect to Clickhouse.
![image](https://user-images.githubusercontent.com/71497399/167336357-e246a73d-da5e-480a-b8a6-b4707f5d4a21.png)
![image](https://user-images.githubusercontent.com/71497399/167336424-afe86cac-192d-44b8-b478-e23f05b0e0cf.png)




## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)