### PR TITLE
feat(transformers): add transformers to provide tags & terms to schema fields based on regex patterns

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_tags.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_tags.py
@@ -1,0 +1,97 @@
+from typing import Callable, List, Union, Optional
+
+import datahub.emitter.mce_builder as builder
+from datahub.configuration.common import ConfigModel, KeyValuePattern
+from datahub.configuration.import_resolver import pydantic_resolve_key
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.transformer.base_transformer import SingleAspectTransformer, BaseTransformer
+from datahub.metadata.schema_classes import (
+    DatasetSnapshotClass, SchemaMetadataClass, SchemaFieldClass, TagAssociationClass, GlobalTagsClass,
+)
+
+
+class AddDatasetSchemaTagsConfig(ConfigModel):
+    # Workaround for https://github.com/python/mypy/issues/708.
+    # Suggested by https://stackoverflow.com/a/64528725/5004662.
+    get_tags_to_add: Union[
+        Callable[[DatasetSnapshotClass], List[TagAssociationClass]],
+        Callable[[DatasetSnapshotClass], List[TagAssociationClass]],
+    ]
+
+    _resolve_tag_fn = pydantic_resolve_key("get_tags_to_add")
+
+
+class AddDatasetSchemaTags(BaseTransformer, SingleAspectTransformer):
+    """Transformer that adds glossary tags to datasets according to a callback function."""
+
+    ctx: PipelineContext
+    config: AddDatasetSchemaTagsConfig
+
+    def __init__(self, config: AddDatasetSchemaTagsConfig, ctx: PipelineContext):
+        super().__init__()
+        self.ctx = ctx
+        self.config = config
+
+    def aspect_name(self) -> str:
+        return "schemaMetadata"
+
+    def entity_types(self) -> List[str]:
+        return ["dataset"]
+
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "AddDatasetTags":
+        config = AddDatasetSchemaTagsConfig.parse_obj(config_dict)
+        return cls(config, ctx)
+
+    def extend_field(self, schema_field: SchemaFieldClass):
+        tags_to_add = self.config.get_tags_to_add(schema_field.fieldPath)
+        if len(tags_to_add) > 0:
+            new_tags = schema_field.globalTags if schema_field.globalTags is not None else GlobalTagsClass(
+                tags=[],
+            )
+            new_tags.tags.extend(tags_to_add)
+            schema_field.globalTags = new_tags
+
+        return schema_field
+
+    def transform_aspect(
+            self, entity_urn: str, aspect_name: str, aspect: Optional[builder.Aspect]
+    ) -> Optional[builder.Aspect]:
+        assert aspect is None or isinstance(aspect, SchemaMetadataClass)
+
+        if aspect is None:
+            return aspect
+
+        schema_metadata_aspect: SchemaMetadataClass = aspect
+
+        schema_metadata_aspect.fields = [
+            self.extend_field(field)
+            for field in schema_metadata_aspect.fields
+        ]
+
+        return schema_metadata_aspect
+
+
+class PatternDatasetTagsConfig(ConfigModel):
+    tag_pattern: KeyValuePattern = KeyValuePattern.all()
+
+
+class PatternAddDatasetSchemaTags(AddDatasetSchemaTags):
+    """Transformer that adds a dynamic set of tags to each field in a dataset based on supplied patterns."""
+
+    def __init__(self, config: PatternDatasetTagsConfig, ctx: PipelineContext):
+        tag_pattern = config.tag_pattern
+        generic_config = AddDatasetSchemaTagsConfig(
+            get_tags_to_add=lambda path: [
+                TagAssociationClass(tag=urn)
+                for urn in tag_pattern.value(path)
+            ],
+        )
+        super().__init__(generic_config, ctx)
+
+    @classmethod
+    def create(
+        cls, config_dict: dict, ctx: PipelineContext
+    ) -> "PatternAddDatasetSchemaTags":
+        config = PatternDatasetTagsConfig.parse_obj(config_dict)
+        return cls(config, ctx)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_terms.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_terms.py
@@ -1,0 +1,104 @@
+from typing import Callable, List, Union, Optional
+
+import datahub.emitter.mce_builder as builder
+from datahub.configuration.common import ConfigModel, KeyValuePattern
+from datahub.configuration.import_resolver import pydantic_resolve_key
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.transformer.base_transformer import SingleAspectTransformer, BaseTransformer
+from datahub.metadata.schema_classes import (
+    AuditStampClass,
+    DatasetSnapshotClass,
+    GlossaryTermAssociationClass,
+    GlossaryTermsClass,
+    MetadataChangeEventClass, SchemaMetadataClass, SchemaFieldClass,
+)
+
+
+class AddDatasetSchemaTermsConfig(ConfigModel):
+    # Workaround for https://github.com/python/mypy/issues/708.
+    # Suggested by https://stackoverflow.com/a/64528725/5004662.
+    get_terms_to_add: Union[
+        Callable[[DatasetSnapshotClass], List[GlossaryTermAssociationClass]],
+        Callable[[DatasetSnapshotClass], List[GlossaryTermAssociationClass]],
+    ]
+
+    _resolve_term_fn = pydantic_resolve_key("get_terms_to_add")
+
+
+class AddDatasetSchemaTerms(BaseTransformer, SingleAspectTransformer):
+    """Transformer that adds glossary terms to datasets according to a callback function."""
+
+    ctx: PipelineContext
+    config: AddDatasetSchemaTermsConfig
+
+    def __init__(self, config: AddDatasetSchemaTermsConfig, ctx: PipelineContext):
+        super().__init__()
+        self.ctx = ctx
+        self.config = config
+
+    def aspect_name(self) -> str:
+        return "schemaMetadata"
+
+    def entity_types(self) -> List[str]:
+        return ["dataset"]
+
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "AddDatasetTerms":
+        config = AddDatasetSchemaTermsConfig.parse_obj(config_dict)
+        return cls(config, ctx)
+
+    def extend_field(self, schema_field: SchemaFieldClass):
+        terms_to_add = self.config.get_terms_to_add(schema_field.fieldPath)
+        if len(terms_to_add) > 0:
+            new_terms = schema_field.glossaryTerms if schema_field.glossaryTerms is not None else GlossaryTermsClass(
+                terms=[],
+                auditStamp=AuditStampClass(
+                    time=builder.get_sys_time(), actor="urn:li:corpUser:restEmitter"
+                ),
+            )
+            new_terms.terms.extend(terms_to_add)
+            schema_field.glossaryTerms = new_terms
+
+        return schema_field
+
+    def transform_aspect(
+            self, entity_urn: str, aspect_name: str, aspect: Optional[builder.Aspect]
+    ) -> Optional[builder.Aspect]:
+        assert aspect is None or isinstance(aspect, SchemaMetadataClass)
+
+        if aspect is None:
+            return aspect
+
+        schema_metadata_aspect: SchemaMetadataClass = aspect
+
+        schema_metadata_aspect.fields = [
+            self.extend_field(field)
+            for field in schema_metadata_aspect.fields
+        ]
+
+        return schema_metadata_aspect
+
+
+class PatternDatasetTermsConfig(ConfigModel):
+    term_pattern: KeyValuePattern = KeyValuePattern.all()
+
+
+class PatternAddDatasetSchemaTerms(AddDatasetSchemaTerms):
+    """Transformer that adds a dynamic set of glossary terms to each field in a dataset based on supplied patterns."""
+
+    def __init__(self, config: PatternDatasetTermsConfig, ctx: PipelineContext):
+        term_pattern = config.term_pattern
+        generic_config = AddDatasetSchemaTermsConfig(
+            get_terms_to_add=lambda path: [
+                GlossaryTermAssociationClass(urn=urn)
+                for urn in term_pattern.value(path)
+            ],
+        )
+        super().__init__(generic_config, ctx)
+
+    @classmethod
+    def create(
+        cls, config_dict: dict, ctx: PipelineContext
+    ) -> "PatternAddDatasetSchemaTerms":
+        config = PatternDatasetTermsConfig.parse_obj(config_dict)
+        return cls(config, ctx)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_terms.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_terms.py
@@ -1,16 +1,19 @@
-from typing import Callable, List, Union, Optional
+from typing import Callable, List, Optional, Union
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigModel, KeyValuePattern
 from datahub.configuration.import_resolver import pydantic_resolve_key
 from datahub.ingestion.api.common import PipelineContext
