### PR TITLE
to support more spark commands

### DIFF
--- a/metadata-integration/java/spark-lineage/build.gradle
+++ b/metadata-integration/java/spark-lineage/build.gradle
@@ -115,8 +115,6 @@ dependencies {
   } // older version to allow older guava
 
   testImplementation(externalDependency.testContainersPostgresql)
-    compile project(':li-utils')
-    compile project(':metadata-models')
 }
 
 task checkShadowJar(type: Exec) {

--- a/metadata-integration/java/spark-lineage/build.gradle
+++ b/metadata-integration/java/spark-lineage/build.gradle
@@ -115,6 +115,8 @@ dependencies {
   } // older version to allow older guava
 
   testImplementation(externalDependency.testContainersPostgresql)
+    compile project(':li-utils')
+    compile project(':metadata-models')
 }
 
 task checkShadowJar(type: Exec) {

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
@@ -3,7 +3,14 @@ package datahub.spark;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Stack;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -112,7 +119,7 @@ public class DatahubSparkListener extends SparkListener {
           allInners.addAll(JavaConversions.asJavaCollection(plan.innerChildren()));
 
           //deal with sparkPlans in complex logical plan
-          if(plan instanceof InMemoryRelation) {
+          if (plan instanceof InMemoryRelation) {
             InMemoryRelation cmd = (InMemoryRelation) plan;
             allInmemoryRelationSparkPlan.add(cmd.cachedPlan());
           }
@@ -142,7 +149,7 @@ public class DatahubSparkListener extends SparkListener {
             inputDS.ifPresent(x -> lineage.addSource(x));
 
             //deal with sparkPlans in complex logical plan
-            if(plan instanceof InMemoryRelation) {
+            if (plan instanceof InMemoryRelation) {
               InMemoryRelation cmd = (InMemoryRelation) plan;
               allInmemoryRelationSparkPlan.add(cmd.cachedPlan());
             }
@@ -156,7 +163,7 @@ public class DatahubSparkListener extends SparkListener {
         });
       }
 
-      for(QueryPlan<?> qpInmemoryRelation : allInmemoryRelationSparkPlan) {
+      for (QueryPlan<?> qpInmemoryRelation : allInmemoryRelationSparkPlan) {
         if (!(qpInmemoryRelation instanceof SparkPlan)) {
           continue;
         }
@@ -169,7 +176,7 @@ public class DatahubSparkListener extends SparkListener {
             inputDSSp.ifPresent(x -> lineage.addSource(x));
             allInmemoryRelationInnersSparkPlan.addAll(JavaConversions.asJavaCollection(sp.innerChildren()));
 
-            if(sp instanceof InMemoryTableScanExec) {
+            if (sp instanceof InMemoryTableScanExec) {
               InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
               allInmemoryRelationTableScanPlan.push(cmd);
             }
@@ -182,7 +189,7 @@ public class DatahubSparkListener extends SparkListener {
         });
       }
 
-      for(QueryPlan<?> qpInmemoryRelationInners : allInmemoryRelationInnersSparkPlan) {
+      for (QueryPlan<?> qpInmemoryRelationInners : allInmemoryRelationInnersSparkPlan) {
         if (!(qpInmemoryRelationInners instanceof SparkPlan)) {
           continue;
         }
@@ -194,7 +201,7 @@ public class DatahubSparkListener extends SparkListener {
             Optional<? extends SparkDataset> inputDSSp = DatasetExtractor.asDataset(sp, ctx, false);
             inputDSSp.ifPresent(x -> lineage.addSource(x));
 
-            if(sp instanceof InMemoryTableScanExec) {
+            if (sp instanceof InMemoryTableScanExec) {
               InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
               allInmemoryRelationTableScanPlan.push(cmd);
             }
@@ -219,7 +226,7 @@ public class DatahubSparkListener extends SparkListener {
             inputDSSp.ifPresent(x -> lineage.addSource(x));
             allInnerPhysicalPlan.addAll(JavaConversions.asJavaCollection(sp.innerChildren()));
 
-            if(sp instanceof InMemoryTableScanExec) {
+            if (sp instanceof InMemoryTableScanExec) {
               InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
               allInmemoryRelationTableScanPlan.push(cmd);
             }
@@ -231,7 +238,7 @@ public class DatahubSparkListener extends SparkListener {
           }
         });
 
-        for(QueryPlan<?> qpInner : allInnerPhysicalPlan) {
+        for (QueryPlan<?> qpInner : allInnerPhysicalPlan) {
           if (!(qpInner instanceof SparkPlan)) {
             continue;
           }
@@ -243,7 +250,7 @@ public class DatahubSparkListener extends SparkListener {
               Optional<? extends SparkDataset> inputDSSp = DatasetExtractor.asDataset(sp, ctx, false);
               inputDSSp.ifPresent(x -> lineage.addSource(x));
 
-              if(sp instanceof InMemoryTableScanExec) {
+              if (sp instanceof InMemoryTableScanExec) {
                 InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
                 allInmemoryRelationTableScanPlan.push(cmd);
               }

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
@@ -3,13 +3,7 @@ package datahub.spark;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -28,6 +22,9 @@ import org.apache.spark.sql.catalyst.plans.QueryPlan;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.execution.QueryExecution;
 import org.apache.spark.sql.execution.SQLExecution;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.columnar.InMemoryRelation;
+import org.apache.spark.sql.execution.columnar.InMemoryTableScanExec;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd;
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionStart;
 
@@ -101,6 +98,9 @@ public class DatahubSparkListener extends SparkListener {
 
       DatasetLineage lineage = new DatasetLineage(sqlStart.description(), plan.toString(), outputDS.get());
       Collection<QueryPlan<?>> allInners = new ArrayList<>();
+      Collection<QueryPlan<?>> allInmemoryRelationSparkPlan = new ArrayList<>();
+      Collection<QueryPlan<?>> allInmemoryRelationInnersSparkPlan = new ArrayList<>();
+      Stack<QueryPlan<?>> allInmemoryRelationTableScanPlan = new Stack<>();
 
       plan.collect(new AbstractPartialFunction<LogicalPlan, Void>() {
 
@@ -110,6 +110,12 @@ public class DatahubSparkListener extends SparkListener {
           Optional<? extends SparkDataset> inputDS = DatasetExtractor.asDataset(plan, ctx, false);
           inputDS.ifPresent(x -> lineage.addSource(x));
           allInners.addAll(JavaConversions.asJavaCollection(plan.innerChildren()));
+
+          //deal with sparkPlans in complex logical plan
+          if(plan instanceof InMemoryRelation) {
+            InMemoryRelation cmd = (InMemoryRelation) plan;
+            allInmemoryRelationSparkPlan.add(cmd.cachedPlan());
+          }
           return null;
         }
 
@@ -134,6 +140,12 @@ public class DatahubSparkListener extends SparkListener {
             inputDS.ifPresent(
                 x -> log.debug("source added for " + ctx.appName() + "/" + sqlStart.executionId() + ": " + x));
             inputDS.ifPresent(x -> lineage.addSource(x));
+
+            //deal with sparkPlans in complex logical plan
+            if(plan instanceof InMemoryRelation) {
+              InMemoryRelation cmd = (InMemoryRelation) plan;
+              allInmemoryRelationSparkPlan.add(cmd.cachedPlan());
+            }
             return null;
           }
 
@@ -142,6 +154,107 @@ public class DatahubSparkListener extends SparkListener {
             return true;
           }
         });
+      }
+
+      for(QueryPlan<?> qpInmemoryRelation : allInmemoryRelationSparkPlan) {
+        if (!(qpInmemoryRelation instanceof SparkPlan)) {
+          continue;
+        }
+        SparkPlan sparkPlan = (SparkPlan) qpInmemoryRelation;
+        sparkPlan.collect(new AbstractPartialFunction<SparkPlan, Void>() {
+
+          @Override
+          public Void apply(SparkPlan sp) {
+            Optional<? extends SparkDataset> inputDSSp = DatasetExtractor.asDataset(sp, ctx, false);
+            inputDSSp.ifPresent(x -> lineage.addSource(x));
+            allInmemoryRelationInnersSparkPlan.addAll(JavaConversions.asJavaCollection(sp.innerChildren()));
+
+            if(sp instanceof InMemoryTableScanExec) {
+              InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
+              allInmemoryRelationTableScanPlan.push(cmd);
+            }
+            return null;
+          }
+          @Override
+          public boolean isDefinedAt(SparkPlan x) {
+            return true;
+          }
+        });
+      }
+
+      for(QueryPlan<?> qpInmemoryRelationInners : allInmemoryRelationInnersSparkPlan) {
+        if (!(qpInmemoryRelationInners instanceof SparkPlan)) {
+          continue;
+        }
+        SparkPlan sparkPlan = (SparkPlan) qpInmemoryRelationInners;
+        sparkPlan.collect(new AbstractPartialFunction<SparkPlan, Void>() {
+
+          @Override
+          public Void apply(SparkPlan sp) {
+            Optional<? extends SparkDataset> inputDSSp = DatasetExtractor.asDataset(sp, ctx, false);
+            inputDSSp.ifPresent(x -> lineage.addSource(x));
+
+            if(sp instanceof InMemoryTableScanExec) {
+              InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
+              allInmemoryRelationTableScanPlan.push(cmd);
+            }
+            return null;
+          }
+          @Override
+          public boolean isDefinedAt(SparkPlan x) {
+            return true;
+          }
+        });
+      }
+
+      while (!allInmemoryRelationTableScanPlan.isEmpty()) {
+        QueryPlan<?> qpInmemoryRelationTableScan = allInmemoryRelationTableScanPlan.pop();
+        InMemoryTableScanExec imPlan = (InMemoryTableScanExec) qpInmemoryRelationTableScan;
+        Collection<QueryPlan<?>> allInnerPhysicalPlan = new ArrayList<>();
+        imPlan.relation().cachedPlan().collect(new AbstractPartialFunction<SparkPlan, Void>() {
+
+          @Override
+          public Void apply(SparkPlan sp) {
+            Optional<? extends SparkDataset> inputDSSp = DatasetExtractor.asDataset(sp, ctx, false);
+            inputDSSp.ifPresent(x -> lineage.addSource(x));
+            allInnerPhysicalPlan.addAll(JavaConversions.asJavaCollection(sp.innerChildren()));
+
+            if(sp instanceof InMemoryTableScanExec) {
+              InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
+              allInmemoryRelationTableScanPlan.push(cmd);
+            }
+            return null;
+          }
+          @Override
+          public boolean isDefinedAt(SparkPlan x) {
+            return true;
+          }
+        });
+
+        for(QueryPlan<?> qpInner : allInnerPhysicalPlan) {
+          if (!(qpInner instanceof SparkPlan)) {
+            continue;
+          }
+          SparkPlan sparkPlan = (SparkPlan) qpInner;
+          sparkPlan.collect(new AbstractPartialFunction<SparkPlan, Void>() {
+
+            @Override
+            public Void apply(SparkPlan sp) {
+              Optional<? extends SparkDataset> inputDSSp = DatasetExtractor.asDataset(sp, ctx, false);
+              inputDSSp.ifPresent(x -> lineage.addSource(x));
+
+              if(sp instanceof InMemoryTableScanExec) {
+                InMemoryTableScanExec cmd = (InMemoryTableScanExec) sp;
+                allInmemoryRelationTableScanPlan.push(cmd);
+              }
+              return null;
+            }
+            @Override
+            public boolean isDefinedAt(SparkPlan x) {
+              return true;
+            }
+          });
+        }
       }
 
       SQLQueryExecStartEvent evt =

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
@@ -125,7 +125,7 @@ public class DatasetExtractor {
 
     PLAN_TO_DATASET.put(WriteToDataSourceV2.class, (p, ctx, datahubConfig) -> {
       WriteToDataSourceV2 cmd = (WriteToDataSourceV2) p;
-      if(!cmd.writer().toString().contains("IcebergWrite")) {
+      if (!cmd.writer().toString().contains("IcebergWrite")) {
         return Optional.empty();
       } else {
         String[] names = cmd.writer().toString().split(",")[0].split("\\.");
@@ -136,7 +136,7 @@ public class DatasetExtractor {
 
     PLAN_TO_DATASET.put(DataSourceV2Relation.class, (p, ctx, datahubConfig) -> {
       DataSourceV2Relation cmd = (DataSourceV2Relation) p;
-      if(!cmd.source().toString().contains("IcebergSource") && !cmd.source().toString().contains("iceberg")) {
+      if (!cmd.source().toString().contains("IcebergSource") && !cmd.source().toString().contains("iceberg")) {
         return Optional.empty();
       } else {
         String[] names = cmd.options().get("path").get().split("\\.");
@@ -147,7 +147,7 @@ public class DatasetExtractor {
 
     SPARKPLAN_TO_DATASET.put(DataSourceV2ScanExec.class, (sp, ctx, datahubConfig) -> {
       DataSourceV2ScanExec cmd = (DataSourceV2ScanExec) sp;
-      if(!sp.toString().contains("iceberg")) {
+      if (!sp.toString().contains("iceberg")) {
         return Optional.empty();
       } else {
         String[] names = cmd.options().get("path").get().split("\\.");
@@ -158,7 +158,8 @@ public class DatasetExtractor {
 
     SPARKPLAN_TO_DATASET.put(FileSourceScanExec.class, (sp, ctx, datahubConfig) -> {
       FileSourceScanExec cmd = (FileSourceScanExec) sp;
-      return Optional.of(new CatalogTableDataset("hive", cmd.tableIdentifier().get().table(), getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
+      String tableName = cmd.tableIdentifier().get().table();
+      return Optional.of(new CatalogTableDataset("hive", tableName, getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
     });
 
     REL_TO_DATASET.put(HadoopFsRelation.class, (r, ctx, datahubConfig) -> {

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
@@ -20,6 +20,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.execution.FileSourceScanExec;
+import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand;
 import org.apache.spark.sql.execution.datasources.HadoopFsRelation;
 import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand;
@@ -27,6 +29,9 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation;
 import org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions;
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCRelation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExec;
+import org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2;
 import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand;
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable;
 import org.apache.spark.sql.sources.BaseRelation;
@@ -43,10 +48,12 @@ import com.typesafe.config.Config;
 public class DatasetExtractor {
   
   private static final Map<Class<? extends LogicalPlan>, PlanToDataset> PLAN_TO_DATASET = new HashMap<>();
+  private static final Map<Class<? extends SparkPlan>, SparkPlanToDataset> SPARKPLAN_TO_DATASET = new HashMap<>();
   private static final Map<Class<? extends BaseRelation>, RelationToDataset> REL_TO_DATASET = new HashMap<>();
   private static final Set<Class<? extends LogicalPlan>> OUTPUT_CMD = ImmutableSet.of(
       InsertIntoHadoopFsRelationCommand.class, SaveIntoDataSourceCommand.class,
-      CreateDataSourceTableAsSelectCommand.class, CreateHiveTableAsSelectCommand.class, InsertIntoHiveTable.class);
+      CreateDataSourceTableAsSelectCommand.class, CreateHiveTableAsSelectCommand.class, InsertIntoHiveTable.class,
+          WriteToDataSourceV2.class);
   private static final String DATASET_ENV_KEY = "metadata.dataset.env";
   private static final String DATASET_PLATFORM_INSTANCE_KEY = "metadata.dataset.platformInstance";
   // TODO InsertIntoHiveDirCommand, InsertIntoDataSourceDirCommand
@@ -56,6 +63,10 @@ public class DatasetExtractor {
  }
   private static interface PlanToDataset {
     Optional<? extends SparkDataset> fromPlanNode(LogicalPlan plan, SparkContext ctx, Config datahubConfig);
+  }
+
+  private static interface SparkPlanToDataset {
+    Optional<? extends SparkDataset> fromSparkPlanNode(SparkPlan plan, SparkContext ctx, Config datahubConfig);
   }
 
   private static interface RelationToDataset {
@@ -112,6 +123,44 @@ public class DatasetExtractor {
       return Optional.of(new CatalogTableDataset(cmd.tableMeta(), getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
     });
 
+    PLAN_TO_DATASET.put(WriteToDataSourceV2.class, (p, ctx, datahubConfig) -> {
+      WriteToDataSourceV2 cmd = (WriteToDataSourceV2) p;
+      if(!cmd.writer().toString().contains("IcebergWrite")) {
+        return Optional.empty();
+      } else {
+        String[] names = cmd.writer().toString().split(",")[0].split("\\.");
+        String tableName = names[names.length - 1];
+        return Optional.of(new CatalogTableDataset("iceberg", tableName, getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
+      }
+    });
+
+    PLAN_TO_DATASET.put(DataSourceV2Relation.class, (p, ctx, datahubConfig) -> {
+      DataSourceV2Relation cmd = (DataSourceV2Relation) p;
+      if(!cmd.source().toString().contains("IcebergSource") && !cmd.source().toString().contains("iceberg")) {
+        return Optional.empty();
+      } else {
+        String[] names = cmd.options().get("path").get().split("\\.");
+        String tableName = names[names.length - 1];
+        return Optional.of(new CatalogTableDataset("iceberg", tableName, getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
+      }
+    });
+
+    SPARKPLAN_TO_DATASET.put(DataSourceV2ScanExec.class, (sp, ctx, datahubConfig) -> {
+      DataSourceV2ScanExec cmd = (DataSourceV2ScanExec) sp;
+      if(!sp.toString().contains("iceberg")) {
+        return Optional.empty();
+      } else {
+        String[] names = cmd.options().get("path").get().split("\\.");
+        String tableName = names[names.length - 1];
+        return Optional.of(new CatalogTableDataset("iceberg", tableName, getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
+      }
+    });
+
+    SPARKPLAN_TO_DATASET.put(FileSourceScanExec.class, (sp, ctx, datahubConfig) -> {
+      FileSourceScanExec cmd = (FileSourceScanExec) sp;
+      return Optional.of(new CatalogTableDataset("hive", cmd.tableIdentifier().get().table(), getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig)));
+    });
+
     REL_TO_DATASET.put(HadoopFsRelation.class, (r, ctx, datahubConfig) -> {
       List<Path> res = JavaConversions.asJavaCollection(((HadoopFsRelation) r).location().rootPaths()).stream()
           .map(p -> getDirectoryPath(p, ctx.hadoopConfiguration())).distinct().collect(Collectors.toList());
@@ -140,6 +189,15 @@ public class DatasetExtractor {
     }
     Config datahubconfig = LineageUtils.parseSparkConfig();
     return PLAN_TO_DATASET.get(logicalPlan.getClass()).fromPlanNode(logicalPlan, ctx, datahubconfig);
+  }
+
+  static Optional<? extends SparkDataset> asDataset(SparkPlan sparkPlan, SparkContext ctx, boolean outputNode) {
+
+    if (!SPARKPLAN_TO_DATASET.containsKey(sparkPlan.getClass())) {
+      return Optional.empty();
+    }
+    Config datahubconfig = LineageUtils.parseSparkConfig();
+    return SPARKPLAN_TO_DATASET.get(sparkPlan.getClass()).fromSparkPlanNode(sparkPlan, ctx, datahubconfig);
   }
 
   private static Path getDirectoryPath(Path p, Configuration hadoopConf) {

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/CatalogTableDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/CatalogTableDataset.java
@@ -17,4 +17,7 @@ public class CatalogTableDataset extends SparkDataset {
     super("hive", platformInstance, dsName, fabricType);
   }
 
+  public CatalogTableDataset(String dbName, String dsName, String platformInstance, FabricType fabricType) {
+    super(dbName, platformInstance, dsName, fabricType);
+  }
 }


### PR DESCRIPTION
This PR:
1. support spark sql to get data from iceberg and write data to iceberg
2. support spark sql to get data from cached data in memory
3. support spark sql to get cached data after complex operations like join, filter, union and so on

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (https://github.com/datahub-project/datahub/issues/4877)
