### PR TITLE
feat(DataHub Operations): Adding GraphQL mutation for reporting Dataset operations

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -124,6 +124,7 @@ import com.linkedin.datahub.graphql.resolvers.mutate.RemoveOwnerResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.RemoveTagResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.RemoveTermResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateDescriptionResolver;
+import com.linkedin.datahub.graphql.resolvers.operation.ReportOperationResolver;
 import com.linkedin.datahub.graphql.resolvers.policy.DeletePolicyResolver;
 import com.linkedin.datahub.graphql.resolvers.policy.GetGrantedPrivilegesResolver;
 import com.linkedin.datahub.graphql.resolvers.policy.ListPoliciesResolver;
@@ -651,6 +652,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("createTest", new CreateTestResolver(this.entityClient))
             .dataFetcher("updateTest", new UpdateTestResolver(this.entityClient))
             .dataFetcher("deleteTest", new DeleteTestResolver(this.entityClient))
+            .dataFetcher("reportOperation", new ReportOperationResolver(this.entityClient))
         );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/operation/ReportOperationResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/operation/ReportOperationResolver.java
@@ -1,0 +1,138 @@
+package com.linkedin.datahub.graphql.resolvers.operation;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.Operation;
+import com.linkedin.common.OperationSourceType;
+import com.linkedin.common.OperationType;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.authorization.ConjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.authorization.DisjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
+import com.linkedin.datahub.graphql.generated.ReportOperationInput;
+import com.linkedin.datahub.graphql.generated.StringMapEntryInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.timeseries.PartitionSpec;
+import com.linkedin.timeseries.PartitionType;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.linkedin.datahub.graphql.resolvers.AuthUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+
+/**
+ * Resolver used for reporting Asset Operations
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class ReportOperationResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private static final List<String> SUPPORTED_ENTITY_TYPES = ImmutableList.of(
+      Constants.DATASET_ENTITY_NAME
+  );
+
+  private final EntityClient _entityClient;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+
+    final QueryContext context = environment.getContext();
+    final ReportOperationInput input = bindArgument(environment.getArgument("input"), ReportOperationInput.class);
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      Urn entityUrn = UrnUtils.getUrn(input.getUrn());
+
+      if (!isAuthorizedToReportOperationForResource(entityUrn, context)) {
+        throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+
+      validateInput(entityUrn, input);
+
+      try {
+        // Create an MCP to emit the operation
+        final MetadataChangeProposal proposal = new MetadataChangeProposal();
+        proposal.setEntityUrn(entityUrn);
+        proposal.setEntityType(entityUrn.getEntityType());
+        proposal.setAspectName(Constants.OPERATION_ASPECT_NAME);
+        proposal.setAspect(GenericRecordUtils.serializeAspect(mapOperation(input, context)));
+        proposal.setChangeType(ChangeType.UPSERT);
+        _entityClient.ingestProposal(proposal, context.getAuthentication());
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to report operation. {}", e.getMessage());
+        throw new RuntimeException("Failed to report operation", e);
+      }
+    });
+  }
+
+  private Operation mapOperation(final ReportOperationInput input, final QueryContext context) throws URISyntaxException {
+
+    final Operation result = new Operation();
+    result.setActor(UrnUtils.getUrn(context.getActorUrn()));
+    result.setOperationType(OperationType.valueOf(input.getOperationType().toString()));
+    result.setCustomOperationType(input.getCustomOperationType(), SetMode.IGNORE_NULL);
+    result.setNumAffectedRows(input.getNumAffectedRows(), SetMode.IGNORE_NULL);
+
+    long timestampMillis = input.getTimestampMillis() != null ? input.getTimestampMillis() : System.currentTimeMillis();
+    result.setLastUpdatedTimestamp(timestampMillis);
+    result.setTimestampMillis(timestampMillis);
+    result.setSourceType(OperationSourceType.valueOf(input.getSourceType().toString()));
+
+    if (input.getPartition() != null) {
+      result.setPartitionSpec(new PartitionSpec().setType(PartitionType.PARTITION).setPartition(input.getPartition()));
+    }
+
+    if (input.getCustomProperties() != null) {
+      result.setCustomProperties(mapCustomProperties(input.getCustomProperties()));
+    }
+
+    return result;
+  }
+
+  private StringMap mapCustomProperties(final List<StringMapEntryInput> properties) throws URISyntaxException {
+    final StringMap result = new StringMap();
+    for (StringMapEntryInput entry : properties) {
+      result.put(entry.getKey(), entry.getValue());
+    }
+    return result;
+  }
+
+  private void validateInput(final Urn entityUrn, final ReportOperationInput input) {
+    if (!SUPPORTED_ENTITY_TYPES.contains(entityUrn.getEntityType())) {
+      throw new DataHubGraphQLException(
+          String.format("Unable to report operation. Invalid entity type %s provided.", entityUrn.getEntityType()),
+          DataHubGraphQLErrorCode.BAD_REQUEST);
+    }
+  }
+
+  private boolean isAuthorizedToReportOperationForResource(final Urn resourceUrn, final QueryContext context) {
+    final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
+        ALL_PRIVILEGES_GROUP,
+        new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.EDIT_ENTITY_OPERATIONS_PRIVILEGE.getType()))
+    ));
+
+    return AuthorizationUtils.isAuthorized(
+        context.getAuthorizer(),
+        context.getActorUrn(),
+        resourceUrn.getEntityType(),
+        resourceUrn.toString(),
+        orPrivilegeGroups);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/OperationMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/OperationMapper.java
@@ -1,6 +1,8 @@
 package com.linkedin.datahub.graphql.types.common.mappers;
 
 import com.linkedin.common.Operation;
+import com.linkedin.data.template.GetMode;
+import com.linkedin.datahub.graphql.generated.OperationSourceType;
 import com.linkedin.datahub.graphql.generated.OperationType;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.types.mappers.TimeSeriesAspectMapper;
@@ -35,6 +37,16 @@ public class OperationMapper implements TimeSeriesAspectMapper<com.linkedin.data
             result.setActor(gmsProfile.getActor().toString());
         }
         result.setOperationType(OperationType.valueOf(OperationType.class, gmsProfile.getOperationType().toString()));
+        result.setCustomOperationType(gmsProfile.getCustomOperationType(GetMode.NULL));
+        if (gmsProfile.hasSourceType()) {
+            result.setSourceType(OperationSourceType.valueOf(gmsProfile.getSourceType().toString()));
+        }
+        if (gmsProfile.hasPartitionSpec()) {
+            result.setPartition(gmsProfile.getPartitionSpec().getPartition(GetMode.NULL));
+        }
+        if (gmsProfile.hasCustomProperties()) {
+            result.setCustomProperties(StringMapMapper.map(gmsProfile.getCustomProperties()));
+        }
         if (gmsProfile.hasNumAffectedRows()) {
             result.setNumAffectedRows(gmsProfile.getNumAffectedRows());
         }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -336,6 +336,15 @@ type Mutation {
       The assertion to remove
       """
       urn: String!): Boolean
+
+    """
+    Report a new operation for an asset
+    """
+    reportOperation(
+      """
+      Input required to report an operation
+      """
+      input: ReportOperationInput!): String
 }
 
 """
@@ -5704,14 +5713,9 @@ Operational info for an entity.
 """
 type Operation implements TimeSeriesAspect {
     """
-    The time at which the profile was reported
+    The time at which the operation was reported
     """
     timestampMillis: Long!
-
-    """
-    When the entity was last updated.
-    """
-    lastUpdatedTimestamp: Long!
 
     """
     Actor who issued this operation.
@@ -5724,6 +5728,16 @@ type Operation implements TimeSeriesAspect {
     operationType: OperationType!
 
     """
+    A custom operation type
+    """
+    customOperationType: String
+
+    """
+    Source of the operation
+    """
+    sourceType: OperationSourceType
+
+    """
     How many rows were affected by this operation.
     """
     numAffectedRows: Long
@@ -5732,6 +5746,21 @@ type Operation implements TimeSeriesAspect {
     Which other datasets were affected by this operation.
     """
     affectedDatasets: [String!]
+
+    """
+    When time at which the asset was actually updated
+    """
+    lastUpdatedTimestamp: Long!
+
+    """
+    Optional partition identifier
+    """
+    partition: String
+
+    """
+    Custom operation properties
+    """
+    customProperties: [StringMapEntry!]
 }
 
 """
@@ -5767,11 +5796,77 @@ enum OperationType {
     When table is dropped
     """
     DROP
-    
+
     """
     Unknown operation
     """
     UNKNOWN
+
+    """
+    Custom
+    """
+    CUSTOM
+}
+
+"""
+Input provided to report an asset operation
+"""
+input ReportOperationInput {
+    """
+    The urn of the asset (e.g. dataset) to report the operation for
+    """
+    urn: String!
+
+    """
+    The type of operation that was performed. Required
+    """
+    operationType: OperationType!
+
+    """
+    A custom type of operation. Required if operation type is CUSTOM.
+    """
+    customOperationType: String
+
+    """
+    The source or reporter of the operation
+    """
+    sourceType: OperationSourceType!
+
+    """
+    A list of key-value parameters to include
+    """
+    customProperties: [StringMapEntryInput!]
+
+    """
+    An optional partition identifier
+    """
+    partition: String
+
+    """
+    Optional: The number of affected rows
+    """
+    numAffectedRows: Long
+
+    """
+    Optional: Provide a timestamp associated with the operation. If not provided, one will be generated for you based
+    on the current time.
+    """
+    timestampMillis: Long
+}
+
+"""
+Enum to define the source/reporter type for an Operation.
+"""
+enum OperationSourceType {
+    """
+    A data process reported the operation.
+    """
+    DATA_PROCESS
+
+    """
+    A data platform reported the operation.
+    """
+    DATA_PLATFORM
 }
 
 """
@@ -7786,4 +7881,19 @@ type Health {
   The causes responsible for the health status
   """
   causes: [String!]
+}
+
+"""
+String map entry input
+"""
+input StringMapEntryInput {
+  """
+  The key of the map entry
+  """
+  key: String!
+
+  """
+  The value fo the map entry
+  """
+  value: String
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/operation/ReportOperationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/operation/ReportOperationResolverTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.datahub.graphql.resolvers.operation;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.Operation;
+import com.linkedin.common.OperationSourceType;
+import com.linkedin.common.OperationType;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.ReportOperationInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class ReportOperationResolverTest {
+
+  private static final String TEST_ENTITY_URN = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    Operation expectedOperation = new Operation()
+        .setTimestampMillis(0L)
+        .setLastUpdatedTimestamp(0L)
+        .setOperationType(OperationType.INSERT)
+        .setSourceType(OperationSourceType.DATA_PLATFORM)
+        .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+        .setCustomOperationType(null, SetMode.IGNORE_NULL)
+        .setNumAffectedRows(1L);
+
+    MetadataChangeProposal expectedProposal = new MetadataChangeProposal()
+        .setAspectName(Constants.OPERATION_ASPECT_NAME)
+        .setChangeType(ChangeType.UPSERT)
+        .setEntityUrn(UrnUtils.getUrn(TEST_ENTITY_URN))
+        .setEntityType(Constants.DATASET_ENTITY_NAME)
+        .setAspect(GenericRecordUtils.serializeAspect(expectedOperation));
+
+    // Test setting the domain
+    Mockito.when(mockClient.ingestProposal(
+        Mockito.eq(expectedProposal),
+        Mockito.any(Authentication.class)))
+      .thenReturn(TEST_ENTITY_URN);
+
+    ReportOperationResolver resolver = new ReportOperationResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(getTestInput());
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    resolver.get(mockEnv).get();
+
+    Mockito.verify(mockClient, Mockito.times(1)).ingestProposal(
+        Mockito.eq(expectedProposal),
+        Mockito.any(Authentication.class)
+    );
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    ReportOperationResolver resolver = new ReportOperationResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(getTestInput());
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockClient, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+  }
+
+  private ReportOperationInput getTestInput() {
+    ReportOperationInput input = new ReportOperationInput();
+    input.setUrn(TEST_ENTITY_URN);
+    input.setOperationType(com.linkedin.datahub.graphql.generated.OperationType.INSERT);
+    input.setNumAffectedRows(1L);
+    input.setTimestampMillis(0L);
+    input.setSourceType(com.linkedin.datahub.graphql.generated.OperationSourceType.DATA_PLATFORM);
+    return input;
+  }
+}

--- a/metadata-ingestion/tests/integration/bigquery-usage/bigquery_usages_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery-usage/bigquery_usages_golden.json
@@ -7,7 +7,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622073693816, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.austin_311.311_service_requests,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.austin_311.311_service_requests,PROD)\"], \"lastUpdatedTimestamp\": 1622073693816}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -26,7 +26,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622074056868, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.austin_311.311_service_requests,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.austin_311.311_service_requests,PROD)\"], \"lastUpdatedTimestamp\": 1622074056868}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -45,7 +45,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622075993220, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.austin_311.311_service_requests,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.austin_311.311_service_requests,PROD)\"], \"lastUpdatedTimestamp\": 1622075993220}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -64,7 +64,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622076153701, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622076153701}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -83,7 +83,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622076935475, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622076935475}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -102,7 +102,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622091452779, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622091452779}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -121,7 +121,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622098252897, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622098252897}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -140,7 +140,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622148197222, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622148197222}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -159,7 +159,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622148734552, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622148734552}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -178,7 +178,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622161940000, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622161940000}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -197,7 +197,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1622243780153, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"]}",
+        "value": "{\"timestampMillis\": 1626739200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": [\"urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_nyt.excess_deaths,PROD)\"], \"lastUpdatedTimestamp\": 1622243780153}",
         "contentType": "application/json"
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_filtered_golden.json
+++ b/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_filtered_golden.json
@@ -7,7 +7,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1631664000000, \"actor\": \"urn:li:corpuser:test-name\", \"operationType\": \"INSERT\"}",
+        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:test-name\", \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1631664000000}",
         "contentType": "application/json"
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_golden.json
+++ b/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_golden.json
@@ -7,7 +7,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1631664000000, \"actor\": \"urn:li:corpuser:test-name\", \"operationType\": \"INSERT\"}",
+        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:test-name\", \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1631664000000}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -26,7 +26,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1631664000000, \"actor\": \"urn:li:corpuser:real_shirshanka\", \"operationType\": \"INSERT\"}",
+        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:real_shirshanka\", \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1631664000000}",
         "contentType": "application/json"
     },
     "systemMetadata": {
@@ -45,7 +45,7 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"lastUpdatedTimestamp\": 1631664000000, \"actor\": \"urn:li:corpuser:real_shirshanka\", \"operationType\": \"DELETE\"}",
+        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:real_shirshanka\", \"operationType\": \"DELETE\", \"lastUpdatedTimestamp\": 1631664000000}",
         "contentType": "application/json"
     },
     "systemMetadata": {

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Operation.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Operation.pdl
@@ -12,12 +12,6 @@ import com.linkedin.timeseries.TimeseriesAspectBase
 record Operation includes TimeseriesAspectBase {
 
   /**
-   * When the entity was last updated.
-   */
-  @TimeseriesField = {}
-  lastUpdatedTimestamp: long
-
-  /**
    * Actor who issued this operation.
    */
   @TimeseriesField = {}
