### PR TITLE
fix(ui) Fix some spacing issues on the search card

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
@@ -7,7 +7,8 @@ import { Container } from '../../../../../../../types.generated';
 import { ANTD_GRAY } from '../../../../constants';
 import ContainerLink from './ContainerLink';
 
-const LogoContainer = styled.span`
+const LogoIcon = styled.span`
+    display: flex;
     margin-right: 8px;
 `;
 
@@ -21,7 +22,7 @@ const PreviewImage = styled(Image)`
 const PlatformContentWrapper = styled.div`
     display: flex;
     align-items: center;
-    margin: 0 8px 8px 0;
+    margin: 0 8px 6px 0;
     flex-wrap: nowrap;
     flex: 1;
 `;
@@ -41,10 +42,6 @@ const PlatformDivider = styled.div`
     border-right: 1px solid ${ANTD_GRAY[4]};
     height: 18px;
     vertical-align: text-top;
-`;
-
-const TypeIcon = styled.span`
-    margin-right: 8px;
 `;
 
 const StyledRightOutlined = styled(RightOutlined)`
@@ -117,14 +114,14 @@ function PlatformContentView(props: Props) {
 
     return (
         <PlatformContentWrapper>
-            {typeIcon && <TypeIcon>{typeIcon}</TypeIcon>}
+            {typeIcon && <LogoIcon>{typeIcon}</LogoIcon>}
             <PlatformText>{entityType}</PlatformText>
             <PlatformDivider />
             {platformName && (
-                <LogoContainer>
+                <LogoIcon>
                     {(!!platformLogoUrl && <PreviewImage preview={false} src={platformLogoUrl} alt={platformName} />) ||
                         entityLogoComponent}
-                </LogoContainer>
+                </LogoIcon>
             )}
             <PlatformText>
                 {platformName}

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -73,17 +73,17 @@ const PlatformDivider = styled.div`
 
 const DescriptionContainer = styled.div`
     color: ${ANTD_GRAY[7]};
+    margin-bottom: 8px;
 `;
 
 const AvatarContainer = styled.div`
-    margin-top: 6px;
     margin-right: 32px;
 `;
 
 const TagContainer = styled.div`
     display: inline-flex;
     margin-left: 0px;
-    margin-top: 5px;
+    margin-top: 3px;
 `;
 
 const TagSeparator = styled.div`


### PR DESCRIPTION
Makes a few CSS tweaks to clean up the spacing and alignment of different elements on the entity header and search card.

First, properly align the platform icon
Before:
![image](https://user-images.githubusercontent.com/28656603/168344224-0e2e2c3c-16a9-4018-8057-22d2cfcbc884.png)

After:
![image](https://user-images.githubusercontent.com/28656603/168344244-bc43e24a-3bca-4983-8f7b-e780b4c55cb2.png)


Here's the search results with entities that have different things on their cards:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/28656603/168344172-f0bb6e3d-aaee-45f0-a512-efac6443f79c.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)