### PR TITLE
fix(gms): Fix incorrect StatefulTokenService init

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubTokenServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubTokenServiceFactory.java
@@ -19,7 +19,7 @@ public class DataHubTokenServiceFactory {
   @Value("${authentication.tokenService.signingKey:}")
   private String signingKey;
 
-  @Value("${authentication.tokenService.saltingKey:}")
+  @Value("${authentication.tokenService.salt:}")
   private String saltingKey;
 
   @Value("${elasticsearch.tokenService.signingAlgorithm:HS256}")


### PR DESCRIPTION
StatefulTokenService was not getting correctly initialised in GMS due to a typo on the configuration for the salt leading to inconsistent hashing logic.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)