### PR TITLE
feat(frontend): Allow overriding frontend with a custom akka http server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,8 @@ project.ext.externalDependency = [
     'playDocs': 'com.typesafe.play:play-docs_2.12:2.7.6',
     'playGuice': 'com.typesafe.play:play-guice_2.12:2.7.6',
     'playJavaJdbc': 'com.typesafe.play:play-java-jdbc_2.12:2.7.6',
+    'playAkkaHttpServer': 'com.typesafe.play:play-akka-http-server_2.12:2.7.6',
+    'playServer': 'com.typesafe.play:play-server_2.12:2.7.6',
     'playTest': 'com.typesafe.play:play-test_2.12:2.7.6',
     'pac4j': 'org.pac4j:pac4j-oidc:3.6.0',
     'playPac4j': 'org.pac4j:play-pac4j_2.12:8.0.2',

--- a/datahub-frontend/app/server/CustomAkkaHttpServer.scala
+++ b/datahub-frontend/app/server/CustomAkkaHttpServer.scala
@@ -1,0 +1,34 @@
+package server
+
+import play.api.Logger
+import play.core.server.AkkaHttpServer
+import play.core.server.AkkaHttpServerProvider
+import play.core.server.ServerProvider
+import akka.http.scaladsl.settings.ParserSettings
+
+/** Custom Akka HTTP server that allows us to overrides some Akka server settings as the current Play / Akka
+ *  versions we're using don't allow us to override these via conf files
+ */
+class CustomAkkaHttpServer(context: AkkaHttpServer.Context) extends AkkaHttpServer(context) {
+
+  protected override def createParserSettings(): ParserSettings = {
+    val defaultSettings: ParserSettings = super.createParserSettings()
+    val maxHeaderCountKey = "play.http.server.akka.max-header-count"
+    if (context.config.configuration.has(maxHeaderCountKey)) {
+      val maxHeaderCount = context.config.configuration.get[Int](maxHeaderCountKey)
+      val logger = Logger(classOf[CustomAkkaHttpServer])
+      logger.info(s"Setting max header count to: $maxHeaderCount")
+      defaultSettings.withMaxHeaderCount(maxHeaderCount)
+    } else
+      defaultSettings
+  }
+}
+
+/** A factory that instantiates a CustomAkkaHttpServer. */
+class CustomAkkaHttpServerProvider extends ServerProvider {
+  def createServer(context: ServerProvider.Context) = {
+    val serverContext = AkkaHttpServer.Context.fromServerProviderContext(context)
+    new CustomAkkaHttpServer(serverContext)
+  }
+}
+

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -30,6 +30,12 @@ play.modules.enabled += "auth.AuthModule"
 play.allowHttpContext = true
 play.allowGlobalApplication = true
 
+# Uncomment to override server provider and set the max header count to a higher value
+# This is useful while using proxies like Envoy that result in the frontend server rejecting GMS
+# responses as there's more than the max of 64 allowed headers
+#play.server.provider = server.CustomAkkaHttpServerProvider
+#play.http.server.akka.max-header-count = 256
+
 # Database configuration
 # ~~~~~
 # You can declare as many datasources as you want.

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -30,11 +30,12 @@ play.modules.enabled += "auth.AuthModule"
 play.allowHttpContext = true
 play.allowGlobalApplication = true
 
-# Uncomment to override server provider and set the max header count to a higher value
+# We override the Akka server provider to allow setting the max header count to a higher value
 # This is useful while using proxies like Envoy that result in the frontend server rejecting GMS
 # responses as there's more than the max of 64 allowed headers
-#play.server.provider = server.CustomAkkaHttpServerProvider
-#play.http.server.akka.max-header-count = 256
+play.server.provider = server.CustomAkkaHttpServerProvider
+play.http.server.akka.max-header-count = 64
+play.http.server.akka.max-header-count = ${?DATAHUB_AKKA_MAX_HEADER_COUNT}
 
 # Database configuration
 # ~~~~~

--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -43,6 +43,8 @@ dependencies {
   implementation externalDependency.shiroCore
   implementation externalDependency.playCache
   implementation externalDependency.playWs
+  implementation externalDependency.playServer
+  implementation externalDependency.playAkkaHttpServer
   implementation externalDependency.kafkaClients
 
   testImplementation externalDependency.mockito

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -45,3 +45,6 @@ ELASTIC_CLIENT_PORT=9200
 
 # Change to disable Metadata Service Authentication
 METADATA_SERVICE_AUTH_ENABLED=true
+
+# Change to override max header count defaults
+DATAHUB_AKKA_MAX_HEADER_COUNT=64


### PR DESCRIPTION
This PR allows us to override the frontend's Akka HTTP server with a custom DataHub specific instance. This allows us to override Akka HTTP server settings such as the max header count (which currently isn't possible with our versions of Play + Akka). This is useful when we're trying to configure the DataHub frontend to talk to GMS using proxies like envoy. These proxies often add additional headers which often results in the frontend rejecting GMS responses as they exceed the allowed max header limits of 64. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)