### PR TITLE
Update data_platforms.json

### DIFF
--- a/metadata-service/war/src/main/resources/boot/data_platforms.json
+++ b/metadata-service/war/src/main/resources/boot/data_platforms.json
@@ -45,7 +45,7 @@
       "name": "clickhouse",
       "displayName": "ClickHouse",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/datahub-project/datahub/master/datahub-web-react/src/images/clickhouselogo.png"
+      "logoUrl": "/assets/platforms/clickhouselogo.png"
     }
   },
   {


### PR DESCRIPTION
Fixed clickHouse data source icon not being displayed after DataHub startup because there is no network

![image](https://user-images.githubusercontent.com/71497399/169441878-7a1cfe36-9415-47a9-b2a3-3559ab79f9b2.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)