### PR TITLE
fix(redash): use dashboard id if slug does not work

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redash.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redash.py
@@ -567,7 +567,13 @@ class RedashSource(Source):
 
                 # Continue producing MCE
                 dashboard_slug = dashboard_response["slug"]
-                dashboard_data = self.client.dashboard(dashboard_slug)
+                try:
+                    dashboard_data = self.client.dashboard(dashboard_slug)
+                except Exception:
+                    dashboard_id = dashboard_response["id"]
+                    dashboard_data = self.client._get(
+                        "api/dashboards/{}".format(dashboard_id)
+                    ).json()
                 logger.debug(dashboard_data)
                 dashboard_snapshot = self._get_dashboard_snapshot(dashboard_data)
                 mce = MetadataChangeEvent(proposedSnapshot=dashboard_snapshot)


### PR DESCRIPTION
I tested calling the Redash endpoint with dashboard_id instead of slug and it responded with dashboard info. This should not be happening as per the API docs https://redash.io/help/user-guide/integrations-and-api/api but the actual behavior is different. Using the ID as fallback because the original change must have been tested with some version of Redash.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)