### PR TITLE
docs(transformer): fix custom transform example

### DIFF
--- a/metadata-ingestion/examples/transforms/custom_transform_example.py
+++ b/metadata-ingestion/examples/transforms/custom_transform_example.py
@@ -30,6 +30,7 @@ class AddCustomOwnership(BaseTransformer, SingleAspectTransformer):
     config: AddCustomOwnershipConfig
 
     def __init__(self, config: AddCustomOwnershipConfig, ctx: PipelineContext):
+        super().__init__()
         self.ctx = ctx
         self.config = config
 

--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -350,6 +350,7 @@ class AddCustomOwnership(BaseTransformer, SingleAspectTransformer):
     config: AddCustomOwnershipConfig
 
     def __init__(self, config: AddCustomOwnershipConfig, ctx: PipelineContext):
+        super().__init__()
         self.ctx = ctx
         self.config = config
 


### PR DESCRIPTION
Added superclass init statement in constructor, which takes care of initialising fields like self.entity_map that are used later when applying transformation.

Earlier, one used to get this error
```
File "/python3.9/site-packages/datahub/ingestion/transformer/base_transformer.py", line 252, in transform for urn, state in self.entity_map.items():

AttributeError: 'AddCustomOwnership' object has no attribute 'entity_map' 
```

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)