@@ -30,6 +24,12 @@ record Operation includes TimeseriesAspectBase {
   operationType: OperationType
 
   /**
+   * A custom type of operation. Required if operationType is CUSTOM.
+   */
+  @TimeseriesField = {}
+  customOperationType: optional string
+
+  /**
    * How many rows were affected by this operation.
    */
   @TimeseriesField = {}
@@ -40,4 +40,21 @@ record Operation includes TimeseriesAspectBase {
    */
   @TimeseriesFieldCollection = {"key":"datasetName"}
   affectedDatasets: optional array[Urn]
+
+  /**
+   * Source Type
+   */
+   @TimeseriesField = {}
+   sourceType: optional OperationSourceType
+
+  /**
+   * Custom properties
+   */
+   customProperties: optional map[string, string]
+
+  /**
+   * The time at which the operation occurred.
+   */
+  @TimeseriesField = {}
+  lastUpdatedTimestamp: long
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/common/OperationSourceType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/OperationSourceType.pdl
@@ -1,0 +1,15 @@
+namespace com.linkedin.common
+
+/**
+  * The source of an operation
+  */
+enum OperationSourceType {
+  /**
+   * Provided by a Data Process
+   */
+  DATA_PROCESS
+  /**
+   * Rows were updated
+   */
+  DATA_PLATFORM
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/common/OperationType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/OperationType.pdl
@@ -4,11 +4,33 @@ namespace com.linkedin.common
   * Enum to define the operation type when an entity changes.
   */
 enum OperationType {
+  /**
+   * Rows were inserted
+   */
   INSERT
+  /**
+   * Rows were updated
+   */
   UPDATE
+  /**
+   * Rows were deleted
+   */
   DELETE
+  /**
+   * Asset was created
+   */
   CREATE
+  /**
+   * Asset was altered
+   */
   ALTER
+  /**
+   * Asset was dropped
+   */
   DROP
+  /**
+   * Custom asset operation
+   */
+  CUSTOM
   UNKNOWN
 }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -57,6 +57,7 @@ public class Constants {
   public static final String STATUS_ASPECT_NAME = "status";
   public static final String SUB_TYPES_ASPECT_NAME = "subTypes";
   public static final String DEPRECATION_ASPECT_NAME = "deprecation";
+  public static final String OPERATION_ASPECT_NAME = "operation";
 
   // User
   public static final String CORP_USER_KEY_ASPECT_NAME = "corpUserKey";

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -134,6 +134,11 @@ public class PoliciesConfig {
       "Edit Assertions",
       "The ability to add and remove assertions from an entity.");
 
+  public static final Privilege EDIT_ENTITY_OPERATIONS_PRIVILEGE = Privilege.of(
+      "EDIT_ENTITY_OPERATIONS",
+      "Edit Operations",
+      "The ability to report or edit operations information about an entity.");
+
   public static final Privilege EDIT_ENTITY_PRIVILEGE = Privilege.of(
       "EDIT_ENTITY",
       "Edit All",


### PR DESCRIPTION
**Summary**
In this PR, we add a new GraphQL mutation for reporting Dataset operations (inserts, updates, and more). 

We also extend the existing Operation model with some additional fields. 

**Changes**
- New ReportOperationResolver, corresponding test
- Adding custom properties, source type, and more to operation aspect
- Updates to entity.graphql correspondingly.

**Status**
Ready for review.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)