### PR TITLE
fix(mysql-setup-job): add mysql default port override support

### DIFF
--- a/docker/mysql-setup/init.sh
+++ b/docker/mysql-setup/init.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+: ${MYSQL_PORT:=3306}
 
 sed -e "s/DATAHUB_DB_NAME/${DATAHUB_DB_NAME}/g" /init.sql | tee -a /tmp/init-final.sql
-mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /tmp/init-final.sql
+mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST -P $MYSQL_PORT < /tmp/init-final.sql


### PR DESCRIPTION
Mysql setup job is given with a port override to use from helm charts but the job itself does not read that variable. Due to this, it is not possible to setup a MySQL DB if your cluster is serving from a port other than 3306(which is the default port of MySQL)

In this pr, I'm adding the port parameter, which should be already present when using [helm charts](https://github.com/acryldata/datahub-helm/blob/fa53c6d15963760315eeedd3067bc29551cfb92d/charts/datahub/values.yaml#L134), to the mysql-setup-job's connection parameters.  

There is also an issue with the documentation of the port parameter for the MySQL. This is also handled in [this pr](https://github.com/acryldata/datahub-helm/pull/125)


## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)