### PR TITLE
fix(ui): do not show copy URN buttons when Clipboard API is not available

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -227,15 +227,17 @@ export const EntityHeader = ({ showDeprecateOption }: Props) => {
                 </MainHeaderContent>
                 <SideHeaderContent>
                     <TopButtonsWrapper>
-                        <Tooltip title="Copy URN. An URN uniquely identifies an entity on DataHub.">
-                            <Button
-                                icon={copiedUrn ? <CheckOutlined /> : <CopyOutlined />}
-                                onClick={() => {
-                                    navigator.clipboard.writeText(urn);
-                                    setCopiedUrn(true);
-                                }}
-                            />
-                        </Tooltip>
+                        {navigator.clipboard && (
+                            <Tooltip title="Copy URN. An URN uniquely identifies an entity on DataHub.">
+                                <Button
+                                    icon={copiedUrn ? <CheckOutlined /> : <CopyOutlined />}
+                                    onClick={() => {
+                                        navigator.clipboard.writeText(urn);
+                                        setCopiedUrn(true);
+                                    }}
+                                />
+                            </Tooltip>
+                        )}
                         {showAdditionalOptions && (
                             <Dropdown
                                 overlay={

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceExecutionList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceExecutionList.tsx
@@ -161,7 +161,7 @@ export const IngestionSourceExecutionList = ({ urn, lastRefresh, onRefresh }: Pr
             key: 'x',
             render: (_, record: any) => (
                 <div style={{ display: 'flex', justifyContent: 'right' }}>
-                    {record.urn && (
+                    {record.urn && navigator.clipboard && (
                         <Tooltip title="Copy Execution Request URN">
                             <Button
                                 style={{ marginRight: 16 }}

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -356,15 +356,17 @@ export const IngestionSourceList = () => {
             key: 'x',
             render: (_, record: any) => (
                 <ActionButtonContainer>
-                    <Tooltip title="Copy Ingestion Source URN">
-                        <Button
-                            style={{ marginRight: 16 }}
-                            icon={<CopyOutlined />}
-                            onClick={() => {
-                                navigator.clipboard.writeText(record.urn);
-                            }}
-                        />
-                    </Tooltip>
+                    {navigator.clipboard && (
+                        <Tooltip title="Copy Ingestion Source URN">
+                            <Button
+                                style={{ marginRight: 16 }}
+                                icon={<CopyOutlined />}
+                                onClick={() => {
+                                    navigator.clipboard.writeText(record.urn);
+                                }}
+                            />
+                        </Tooltip>
+                    )}
                     <Button style={{ marginRight: 16 }} onClick={() => onEdit(record.urn)}>
                         EDIT
                     </Button>


### PR DESCRIPTION
This PR fixes #4921 by hiding the copy URN buttons when they do not work anyway because the Clipboard API is not available (e.g. in an insecure context or when using an incompatible browser).


## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)