### PR TITLE
feat(model): add created, lastModified auditstamps to SchemaField

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -5744,14 +5744,20 @@ enum OperationType {
     DELETE
 
     """
-    When data is created.
+    When table is created.
     """
     CREATE
 
     """
-    When data is dropped
+    When table is altered
+    """
+    ALTER
+
+    """
+    When table is dropped
     """
     DROP
+    
     """
     Unknown operation
     """

--- a/metadata-ingestion/examples/library/dataset_schema.py
+++ b/metadata-ingestion/examples/library/dataset_schema.py
@@ -5,6 +5,7 @@ from datahub.emitter.rest_emitter import DatahubRestEmitter
 
 # Imports for metadata model classes
 from datahub.metadata.schema_classes import (
+    AuditStampClass,
     ChangeTypeClass,
     DateTypeClass,
     OtherSchemaClass,
@@ -25,24 +26,39 @@ event: MetadataChangeProposalWrapper = MetadataChangeProposalWrapper(
         version=0,  # when the source system has a notion of versioning of schemas, insert this in, otherwise leave as 0
         hash="",  # when the source system has a notion of unique schemas identified via hash, include a hash, else leave it as empty string
         platformSchema=OtherSchemaClass(rawSchema="__insert raw schema here__"),
+        lastModified=AuditStampClass(
+            time=1640692800000, actor="urn:li:corpuser:ingestion"
+        ),
         fields=[
             SchemaFieldClass(
                 fieldPath="address.zipcode",
                 type=SchemaFieldDataTypeClass(type=StringTypeClass()),
                 nativeDataType="VARCHAR(50)",  # use this to provide the type of the field in the source system's vernacular
                 description="This is the zipcode of the address. Specified using extended form and limited to addresses in the United States",
+                lastModified=AuditStampClass(
+                    time=1640692800000, actor="urn:li:corpuser:ingestion"
+                ),
             ),
             SchemaFieldClass(
                 fieldPath="address.street",
                 type=SchemaFieldDataTypeClass(type=StringTypeClass()),
                 nativeDataType="VARCHAR(100)",
                 description="Street corresponding to the address",
+                lastModified=AuditStampClass(
+                    time=1640692800000, actor="urn:li:corpuser:ingestion"
+                ),
             ),
             SchemaFieldClass(
                 fieldPath="last_sold_date",
                 type=SchemaFieldDataTypeClass(type=DateTypeClass()),
                 nativeDataType="Date",
                 description="Date of the last sale date for this property",
+                created=AuditStampClass(
+                    time=1640692800000, actor="urn:li:corpuser:ingestion"
+                ),
+                lastModified=AuditStampClass(
+                    time=1640692800000, actor="urn:li:corpuser:ingestion"
+                ),
             ),
         ],
     ),

--- a/metadata-models/src/main/pegasus/com/linkedin/common/OperationType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/OperationType.pdl
@@ -8,6 +8,7 @@ enum OperationType {
   UPDATE
   DELETE
   CREATE
+  ALTER
   DROP
   UNKNOWN
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/schema/SchemaField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/schema/SchemaField.pdl
@@ -3,6 +3,7 @@ namespace com.linkedin.schema
 import com.linkedin.dataset.SchemaFieldPath
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.GlossaryTerms
+import com.linkedin.common.AuditStamp
 
 /**
  * SchemaField to describe metadata related to dataset schema.
@@ -38,6 +39,16 @@ record SchemaField {
     "boostScore": 0.1
   }
   description: optional string
+
+  /**
+   * An AuditStamp corresponding to the creation of this schema field.
+   */
+  created: optional AuditStamp
+
+  /**
+   * An AuditStamp corresponding to the last modification of this schema field.
+   */
+  lastModified: optional AuditStamp
 
   /**
    * Platform independent field type of the field.

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -702,8 +702,10 @@
       "doc" : "Instance of the data platform (e.g. db instance)",
       "optional" : true,
       "Searchable" : {
+        "addToFilters" : true,
         "fieldName" : "platformInstance",
-        "fieldType" : "URN"
+        "fieldType" : "URN",
+        "filterNameOverride" : "Platform Instance"
       }
     } ],
     "Aspect" : {
@@ -804,6 +806,10 @@
               }
             },
             "doc" : "Urn of the applied tag",
+            "Relationship" : {
+              "entityTypes" : [ "tag" ],
+              "name" : "TaggedWith"
+            },
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
@@ -881,6 +887,10 @@
         }
       },
       "doc" : "Urn of the applied glossary term",
+      "Relationship" : {
+        "entityTypes" : [ "glossaryTerm" ],
+        "name" : "TermedWith"
+      },
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
@@ -2363,6 +2373,16 @@
                 "fieldType" : "TEXT"
               }
             }, {
+              "name" : "created",
+              "type" : "com.linkedin.common.AuditStamp",
+              "doc" : "An AuditStamp corresponding to the creation of this schema field.",
+              "optional" : true
+            }, {
+              "name" : "lastModified",
+              "type" : "com.linkedin.common.AuditStamp",
+              "doc" : "An AuditStamp corresponding to the last modification of this schema field.",
+              "optional" : true
+            }, {
               "name" : "type",
               "type" : {
                 "type" : "record",
@@ -2483,7 +2503,7 @@
               "Relationship" : {
                 "/tags/*/tag" : {
                   "entityTypes" : [ "tag" ],
-                  "name" : "FieldTaggedWith"
+                  "name" : "SchemaFieldTaggedWith"
                 }
               },
               "Searchable" : {
@@ -2501,7 +2521,7 @@
               "Relationship" : {
                 "/terms/*/urn" : {
                   "entityTypes" : [ "glossaryTerm" ],
-                  "name" : "FieldWithGlossaryTerm"
+                  "name" : "SchemaFieldWithGlossaryTerm"
                 }
               },
               "Searchable" : {
@@ -2670,7 +2690,7 @@
               "Relationship" : {
                 "/tags/*/tag" : {
                   "entityTypes" : [ "tag" ],
-                  "name" : "EditableFieldTaggedWith"
+                  "name" : "EditableSchemaFieldTaggedWith"
                 }
               },
               "Searchable" : {
@@ -2688,7 +2708,7 @@
               "Relationship" : {
                 "/terms/*/urn" : {
                   "entityTypes" : [ "glossaryTerm" ],
-                  "name" : "EditableFieldWithGlossaryTerm"
+                  "name" : "EditableSchemaFieldWithGlossaryTerm"
                 }
               },
               "Searchable" : {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -581,8 +581,10 @@
       "doc" : "Instance of the data platform (e.g. db instance)",
       "optional" : true,
       "Searchable" : {
+        "addToFilters" : true,
         "fieldName" : "platformInstance",
-        "fieldType" : "URN"
+        "fieldType" : "URN",
+        "filterNameOverride" : "Platform Instance"
       }
     } ],
     "Aspect" : {
@@ -785,6 +787,10 @@
               }
             },
             "doc" : "Urn of the applied tag",
+            "Relationship" : {
+              "entityTypes" : [ "tag" ],
+              "name" : "TaggedWith"
+            },
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
@@ -862,6 +868,10 @@
         }
       },
       "doc" : "Urn of the applied glossary term",