-from datahub.ingestion.transformer.base_transformer import SingleAspectTransformer, BaseTransformer
+from datahub.ingestion.transformer.base_transformer import (
+    BaseTransformer,
+    SingleAspectTransformer,
+)
 from datahub.metadata.schema_classes import (
     AuditStampClass,
-    DatasetSnapshotClass,
     GlossaryTermAssociationClass,
     GlossaryTermsClass,
-    MetadataChangeEventClass, SchemaMetadataClass, SchemaFieldClass,
+    SchemaFieldClass,
+    SchemaMetadataClass,
 )
 
 
@@ -18,8 +21,8 @@ class AddDatasetSchemaTermsConfig(ConfigModel):
     # Workaround for https://github.com/python/mypy/issues/708.
     # Suggested by https://stackoverflow.com/a/64528725/5004662.
     get_terms_to_add: Union[
-        Callable[[DatasetSnapshotClass], List[GlossaryTermAssociationClass]],
-        Callable[[DatasetSnapshotClass], List[GlossaryTermAssociationClass]],
+        Callable[[str], List[GlossaryTermAssociationClass]],
+        Callable[[str], List[GlossaryTermAssociationClass]],
     ]
 
     _resolve_term_fn = pydantic_resolve_key("get_terms_to_add")
@@ -43,18 +46,22 @@ class AddDatasetSchemaTerms(BaseTransformer, SingleAspectTransformer):
         return ["dataset"]
 
     @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "AddDatasetTerms":
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "AddDatasetSchemaTerms":
         config = AddDatasetSchemaTermsConfig.parse_obj(config_dict)
         return cls(config, ctx)
 
