### PR TITLE
fix(glossaryTerms) Display all related terms for Glossary Terms

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
@@ -10,7 +10,7 @@ import { PreviewType } from '../../Entity';
 
 export type Props = {
     glossaryRelatedTermType: string;
-    glossaryRelatedTermResult: Array<any>;
+    glossaryRelatedTermUrns: Array<string>;
 };
 
 const ListContainer = styled.div`
@@ -33,12 +33,8 @@ const Profile = styled.div`
 
 const messageStyle = { marginTop: '10%' };
 
-export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, glossaryRelatedTermResult }: Props) {
+export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, glossaryRelatedTermUrns }: Props) {
     const entityRegistry = useEntityRegistry();
-    const glossaryRelatedTermUrns: Array<string> = [];
-    glossaryRelatedTermResult.forEach((item: any) => {
-        glossaryRelatedTermUrns.push(item?.entity?.urn);
-    });
     const glossaryTermInfo: QueryResult<GetGlossaryTermQuery, Exact<{ urn: string }>>[] = [];
 
     for (let i = 0; i < glossaryRelatedTermUrns.length; i++) {

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -84,6 +84,10 @@ export type GenericEntityProperties = {
     parentContainers?: Maybe<ParentContainersResult>;
     children?: Maybe<EntityRelationshipsResult>;
     parentNodes?: Maybe<ParentNodesResult>;
+    isRelatedTerms?: Maybe<EntityRelationshipsResult>;
+    hasRelatedTerms?: Maybe<EntityRelationshipsResult>;
+    childTerms?: Maybe<EntityRelationshipsResult>;
+    parentTerms?: Maybe<EntityRelationshipsResult>;
 };
 
 export type GenericEntityUpdate = {

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -28,6 +28,30 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
                 }
             }
         }
+        childTerms: relationships(input: { types: ["IsA"], direction: INCOMING, start: $start, count: $count }) {
+            start
+            count
+            total
+            relationships {
+                entity {
+                    ... on GlossaryTerm {
+                        urn
+                    }
+                }
+            }
+        }
+        parentTerms: relationships(input: { types: ["HasA"], direction: INCOMING, start: $start, count: $count }) {
+            start
+            count
+            total
+            relationships {
+                entity {
+                    ... on GlossaryTerm {
+                        urn
+                    }
+                }
+            }
+        }
         parentNodes {
             ...parentNodesFields
         }


### PR DESCRIPTION
Right now the only way to establish what Glossary Terms are related to others (inheriting or containing) we have to ingest that data. We were experiencing a situation where a user may set `GlossaryRelatedTerms` on one term setting a relationship, but not setting that same relationship on another term when ingesting data. If that happens, we show the relationship on the Related Terms tab for the term we set the `GlossaryRelatedTerms` on but not the other one. That can result in a weird situation where something seems missing.

An example: TermA inherits from TermB and we set that in our yaml file. We forget to add that TermB contains TermA in the yaml file. On the frontend, TermA's profile page says it inherits from TermB, but on TermB's profile page, TermA is not listed as a term it contains.

This fixes that by getting all `GlossaryRelatedTerms` relationships, both OUTGOING and INCOMING, and displays all the parents or children in this related terms tab as long as there is a relationship established one way or another.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)