### PR TITLE
fix(bigquery): reduce number of calls for details of partitioning

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -704,7 +704,7 @@ class BigQuerySource(SQLAlchemySource):
         else:
             return True
 
-    def add_information_for_schema(self, inspector: Inspector, schema: str):
+    def add_information_for_schema(self, inspector: Inspector, schema: str) -> None:
         url = self.config.get_sql_alchemy_url()
         engine = create_engine(url, **self.config.options)
         project_id = self.get_db_name(inspector)

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -332,6 +332,7 @@ class BigQuerySource(SQLAlchemySource):
         self.report: BigQueryReport = BigQueryReport()
         self.lineage_metadata: Optional[Dict[str, Set[str]]] = None
         self.maximum_shard_ids: Dict[str, str] = dict()
+        self.partition_info: Dict[str, str] = dict()
         atexit.register(cleanup, config)
 
     def get_db_name(self, inspector: Inspector = None) -> str:
@@ -703,15 +704,35 @@ class BigQuerySource(SQLAlchemySource):
         else:
             return True
 
+    def add_information_for_schema(self, inspector: Inspector, schema: str):
+        url = self.config.get_sql_alchemy_url()
+        engine = create_engine(url, **self.config.options)
+        project_id = self.get_db_name(inspector)
+        with engine.connect() as con:
+            inspector = inspect(con)
+            sql = f"""
+                select table_name, column_name
+                from `{project_id}.{schema}.INFORMATION_SCHEMA.COLUMNS`
+                where is_partitioning_column = 'YES';
+            """
+            result = con.execute(sql)
+            for row in result.fetchall():
+                table = row[0]
+                partition_column = row[1]
+                self.partition_info[f"{project_id}.{schema}.{table}"] = partition_column
+        self.report.partition_info = self.partition_info
+
     def get_extra_tags(
         self, inspector: Inspector, schema: str, table: str
     ) -> Dict[str, List[str]]:
         extra_tags: Dict[str, List[str]] = {}
-        partition: Optional[BigQueryPartitionColumn] = self.get_latest_partition(
-            schema, table
-        )
-        if partition:
-            extra_tags[partition.column_name] = [Constants.TAG_PARTITION_KEY]
+        project_id = self.get_db_name(inspector)
+
+        partition_lookup_key = f"{project_id}.{schema}.{table}"
+        if partition_lookup_key in self.partition_info:
+            extra_tags[self.partition_info[partition_lookup_key]] = [
+                Constants.TAG_PARTITION_KEY
+            ]
         return extra_tags
 
     def generate_partition_profiler_query(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -872,7 +872,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
         except Exception as e:
             self.report.report_failure(f"{schema}", f"Tables error: {e}")
 
-    def add_information_for_schema(self, inspector: Inspector, schema: str):
+    def add_information_for_schema(self, inspector: Inspector, schema: str) -> None:
         pass
 
     def get_extra_tags(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -718,6 +718,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
                 if not sql_config.schema_pattern.allowed(schema):
                     self.report.report_dropped(f"{schema}.*")
                     continue
+                self.add_information_for_schema(inspector, schema)
 
                 yield from self.gen_schema_containers(schema, db_name)
 
@@ -870,6 +871,9 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
                     )
         except Exception as e:
             self.report.report_failure(f"{schema}", f"Tables error: {e}")
+
+    def add_information_for_schema(self, inspector: Inspector, schema: str):
+        pass
 
     def get_extra_tags(
         self, inspector: Inspector, schema: str, table: str

--- a/metadata-ingestion/src/datahub/ingestion/source_report/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_report/sql/bigquery.py
@@ -31,3 +31,4 @@ class BigQueryReport(SQLSourceReport):
     audit_start_time: Optional[str] = None
     audit_end_time: Optional[str] = None
     upstream_lineage: Dict = field(default_factory=dict)
+    partition_info: Dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
Report shows the info
<img width="704" alt="image" src="https://user-images.githubusercontent.com/4127841/170512283-a985fdca-1945-4a4a-a2ce-981c9a442fd2.png">

Info still has the tag
<img width="533" alt="image" src="https://user-images.githubusercontent.com/4127841/170512444-6da3d795-33c1-4565-a2ee-40717bb4c674.png">

This was added in https://github.com/datahub-project/datahub/pull/4974

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)