### PR TITLE
feat(Tests): Metadata Tests Models + APIs + UI (Part 1) 

### DIFF
--- a/datahub-graphql-core/build.gradle
+++ b/datahub-graphql-core/build.gradle
@@ -31,6 +31,7 @@ graphqlCodegen {
         "$projectDir/src/main/resources/ingestion.graphql".toString(),
         "$projectDir/src/main/resources/auth.graphql".toString(),
         "$projectDir/src/main/resources/timeline.graphql".toString(),
+        "$projectDir/src/main/resources/tests.graphql".toString(),
     ]
     outputDir = new File("$projectDir/src/mainGeneratedGraphQL/java")
     packageName = "com.linkedin.datahub.graphql.generated"

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/Constants.java
@@ -16,6 +16,7 @@ public class Constants {
     public static final String RECOMMENDATIONS_SCHEMA_FILE = "recommendation.graphql";
     public static final String INGESTION_SCHEMA_FILE = "ingestion.graphql";
     public static final String TIMELINE_SCHEMA_FILE = "timeline.graphql";
+    public static final String TESTS_SCHEMA_FILE = "tests.graphql";
     public static final String BROWSE_PATH_DELIMITER = "/";
     public static final String VERSION_STAMP_FIELD_NAME = "versionStamp";
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -41,6 +41,7 @@ import com.linkedin.datahub.graphql.generated.InstitutionalMemoryMetadata;
 import com.linkedin.datahub.graphql.generated.LineageRelationship;
 import com.linkedin.datahub.graphql.generated.ListAccessTokenResult;
 import com.linkedin.datahub.graphql.generated.ListDomainsResult;
+import com.linkedin.datahub.graphql.generated.ListTestsResult;
 import com.linkedin.datahub.graphql.generated.MLFeature;
 import com.linkedin.datahub.graphql.generated.MLFeatureProperties;
 import com.linkedin.datahub.graphql.generated.MLFeatureTable;
@@ -56,6 +57,8 @@ import com.linkedin.datahub.graphql.generated.PolicyMatchCriterionValue;
 import com.linkedin.datahub.graphql.generated.RecommendationContent;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResult;
 import com.linkedin.datahub.graphql.generated.SearchResult;
+import com.linkedin.datahub.graphql.generated.Test;
+import com.linkedin.datahub.graphql.generated.TestResult;
 import com.linkedin.datahub.graphql.generated.UserUsageCounts;
 import com.linkedin.datahub.graphql.generated.VisualConfiguration;
 import com.linkedin.datahub.graphql.resolvers.MeResolver;
@@ -132,6 +135,11 @@ import com.linkedin.datahub.graphql.resolvers.search.SearchAcrossEntitiesResolve
 import com.linkedin.datahub.graphql.resolvers.search.SearchAcrossLineageResolver;
 import com.linkedin.datahub.graphql.resolvers.search.SearchResolver;
 import com.linkedin.datahub.graphql.resolvers.tag.SetTagColorResolver;
+import com.linkedin.datahub.graphql.resolvers.test.CreateTestResolver;
+import com.linkedin.datahub.graphql.resolvers.test.DeleteTestResolver;
+import com.linkedin.datahub.graphql.resolvers.test.ListTestsResolver;
+import com.linkedin.datahub.graphql.resolvers.test.TestResultsResolver;
+import com.linkedin.datahub.graphql.resolvers.test.UpdateTestResolver;
 import com.linkedin.datahub.graphql.resolvers.timeline.GetSchemaBlameResolver;
 import com.linkedin.datahub.graphql.resolvers.type.AspectInterfaceTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.type.EntityInterfaceTypeResolver;
@@ -172,6 +180,7 @@ import com.linkedin.datahub.graphql.types.mlmodel.MLModelType;
 import com.linkedin.datahub.graphql.types.mlmodel.MLPrimaryKeyType;
 import com.linkedin.datahub.graphql.types.notebook.NotebookType;
 import com.linkedin.datahub.graphql.types.tag.TagType;
+import com.linkedin.datahub.graphql.types.test.TestType;
 import com.linkedin.datahub.graphql.types.usage.UsageType;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.config.IngestionConfiguration;
@@ -265,6 +274,7 @@ public class GmsGraphQLEngine {
     private final VersionedDatasetType versionedDatasetType;
     private final DataPlatformInstanceType dataPlatformInstanceType;
     private final AccessTokenMetadataType accessTokenMetadataType;
+    private final TestType testType;
 
     /**
      * Configures the graph objects that can be fetched primary key.
@@ -357,6 +367,7 @@ public class GmsGraphQLEngine {
         this.versionedDatasetType = new VersionedDatasetType(entityClient);
         this.dataPlatformInstanceType = new DataPlatformInstanceType(entityClient);
         this.accessTokenMetadataType = new AccessTokenMetadataType(entityClient);
+        this.testType = new TestType(entityClient);
         // Init Lists
         this.entityTypes = ImmutableList.of(
             datasetType,
@@ -380,7 +391,8 @@ public class GmsGraphQLEngine {
             assertionType,
             versionedDatasetType,
             dataPlatformInstanceType,
-            accessTokenMetadataType
+            accessTokenMetadataType,
+            testType
         );
         this.loadableTypes = new ArrayList<>(entityTypes);
         this.ownerTypes = ImmutableList.of(corpUserType, corpGroupType);
@@ -435,6 +447,7 @@ public class GmsGraphQLEngine {
         configureDataProcessInstanceResolvers(builder);
         configureVersionedDatasetResolvers(builder);
         configureAccessAccessTokenMetadataResolvers(builder);
+        configureTestResultResolvers(builder);
     }
 
     public GraphQLEngine.Builder builder() {
@@ -447,6 +460,7 @@ public class GmsGraphQLEngine {
             .addSchema(fileBasedSchema(RECOMMENDATIONS_SCHEMA_FILE))
             .addSchema(fileBasedSchema(INGESTION_SCHEMA_FILE))
             .addSchema(fileBasedSchema(TIMELINE_SCHEMA_FILE))
+            .addSchema(fileBasedSchema(TESTS_SCHEMA_FILE))
             .addDataLoaders(loaderSuppliers(loadableTypes))
             .addDataLoader("Aspect", context -> createDataLoader(aspectType, context))
             .addDataLoader("UsageQueryResult", context -> createDataLoader(usageType, context))
@@ -569,6 +583,8 @@ public class GmsGraphQLEngine {
             .dataFetcher("ingestionSource", new GetIngestionSourceResolver(this.entityClient))
             .dataFetcher("executionRequest", new GetIngestionExecutionRequestResolver(this.entityClient))
             .dataFetcher("getSchemaBlame", new GetSchemaBlameResolver(this.timelineService))
+            .dataFetcher("test", getResolver(testType))
+            .dataFetcher("listTests", new ListTestsResolver(entityClient))
         );
     }
 
@@ -632,6 +648,9 @@ public class GmsGraphQLEngine {
             .dataFetcher("createIngestionExecutionRequest", new CreateIngestionExecutionRequestResolver(this.entityClient, this.ingestionConfiguration))
             .dataFetcher("cancelIngestionExecutionRequest", new CancelIngestionExecutionRequestResolver(this.entityClient))
             .dataFetcher("deleteAssertion", new DeleteAssertionResolver(this.entityClient, this.entityService))
+            .dataFetcher("createTest", new CreateTestResolver(this.entityClient))
+            .dataFetcher("updateTest", new UpdateTestResolver(this.entityClient))
+            .dataFetcher("deleteTest", new DeleteTestResolver(this.entityClient))
         );
     }
 
@@ -687,6 +706,12 @@ public class GmsGraphQLEngine {
             .type("PolicyMatchCriterionValue", typeWiring -> typeWiring
                 .dataFetcher("entity", new EntityTypeResolver(entityTypes,
                         (env) -> ((PolicyMatchCriterionValue) env.getSource()).getEntity()))
+            )
+            .type("ListTestsResult", typeWiring -> typeWiring
+                .dataFetcher("tests", new LoadableTypeBatchResolver<>(testType,
+                    (env) -> ((ListTestsResult) env.getSource()).getTests().stream()
+                        .map(Test::getUrn)
+                        .collect(Collectors.toList())))
             );
     }
 
@@ -740,6 +765,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("health", new DatasetHealthResolver(graphClient, timeseriesAspectService))
                 .dataFetcher("schemaMetadata", new AspectResolver())
                 .dataFetcher("assertions", new EntityAssertionsResolver(entityClient, graphClient))
+                .dataFetcher("testResults", new TestResultsResolver(entityClient))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                 .dataFetcher("subTypes", new SubTypesResolver(
                    this.entityClient,
@@ -1259,6 +1285,17 @@ public class GmsGraphQLEngine {
                     DataProcessInstanceRunEventMapper::map
                 )
             )
+        );
+    }
+
+    private void configureTestResultResolvers(final RuntimeWiring.Builder builder) {
+        // Tests not in OSS
+        builder.type("TestResult", typeWiring -> typeWiring
+            .dataFetcher("test", new LoadableTypeResolver<>(testType,
+                (env) -> {
+                    final TestResult testResult = env.getSource();
+                    return testResult.getTest() != null ? testResult.getTest().getUrn() : null;
+                }))
         );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1289,7 +1289,6 @@ public class GmsGraphQLEngine {
     }
 
     private void configureTestResultResolvers(final RuntimeWiring.Builder builder) {
-        // Tests not in OSS
         builder.type("TestResult", typeWiring -> typeWiring
             .dataFetcher("test", new LoadableTypeResolver<>(testType,
                 (env) -> {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/EntityTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/EntityTypeMapper.java
@@ -33,6 +33,7 @@ public class EntityTypeMapper {
           .put(EntityType.DOMAIN, "domain")
           .put(EntityType.NOTEBOOK, "notebook")
           .put(EntityType.DATA_PLATFORM_INSTANCE, "dataPlatformInstance")
+          .put(EntityType.TEST, "test")
           .build();
 
   private static final Map<String, EntityType> ENTITY_NAME_TO_TYPE =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
@@ -103,7 +103,7 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
   }
 
   /**
-   * Returns true if the authenticated user has privileges to view metadata proposals.
+   * Returns true if the authenticated user has privileges to manage (add or remove) tests.
    */
   private boolean canManageTests(final QueryContext context) {
     return isAuthorized(context.getAuthorizer(), context.getActorUrn(), PoliciesConfig.MANAGE_TESTS_PRIVILEGE);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
@@ -61,6 +61,7 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
         platformPrivileges.setManageIngestion(canManageIngestion(context));
         platformPrivileges.setManageSecrets(canManageSecrets(context));
         platformPrivileges.setManageTokens(canManageTokens(context));
+        platformPrivileges.setManageTests(canManageTests(context));
 
         // Construct and return authenticated user object.
         final AuthenticatedUser authUser = new AuthenticatedUser();
@@ -101,6 +102,12 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
     return isAuthorized(context.getAuthorizer(), context.getActorUrn(), PoliciesConfig.GENERATE_PERSONAL_ACCESS_TOKENS_PRIVILEGE);
   }
 
+  /**
+   * Returns true if the authenticated user has privileges to view metadata proposals.
+   */
+  private boolean canManageTests(final QueryContext context) {
+    return isAuthorized(context.getAuthorizer(), context.getActorUrn(), PoliciesConfig.MANAGE_TESTS_PRIVILEGE);
+  }
 
   /**
    * Returns true if the authenticated user has privileges to manage domains

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/CreateTestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/CreateTestResolver.java
@@ -1,0 +1,81 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.CreateTestInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.TestKey;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.test.TestInfo;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.test.TestUtils.*;
+
+
+/**
+ * Creates or updates a Test. Requires the MANAGE_TESTS privilege.
+ */
+public class CreateTestResolver implements DataFetcher<CompletableFuture<String>> {
+
+  private final EntityClient _entityClient;
+
+  public CreateTestResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<String> get(final DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (canManageTests(context)) {
+
+        final CreateTestInput input = bindArgument(environment.getArgument("input"), CreateTestInput.class);
+        final MetadataChangeProposal proposal = new MetadataChangeProposal();
+
+        // Create new test
+        // Since we are creating a new Test, we need to generate a unique UUID.
+        final UUID uuid = UUID.randomUUID();
+        final String uuidStr = input.getId() == null ? uuid.toString() : input.getId();
+
+        // Create the Ingestion source key
+        final TestKey key = new TestKey();
+        key.setId(uuidStr);
+        proposal.setEntityKeyAspect(GenericRecordUtils.serializeAspect(key));
+
+        // Create the Test info.
+        final TestInfo info = mapCreateTestInput(input);
+        proposal.setEntityType(Constants.TEST_ENTITY_NAME);
+        proposal.setAspectName(Constants.TEST_INFO_ASPECT_NAME);
+        proposal.setAspect(GenericRecordUtils.serializeAspect(info));
+        proposal.setChangeType(ChangeType.UPSERT);
+
+        try {
+          return _entityClient.ingestProposal(proposal, context.getAuthentication());
+        } catch (Exception e) {
+          throw new RuntimeException(String.format("Failed to perform update against Test with urn %s", input.toString()), e);
+        }
+      }
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    });
+  }
+
+  private static TestInfo mapCreateTestInput(final CreateTestInput input) {
+    final TestInfo result = new TestInfo();
+    result.setName(input.getName());
+    result.setCategory(input.getCategory());
+    result.setDescription(input.getDescription(), SetMode.IGNORE_NULL);
+    result.setDefinition(mapDefinition(input.getDefinition()));
+    return result;
+  }
+
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/DeleteTestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/DeleteTestResolver.java
@@ -1,0 +1,42 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import static com.linkedin.datahub.graphql.resolvers.test.TestUtils.*;
+
+
+/**
+ * Resolver responsible for hard deleting a particular DataHub Test. Requires MANAGE_TESTS
+ * privilege.
+ */
+public class DeleteTestResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityClient _entityClient;
+
+  public DeleteTestResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+    final String testUrn = environment.getArgument("urn");
+    final Urn urn = Urn.createFromString(testUrn);
+    return CompletableFuture.supplyAsync(() -> {
+      if (canManageTests(context)) {
+        try {
+          _entityClient.deleteEntity(urn, context.getAuthentication());
+          return true;
+        } catch (Exception e) {
+          throw new RuntimeException(String.format("Failed to perform delete against Test with urn %s", testUrn), e);
+        }
+      }
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    });
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/ListTestsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/ListTestsResolver.java
@@ -1,0 +1,90 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.Test;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.ListTestsInput;
+import com.linkedin.datahub.graphql.generated.ListTestsResult;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.test.TestUtils.*;
+
+
+/**
+ * Resolver used for listing all Tests defined within DataHub. Requires the MANAGE_DOMAINS platform privilege.
+ */
+public class ListTestsResolver implements DataFetcher<CompletableFuture<ListTestsResult>> {
+
+  private static final Integer DEFAULT_START = 0;
+  private static final Integer DEFAULT_COUNT = 20;
+
+  private final EntityClient _entityClient;
+
+  public ListTestsResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<ListTestsResult> get(final DataFetchingEnvironment environment) throws Exception {
+
+    final QueryContext context = environment.getContext();
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (canManageTests(context)) {
+        final ListTestsInput input = bindArgument(environment.getArgument("input"), ListTestsInput.class);
+        final Integer start = input.getStart() == null ? DEFAULT_START : input.getStart();
+        final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
+        final String query = input.getQuery() == null ? "" : input.getQuery();
+
+        try {
+          // First, get all group Urns.
+          final SearchResult gmsResult = _entityClient.search(
+              Constants.TEST_ENTITY_NAME,
+              query,
+              Collections.emptyMap(),
+              start,
+              count,
+              context.getAuthentication());
+
+          // Now that we have entities we can bind this to a result.
+          final ListTestsResult result = new ListTestsResult();
+          result.setStart(gmsResult.getFrom());
+          result.setCount(gmsResult.getPageSize());
+          result.setTotal(gmsResult.getNumEntities());
+          result.setTests(mapUnresolvedTests(gmsResult.getEntities()));
+          return result;
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to list tests", e);
+        }
+      }
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    });
+  }
+
+  // This method maps urns returned from the list endpoint into Partial Test objects which will be resolved be a separate Batch resolver.
+  private List<Test> mapUnresolvedTests(final SearchEntityArray entityArray) {
+    final List<Test> results = new ArrayList<>();
+    for (final SearchEntity entity : entityArray) {
+      final Urn urn = entity.getEntity();
+      final Test unresolvedTest = new Test();
+      unresolvedTest.setUrn(urn.toString());
+      unresolvedTest.setType(EntityType.TEST);
+      results.add(unresolvedTest);
+    }
+    return results;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/TestResultsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/TestResultsResolver.java
@@ -1,0 +1,92 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.Test;
+import com.linkedin.datahub.graphql.generated.TestResult;
+import com.linkedin.datahub.graphql.generated.TestResultType;
+import com.linkedin.datahub.graphql.generated.TestResults;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * GraphQL Resolver used for fetching the list of tests for an entity
+ */
+@Slf4j
+public class TestResultsResolver implements DataFetcher<CompletableFuture<TestResults>> {
+
+  private final EntityClient _entityClient;
+
+  public TestResultsResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<TestResults> get(DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+    final Urn entityUrn = Urn.createFromString(((Entity) environment.getSource()).getUrn());
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      final com.linkedin.test.TestResults gmsTestResults = getTestResults(entityUrn, context);
+
+      if (gmsTestResults == null) {
+         return null;
+      }
+
+      TestResults testResults = new TestResults();
+      testResults.setPassing(mapTestResults(gmsTestResults.getPassing()));
+      testResults.setFailing(mapTestResults(gmsTestResults.getFailing()));
+      return testResults;
+    });
+  }
+
+  @Nullable
+  private com.linkedin.test.TestResults getTestResults(final Urn entityUrn, final QueryContext context) {
+    try {
+      final EntityResponse entityResponse = _entityClient.getV2(
+          entityUrn.getEntityType(),
+          entityUrn,
+          ImmutableSet.of(Constants.TEST_RESULTS_ASPECT_NAME),
+          context.getAuthentication());
+      if (entityResponse.hasAspects() && entityResponse.getAspects().containsKey(Constants.TEST_RESULTS_ASPECT_NAME)) {
+        return new com.linkedin.test.TestResults(
+            entityResponse.getAspects().get(Constants.TEST_RESULTS_ASPECT_NAME)
+                .getValue()
+                .data());
+      }
+      return null;
+    } catch (Exception e) {
+     throw new RuntimeException("Failed to get test results", e);
+    }
+  }
+
+  private List<TestResult> mapTestResults(final @Nonnull List<com.linkedin.test.TestResult> gmsResults) {
+    final List<TestResult> results = new ArrayList<>();
+    for (com.linkedin.test.TestResult gmsResult : gmsResults) {
+      results.add(mapTestResult(gmsResult));
+    }
+    return results;
+  }
+
+  private TestResult mapTestResult(final @Nonnull com.linkedin.test.TestResult gmsResult) {
+    final TestResult testResult = new TestResult();
+    final Test partialTest = new Test();
+    partialTest.setUrn(gmsResult.getTest().toString());
+    testResult.setTest(partialTest);
+    testResult.setType(TestResultType.valueOf(gmsResult.getType().toString()));
+    return testResult;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/TestUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/TestUtils.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.test;
 
 import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.generated.CreateTestInput;
 import com.linkedin.datahub.graphql.generated.TestDefinitionInput;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.test.TestDefinition;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/TestUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/TestUtils.java
@@ -1,0 +1,33 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.CreateTestInput;
+import com.linkedin.datahub.graphql.generated.TestDefinitionInput;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.test.TestDefinition;
+import com.linkedin.test.TestDefinitionType;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.*;
+
+
+public class TestUtils {
+
+  /**
+   * Returns true if the authenticated user is able to manage tests.
+   */
+  public static boolean canManageTests(@Nonnull QueryContext context) {
+    return isAuthorized(context, Optional.empty(), PoliciesConfig.MANAGE_TESTS_PRIVILEGE);
+  }
+
+  public static TestDefinition mapDefinition(final TestDefinitionInput testDefInput) {
+    final TestDefinition result = new TestDefinition();
+    result.setType(TestDefinitionType.JSON); // Always JSON for now.
+    result.setJson(testDefInput.getJson(), SetMode.IGNORE_NULL);
+    return result;
+  }
+
+  private TestUtils() { }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/UpdateTestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/test/UpdateTestResolver.java
@@ -1,0 +1,71 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.UpdateTestInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.test.TestInfo;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.test.TestUtils.*;
+
+
+/**
+ * Updates or updates a Test. Requires the MANAGE_TESTS privilege.
+ */
+public class UpdateTestResolver implements DataFetcher<CompletableFuture<String>> {
+
+  private final EntityClient _entityClient;
+
+  public UpdateTestResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<String> get(final DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (canManageTests(context)) {
+
+        final String urn = environment.getArgument("urn");
+        final UpdateTestInput input = bindArgument(environment.getArgument("input"), UpdateTestInput.class);
+        final MetadataChangeProposal proposal = new MetadataChangeProposal();
+
+        // Update the Test info - currently this simply creates a new test with same urn.
+        final TestInfo info = mapUpdateTestInput(input);
+        proposal.setEntityUrn(UrnUtils.getUrn(urn));
+        proposal.setEntityType(Constants.TEST_ENTITY_NAME);
+        proposal.setAspectName(Constants.TEST_INFO_ASPECT_NAME);
+        proposal.setAspect(GenericRecordUtils.serializeAspect(info));
+        proposal.setChangeType(ChangeType.UPSERT);
+
+        try {
+          return _entityClient.ingestProposal(proposal, context.getAuthentication());
+        } catch (Exception e) {
+          throw new RuntimeException(String.format("Failed to perform update against Test with urn %s", input.toString()), e);
+        }
+      }
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    });
+  }
+
+  private static TestInfo mapUpdateTestInput(final UpdateTestInput input) {
+    final TestInfo result = new TestInfo();
+    result.setName(input.getName());
+    result.setCategory(input.getCategory());
+    result.setDescription(input.getDescription(), SetMode.IGNORE_NULL);
+    result.setDefinition(mapDefinition(input.getDefinition()));
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
@@ -23,6 +23,7 @@ import com.linkedin.datahub.graphql.generated.MLModelGroup;
 import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
 import com.linkedin.datahub.graphql.generated.Notebook;
 import com.linkedin.datahub.graphql.generated.Tag;
+import com.linkedin.datahub.graphql.generated.Test;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import javax.annotation.Nonnull;
 
@@ -136,6 +137,11 @@ public class UrnToEntityMapper implements ModelMapper<com.linkedin.common.urn.Ur
       partialEntity = new Assertion();
       ((Assertion) partialEntity).setUrn(input.toString());
       ((Assertion) partialEntity).setType(EntityType.ASSERTION);
+    }
+    if (input.getEntityType().equals("test")) {
+      partialEntity = new Test();
+      ((Assertion) partialEntity).setUrn(input.toString());
+      ((Assertion) partialEntity).setType(EntityType.TEST);
     }
     return partialEntity;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/test/TestMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/test/TestMapper.java
@@ -1,0 +1,40 @@
+package com.linkedin.datahub.graphql.types.test;
+
+import com.linkedin.datahub.graphql.generated.TestDefinition;
+import com.linkedin.test.TestInfo;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.Test;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.Constants;
+
+
+public class TestMapper {
+
+  public static Test map(final EntityResponse entityResponse) {
+
+    final Test result = new Test();
+    final Urn entityUrn = entityResponse.getUrn();
+    final EnvelopedAspectMap aspects = entityResponse.getAspects();
+
+    result.setUrn(entityUrn.toString());
+    result.setType(EntityType.TEST);
+
+    final EnvelopedAspect envelopedTestInfo = aspects.get(Constants.TEST_INFO_ASPECT_NAME);
+    if (envelopedTestInfo != null) {
+      final TestInfo testInfo = new TestInfo(envelopedTestInfo.getValue().data());
+      result.setCategory(testInfo.getCategory());
+      result.setName(testInfo.getName());
+      result.setDescription(testInfo.getDescription());
+      result.setDefinition(new TestDefinition(testInfo.getDefinition().getJson()));
+    } else  {
+      return null;
+    }
+    return result;
+  }
+
+  private TestMapper() {
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/test/TestType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/test/TestType.java
@@ -1,0 +1,86 @@
+package com.linkedin.datahub.graphql.types.test;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Test;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import graphql.execution.DataFetcherResult;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
+
+public class TestType implements com.linkedin.datahub.graphql.types.EntityType<Test, String> {
+
+  static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of(
+      Constants.TEST_INFO_ASPECT_NAME
+  );
+  private final EntityClient _entityClient;
+
+  public TestType(final EntityClient entityClient)  {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public EntityType type() {
+    return EntityType.TEST;
+  }
+
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
+
+  @Override
+  public Class<Test> objectClass() {
+    return Test.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<Test>> batchLoad(@Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> testUrns = urns.stream()
+        .map(this::getUrn)
+        .collect(Collectors.toList());
+
+    try {
+      final Map<Urn, EntityResponse> entities = _entityClient.batchGetV2(
+          Constants.TEST_ENTITY_NAME,
+          new HashSet<>(testUrns),
+          ASPECTS_TO_FETCH,
+          context.getAuthentication());
+
+      final List<EntityResponse> gmsResults = new ArrayList<>();
+      for (Urn urn : testUrns) {
+        gmsResults.add(entities.getOrDefault(urn, null));
+      }
+      return gmsResults.stream()
+          .map(gmsResult ->
+              gmsResult == null ? null : DataFetcherResult.<Test>newResult()
+                  .data(TestMapper.map(gmsResult))
+                  .build()
+          )
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load Tests", e);
+    }
+  }
+
+  private Urn getUrn(final String urnStr) {
+    try {
+      return Urn.createFromString(urnStr);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(String.format("Failed to convert urn string %s into Urn", urnStr));
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -71,6 +71,11 @@ type PlatformPrivileges {
   Whether the user should be able to manage tokens on behalf of other users.
   """
   manageTokens: Boolean!
+
+  """
+  Whether the user is able to manage Tests
+  """
+  manageTests: Boolean!
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -481,6 +481,11 @@ enum EntityType {
     A DataHub Access Token
     """
     ACCESS_TOKEN
+
+    """
+    A DataHub Test
+    """
+    TEST
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/tests.graphql
+++ b/datahub-graphql-core/src/main/resources/tests.graphql
@@ -1,0 +1,231 @@
+"""
+A metadata entity representing a DataHub Test
+"""
+type Test implements Entity {
+    """
+    The primary key of the Test itself
+    """
+    urn: String!
+
+    """
+    The standard Entity Type
+    """
+    type: EntityType!
+
+    """
+    The name of the Test
+    """
+    name: String!
+
+    """
+    The category of the Test (user defined)
+    """
+    category: String!
+
+    """
+    Description of the test
+    """
+    description: String
+
+    """
+    Definition for the test
+    """
+    definition: TestDefinition!
+
+    """
+    Unused for tests
+    """
+    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+}
+
+"""
+Definition of the test
+"""
+type TestDefinition {
+  """
+  JSON-based def for the test
+  """
+  json: String
+}
+
+"""
+The result type of a test that has been run
+"""
+enum TestResultType {
+    """
+    The test succeeded.
+    """
+    SUCCESS
+
+    """
+    The test failed.
+    """
+    FAILURE
+}
+
+"""
+A set of test results
+"""
+type TestResults {
+  """
+  The tests passing
+  """
+  passing: [TestResult!]!
+
+  """
+  The tests failing
+  """
+  failing: [TestResult!]!
+}
+
+"""
+The result of running a test
+"""
+type TestResult {
+  """
+  The test itself, or null if the test has been deleted
+  """
+  test: Test
+
+  """
+  The final result, e.g. either SUCCESS or FAILURE.
+  """
+  type: TestResultType!
+}
+
+extend type Dataset {
+    """
+    The results of evaluating tests
+    """
+    testResults: TestResults
+}
+
+extend type Query {
+  """
+  Fetch a Test by primary key (urn)
+  """
+  test(urn: String!): Test
+
+  """
+  List all DataHub Tests
+  """
+  listTests(input: ListTestsInput!): ListTestsResult
+}
+
+"""
+Input required when listing DataHub Tests
+"""
+input ListTestsInput {
+  """
+  The starting offset of the result set returned
+  """
+  start: Int
+
+  """
+  The maximum number of Domains to be returned in the result set
+  """
+  count: Int
+
+  """
+  Optional query string to match on
+  """
+  query: String
+}
+
+"""
+The result obtained when listing DataHub Tests
+"""
+type ListTestsResult {
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
+
+  """
+  The number of Tests in the returned result set
+  """
+  count: Int!
+
+  """
+  The total number of Tests in the result set
+  """
+  total: Int!
+
+  """
+  The Tests themselves
+  """
+  tests: [Test!]!
+}
+
+input CreateTestInput {
+  """
+  Advanced: a custom id for the test.
+  """
+  id: String
+
+  """
+  The name of the Test
+  """
+  name: String!
+
+  """
+  The category of the Test (user defined)
+  """
+  category: String!
+
+  """
+  Description of the test
+  """
+  description: String
+
+  """
+  The test definition
+  """
+  definition: TestDefinitionInput!
+}
+
+input UpdateTestInput {
+  """
+  The name of the Test
+  """
+  name: String!
+
+  """
+  The category of the Test (user defined)
+  """
+  category: String!
+
+  """
+  Description of the test
+  """
+  description: String
+
+  """
+  The test definition
+  """
+  definition: TestDefinitionInput!
+}
+
+input TestDefinitionInput {
+  """
+  The string representation of the Test
+  """
+  json: String
+}
+
+extend type Mutation {
+  """
+  Create a new test
+  """
+  createTest(input: CreateTestInput!): String
+
+  """
+  Update an existing test
+  """
+  updateTest(urn: String!, input: UpdateTestInput!): String
+
+  """
+  Create an existing test - note that this will NOT delete dangling pointers until the next execution of the test.
+  """
+  deleteTest(urn: String!): Boolean
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/CreateTestResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/CreateTestResolverTest.java
@@ -1,0 +1,107 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.CreateTestInput;
+import com.linkedin.datahub.graphql.generated.TestDefinitionInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.TestKey;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.test.TestDefinition;
+import com.linkedin.test.TestDefinitionType;
+import com.linkedin.test.TestInfo;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class CreateTestResolverTest {
+
+  private static final CreateTestInput TEST_INPUT = new CreateTestInput(
+      "test-id",
+      "test-name",
+      "test-category",
+      "test-description",
+      new TestDefinitionInput("{}")
+  );
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    CreateTestResolver resolver = new CreateTestResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    final TestKey key = new TestKey();
+    key.setId("test-id");
+
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityKeyAspect(GenericRecordUtils.serializeAspect(key));
+    proposal.setEntityType(Constants.TEST_ENTITY_NAME);
+    TestInfo info = new TestInfo();
+    info.setCategory("test-category");
+    info.setDescription("test-description");
+    info.setName("test-name");
+    info.setDefinition(new TestDefinition().setJson("{}").setType(TestDefinitionType.JSON));
+    proposal.setAspectName(Constants.TEST_INFO_ASPECT_NAME);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(info));
+    proposal.setChangeType(ChangeType.UPSERT);
+
+    // Not ideal to match against "any", but we don't know the auto-generated execution request id
+    Mockito.verify(mockClient, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal),
+        Mockito.any(Authentication.class)
+    );
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    CreateTestResolver resolver = new CreateTestResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockClient, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.doThrow(RemoteInvocationException.class).when(mockClient).ingestProposal(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+    CreateTestResolver resolver = new CreateTestResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/DeleteTestResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/DeleteTestResolverTest.java
@@ -1,0 +1,56 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class DeleteTestResolverTest {
+
+  private static final String TEST_URN = "urn:li:test:test-id";
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DeleteTestResolver resolver = new DeleteTestResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_URN);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertTrue(resolver.get(mockEnv).get());
+
+    Mockito.verify(mockClient, Mockito.times(1)).deleteEntity(
+        Mockito.eq(Urn.createFromString(TEST_URN)),
+        Mockito.any(Authentication.class)
+    );
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DeleteTestResolver resolver = new DeleteTestResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_URN);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockClient, Mockito.times(0)).deleteEntity(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/ListTestsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/ListTestsResolverTest.java
@@ -1,0 +1,112 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.ListTestsInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class ListTestsResolverTest {
+
+  private static final Urn TEST_URN = Urn.createFromTuple("test", "test-id");
+
+  private static final ListTestsInput TEST_INPUT = new ListTestsInput(
+      0, 20, null
+  );
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    Mockito.when(mockClient.search(
+        Mockito.eq(Constants.TEST_ENTITY_NAME),
+        Mockito.eq(""),
+        Mockito.eq(Collections.emptyMap()),
+        Mockito.eq(0),
+        Mockito.eq(20),
+        Mockito.any(Authentication.class)
+    )).thenReturn(
+        new SearchResult()
+            .setFrom(0)
+            .setPageSize(1)
+            .setNumEntities(1)
+            .setEntities(new SearchEntityArray(ImmutableSet.of(new SearchEntity().setEntity(TEST_URN))))
+    );
+
+    ListTestsResolver resolver = new ListTestsResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    // Data Assertions
+    assertEquals((int) resolver.get(mockEnv).get().getStart(), 0);
+    assertEquals((int) resolver.get(mockEnv).get().getCount(), 1);
+    assertEquals((int) resolver.get(mockEnv).get().getTotal(), 1);
+    assertEquals(resolver.get(mockEnv).get().getTests().size(), 1);
+    assertEquals(resolver.get(mockEnv).get().getTests().get(0).getUrn(), TEST_URN.toString());
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    ListTestsResolver resolver = new ListTestsResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(
+        TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockClient, Mockito.times(0)).search(
+        Mockito.any(),
+        Mockito.eq(""),
+        Mockito.anyMap(),
+        Mockito.anyInt(),
+        Mockito.anyInt(),
+        Mockito.any(Authentication.class));
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.doThrow(RemoteInvocationException.class).when(mockClient).search(
+        Mockito.any(),
+        Mockito.eq(""),
+        Mockito.anyMap(),
+        Mockito.anyInt(),
+        Mockito.anyInt(),
+        Mockito.any(Authentication.class));
+    ListTestsResolver resolver = new ListTestsResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/UpdateTestResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/test/UpdateTestResolverTest.java
@@ -1,0 +1,106 @@
+package com.linkedin.datahub.graphql.resolvers.test;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.UpdateTestInput;
+import com.linkedin.datahub.graphql.generated.TestDefinitionInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.test.TestDefinition;
+import com.linkedin.test.TestDefinitionType;
+import com.linkedin.test.TestInfo;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class UpdateTestResolverTest {
+
+  private static final String TEST_URN = "urn:li:test:test-id";
+  private static final UpdateTestInput TEST_INPUT = new UpdateTestInput(
+      "test-name",
+      "test-category",
+      "test-description",
+      new TestDefinitionInput("{}")
+  );
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Update resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    UpdateTestResolver resolver = new UpdateTestResolver(mockClient);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_URN);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(UrnUtils.getUrn(TEST_URN));
+    proposal.setEntityType(Constants.TEST_ENTITY_NAME);
+    TestInfo info = new TestInfo();
+    info.setCategory("test-category");
+    info.setDescription("test-description");
+    info.setName("test-name");
+    info.setDefinition(new TestDefinition().setJson("{}").setType(TestDefinitionType.JSON));
+    proposal.setAspectName(Constants.TEST_INFO_ASPECT_NAME);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(info));
+    proposal.setChangeType(ChangeType.UPSERT);
+
+    // Not ideal to match against "any", but we don't know the auto-generated execution request id
+    Mockito.verify(mockClient, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal),
+        Mockito.any(Authentication.class)
+    );
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Update resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    UpdateTestResolver resolver = new UpdateTestResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_URN);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockClient, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    // Update resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.doThrow(RemoteInvocationException.class).when(mockClient).ingestProposal(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+    UpdateTestResolver resolver = new UpdateTestResolver(mockClient);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-web-react/codegen.yml
+++ b/datahub-web-react/codegen.yml
@@ -8,6 +8,7 @@ schema:
     - '../datahub-graphql-core/src/main/resources/auth.graphql'
     - '../datahub-graphql-core/src/main/resources/ingestion.graphql'
     - '../datahub-graphql-core/src/main/resources/timeline.graphql'
+    - '../datahub-graphql-core/src/main/resources/tests.graphql'
 config:
     scalars:
         Long: number

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -209,6 +209,7 @@ export const dataset1 = {
     health: null,
     assertions: null,
     deprecation: null,
+    testResults: null,
 };
 
 export const dataset2 = {
@@ -290,6 +291,7 @@ export const dataset2 = {
     assertions: null,
     status: null,
     deprecation: null,
+    testResults: null,
 };
 
 export const dataset3 = {
@@ -500,6 +502,7 @@ export const dataset3 = {
     status: null,
     readRuns: null,
     writeRuns: null,
+    testResults: null,
 } as Dataset;
 
 export const dataset4 = {

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -146,7 +146,9 @@ export class DatasetEntity implements Entity<Dataset> {
                     display: {
                         visible: (_, _1) => true,
                         enabled: (_, dataset: GetDatasetQuery) => {
-                            return (dataset?.dataset?.assertions?.total || 0) > 0;
+                            return (
+                                (dataset?.dataset?.assertions?.total || 0) > 0 || dataset?.dataset?.testResults !== null
+                            );
                         },
                     },
                 },

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/TestResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/TestResults.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TestResult } from '../../../../../../types.generated';
+import { TestResultsList } from './TestResultsList';
+import { TestResultsSummary } from './TestResultsSummary';
+
+type Props = {
+    passing: Array<TestResult>;
+    failing: Array<TestResult>;
+};
+
+export const TestResults = ({ passing, failing }: Props) => {
+    const filteredPassing = passing.filter((testResult) => testResult.test !== null);
+    const filteredFailing = failing.filter((testResult) => testResult.test !== null);
+    const totalTests = filteredPassing.length + filteredFailing.length;
+
+    return (
+        <>
+            <TestResultsSummary
+                summary={{
+                    passing: filteredPassing.length,
+                    failing: filteredFailing.length,
+                    total: totalTests,
+                }}
+            />
+            {filteredFailing.length > 0 && (
+                <TestResultsList title="Test Results" results={[...filteredFailing, ...filteredPassing]} />
+            )}
+        </>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/TestResultsList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/TestResultsList.tsx
@@ -1,0 +1,109 @@
+import { CopyOutlined, StopOutlined } from '@ant-design/icons';
+import { Button, Divider, Empty, Tag, Tooltip, Typography } from 'antd';
+import styled from 'styled-components';
+import React from 'react';
+import { TestResult } from '../../../../../../types.generated';
+import { StyledTable } from '../../../components/styled/StyledTable';
+import { getResultColor, getResultIcon, getResultText } from './testUtils';
+
+const ResultContainer = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: left;
+`;
+
+const TestResultsContainer = styled.div`
+    padding: 20px;
+`;
+
+const TestName = styled(Typography.Title)`
+    margin: 0px;
+    padding: 0px;
+
+    && {
+        margin-bottom: 4px;
+    }
+`;
+
+const TestCategory = styled(Typography.Text)`
+    margin: 0px;
+    padding: 0px;
+`;
+
+const ResultTypeText = styled(Typography.Text)`
+    margin-left: 8px;
+`;
+
+type Props = {
+    title: string;
+    results: Array<TestResult>;
+};
+
+export const TestResultsList = ({ title, results }: Props) => {
+    const resultsTableData = results.map((result) => ({
+        urn: result.test?.urn,
+        name: result?.test?.name,
+        category: result?.test?.category,
+        description: result?.test?.description,
+        resultType: result.type,
+    }));
+
+    const resultsTableCols = [
+        {
+            title: '',
+            dataIndex: '',
+            key: '',
+            render: (_, record: any) => {
+                const resultColor = (record.resultType && getResultColor(record.resultType)) || 'default';
+                const resultText = (record.resultType && getResultText(record.resultType)) || 'No Evaluations';
+                const resultIcon = (record.resultType && getResultIcon(record.resultType)) || <StopOutlined />;
+                return (
+                    <ResultContainer>
+                        <div>
+                            <Tag style={{ borderColor: resultColor }}>
+                                {resultIcon}
+                                <ResultTypeText style={{ color: resultColor }}>{resultText}</ResultTypeText>
+                            </Tag>
+                        </div>
+                        <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
+                            <div style={{ marginLeft: 8 }}>
+                                <div>
+                                    <TestName level={5}>{record.name}</TestName>
+                                    <TestCategory type="secondary">{record.category}</TestCategory>
+                                    <Divider type="vertical" />
+                                    <Typography.Text type={record.description ? undefined : 'secondary'}>
+                                        {record.description || 'No description'}
+                                    </Typography.Text>
+                                </div>
+                            </div>
+                            <Tooltip title="Copy URN. An URN uniquely identifies an entity on DataHub.">
+                                <Button
+                                    icon={<CopyOutlined />}
+                                    onClick={() => {
+                                        navigator.clipboard.writeText(record.urn);
+                                    }}
+                                />
+                            </Tooltip>
+                        </div>
+                    </ResultContainer>
+                );
+            },
+        },
+    ];
+
+    return (
+        <TestResultsContainer>
+            <Typography.Title level={5}>{title}</Typography.Title>
+            <StyledTable
+                columns={resultsTableCols}
+                dataSource={resultsTableData}
+                rowKey="urn"
+                locale={{
+                    emptyText: <Empty description="No Tests Found :(" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
+                }}
+                showHeader={false}
+                pagination={false}
+            />
+        </TestResultsContainer>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/TestResultsSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/TestResultsSummary.tsx
@@ -1,0 +1,86 @@
+import { CheckCircleFilled, CloseCircleFilled, StopOutlined } from '@ant-design/icons';
+import { Tooltip, Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import { ANTD_GRAY } from '../../../constants';
+
+const SummaryHeader = styled.div`
+    width: 100%;
+    padding-left: 40px;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid ${ANTD_GRAY[4.5]};
+`;
+
+const SummaryContainer = styled.div``;
+
+const SummaryMessage = styled.div`
+    display: inline-block;
+    margin-left: 20px;
+`;
+
+const SummaryTitle = styled(Typography.Title)`
+    && {
+        padding-bottom: 0px;
+        margin-bottom: 0px;
+    }
+`;
+
+export type TestsSummary = {
+    failing: number;
+    passing: number;
+    total: number;
+};
+
+type Props = {
+    summary: TestsSummary;
+};
+
+const SUCCESS_COLOR_HEX = '#52C41A';
+const FAILURE_COLOR_HEX = '#F5222D';
+
+const getSummaryIcon = (summary: TestsSummary) => {
+    if (summary.failing === 0) {
+        return <StopOutlined style={{ color: ANTD_GRAY[6], fontSize: 28 }} />;
+    }
+    if (summary.passing === summary.total) {
+        return <CheckCircleFilled style={{ color: SUCCESS_COLOR_HEX, fontSize: 28 }} />;
+    }
+    return <CloseCircleFilled style={{ color: FAILURE_COLOR_HEX, fontSize: 28 }} />;
+};
+
+const getSummaryMessage = (summary: TestsSummary) => {
+    if (summary.total === 0) {
+        return 'No tests have run';
+    }
+    if (summary.passing === summary.total) {
+        return 'All tests are passing';
+    }
+    if (summary.failing === summary.total) {
+        return 'All tests are failing';
+    }
+    return 'Some tests are failing';
+};
+
+export const TestResultsSummary = ({ summary }: Props) => {
+    const summaryIcon = getSummaryIcon(summary);
+    const summaryMessage = getSummaryMessage(summary);
+    const subtitleMessage = `${summary.passing} passing tests, ${summary.failing} failing tests`;
+    return (
+        <SummaryHeader>
+            <SummaryContainer>
+                <Tooltip title="This status is based on the most recent run of each test.">
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                        {summaryIcon}
+                        <SummaryMessage>
+                            <SummaryTitle level={5}>{summaryMessage}</SummaryTitle>
+                            <Typography.Text type="secondary">{subtitleMessage}</Typography.Text>
+                        </SummaryMessage>
+                    </div>
+                </Tooltip>
+            </SummaryContainer>
+        </SummaryHeader>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/ValidationsTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/ValidationsTab.tsx
@@ -1,6 +1,6 @@
-import { FileProtectOutlined } from '@ant-design/icons';
+import { FileDoneOutlined, FileProtectOutlined } from '@ant-design/icons';
 import { Button } from 'antd';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useGetDatasetAssertionsQuery } from '../../../../../../graphql/dataset.generated';
 import { Assertion, AssertionResultType } from '../../../../../../types.generated';
 import TabToolbar from '../../../components/styled/TabToolbar';
@@ -8,6 +8,7 @@ import { useEntityData } from '../../../EntityContext';
 import { DatasetAssertionsList } from './DatasetAssertionsList';
 import { DatasetAssertionsSummary } from './DatasetAssertionsSummary';
 import { sortAssertions } from './assertionUtils';
+import { TestResults } from './TestResults';
 
 /**
  * Returns a status summary for the assertions associated with a Dataset.
@@ -35,15 +36,34 @@ const getAssertionsStatusSummary = (assertions: Array<Assertion>) => {
     return summary;
 };
 
+enum ViewType {
+    ASSERTIONS,
+    TESTS,
+}
+
 /**
  * Component used for rendering the Validations Tab on the Dataset Page.
  */
 export const ValidationsTab = () => {
     const { urn, entityData } = useEntityData();
     const { data, refetch } = useGetDatasetAssertionsQuery({ variables: { urn } });
+    /**
+     * Determines which view should be visible: assertions or tests.
+     */
+    const [view, setView] = useState(ViewType.ASSERTIONS);
 
     const assertions = (data && data.dataset?.assertions?.assertions?.map((assertion) => assertion as Assertion)) || [];
     const totalAssertions = data?.dataset?.assertions?.total || 0;
+
+    const passingTests = (entityData as any)?.testResults?.passing || [];
+    const maybeFailingTests = (entityData as any)?.testResults?.failing || [];
+    const totalTests = maybeFailingTests.length + passingTests.length;
+
+    useEffect(() => {
+        if (totalAssertions === 0) {
+            setView(ViewType.TESTS);
+        }
+    }, [totalAssertions]);
 
     // Pre-sort the list of assertions based on which has been most recently executed.
     assertions.sort(sortAssertions);
@@ -52,14 +72,22 @@ export const ValidationsTab = () => {
         <>
             <TabToolbar>
                 <div>
-                    <Button type="text">
+                    <Button type="text" disabled={totalAssertions === 0} onClick={() => setView(ViewType.ASSERTIONS)}>
                         <FileProtectOutlined />
                         Assertions ({totalAssertions})
                     </Button>
+                    <Button type="text" disabled={totalTests === 0} onClick={() => setView(ViewType.TESTS)}>
+                        <FileDoneOutlined />
+                        Tests ({totalTests})
+                    </Button>
                 </div>
             </TabToolbar>
-            <DatasetAssertionsSummary summary={getAssertionsStatusSummary(assertions)} />
-            {entityData && <DatasetAssertionsList assertions={assertions} onDelete={() => refetch()} />}
+            {(view === ViewType.ASSERTIONS && (
+                <>
+                    <DatasetAssertionsSummary summary={getAssertionsStatusSummary(assertions)} />
+                    {entityData && <DatasetAssertionsList assertions={assertions} onDelete={() => refetch()} />}
+                </>
+            )) || <TestResults passing={passingTests} failing={maybeFailingTests} />}
         </>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/testUtils.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/testUtils.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons';
+import { TestResultType } from '../../../../../../types.generated';
+
+/**
+ * Returns the display text assoociated with an Test Result Type
+ */
+export const getResultText = (result: TestResultType) => {
+    switch (result) {
+        case TestResultType.Success:
+            return 'Passing';
+        case TestResultType.Failure:
+            return 'Failing';
+        default:
+            throw new Error(`Unsupported Test Result Type ${result} provided.`);
+    }
+};
+
+/**
+ * Returns the display color assoociated with an TestResultType
+ */
+const SUCCESS_COLOR_HEX = '#4db31b';
+const FAILURE_COLOR_HEX = '#F5222D';
+
+export const getResultColor = (result: TestResultType) => {
+    switch (result) {
+        case TestResultType.Success:
+            return SUCCESS_COLOR_HEX;
+        case TestResultType.Failure:
+            return FAILURE_COLOR_HEX;
+        default:
+            throw new Error(`Unsupported Test Result Type ${result} provided.`);
+    }
+};
+
+/**
+ * Returns the display icon assoociated with an TestResultType
+ */
+export const getResultIcon = (result: TestResultType) => {
+    const resultColor = getResultColor(result);
+    switch (result) {
+        case TestResultType.Success:
+            return <CheckCircleOutlined style={{ color: resultColor }} />;
+        case TestResultType.Failure:
+            return <CloseCircleOutlined style={{ color: resultColor }} />;
+        default:
+            throw new Error(`Unsupported Test Result Type ${result} provided.`);
+    }
+};

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -154,6 +154,20 @@ query getDataset($urn: String!) {
             start
             total
         }
+        testResults {
+            passing {
+                test {
+                    ...testFields
+                }
+                type
+            }
+            failing {
+                test {
+                    ...testFields
+                }
+                type
+            }
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/me.graphql
+++ b/datahub-web-react/src/graphql/me.graphql
@@ -28,6 +28,7 @@ query getMe {
             manageIngestion
             manageSecrets
             manageDomains
+            manageTests
         }
     }
 }

--- a/datahub-web-react/src/graphql/test.graphql
+++ b/datahub-web-react/src/graphql/test.graphql
@@ -1,0 +1,34 @@
+fragment testFields on Test {
+    urn
+    name
+    category
+    description
+    definition {
+        json
+    }
+}
+
+query getTest($urn: String!) {
+    test(urn: $urn) {
+        ...testFields
+    }
+}
+
+query listTests($input: ListTestsInput!) {
+    listTests(input: $input) {
+        start
+        count
+        total
+        tests {
+            ...testFields
+        }
+    }
+}
+
+mutation createTest($input: CreateTestInput!) {
+    createTest(input: $input)
+}
+
+mutation deleteTest($urn: String!) {
+    deleteTest(urn: $urn)
+}

--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -3242,5 +3242,44 @@
       "contentType":"application/json"
     },
     "systemMetadata":null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "test",
+    "entityUrn": "urn:li:test:953001aa-fb7b-4a43-916f-3efd95ab9047",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "testInfo",
+    "aspect": {
+      "value": "{\"name\": \"Sample Test 1\", \"category\": \"Examples\", \"description\": \"An example of Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{}\"} }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "test",
+    "entityUrn": "urn:li:test:76ca947d-d988-4f0d-8c2f-055de2c6f4b5",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "testInfo",
+    "aspect": {
+      "value": "{\"name\": \"Sample Test 2\", \"category\": \"Examples\", \"description\": \"An example of another Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{}\"} }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "testResults",
+    "aspect": {
+      "value": "{\"failing\": [ { \"test\": \"urn:li:test:953001aa-fb7b-4a43-916f-3efd95ab9047\", \"type\": \"FAILURE\" } ], \"passing\": [ { \"test\": \"urn:li:test:76ca947d-d988-4f0d-8c2f-055de2c6f4b5\", \"type\": \"SUCCESS\" }]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
   }
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/key/TestKey.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/key/TestKey.pdl
@@ -1,0 +1,16 @@
+namespace com.linkedin.metadata.key
+
+import com.linkedin.common.Urn
+
+/**
+ * Key for a Test
+ */
+@Aspect = {
+  "name": "testKey",
+}
+record TestKey {
+  /**
+  * Unique id for the test
+  */
+  id: string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/test/TestInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/test/TestInfo.pdl
@@ -1,0 +1,53 @@
+namespace com.linkedin.test
+
+/**
+ * Information about a DataHub Test
+ */
+@Aspect = {
+  "name": "testInfo"
+}
+record TestInfo {
+    /**
+    * The name of the test
+    */
+    @Searchable = {
+      "fieldType": "TEXT_PARTIAL"
+    }
+    name: string
+
+    /**
+    * Category of the test
+    */
+    @Searchable = {
+      "fieldType": "KEYWORD"
+    }
+    category: string
+
+    /**
+     * Description of the test
+     */
+     @Searchable = {
+       "fieldType": "TEXT"
+     }
+    description: optional string
+
+    /**
+    * Configuration for the Test
+    */
+    definition: record TestDefinition {
+      /**
+       * The Test Definition Type
+       */
+       type: enum TestDefinitionType {
+        /**
+         * JSON / YAML test def
+         */
+         JSON
+       }
+
+      /**
+       * JSON format configuration for the test
+       */
+       json: optional string
+    }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/test/TestResult.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/test/TestResult.pdl
@@ -1,0 +1,27 @@
+namespace com.linkedin.test
+
+import com.linkedin.common.Urn
+
+/**
+ * Information about a Test Result
+ */
+record TestResult {
+    /**
+     * The urn of the test
+     */
+    test: Urn
+
+    /**
+    * The type of the result
+    */
+    type: enum TestResultType {
+      /**
+      *  The Test Succeeded
+      */
+      SUCCESS
+      /**
+      *  The Test Failed
+      */
+      FAILURE
+    }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/test/TestResults.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/test/TestResults.pdl
@@ -1,0 +1,45 @@
+namespace com.linkedin.test
+
+/**
+ * Information about a Test Result
+ */
+@Aspect = {
+ "name": "testResults"
+}
+record TestResults {
+    /**
+     * Results that are failing
+     */
+    @Searchable = {
+      "/*/test": {
+        "fieldType": "URN",
+        "fieldName": "failingTests"
+        "hasValuesFieldName": "hasFailingTests",
+      }
+    }
+    @Relationship = {
+      "/*/test": {
+        "name": "IsFailing",
+        "entityTypes": [ "test" ]
+      }
+    }
+    failing: array[TestResult]
+
+    /**
+     * Results that are passing
+     */
+    @Searchable = {
+      "/*/test": {
+        "fieldType": "URN",
+        "fieldName": "passingTests",
+        "hasValuesFieldName": "hasPassingTests",
+      }
+    }
+    @Relationship = {
+      "/*/test": {
+        "name": "IsPassing",
+        "entityTypes": [ "test" ]
+      }
+    }
+    passing: array[TestResult]
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -19,6 +19,7 @@ entities:
       - status
       - container
       - deprecation
+      - testResults
   - name: dataHubPolicy
     doc: DataHub Policies represent access policies granted to users or groups on metadata operations like edit, view etc.
     category: internal
@@ -219,4 +220,10 @@ entities:
     keyAspect: dataHubAccessTokenKey
     aspects:
       - dataHubAccessTokenInfo
+  - name: test
+    doc: A DataHub test
+    category: core
+    keyAspect: testKey
+    aspects:
+      - testInfo
 events:

--- a/metadata-service/war/src/main/resources/boot/policies.json
+++ b/metadata-service/war/src/main/resources/boot/policies.json
@@ -18,7 +18,8 @@
         "VIEW_ANALYTICS",
         "GENERATE_PERSONAL_ACCESS_TOKENS",
         "MANAGE_ACCESS_TOKENS",
-        "MANAGE_DOMAINS"
+        "MANAGE_DOMAINS",
+        "MANAGE_TESTS"
       ],
       "displayName":"Root User - All Platform Privileges",
       "description":"Grants full platform privileges to root datahub super user.",
@@ -79,7 +80,8 @@
         "MANAGE_USERS_AND_GROUPS",
         "VIEW_ANALYTICS",
         "GENERATE_PERSONAL_ACCESS_TOKENS",
-        "MANAGE_DOMAINS"
+        "MANAGE_DOMAINS",
+        "MANAGE_TESTS"
       ],
       "displayName":"All Users - All Platform Privileges",
       "description":"Grants full platform privileges to ALL users of DataHub. Change this policy to alter that behavior.",

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -182,6 +182,12 @@ public class Constants {
   public static final String ASSERTION_RUN_EVENT_ASPECT_NAME = "assertionRunEvent";
   public static final String ASSERTION_RUN_EVENT_STATUS_COMPLETE = "COMPLETE";
 
+  // Tests
+  public static final String TEST_ENTITY_NAME = "test";
+  public static final String TEST_KEY_ASPECT_NAME = "testKey";
+  public static final String TEST_INFO_ASPECT_NAME = "testInfo";
+  public static final String TEST_RESULTS_ASPECT_NAME = "testResults";
+
   // DataHub Ingestion Source
   public static final String INGESTION_SOURCE_KEY_ASPECT_NAME = "dataHubIngestionSourceKey";
   public static final String INGESTION_INFO_ASPECT_NAME = "dataHubIngestionSourceInfo";
@@ -198,7 +204,7 @@ public class Constants {
   public static final String ACCESS_TOKEN_KEY_ASPECT_NAME = "dataHubAccessTokenKey";
   public static final String ACCESS_TOKEN_INFO_NAME = "dataHubAccessTokenInfo";
 
-  // acryl-main only
+
   public static final String CHANGE_EVENT_PLATFORM_EVENT_NAME = "entityChangeEvent";
 
   /**

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -65,6 +65,11 @@ public class PoliciesConfig {
       "Manage Domains",
       "Create and remove Asset Domains.");
 
+  public static final Privilege MANAGE_TESTS_PRIVILEGE = Privilege.of(
+      "MANAGE_TESTS",
+      "Manage Tests",
+      "Create and remove Asset Tests.");
+
   public static final List<Privilege> PLATFORM_PRIVILEGES = ImmutableList.of(
       MANAGE_POLICIES_PRIVILEGE,
       MANAGE_USERS_AND_GROUPS_PRIVILEGE,
@@ -73,7 +78,8 @@ public class PoliciesConfig {
       MANAGE_INGESTION_PRIVILEGE,
       MANAGE_SECRETS_PRIVILEGE,
       GENERATE_PERSONAL_ACCESS_TOKENS_PRIVILEGE,
-      MANAGE_ACCESS_TOKENS
+      MANAGE_ACCESS_TOKENS,
+      MANAGE_TESTS_PRIVILEGE
   );
 
   // Resource Privileges //

--- a/smoke-test/tests/tests/data.json
+++ b/smoke-test/tests/tests/data.json
@@ -1,0 +1,182 @@
+[
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:kafka,test-tests-sample,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.common.BrowsePaths": {
+              "paths": ["/prod/kafka/SampleKafkaDataset"]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": null,
+              "uri": null,
+              "tags": [],
+              "customProperties": {
+                "prop1": "fakeprop",
+                "prop2": "pikachu"
+              }
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.Ownership": {
+              "owners": [
+                {
+                  "owner": "urn:li:corpuser:jdoe",
+                  "type": "DATAOWNER",
+                  "source": null
+                },
+                {
+                  "owner": "urn:li:corpuser:datahub",
+                  "type": "DATAOWNER",
+                  "source": null
+                }
+              ],
+              "lastModified": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:jdoe",
+                "impersonator": null
+              }
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.InstitutionalMemory": {
+              "elements": [
+                {
+                  "url": "https://www.linkedin.com",
+                  "description": "Sample doc",
+                  "createStamp": {
+                    "time": 1581407189000,
+                    "actor": "urn:li:corpuser:jdoe",
+                    "impersonator": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+              "schemaName": "SampleKafkaSchema",
+              "platform": "urn:li:dataPlatform:kafka",
+              "version": 0,
+              "created": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:jdoe",
+                "impersonator": null
+              },
+              "lastModified": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:jdoe",
+                "impersonator": null
+              },
+              "deleted": null,
+              "dataset": null,
+              "cluster": null,
+              "hash": "",
+              "platformSchema": {
+                "com.linkedin.pegasus2avro.schema.KafkaSchema": {
+                  "documentSchema": "{\"type\":\"record\",\"name\":\"SampleKafkaSchema\",\"namespace\":\"com.linkedin.dataset\",\"doc\":\"Sample Kafka dataset\",\"fields\":[{\"name\":\"field_foo\",\"type\":[\"string\"]},{\"name\":\"field_bar\",\"type\":[\"boolean\"]}]}"
+                }
+              },
+              "fields": [
+                {
+                  "fieldPath": "[version=2.0].[type=boolean].field_foo_2",
+                  "jsonPath": null,
+                  "nullable": false,
+                  "description": {
+                    "string": "Foo field description"
+                  },
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                    }
+                  },
+                  "nativeDataType": "varchar(100)",
+                  "globalTags": {
+                    "tags": [{ "tag": "urn:li:tag:NeedsDocumentation" }]
+                  },
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[type=boolean].field_bar",
+                  "jsonPath": null,
+                  "nullable": false,
+                  "description": {
+                    "string": "Bar field description"
+                  },
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                    }
+                  },
+                  "nativeDataType": "boolean",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[key=True].[type=int].id",
+                  "jsonPath": null,
+                  "nullable": false,
+                  "description": {
+                    "string": "Id specifying which partition the message should go to"
+                  },
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                    }
+                  },
+                  "nativeDataType": "boolean",
+                  "recursive": false
+                }
+              ],
+              "primaryKeys": null,
+              "foreignKeysSpecs": null
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "test",
+    "entityUrn": "urn:li:test:test-1",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "testInfo",
+    "aspect": {
+      "value": "{\"name\": \"Sample Test 1\", \"category\": \"Examples\", \"description\": \"An example of Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{}\"} }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "test",
+    "entityUrn": "urn:li:test:test-2",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "testInfo",
+    "aspect": {
+      "value": "{\"name\": \"Sample Test 2\", \"category\": \"Examples\", \"description\": \"An example of another Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{}\"} }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,test-tests-sample,PROD)",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "testResults",
+    "aspect": {
+      "value": "{\"failing\": [ { \"test\": \"urn:li:test:test-1\", \"type\": \"FAILURE\" } ], \"passing\": [ { \"test\": \"urn:li:test:test-2\", \"type\": \"SUCCESS\" }]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  }
+]

--- a/smoke-test/tests/tests/tests_test.py
+++ b/smoke-test/tests/tests/tests_test.py
@@ -1,0 +1,288 @@
+import pytest
+import time
+from tests.utils import FRONTEND_ENDPOINT
+from tests.utils import ingest_file_via_rest
+from tests.utils import delete_urns_from_file
+
+@pytest.fixture(scope="module", autouse=True)
+def ingest_cleanup_data(request):
+    print("ingesting test data")
+    ingest_file_via_rest("tests/tests/data.json")
+    yield
+    print("removing test data")
+    delete_urns_from_file("tests/tests/data.json")
+
+@pytest.mark.dependency()
+def test_healthchecks(wait_for_healthchecks):
+    # Call to wait_for_healthchecks fixture will do the actual functionality.
+    pass
+
+test_id = "test id"
+test_name = "test name"
+test_category = "test category"
+test_description = "test description"
+test_description = "test description"
+
+def create_test(frontend_session):
+
+    # Create new Test
+    create_test_json = {
+        "query": """mutation createTest($input: CreateTestInput!) {\n
+            createTest(input: $input)
+        }""",
+        "variables": {
+          "input": {
+              "id": test_id,
+              "name": test_name,
+              "category": test_category,
+              "description": test_description,
+              "definition": {
+                "json": "{}"
+              }
+          }
+        }
+    }
+
+    response = frontend_session.post(
+        f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=create_test_json
+    )
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["createTest"] is not None
+    assert "errors" not in res_data
+
+    return res_data["data"]["createTest"]
+
+def delete_test(frontend_session, test_urn):
+    delete_test_json = {
+        "query": """mutation deleteTest($urn: String!) {\n
+            deleteTest(urn: $urn)
+        }""",
+        "variables": {
+          "urn": test_urn
+        }
+    }
+
+    response = frontend_session.post(
+        f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=delete_test_json
+    )
+    response.raise_for_status()
+
+@pytest.mark.dependency(depends=["test_healthchecks"])
+def test_create_test(frontend_session,wait_for_healthchecks):
+
+    test_urn = create_test(frontend_session)
+
+    # Get the test
+    get_test_json = {
+        "query": """query test($urn: String!) {\n
+            test(urn: $urn) { \n
+              urn\n
+              name\n
+              category\n
+              description\n
+              definition {\n
+                json\n
+              }\n
+            }
+        }""",
+        "variables": {
+          "urn": test_urn
+        }
+    }
+    response = frontend_session.post(
+        f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=get_test_json
+    )
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["test"] == {
+      "urn": test_urn,
+      "name": test_name,
+      "category": test_category,
+      "description": test_description,
+      "definition": {
+        "json": "{}",
+      }
+    }
+    assert "errors" not in res_data
+
+    # Delete test
+    delete_test(frontend_session, test_urn)
+
+    # Ensure the test no longer exists
+    response = frontend_session.post(
+        f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=get_test_json
+    )
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data["data"]["test"] is None
+    assert "errors" not in res_data
+
+
+@pytest.mark.dependency(depends=["test_healthchecks", "test_create_test"])
+def test_update_test(frontend_session,wait_for_healthchecks):
+    test_urn = create_test(frontend_session)
+    test_name = "new name"
+    test_category = "new category"
+    test_description = "new description"
+    test_description = "new description"
+
+    # Update Test
+    update_test_json = {
+        "query": """mutation updateTest($urn: String!, $input: UpdateTestInput!) {\n
+            updateTest(urn: $urn, input: $input)
+        }""",
+        "variables": {
+          "urn": test_urn,
+          "input": {
+              "name": test_name,
+              "category": test_category,
+              "description": test_description,
+              "definition": {
+                "json": "{}"
+              }
+          }
+        }
+    }
+
+    response = frontend_session.post(
+        f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=update_test_json
+    )
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["updateTest"] is not None
+    assert "errors" not in res_data
+
+    # Get the test
+    get_test_json = {
+        "query": """query test($urn: String!) {\n
+            test(urn: $urn) { \n
+              urn\n
+              name\n
+              category\n
+              description\n
+              definition {\n
+                json\n
+              }\n
+            }
+        }""",
+        "variables": {
+          "urn": test_urn
+        }
+    }
+    response = frontend_session.post(
+        f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=get_test_json
+    )
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["test"] == {
+      "urn": test_urn,
+      "name": test_name,
+      "category": test_category,
+      "description": test_description,
+      "definition": {
+        "json": "{}",
+      }
+    }
+    assert "errors" not in res_data
+
+    delete_test(frontend_session, test_urn)
+
+@pytest.mark.dependency(depends=["test_healthchecks", "test_update_test"])
+def test_list_tests(frontend_session,wait_for_healthchecks):
+  list_tests_json = {
+      "query": """query listTests($input: ListTestsInput!) {\n
+          listTests(input: $input) {\n
+            start\n
+            count\n
+            total\n
+            tests {\n
+              urn\n
+            }\n
+          }\n
+      }""",
+      "variables": {
+        "input": {
+            "start": "0",
+            "count": "20"
+        }
+      }
+  }
+
+  response = frontend_session.post(
+      f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=list_tests_json
+  )
+  response.raise_for_status()
+  res_data = response.json()
+
+  assert res_data
+  assert res_data["data"]
+  assert res_data["data"]["listTests"]["total"] >= 2
+  assert len(res_data["data"]["listTests"]["tests"]) >= 2
+  assert "errors" not in res_data
+
+
+@pytest.mark.dependency(depends=["test_healthchecks"])
+def test_get_test_results(frontend_session,wait_for_healthchecks):
+    urn = "urn:li:dataset:(urn:li:dataPlatform:kafka,test-tests-sample,PROD)" # Test urn
+    json = {
+        "query": """query getDataset($urn: String!) {\n
+            dataset(urn: $urn) {\n
+                urn\n
+                testResults {\n
+                    failing {\n
+                      test {\n
+                        urn\n
+                      }\n
+                      type
+                    }\n
+                    passing {\n
+                      test {\n
+                        urn\n
+                      }\n
+                      type
+                    }\n
+                }\n
+            }\n
+        }""",
+        "variables": {"urn": urn },
+    }
+    response = frontend_session.post(f"{FRONTEND_ENDPOINT}/api/v2/graphql", json=json)
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["dataset"]
+    assert res_data["data"]["dataset"]["urn"] == urn
+    assert res_data["data"]["dataset"]["testResults"] == {
+      "failing": [
+        {
+          "test": {
+            "urn": "urn:li:test:test-1"
+          },
+          "type": "FAILURE"
+        }
+      ],
+      "passing": [
+        {
+          "test": {
+            "urn": "urn:li:test:test-2"
+          },
+          "type": "SUCCESS"
+        }
+      ]
+    }


### PR DESCRIPTION
**Summary**
This PR introduces models for a new feature called "Tests", which allows you to define tests against your Graph. 

This PR represents the first milestone in the project, wherein we are adding the Models for Tests and also implementing GraphQL resolvers for creating, updating, deleting, fetching, and listing tests. Finally, it includes fetching and showing the Tests for an Dataset under the Validations Tab.

**Changes**
- Test Entity
- Test Info, Test Results aspect
- Resolvers in GraphQL (CreateTest, UpdateTest, DeleteTest, ListTest)
- Adding TestResults aspect to Datasets (TODO in followup: Adding this to other entities.)
- Addition to React Validations Tab a new "Tests" tab for surfacing test results
- Resolver Tests
- Integration Tests

**Status** 
Ready for review

**Next Steps**
We will extend the model to other entities (Dashboards, Charts, Data Flows, Data Jobs, ML models). 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)