### PR TITLE
fix(build): Fix for hana build failure for aarch64.

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -201,7 +201,11 @@ plugins: Dict[str, Set[str]] = {
     "feast": {"feast==0.18.0", "flask-openid>=1.3.0"},
     "glue": aws_common,
     # hdbcli is supported officially by SAP, sqlalchemy-hana is built on top but not officially supported
-    "hana": sql_common | {"sqlalchemy-hana>=0.5.0", "hdbcli>=2.11.20"},
+    "hana": sql_common
+    | {
+        "sqlalchemy-hana>=0.5.0; platform_machine != 'aarch64'",
+        "hdbcli>=2.11.20; platform_machine != 'aarch64'",
+    },
     "hive": sql_common
     | {
         # Acryl Data maintains a fork of PyHive

--- a/metadata-ingestion/tests/integration/hana/test_hana.py
+++ b/metadata-ingestion/tests/integration/hana/test_hana.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 from freezegun import freeze_time
 
@@ -10,6 +12,10 @@ FROZEN_TIME = "2020-04-14 07:00:00"
 
 @freeze_time(FROZEN_TIME)
 @pytest.mark.slow_integration
+@pytest.mark.skipif(
+    platform.machine().lower() == "aarch64",
+    "The hdbcli dependency is not available for aarch64",
+)
 def test_hana_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
     test_resources_dir = pytestconfig.rootpath / "tests/integration/hana"
 

--- a/metadata-ingestion/tests/integration/hana/test_hana.py
+++ b/metadata-ingestion/tests/integration/hana/test_hana.py
@@ -14,7 +14,7 @@ FROZEN_TIME = "2020-04-14 07:00:00"
 @pytest.mark.slow_integration
 @pytest.mark.skipif(
     platform.machine().lower() == "aarch64",
-    "The hdbcli dependency is not available for aarch64",
+    reason="The hdbcli dependency is not available for aarch64",
 )
 def test_hana_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
     test_resources_dir = pytestconfig.rootpath / "tests/integration/hana"

--- a/metadata-ingestion/tests/unit/test_hana_source.py
+++ b/metadata-ingestion/tests/unit/test_hana_source.py
@@ -8,7 +8,7 @@ from datahub.ingestion.source.sql.hana import HanaConfig, HanaSource
 
 @pytest.mark.skipif(
     platform.machine().lower() == "aarch64",
-    "The hdbcli dependency is not available for aarch64",
+    reason="The hdbcli dependency is not available for aarch64",
 )
 def test_platform_correctly_set_hana():
     source = HanaSource(
@@ -20,7 +20,7 @@ def test_platform_correctly_set_hana():
 
 @pytest.mark.skipif(
     platform.machine().lower() == "aarch64",
-    "The hdbcli dependency is not available for aarch64",
+    reason="The hdbcli dependency is not available for aarch64",
 )
 def test_hana_uri_native():
     config = HanaConfig.parse_obj(
@@ -36,7 +36,7 @@ def test_hana_uri_native():
 
 @pytest.mark.skipif(
     platform.machine().lower() == "aarch64",
-    "The hdbcli dependency is not available for aarch64",
+    reason="The hdbcli dependency is not available for aarch64",
 )
 def test_hana_uri_native_db():
     config = HanaConfig.parse_obj(

--- a/metadata-ingestion/tests/unit/test_hana_source.py
+++ b/metadata-ingestion/tests/unit/test_hana_source.py
@@ -1,7 +1,15 @@
+import platform
+
+import pytest
+
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.sql.hana import HanaConfig, HanaSource
 
 
+@pytest.mark.skipif(
+    platform.machine().lower() == "aarch64",
+    "The hdbcli dependency is not available for aarch64",
+)
 def test_platform_correctly_set_hana():
     source = HanaSource(
         ctx=PipelineContext(run_id="hana-source-test"),
@@ -10,6 +18,10 @@ def test_platform_correctly_set_hana():
     assert source.platform == "hana"
 
 
+@pytest.mark.skipif(
+    platform.machine().lower() == "aarch64",
+    "The hdbcli dependency is not available for aarch64",
+)
 def test_hana_uri_native():
     config = HanaConfig.parse_obj(
         {
@@ -22,6 +34,10 @@ def test_hana_uri_native():
     assert config.get_sql_alchemy_url() == "hana+hdbcli://user:password@host:39041"
 
 
+@pytest.mark.skipif(
+    platform.machine().lower() == "aarch64",
+    "The hdbcli dependency is not available for aarch64",
+)
 def test_hana_uri_native_db():
     config = HanaConfig.parse_obj(
         {


### PR DESCRIPTION
This PR fixes the build failure for the hana connector when the machine architecture is `aarch64` by preventing installation of the plugin and skipping the tests.
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)