-    def extend_field(self, schema_field: SchemaFieldClass):
+    def extend_field(self, schema_field: SchemaFieldClass) -> SchemaFieldClass:
         terms_to_add = self.config.get_terms_to_add(schema_field.fieldPath)
         if len(terms_to_add) > 0:
-            new_terms = schema_field.glossaryTerms if schema_field.glossaryTerms is not None else GlossaryTermsClass(
-                terms=[],
-                auditStamp=AuditStampClass(
-                    time=builder.get_sys_time(), actor="urn:li:corpUser:restEmitter"
-                ),
+            new_terms = (
+                schema_field.glossaryTerms
+                if schema_field.glossaryTerms is not None
+                else GlossaryTermsClass(
+                    terms=[],
+                    auditStamp=AuditStampClass(
+                        time=builder.get_sys_time(), actor="urn:li:corpUser:restEmitter"
+                    ),
+                )
             )
             new_terms.terms.extend(terms_to_add)
             schema_field.glossaryTerms = new_terms
@@ -62,7 +69,7 @@ class AddDatasetSchemaTerms(BaseTransformer, SingleAspectTransformer):
         return schema_field
 
     def transform_aspect(
-            self, entity_urn: str, aspect_name: str, aspect: Optional[builder.Aspect]
+        self, entity_urn: str, aspect_name: str, aspect: Optional[builder.Aspect]
     ) -> Optional[builder.Aspect]:
         assert aspect is None or isinstance(aspect, SchemaMetadataClass)
 
@@ -72,11 +79,10 @@ class AddDatasetSchemaTerms(BaseTransformer, SingleAspectTransformer):
         schema_metadata_aspect: SchemaMetadataClass = aspect
 
         schema_metadata_aspect.fields = [
-            self.extend_field(field)
-            for field in schema_metadata_aspect.fields
+            self.extend_field(field) for field in schema_metadata_aspect.fields
         ]
 
-        return schema_metadata_aspect
+        return schema_metadata_aspect  # type: ignore
 
 
 class PatternDatasetTermsConfig(ConfigModel):

--- a/metadata-ingestion/src/datahub/ingestion/transformer/transform_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/transform_registry.py
@@ -12,6 +12,8 @@ from datahub.ingestion.transformer.add_dataset_properties import (
     AddDatasetProperties,
     SimpleAddDatasetProperties,
 )
+from datahub.ingestion.transformer.add_dataset_schema_tags import PatternAddDatasetSchemaTags
+from datahub.ingestion.transformer.add_dataset_schema_terms import PatternAddDatasetSchemaTerms
 from datahub.ingestion.transformer.add_dataset_tags import (
     AddDatasetTags,
     PatternAddDatasetTags,
@@ -49,3 +51,6 @@ transform_registry.register("pattern_add_dataset_terms", PatternAddDatasetTerms)
 
 transform_registry.register("add_dataset_properties", AddDatasetProperties)
 transform_registry.register("simple_add_dataset_properties", SimpleAddDatasetProperties)
+
+transform_registry.register("pattern_add_dataset_schema_terms", PatternAddDatasetSchemaTerms)
+transform_registry.register("pattern_add_dataset_schema_tags", PatternAddDatasetSchemaTags)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/transform_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/transform_registry.py
@@ -12,8 +12,12 @@ from datahub.ingestion.transformer.add_dataset_properties import (
     AddDatasetProperties,
     SimpleAddDatasetProperties,
 )
-from datahub.ingestion.transformer.add_dataset_schema_tags import PatternAddDatasetSchemaTags
-from datahub.ingestion.transformer.add_dataset_schema_terms import PatternAddDatasetSchemaTerms
+from datahub.ingestion.transformer.add_dataset_schema_tags import (
+    PatternAddDatasetSchemaTags,
+)
+from datahub.ingestion.transformer.add_dataset_schema_terms import (
+    PatternAddDatasetSchemaTerms,
+)
 from datahub.ingestion.transformer.add_dataset_tags import (
     AddDatasetTags,
     PatternAddDatasetTags,
@@ -52,5 +56,9 @@ transform_registry.register("pattern_add_dataset_terms", PatternAddDatasetTerms)
 transform_registry.register("add_dataset_properties", AddDatasetProperties)
 transform_registry.register("simple_add_dataset_properties", SimpleAddDatasetProperties)
 
-transform_registry.register("pattern_add_dataset_schema_terms", PatternAddDatasetSchemaTerms)
-transform_registry.register("pattern_add_dataset_schema_tags", PatternAddDatasetSchemaTags)
+transform_registry.register(
+    "pattern_add_dataset_schema_terms", PatternAddDatasetSchemaTerms
+)
+transform_registry.register(
+    "pattern_add_dataset_schema_tags", PatternAddDatasetSchemaTags
+)

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -25,8 +25,12 @@ from datahub.ingestion.transformer.add_dataset_properties import (
     AddDatasetPropertiesResolverBase,
     SimpleAddDatasetProperties,
 )
-from datahub.ingestion.transformer.add_dataset_schema_tags import PatternAddDatasetSchemaTags
-from datahub.ingestion.transformer.add_dataset_schema_terms import PatternAddDatasetSchemaTerms
+from datahub.ingestion.transformer.add_dataset_schema_tags import (
+    PatternAddDatasetSchemaTags,
+)
+from datahub.ingestion.transformer.add_dataset_schema_terms import (
+    PatternAddDatasetSchemaTerms,
+)
 from datahub.ingestion.transformer.add_dataset_tags import (
     AddDatasetTags,
     PatternAddDatasetTags,
@@ -1412,35 +1416,47 @@ def test_old_transformers_working_as_before(mock_time):
 
 def test_pattern_dataset_schema_terms_transformation(mock_time):
     dataset_mce = make_generic_dataset(
-        aspects=[models.SchemaMetadataClass(
-            schemaName="customer",  # not used
-            platform=builder.make_data_platform_urn("hive"),  # important <- platform must be an urn
-            version=0,
-            # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
-            hash="",
-            # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
-            platformSchema=models.OtherSchemaClass(rawSchema="__insert raw schema here__"),
-            fields=[
-                models.SchemaFieldClass(
-                    fieldPath="address",
-                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
-                    nativeDataType="VARCHAR(100)",
-                    # use this to provide the type of the field in the source system's vernacular
+        aspects=[
+            models.SchemaMetadataClass(
+                schemaName="customer",  # not used
+                platform=builder.make_data_platform_urn(
+                    "hive"
+                ),  # important <- platform must be an urn
+                version=0,
+                # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
+                hash="",
+                # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
+                platformSchema=models.OtherSchemaClass(
+                    rawSchema="__insert raw schema here__"
                 ),
-                models.SchemaFieldClass(
-                    fieldPath="first_name",
-                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
-                    nativeDataType="VARCHAR(100)",
-                    # use this to provide the type of the field in the source system's vernacular
-                ),
-                models.SchemaFieldClass(
-                    fieldPath="last_name",
-                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
-                    nativeDataType="VARCHAR(100)",
-                    # use this to provide the type of the field in the source system's vernacular
-                ),
-            ],
-        )]
+                fields=[
+                    models.SchemaFieldClass(
+                        fieldPath="address",
+                        type=models.SchemaFieldDataTypeClass(
+                            type=models.StringTypeClass()
+                        ),
+                        nativeDataType="VARCHAR(100)",
+                        # use this to provide the type of the field in the source system's vernacular
+                    ),
+                    models.SchemaFieldClass(
+                        fieldPath="first_name",
+                        type=models.SchemaFieldDataTypeClass(
+                            type=models.StringTypeClass()
+                        ),
+                        nativeDataType="VARCHAR(100)",
+                        # use this to provide the type of the field in the source system's vernacular
+                    ),
+                    models.SchemaFieldClass(
+                        fieldPath="last_name",
+                        type=models.SchemaFieldDataTypeClass(
+                            type=models.StringTypeClass()
+                        ),
+                        nativeDataType="VARCHAR(100)",
+                        # use this to provide the type of the field in the source system's vernacular
+                    ),
+                ],
+            )
+        ]
     )
 
     transformer = PatternAddDatasetSchemaTerms.create(
@@ -1477,44 +1493,64 @@ def test_pattern_dataset_schema_terms_transformation(mock_time):
     assert schema_aspect.fields[0].fieldPath == "address"
     assert schema_aspect.fields[0].glossaryTerms is None
     assert schema_aspect.fields[1].fieldPath == "first_name"
-    assert schema_aspect.fields[1].glossaryTerms.terms[0].urn == builder.make_term_urn("Name")
-    assert schema_aspect.fields[1].glossaryTerms.terms[1].urn == builder.make_term_urn("FirstName")
+    assert schema_aspect.fields[1].glossaryTerms.terms[0].urn == builder.make_term_urn(
+        "Name"
+    )
+    assert schema_aspect.fields[1].glossaryTerms.terms[1].urn == builder.make_term_urn(
+        "FirstName"
+    )
     assert schema_aspect.fields[2].fieldPath == "last_name"
-    assert schema_aspect.fields[2].glossaryTerms.terms[0].urn == builder.make_term_urn("Name")
-    assert schema_aspect.fields[2].glossaryTerms.terms[1].urn == builder.make_term_urn("LastName")
+    assert schema_aspect.fields[2].glossaryTerms.terms[0].urn == builder.make_term_urn(
+        "Name"
+    )
+    assert schema_aspect.fields[2].glossaryTerms.terms[1].urn == builder.make_term_urn(
+        "LastName"
+    )
 
 
 def test_pattern_dataset_schema_tags_transformation(mock_time):
     dataset_mce = make_generic_dataset(
-        aspects=[models.SchemaMetadataClass(
-            schemaName="customer",  # not used
-            platform=builder.make_data_platform_urn("hive"),  # important <- platform must be an urn
-            version=0,
-            # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
-            hash="",
-            # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
-            platformSchema=models.OtherSchemaClass(rawSchema="__insert raw schema here__"),
-            fields=[
-                models.SchemaFieldClass(
-                    fieldPath="address",
-                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
-                    nativeDataType="VARCHAR(100)",
-                    # use this to provide the type of the field in the source system's vernacular
+        aspects=[
+            models.SchemaMetadataClass(
+                schemaName="customer",  # not used
+                platform=builder.make_data_platform_urn(
+                    "hive"
+                ),  # important <- platform must be an urn
+                version=0,
+                # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
+                hash="",
+                # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
+                platformSchema=models.OtherSchemaClass(
+                    rawSchema="__insert raw schema here__"
                 ),
-                models.SchemaFieldClass(
-                    fieldPath="first_name",
-                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
-                    nativeDataType="VARCHAR(100)",
-                    # use this to provide the type of the field in the source system's vernacular
-                ),
-                models.SchemaFieldClass(
-                    fieldPath="last_name",
-                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
-                    nativeDataType="VARCHAR(100)",
-                    # use this to provide the type of the field in the source system's vernacular
-                ),
-            ],
-        )]
+                fields=[
+                    models.SchemaFieldClass(
+                        fieldPath="address",
+                        type=models.SchemaFieldDataTypeClass(
+                            type=models.StringTypeClass()
+                        ),
+                        nativeDataType="VARCHAR(100)",
+                        # use this to provide the type of the field in the source system's vernacular
+                    ),
+                    models.SchemaFieldClass(
+                        fieldPath="first_name",
+                        type=models.SchemaFieldDataTypeClass(
+                            type=models.StringTypeClass()
+                        ),
+                        nativeDataType="VARCHAR(100)",
+                        # use this to provide the type of the field in the source system's vernacular
+                    ),
+                    models.SchemaFieldClass(
+                        fieldPath="last_name",
+                        type=models.SchemaFieldDataTypeClass(
+                            type=models.StringTypeClass()
+                        ),
+                        nativeDataType="VARCHAR(100)",
+                        # use this to provide the type of the field in the source system's vernacular
+                    ),
+                ],
+            )
+        ]
     )
 
     transformer = PatternAddDatasetSchemaTags.create(
@@ -1551,8 +1587,16 @@ def test_pattern_dataset_schema_tags_transformation(mock_time):
     assert schema_aspect.fields[0].fieldPath == "address"
     assert schema_aspect.fields[0].globalTags is None
     assert schema_aspect.fields[1].fieldPath == "first_name"
-    assert schema_aspect.fields[1].globalTags.tags[0].tag == builder.make_tag_urn("Name")
-    assert schema_aspect.fields[1].globalTags.tags[1].tag == builder.make_tag_urn("FirstName")
+    assert schema_aspect.fields[1].globalTags.tags[0].tag == builder.make_tag_urn(
+        "Name"
+    )
+    assert schema_aspect.fields[1].globalTags.tags[1].tag == builder.make_tag_urn(
+        "FirstName"
+    )
     assert schema_aspect.fields[2].fieldPath == "last_name"
-    assert schema_aspect.fields[2].globalTags.tags[0].tag == builder.make_tag_urn("Name")
-    assert schema_aspect.fields[2].globalTags.tags[1].tag == builder.make_tag_urn("LastName")
+    assert schema_aspect.fields[2].globalTags.tags[0].tag == builder.make_tag_urn(
+        "Name"
+    )
+    assert schema_aspect.fields[2].globalTags.tags[1].tag == builder.make_tag_urn(
+        "LastName"
+    )

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -25,6 +25,8 @@ from datahub.ingestion.transformer.add_dataset_properties import (
     AddDatasetPropertiesResolverBase,
     SimpleAddDatasetProperties,
 )
+from datahub.ingestion.transformer.add_dataset_schema_tags import PatternAddDatasetSchemaTags
+from datahub.ingestion.transformer.add_dataset_schema_terms import PatternAddDatasetSchemaTerms
 from datahub.ingestion.transformer.add_dataset_tags import (
     AddDatasetTags,
     PatternAddDatasetTags,
@@ -1406,3 +1408,151 @@ def test_old_transformers_working_as_before(mock_time):
     assert outputs[0].record == dataset_mcps[0]
     assert outputs[1].record == dataset_mcps[1]
     assert isinstance(outputs[-1].record, EndOfStream)
+
+
+def test_pattern_dataset_schema_terms_transformation(mock_time):
+    dataset_mce = make_generic_dataset(
+        aspects=[models.SchemaMetadataClass(
+            schemaName="customer",  # not used
+            platform=builder.make_data_platform_urn("hive"),  # important <- platform must be an urn
+            version=0,
+            # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
+            hash="",
+            # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
+            platformSchema=models.OtherSchemaClass(rawSchema="__insert raw schema here__"),
+            fields=[
+                models.SchemaFieldClass(
+                    fieldPath="address",
+                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
+                    nativeDataType="VARCHAR(100)",
+                    # use this to provide the type of the field in the source system's vernacular
+                ),
+                models.SchemaFieldClass(
+                    fieldPath="first_name",
+                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
+                    nativeDataType="VARCHAR(100)",
+                    # use this to provide the type of the field in the source system's vernacular
+                ),
+                models.SchemaFieldClass(
+                    fieldPath="last_name",
+                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
+                    nativeDataType="VARCHAR(100)",
+                    # use this to provide the type of the field in the source system's vernacular
+                ),
+            ],
+        )]
+    )
+
+    transformer = PatternAddDatasetSchemaTerms.create(
+        {
+            "term_pattern": {
+                "rules": {
+                    ".*first_name.*": [
+                        builder.make_term_urn("Name"),
+                        builder.make_term_urn("FirstName"),
+                    ],
+                    ".*last_name.*": [
+                        builder.make_term_urn("Name"),
+                        builder.make_term_urn("LastName"),
+                    ],
+                }
+            },
+        },
+        PipelineContext(run_id="test-schema-terms"),
+    )
+
+    outputs = list(
+        transformer.transform(
+            [
+                RecordEnvelope(input, metadata={})
+                for input in [dataset_mce, EndOfStream()]
+            ]
+        )
+    )
+
+    assert len(outputs) == 2
+    # Check that glossary terms were added.
+    schema_aspect = outputs[0].record.proposedSnapshot.aspects[0]
+    assert schema_aspect
+    assert schema_aspect.fields[0].fieldPath == "address"
+    assert schema_aspect.fields[0].glossaryTerms is None
+    assert schema_aspect.fields[1].fieldPath == "first_name"
+    assert schema_aspect.fields[1].glossaryTerms.terms[0].urn == builder.make_term_urn("Name")
+    assert schema_aspect.fields[1].glossaryTerms.terms[1].urn == builder.make_term_urn("FirstName")
+    assert schema_aspect.fields[2].fieldPath == "last_name"
+    assert schema_aspect.fields[2].glossaryTerms.terms[0].urn == builder.make_term_urn("Name")
+    assert schema_aspect.fields[2].glossaryTerms.terms[1].urn == builder.make_term_urn("LastName")
+
+
+def test_pattern_dataset_schema_tags_transformation(mock_time):
+    dataset_mce = make_generic_dataset(
+        aspects=[models.SchemaMetadataClass(
+            schemaName="customer",  # not used
+            platform=builder.make_data_platform_urn("hive"),  # important <- platform must be an urn
+            version=0,
+            # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
+            hash="",
+            # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
+            platformSchema=models.OtherSchemaClass(rawSchema="__insert raw schema here__"),
+            fields=[
+                models.SchemaFieldClass(
+                    fieldPath="address",
+                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
+                    nativeDataType="VARCHAR(100)",
+                    # use this to provide the type of the field in the source system's vernacular
+                ),
+                models.SchemaFieldClass(
+                    fieldPath="first_name",
+                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
+                    nativeDataType="VARCHAR(100)",
+                    # use this to provide the type of the field in the source system's vernacular
+                ),
+                models.SchemaFieldClass(
+                    fieldPath="last_name",
+                    type=models.SchemaFieldDataTypeClass(type=models.StringTypeClass()),
+                    nativeDataType="VARCHAR(100)",
+                    # use this to provide the type of the field in the source system's vernacular
+                ),
+            ],
+        )]
+    )
+
+    transformer = PatternAddDatasetSchemaTags.create(
+        {
+            "tag_pattern": {
+                "rules": {
+                    ".*first_name.*": [
+                        builder.make_tag_urn("Name"),
+                        builder.make_tag_urn("FirstName"),
+                    ],
+                    ".*last_name.*": [
+                        builder.make_tag_urn("Name"),
+                        builder.make_tag_urn("LastName"),
+                    ],
+                }
+            },
+        },
+        PipelineContext(run_id="test-schema-tags"),
+    )
+
+    outputs = list(
+        transformer.transform(
+            [
+                RecordEnvelope(input, metadata={})
+                for input in [dataset_mce, EndOfStream()]
+            ]
+        )
+    )
+
+    assert len(outputs) == 2
+    # Check that glossary terms were added.
+    schema_aspect = outputs[0].record.proposedSnapshot.aspects[0]
+    assert schema_aspect
+    assert schema_aspect.fields[0].fieldPath == "address"
+    assert schema_aspect.fields[0].globalTags is None
+    assert schema_aspect.fields[1].fieldPath == "first_name"
+    assert schema_aspect.fields[1].globalTags.tags[0].tag == builder.make_tag_urn("Name")
+    assert schema_aspect.fields[1].globalTags.tags[1].tag == builder.make_tag_urn("FirstName")
+    assert schema_aspect.fields[2].fieldPath == "last_name"
+    assert schema_aspect.fields[2].globalTags.tags[0].tag == builder.make_tag_urn("Name")
+    assert schema_aspect.fields[2].globalTags.tags[1].tag == builder.make_tag_urn("LastName")

--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -41,6 +41,22 @@ transformers:
           ".*example2.*": ["urn:li:tag:NeedsDocumentation"]
 ```
 
+### Adding tags by schema field pattern
+
+We can also append a series of tags to specific schema fields. To do so, we can use the `pattern_add_dataset_schema_tags` module. This will match the regex pattern to each schema field path and assign the respective tags urns given in the array.
+
+The config would look like this:
+
+```yaml
+transformers:
+  - type: "pattern_add_dataset_schema_tags"
+    config:
+      tag_pattern:
+        rules:
+          ".*email.*": ["urn:li:tag:Email"]
+          ".*name.*": ["urn:li:tag:Name"]
+```
+
 ### Add your own custom Transformer
 
 If you'd like to add more complex logic for assigning tags, you can use the more generic add_dataset_tags transformer, which calls a user-provided function to determine the tags for each dataset.
@@ -117,6 +133,20 @@ transformers:
         rules:
           ".*example1.*": ["urn:li:glossaryTerm:Email", "urn:li:glossaryTerm:Address"]
           ".*example2.*": ["urn:li:glossaryTerm:PostalCode"]
+```
+
+### Adding glossary terms by schema field pattern
+
+Similar to the above example with tags applied to schema fields, we can add glossary terms to schema fields based on a regex filter.
+
+```yaml
+transformers:
+  - type: "pattern_add_dataset_schema_terms"
+    config:
+      term_pattern:
+        rules:
+          ".*email.*": ["urn:li:glossaryTerm:Email"]
+          ".*name.*": ["urn:li:glossaryTerm:Name"]
 ```
 
 ### Change owners

--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -45,6 +45,8 @@ transformers:
 
 We can also append a series of tags to specific schema fields. To do so, we can use the `pattern_add_dataset_schema_tags` module. This will match the regex pattern to each schema field path and assign the respective tags urns given in the array.
 
+Note that the tags from the first matching pattern will be applied, not all matching patterns.
+
 The config would look like this:
 
 ```yaml
@@ -138,6 +140,7 @@ transformers:
 ### Adding glossary terms by schema field pattern
 
 Similar to the above example with tags applied to schema fields, we can add glossary terms to schema fields based on a regex filter.
+Again, note that only terms from the first matching pattern will be applied.
 
 ```yaml
 transformers:


### PR DESCRIPTION
Config examples:

```
transformers:
  - type: "pattern_add_dataset_schema_terms"
    config:
      term_pattern:
        rules:
          ".*email.*": ["urn:li:glossaryTerm:Email"]
          ".*name.*": ["urn:li:glossaryTerm:Name"]
```

and

```yaml
transformers:
  - type: "pattern_add_dataset_schema_tags"
    config:
      tag_pattern:
        rules:
          ".*email.*": ["urn:li:tag:Email"]
          ".*name.*": ["urn:li:tag:Name"]
```

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)