### PR TITLE
fix(gql): make graphql OperationType enum match up w/ pdl

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -5737,14 +5737,25 @@ enum OperationType {
     When data is updated.
     """
     UPDATE
+
     """
     When data is deleted.
     """
     DELETE
+
     """
     When data is created.
     """
     CREATE
+
+    """
+    When data is dropped
+    """
+    DROP
+    """
+    Unknown operation
+    """
+    UNKNOWN
 }
 
 """


### PR DESCRIPTION
These fields were in `.pdl` but previously not also represented in gql.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)