### PR TITLE
docs(website): Remove banner and nav item for metadata day 2022

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -71,11 +71,6 @@ module.exports = {
           position: "right",
         },
         {
-          href: "http://metadataday.datahubproject.io/",
-          label: "Metadata Day 2022",
-          position: "right",
-        },
-        {
           href: "https://slack.datahubproject.io",
           "aria-label": "Slack",
           position: "right",

--- a/docs-website/src/components/Hero.js
+++ b/docs-website/src/components/Hero.js
@@ -10,17 +10,6 @@ import RoundedImage from "./RoundedImage";
 const Hero = ({}) => (
   <header className={clsx("hero", styles.hero)}>
     <div className="container">
-      <div className="hero__alert alert alert--primary">
-        <span>
-          <strong>🎉&nbsp; May 17th &amp; 18th 2022: Metadata Day, Governance as Code.</strong> Join us for expert panel discussions, lightning talks,
-          and our inaugural Hackathon!
-        </span>
-
-        <Link className="button button--primary button--md" href="http://metadataday.datahubproject.io/" target="_blank">
-          RSVP Here →
-        </Link>
-      </div>
-
       <div className="row row--centered">
         <div className="col col--5">
           <div className="hero__content">

--- a/docs-website/src/components/HeroAnnouncement.js
+++ b/docs-website/src/components/HeroAnnouncement.js
@@ -1,0 +1,17 @@
+import React from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+import styles from "../styles/hero-announcement.module.scss";
+
+const HeroAnnouncement = ({ message, linkUrl, linkText }) => (
+  <div className={clsx("hero__alert alert alert--primary", styles.hero__alert)}>
+    <span>{message}</span>
+    {linkUrl && (
+      <Link className="button button--primary button--md" href={linkUrl} target="_blank">
+        {linkText}
+      </Link>
+    )}
+  </div>
+);
+
+export default HeroAnnouncement;

--- a/docs-website/src/styles/global.scss
+++ b/docs-website/src/styles/global.scss
@@ -95,7 +95,7 @@ div[class^="announcementBarContent"] {
   }
 }
 
-@media only screen and (max-width: 1245px) {
+@media only screen and (max-width: 1050px) {
   .navbar__toggle {
     display: inherit;
   }

--- a/docs-website/src/styles/hero-announcement.module.scss
+++ b/docs-website/src/styles/hero-announcement.module.scss
@@ -1,0 +1,17 @@
+.hero__alert {
+  margin-bottom: 2rem;
+  @media (min-width: 690px) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .button {
+    text-decoration: none;
+    margin: 0.5rem 0 0 0;
+    display: block;
+    white-space: nowrap;
+    @media (min-width: 690px) {
+      margin: 0 0 0 0.5rem;
+    }
+  }
+}


### PR DESCRIPTION
Removes banner and nav item. Also moves code into a component so we can easily re-add announcements in the future.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)