### PR TITLE
doc(ingestion): default boolean fix, broken bigquery docgen

### DIFF
--- a/metadata-ingestion/scripts/docgen.py
+++ b/metadata-ingestion/scripts/docgen.py
@@ -132,7 +132,7 @@ def gen_md_table(
                 type_name="Enum",
                 required=field_dict.get("required") or False,
                 description=f"one of {','.join(field_dict['enum'])}",
-                default=field_dict.get("default") or "None",
+                default=str(field_dict.get("default", "None")),
             )
         )
         # md_str.append(
@@ -157,7 +157,7 @@ def gen_md_table(
                             description=get_enum_description(
                                 value.get("description"), def_dict["enum"]
                             ),
-                            default=str(value.get("default")) or "",
+                            default=str(value.get("default", "")),
                             required=required_field,
                         )
                         md_str.append(row)
@@ -167,7 +167,7 @@ def gen_md_table(
                             path=get_prefixed_name(field_prefix, field_name),
                             type_name=f"{reference.split('/')[-1]} (see below for fields)",
                             description=value.get("description") or "",
-                            default=str(value.get("default")) or "",
+                            default=str(value.get("default", "")),
                             required=required_field,
                         )
                         md_str.append(row)
@@ -194,7 +194,7 @@ def gen_md_table(
                         type_name="Enum",
                         description=f"one of {','.join(def_dict['enum'])}",
                         required=required_field,
-                        default=value.get("default") or "None",
+                        default=str(value.get("default", "None")),
                     )
                     #                    f"| {get_prefixed_name(field_prefix, field_name)} | Enum | one of {','.join(def_dict['enum'])} | {def_dict['type']} | \n"
                 )
@@ -216,7 +216,7 @@ def gen_md_table(
                             path=get_prefixed_name(field_prefix, field_name),
                             type_name=f"Dict[str, {value_ref.split('/')[-1]}]",
                             description=value.get("description") or "",
-                            default=value.get("default") or "",
+                            default=str(value.get("default", "")),
                             required=required_field,
                         )
                         md_str.append(row)
@@ -237,7 +237,7 @@ def gen_md_table(
                                 if value_type
                                 else "Dict",
                                 description=value.get("description") or "",
-                                default=value.get("default") or "",
+                                default=str(value.get("default", "")),
                                 required=required_field,
                             )
                         )
@@ -247,7 +247,7 @@ def gen_md_table(
                         path=get_prefixed_name(field_prefix, field_name),
                         type_name=f"{object_definition.split('/')[-1]} (see below for fields)",
                         description=value.get("description") or "",
-                        default=value.get("default") or "",
+                        default=str(value.get("default", "")),
                         required=required_field,
                     )
 
@@ -272,7 +272,7 @@ def gen_md_table(
                         path=get_prefixed_name(field_prefix, field_name),
                         type_name=f"Array of {items_type}",
                         description=value.get("description") or "",
-                        default=str(value.get("default")) or "None",
+                        default=str(value.get("default", "None")),
                         required=required_field,
                     )
                     #                    f"| {get_prefixed_name(field_prefix, field_name)} | Array of {items_type} | {value.get('description') or ''} | {value.get('default')} |  \n"
@@ -284,7 +284,7 @@ def gen_md_table(
                         path=get_prefixed_name(field_prefix, field_name),
                         type_name=value["type"],
                         description=value.get("description") or "",
-                        default=value.get("default") or "None",
+                        default=str(value.get("default", "None")),
                         required=required_field,
                     )
                     # f"| {get_prefixed_name(field_prefix, field_name)} | {value['type']} | {value.get('description') or ''} | {value.get('default')} | \n"
@@ -298,7 +298,7 @@ def gen_md_table(
                     path=get_prefixed_name(field_prefix, field_name),
                     type_name=f"{object_definition.split('/')[-1]} (see below for fields)",
                     description=value.get("description") or "",
-                    default=value.get("default") or "",
+                    default=str(value.get("default", "")),
                     required=required_field,
                 )
 
@@ -319,7 +319,7 @@ def gen_md_table(
                         path=get_prefixed_name(field_prefix, field_name),
                         type_name="Generic dict",
                         description=value.get("description", ""),
-                        default=value.get("default", "None"),
+                        default=str(value.get("default", "None")),
                         required=required_field,
                     )
                     # f"| {get_prefixed_name(field_prefix, field_name)} | Any dict | {value.get('description') or ''} | {value.get('default')} |\n"

--- a/metadata-ingestion/src/datahub/ingestion/source_config/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/bigquery.py
@@ -5,7 +5,7 @@ from datahub.configuration.common import ConfigModel
 
 class BigQueryBaseConfig(ConfigModel):
     rate_limit: bool = pydantic.Field(
-        default=False, description="Should we rate limit reqeusts made to API."
+        default=False, description="Should we rate limit requests made to API."
     )
     requests_per_min: int = pydantic.Field(
         default=60,

--- a/metadata-ingestion/src/datahub/ingestion/source_config/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/usage/bigquery_usage.py
@@ -20,7 +20,7 @@ class BigQueryCredential(ConfigModel):
     project_id: str = pydantic.Field(description="Project id to set the credentials")
     private_key_id: str = pydantic.Field(description="Private key id")
     private_key: str = pydantic.Field(
-        description="Private key in a form of '-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----\n'"
+        description="Private key in a form of '-----BEGIN PRIVATE KEY-----\\nprivate-key\\n-----END PRIVATE KEY-----\\n'"
     )
     client_email: str = pydantic.Field(description="Client email")
     client_id: str = pydantic.Field(description="Client Id")


### PR DESCRIPTION
- default `False` was being turned into `None` because of the or conditions
- broken bigquery doc generation
- fix typo in bigquery docs

before
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/4127841/170038050-d3af3eeb-9aa8-4934-8222-1d3f5a2f4e1f.png">

after PR
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/4127841/170038079-f2e6d3d2-d8ef-4c08-ae65-f94a4ddce39d.png">


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)