### PR TITLE
fix(restore indices): Add RESTATE ChangeType to MCL / MCP to permit restore indices

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -114,7 +114,7 @@ public class SendMAEStep implements UpgradeStep {
           _entityService.produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, null, aspectRecord, null,
               latestSystemMetadata,
               new AuditStamp().setActor(UrnUtils.getUrn(SYSTEM_ACTOR)).setTime(System.currentTimeMillis()),
-              ChangeType.UPSERT);
+              ChangeType.RESTORE);
 
           totalRowsMigrated++;
         }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -114,7 +114,7 @@ public class SendMAEStep implements UpgradeStep {
           _entityService.produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, null, aspectRecord, null,
               latestSystemMetadata,
               new AuditStamp().setActor(UrnUtils.getUrn(SYSTEM_ACTOR)).setTime(System.currentTimeMillis()),
-              ChangeType.RESTORE);
+              ChangeType.RESTATE);
 
           totalRowsMigrated++;
         }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -95,7 +95,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
     }
     Urn urn = EntityKeyUtils.getUrnFromLog(event, entitySpec.getKeyAspectSpec());
 
-    if (event.getChangeType() == ChangeType.UPSERT || event.getChangeType() == ChangeType.RESTORE) {
+    if (event.getChangeType() == ChangeType.UPSERT || event.getChangeType() == ChangeType.RESTATE) {
 
       if (!event.hasAspectName() || !event.hasAspect()) {
         log.error("Aspect or aspect name is missing");

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -95,7 +95,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
     }
     Urn urn = EntityKeyUtils.getUrnFromLog(event, entitySpec.getKeyAspectSpec());
 
-    if (event.getChangeType() == ChangeType.UPSERT) {
+    if (event.getChangeType() == ChangeType.UPSERT || event.getChangeType() == ChangeType.RESTORE) {
 
       if (!event.hasAspectName() || !event.hasAspect()) {
         log.error("Aspect or aspect name is missing");

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
@@ -79,6 +79,14 @@ public class EntityChangeEventGeneratorHook implements MetadataChangeLogHook {
       Constants.TAG_KEY_ASPECT_NAME,
       Constants.STATUS_ASPECT_NAME
   );
+  /**
+   * The list of aspects that are supported for generating semantic change events.
+   */
+  private static final Set<String> SUPPORTED_OPERATIONS = ImmutableSet.of(
+      "CREATE",
+      "UPSERT",
+      "DELETE"
+  );
   private final AspectDifferRegistry _aspectDifferRegistry;
   private final EntityClient _entityClient;
   private final Authentication _systemAuthentication;
@@ -167,7 +175,7 @@ public class EntityChangeEventGeneratorHook implements MetadataChangeLogHook {
   }
 
   private boolean isEligibleForProcessing(final MetadataChangeLog log) {
-    return SUPPORTED_ASPECT_NAMES.contains(log.getAspectName());
+    return SUPPORTED_OPERATIONS.contains(log.getChangeType().toString()) && SUPPORTED_ASPECT_NAMES.contains(log.getAspectName());
   }
 
   private void emitPlatformEvent(@Nonnull final PlatformEvent event, @Nonnull final String partitioningKey) throws Exception {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
@@ -80,7 +80,7 @@ public class EntityChangeEventGeneratorHook implements MetadataChangeLogHook {
       Constants.STATUS_ASPECT_NAME
   );
   /**
-   * The list of aspects that are supported for generating semantic change events.
+   * The list of change types that are supported for generating semantic change events.
    */
   private static final Set<String> SUPPORTED_OPERATIONS = ImmutableSet.of(
       "CREATE",

--- a/metadata-models/src/main/pegasus/com/linkedin/events/metadata/ChangeType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/events/metadata/ChangeType.pdl
@@ -34,7 +34,7 @@ enum ChangeType {
   PATCH
 
   /**
-   * Restore an aspect, eg. in a backfill.
+   * Restate an aspect, eg. in a index refresh.
    */
-  RESTORE
+  RESTATE
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/events/metadata/ChangeType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/events/metadata/ChangeType.pdl
@@ -32,4 +32,9 @@ enum ChangeType {
    * patch the changes instead of full replace
    */
   PATCH
+
+  /**
+   * Restore an aspect, eg. in a backfill.
+   */
+  RESTORE
 }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1679,11 +1679,12 @@
     "name" : "ChangeType",
     "namespace" : "com.linkedin.events.metadata",
     "doc" : "Descriptor for a change action",
-    "symbols" : [ "UPSERT", "CREATE", "UPDATE", "DELETE", "PATCH" ],
+    "symbols" : [ "UPSERT", "CREATE", "UPDATE", "DELETE", "PATCH", "RESTORE" ],
     "symbolDocs" : {
       "CREATE" : "NOT SUPPORTED YET\ninsert if not exists. otherwise fail",
       "DELETE" : "NOT SUPPORTED YET\ndelete action",
       "PATCH" : "NOT SUPPORTED YET\npatch the changes instead of full replace",
+      "RESTORE" : "Restore an aspect, eg. in a backfill.",
       "UPDATE" : "NOT SUPPORTED YET\nupdate if exists. otherwise fail",
       "UPSERT" : "insert if not exists. otherwise update"
     }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1679,12 +1679,12 @@
     "name" : "ChangeType",
     "namespace" : "com.linkedin.events.metadata",
     "doc" : "Descriptor for a change action",
-    "symbols" : [ "UPSERT", "CREATE", "UPDATE", "DELETE", "PATCH", "RESTORE" ],
+    "symbols" : [ "UPSERT", "CREATE", "UPDATE", "DELETE", "PATCH", "RESTATE" ],
     "symbolDocs" : {
       "CREATE" : "NOT SUPPORTED YET\ninsert if not exists. otherwise fail",
       "DELETE" : "NOT SUPPORTED YET\ndelete action",
       "PATCH" : "NOT SUPPORTED YET\npatch the changes instead of full replace",
-      "RESTORE" : "Restore an aspect, eg. in a backfill.",
+      "RESTATE" : "Restate an aspect, eg. in a index refresh.",
       "UPDATE" : "NOT SUPPORTED YET\nupdate if exists. otherwise fail",
       "UPSERT" : "insert if not exists. otherwise update"
     }


### PR DESCRIPTION
**Summary**
Currently we use the normal UPSERT change type in MCLs produced from running the restore indices job. This change introduces a new RESTORE change type and modifies restore indices / corresponding hooks to recognize only those events with a specific type. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)