+      "Relationship" : {
+        "entityTypes" : [ "glossaryTerm" ],
+        "name" : "TermedWith"
+      },
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
@@ -2756,6 +2766,16 @@
                             "fieldType" : "TEXT"
                           }
                         }, {
+                          "name" : "created",
+                          "type" : "com.linkedin.common.AuditStamp",
+                          "doc" : "An AuditStamp corresponding to the creation of this schema field.",
+                          "optional" : true
+                        }, {
+                          "name" : "lastModified",
+                          "type" : "com.linkedin.common.AuditStamp",
+                          "doc" : "An AuditStamp corresponding to the last modification of this schema field.",
+                          "optional" : true
+                        }, {
                           "name" : "type",
                           "type" : {
                             "type" : "record",
@@ -2876,7 +2896,7 @@
                           "Relationship" : {
                             "/tags/*/tag" : {
                               "entityTypes" : [ "tag" ],
-                              "name" : "FieldTaggedWith"
+                              "name" : "SchemaFieldTaggedWith"
                             }
                           },
                           "Searchable" : {
@@ -2894,7 +2914,7 @@
                           "Relationship" : {
                             "/terms/*/urn" : {
                               "entityTypes" : [ "glossaryTerm" ],
-                              "name" : "FieldWithGlossaryTerm"
+                              "name" : "SchemaFieldWithGlossaryTerm"
                             }
                           },
                           "Searchable" : {
@@ -3063,7 +3083,7 @@
                           "Relationship" : {
                             "/tags/*/tag" : {
                               "entityTypes" : [ "tag" ],
-                              "name" : "EditableFieldTaggedWith"
+                              "name" : "EditableSchemaFieldTaggedWith"
                             }
                           },
                           "Searchable" : {
@@ -3081,7 +3101,7 @@
                           "Relationship" : {
                             "/terms/*/urn" : {
                               "entityTypes" : [ "glossaryTerm" ],
-                              "name" : "EditableFieldWithGlossaryTerm"
+                              "name" : "EditableSchemaFieldWithGlossaryTerm"
                             }
                           },
                           "Searchable" : {
@@ -4602,12 +4622,15 @@
                     "type" : "string",
                     "doc" : "Display name of the Policy",
                     "Searchable" : {
-                      "fieldType" : "KEYWORD"
+                      "fieldType" : "TEXT_PARTIAL"
                     }
                   }, {
                     "name" : "description",
                     "type" : "string",
-                    "doc" : "Description of the Policy"
+                    "doc" : "Description of the Policy",
+                    "Searchable" : {
+                      "fieldType" : "TEXT"
+                    }
                   }, {
                     "name" : "type",
                     "type" : "string",
@@ -5223,7 +5246,7 @@
           "fields" : [ {
             "name" : "entity",
             "type" : "com.linkedin.common.Urn",
-            "doc" : " Urn of the entity containing a related aspect"
+            "doc" : " Urn of the entity that is referenced by the aspect."
           }, {
             "name" : "aspect",
             "type" : "string"

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -462,8 +462,10 @@
       "doc" : "Instance of the data platform (e.g. db instance)",
       "optional" : true,
       "Searchable" : {
+        "addToFilters" : true,
         "fieldName" : "platformInstance",
-        "fieldType" : "URN"
+        "fieldType" : "URN",
+        "filterNameOverride" : "Platform Instance"
       }
     } ],
     "Aspect" : {
@@ -564,6 +566,10 @@
               }
             },
             "doc" : "Urn of the applied tag",
+            "Relationship" : {
+              "entityTypes" : [ "tag" ],
+              "name" : "TaggedWith"
+            },
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
@@ -641,6 +647,10 @@
         }
       },
       "doc" : "Urn of the applied glossary term",
+      "Relationship" : {
+        "entityTypes" : [ "glossaryTerm" ],
+        "name" : "TermedWith"
+      },
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
@@ -2110,6 +2120,16 @@
                 "fieldType" : "TEXT"
               }
             }, {
+              "name" : "created",
+              "type" : "com.linkedin.common.AuditStamp",
+              "doc" : "An AuditStamp corresponding to the creation of this schema field.",
+              "optional" : true
+            }, {
+              "name" : "lastModified",
+              "type" : "com.linkedin.common.AuditStamp",
+              "doc" : "An AuditStamp corresponding to the last modification of this schema field.",
+              "optional" : true
+            }, {
               "name" : "type",
               "type" : {
                 "type" : "record",
@@ -2230,7 +2250,7 @@
               "Relationship" : {
                 "/tags/*/tag" : {
                   "entityTypes" : [ "tag" ],
-                  "name" : "FieldTaggedWith"
+                  "name" : "SchemaFieldTaggedWith"
                 }
               },
               "Searchable" : {
@@ -2248,7 +2268,7 @@
               "Relationship" : {
                 "/terms/*/urn" : {
                   "entityTypes" : [ "glossaryTerm" ],
-                  "name" : "FieldWithGlossaryTerm"
+                  "name" : "SchemaFieldWithGlossaryTerm"
                 }
               },
               "Searchable" : {
@@ -2417,7 +2437,7 @@
               "Relationship" : {
                 "/tags/*/tag" : {
                   "entityTypes" : [ "tag" ],
-                  "name" : "EditableFieldTaggedWith"
+                  "name" : "EditableSchemaFieldTaggedWith"
                 }
               },
               "Searchable" : {
@@ -2435,7 +2455,7 @@
               "Relationship" : {
                 "/terms/*/urn" : {
                   "entityTypes" : [ "glossaryTerm" ],
-                  "name" : "EditableFieldWithGlossaryTerm"
+                  "name" : "EditableSchemaFieldWithGlossaryTerm"
                 }
               },
               "Searchable" : {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -581,8 +581,10 @@
       "doc" : "Instance of the data platform (e.g. db instance)",
       "optional" : true,
       "Searchable" : {
+        "addToFilters" : true,
         "fieldName" : "platformInstance",
-        "fieldType" : "URN"
+        "fieldType" : "URN",
+        "filterNameOverride" : "Platform Instance"
       }
     } ],
     "Aspect" : {
@@ -785,6 +787,10 @@
               }
             },
             "doc" : "Urn of the applied tag",
+            "Relationship" : {
+              "entityTypes" : [ "tag" ],
+              "name" : "TaggedWith"
+            },
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
@@ -862,6 +868,10 @@
         }
       },
       "doc" : "Urn of the applied glossary term",
+      "Relationship" : {
+        "entityTypes" : [ "glossaryTerm" ],
+        "name" : "TermedWith"
+      },
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
@@ -2756,6 +2766,16 @@
                             "fieldType" : "TEXT"
                           }
                         }, {
+                          "name" : "created",
+                          "type" : "com.linkedin.common.AuditStamp",
+                          "doc" : "An AuditStamp corresponding to the creation of this schema field.",
+                          "optional" : true
+                        }, {
+                          "name" : "lastModified",
+                          "type" : "com.linkedin.common.AuditStamp",
+                          "doc" : "An AuditStamp corresponding to the last modification of this schema field.",
+                          "optional" : true
+                        }, {
                           "name" : "type",
                           "type" : {
                             "type" : "record",
@@ -2876,7 +2896,7 @@
                           "Relationship" : {
                             "/tags/*/tag" : {
                               "entityTypes" : [ "tag" ],
-                              "name" : "FieldTaggedWith"
+                              "name" : "SchemaFieldTaggedWith"
                             }
                           },
                           "Searchable" : {
@@ -2894,7 +2914,7 @@
                           "Relationship" : {
                             "/terms/*/urn" : {
                               "entityTypes" : [ "glossaryTerm" ],
-                              "name" : "FieldWithGlossaryTerm"
+                              "name" : "SchemaFieldWithGlossaryTerm"
                             }
                           },
                           "Searchable" : {
@@ -3063,7 +3083,7 @@
                           "Relationship" : {
                             "/tags/*/tag" : {
                               "entityTypes" : [ "tag" ],
-                              "name" : "EditableFieldTaggedWith"
+                              "name" : "EditableSchemaFieldTaggedWith"
                             }
                           },
                           "Searchable" : {
@@ -3081,7 +3101,7 @@
                           "Relationship" : {
                             "/terms/*/urn" : {
                               "entityTypes" : [ "glossaryTerm" ],
-                              "name" : "EditableFieldWithGlossaryTerm"
+                              "name" : "EditableSchemaFieldWithGlossaryTerm"
                             }
                           },
                           "Searchable" : {
@@ -4602,12 +4622,15 @@
                     "type" : "string",
                     "doc" : "Display name of the Policy",
                     "Searchable" : {
-                      "fieldType" : "KEYWORD"
+                      "fieldType" : "TEXT_PARTIAL"
                     }
                   }, {
                     "name" : "description",
                     "type" : "string",
-                    "doc" : "Description of the Policy"
+                    "doc" : "Description of the Policy",
+                    "Searchable" : {
+                      "fieldType" : "TEXT"
+                    }
                   }, {
                     "name" : "type",
                     "type" : "string",


### PR DESCRIPTION
This PR
- adds optional `created`, `lastModified` auditStamps to `SchemaField`  in order to capture who added/updated the field in dataset and exactly when. Earlier field level timestamp details were not captured at model level.
- adds `ALTER` to `operationType` enum to represent operations on dataset as a result of ALTER TABLE to add/update fields or add/update table properties. Earlier, one could use less meaningful `UNKNOWN` operationType.
-  updates descriptions in graphql for operationTypes representing table level operations.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)