### PR TITLE
feat: user authentication for datasets privileges poc

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -10,6 +10,7 @@ import StripMarkdownText, { removeMarkdown } from '../../../../shared/components
 import MarkdownViewer from '../../../../shared/components/legacy/MarkdownViewer';
 import SchemaEditableContext from '../../../../../shared/SchemaEditableContext';
 import { useEntityData } from '../../../../shared/EntityContext';
+import { useEntitySchemaPrivileges } from '../../../../shared/EntityAuthorizationContext';
 import analytics, { EventType, EntityActionType } from '../../../../../analytics';
 
 const EditIcon = styled(EditOutlined)`
@@ -92,6 +93,7 @@ export default function DescriptionField({ description, onUpdate, isEdited = fal
     const isSchemaEditable = React.useContext(SchemaEditableContext);
     const onCloseModal = () => setShowAddModal(false);
     const { urn, entityType } = useEntityData();
+    const { editSchemaFieldDescription, editSchemaAddFieldDescription } = useEntitySchemaPrivileges();
 
     const sendAnalytics = () => {
         analytics.event({
@@ -117,7 +119,7 @@ export default function DescriptionField({ description, onUpdate, isEdited = fal
     };
 
     const EditButton =
-        (isSchemaEditable && description && (
+        (editSchemaFieldDescription && isSchemaEditable && description && (
             <EditIcon twoToneColor="#52c41a" onClick={() => setShowAddModal(true)} />
         )) ||
         undefined;
@@ -165,7 +167,7 @@ export default function DescriptionField({ description, onUpdate, isEdited = fal
                     </StripMarkdownText>
                 </>
             )}
-            {isSchemaEditable && isEdited && <EditedLabel>(edited)</EditedLabel>}
+            {editSchemaFieldDescription && isSchemaEditable && isEdited && <EditedLabel>(edited)</EditedLabel>}
             {showAddModal && (
                 <div>
                     <UpdateDescriptionModal
@@ -178,7 +180,7 @@ export default function DescriptionField({ description, onUpdate, isEdited = fal
                     />
                 </div>
             )}
-            {showAddDescription && (
+            {editSchemaAddFieldDescription && showAddDescription && (
                 <AddNewDescription type="text" onClick={() => setShowAddModal(true)}>
                     + Add Description
                 </AddNewDescription>

--- a/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
@@ -1,22 +1,13 @@
 import React, { useContext } from 'react';
 
-// TODO: move the types into types.ts file
-// export type CommonPrivileges = {
-//     editOwners: boolean;
-//     editDocumentation: boolean;
-//     editGlossaryTerms: boolean;
-//     editTags: boolean;
-//     editDomain: boolean;
-//     editLinks: boolean;
-//     editDeprecation: boolean;
-// };
-// TODO: move the types into types.ts file
 export interface DataSetsPrivileges {
     editSchemaFieldDescription: boolean;
+    editSchemaAddFieldDescription?: boolean;
     editSchemaFieldTags: boolean;
+    editSchemaAddFieldTags: boolean;
     editSchemaFieldGlossaryTerms: boolean;
+    editSchemaAddFieldGlossaryTerms: boolean;
 }
-// TODO: move the types into types.ts file
 export interface EntityAuthorizationType extends DataSetsPrivileges {
     editOwners: boolean;
     editDocumentation: boolean;
@@ -38,9 +29,13 @@ const EntityAuthorizationContext = React.createContext<EntityAuthorizationType>(
     editDeprecation: true,
     // Dataset-only
     editSchemaFieldDescription: true,
+    editSchemaAddFieldDescription: true,
     editSchemaFieldTags: true,
-    editSchemaFieldGlossaryTerms: false,
+    editSchemaAddFieldTags: true,
+    editSchemaFieldGlossaryTerms: true,
+    editSchemaAddFieldGlossaryTerms: true,
 });
+
 // display name set to context
 EntityAuthorizationContext.displayName = 'AuthorizationContext';
 
@@ -57,5 +52,24 @@ export const useEntityCommonPrivileges = () => {
         editDomain,
         editLinks,
         editDeprecation,
+    };
+};
+
+export const useEntitySchemaPrivileges = () => {
+    const {
+        editSchemaFieldDescription,
+        editSchemaAddFieldDescription,
+        editSchemaFieldTags,
+        editSchemaAddFieldTags,
+        editSchemaFieldGlossaryTerms,
+        editSchemaAddFieldGlossaryTerms,
+    } = useContext(EntityAuthorizationContext);
+    return {
+        editSchemaFieldDescription,
+        editSchemaAddFieldDescription,
+        editSchemaFieldTags,
+        editSchemaAddFieldTags,
+        editSchemaFieldGlossaryTerms,
+        editSchemaAddFieldGlossaryTerms,
     };
 };

--- a/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
@@ -1,7 +1,23 @@
 import React, { useContext } from 'react';
 
 // TODO: move the types into types.ts file
-export type CommonPrivileges = {
+// export type CommonPrivileges = {
+//     editOwners: boolean;
+//     editDocumentation: boolean;
+//     editGlossaryTerms: boolean;
+//     editTags: boolean;
+//     editDomain: boolean;
+//     editLinks: boolean;
+//     editDeprecation: boolean;
+// };
+// TODO: move the types into types.ts file
+export interface DataSetsPrivileges {
+    editSchemaFieldDescription: boolean;
+    editSchemaFieldTags: boolean;
+    editSchemaFieldGlossaryTerms: boolean;
+}
+// TODO: move the types into types.ts file
+export interface EntityAuthorizationType extends DataSetsPrivileges {
     editOwners: boolean;
     editDocumentation: boolean;
     editGlossaryTerms: boolean;
@@ -9,36 +25,21 @@ export type CommonPrivileges = {
     editDomain: boolean;
     editLinks: boolean;
     editDeprecation: boolean;
-};
-// TODO: move the types into types.ts file
-export type DataSetsPrivileges = {
-    editSchemaFieldDescription: boolean;
-    editSchemaFieldTags: boolean;
-    editSchemaFieldGlossaryTerms: boolean;
-};
-// TODO: move the types into types.ts file
-export type EntityAuthorizationType = {
-    commonPrivileges: CommonPrivileges;
-    dataSets: DataSetsPrivileges;
-};
+}
 
-const EntityAuthorizationContext = React.createContext({
+const EntityAuthorizationContext = React.createContext<EntityAuthorizationType>({
     // Common Privileges
-    commonPrivileges: {
-        editOwners: true,
-        editDocumentation: false,
-        editGlossaryTerms: true,
-        editTags: true,
-        editDomain: false,
-        editLinks: true,
-        editDeprecation: false,
-    },
+    editOwners: true,
+    editDocumentation: true,
+    editGlossaryTerms: true,
+    editTags: true,
+    editDomain: true,
+    editLinks: true,
+    editDeprecation: true,
     // Dataset-only
-    dataSets: {
-        editSchemaFieldDescription: true,
-        editSchemaFieldTags: true,
-        editSchemaFieldGlossaryTerms: false,
-    },
+    editSchemaFieldDescription: true,
+    editSchemaFieldTags: true,
+    editSchemaFieldGlossaryTerms: false,
 });
 // display name set to context
 EntityAuthorizationContext.displayName = 'AuthorizationContext';
@@ -46,6 +47,15 @@ EntityAuthorizationContext.displayName = 'AuthorizationContext';
 export default EntityAuthorizationContext;
 
 export const useEntityCommonPrivileges = () => {
-    const { commonPrivileges } = useContext(EntityAuthorizationContext);
-    return { commonPrivileges };
+    const { editOwners, editDocumentation, editGlossaryTerms, editTags, editDomain, editLinks, editDeprecation } =
+        useContext(EntityAuthorizationContext);
+    return {
+        editOwners,
+        editDocumentation,
+        editGlossaryTerms,
+        editTags,
+        editDomain,
+        editLinks,
+        editDeprecation,
+    };
 };

--- a/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
@@ -1,0 +1,49 @@
+import React, { useContext } from 'react';
+
+// TODO: move the types into types.ts file
+export type CommonPrivileges = {
+    editOwners: boolean;
+    editDocumentation: boolean;
+    editGlossaryTerms: boolean;
+    editTags: boolean;
+    editDomain: boolean;
+    editLinks: boolean;
+    editDeprecation: boolean;
+};
+// TODO: move the types into types.ts file
+export type DataSetsPrivileges = {
+    editSchemaFieldDescription: boolean;
+    editSchemaFieldTags: boolean;
+    editSchemaFieldGlossaryTerms: boolean;
+};
+// TODO: move the types into types.ts file
+export type EntityAuthorizationType = {
+    commonPrivileges: CommonPrivileges;
+    dataSets: DataSetsPrivileges;
+};
+
+const EntityAuthorizationContext = React.createContext({
+    // Common Privileges
+    commonPrivileges: {
+        editOwners: true,
+        editDocumentation: false,
+        editGlossaryTerms: true,
+        editTags: true,
+        editDomain: false,
+        editLinks: true,
+        editDeprecation: false,
+    },
+    // Dataset-only
+    dataSets: {
+        editSchemaFieldDescription: true,
+        editSchemaFieldTags: true,
+        editSchemaFieldGlossaryTerms: false,
+    },
+});
+
+export default EntityAuthorizationContext;
+
+export const useEntityCommonPrivileges = () => {
+    const { commonPrivileges } = useContext(EntityAuthorizationContext);
+    return { commonPrivileges };
+};

--- a/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityAuthorizationContext.tsx
@@ -40,6 +40,8 @@ const EntityAuthorizationContext = React.createContext({
         editSchemaFieldGlossaryTerms: false,
     },
 });
+// display name set to context
+EntityAuthorizationContext.displayName = 'AuthorizationContext';
 
 export default EntityAuthorizationContext;
 

--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedOwner.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedOwner.tsx
@@ -16,6 +16,7 @@ type Props = {
     owner: Owner;
     hidePopOver?: boolean | undefined;
     refetch?: () => Promise<any>;
+    isEditOwner?: boolean;
 };
 
 const OwnerTag = styled(Tag)`
@@ -26,7 +27,7 @@ const OwnerTag = styled(Tag)`
     align-items: center;
 `;
 
-export const ExpandedOwner = ({ entityUrn, owner, hidePopOver, refetch }: Props) => {
+export const ExpandedOwner = ({ entityUrn, owner, hidePopOver, refetch, isEditOwner }: Props) => {
     const entityRegistry = useEntityRegistry();
     const { entityType } = useEntityData();
     const [removeOwnerMutation] = useRemoveOwnerMutation();
@@ -84,7 +85,7 @@ export const ExpandedOwner = ({ entityUrn, owner, hidePopOver, refetch }: Props)
     };
 
     return (
-        <OwnerTag onClose={onClose} closable>
+        <OwnerTag onClose={onClose} closable={isEditOwner}>
             <Link to={`/${entityRegistry.getPathName(owner.owner.type)}/${owner.owner.urn}`}>
                 <CustomAvatar name={name} photoUrl={pictureLink} useDefaultAvatar={false} />
                 {(hidePopOver && <>{name}</>) || (

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -118,12 +118,12 @@ const MIN_SIDEBAR_WIDTH = 200;
 // Initial Privileges
 const PRIVILEGES = {
     commonPrivileges: {
-        editOwners: true,
+        editOwners: false,
         editDocumentation: false,
-        editGlossaryTerms: true,
-        editTags: true,
+        editGlossaryTerms: false,
+        editTags: false,
         editDomain: false,
-        editLinks: true,
+        editLinks: false,
         editDeprecation: false,
     },
     dataSets: {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -13,6 +13,7 @@ import { EntityHeader } from './header/EntityHeader';
 import { EntityTabs } from './header/EntityTabs';
 import { EntitySidebar } from './sidebar/EntitySidebar';
 import EntityContext from '../../EntityContext';
+import EntityAuthorizationContext from '../../EntityAuthorizationContext';
 import useIsLineageMode from '../../../../lineage/utils/useIsLineageMode';
 import { useEntityRegistry } from '../../../../useEntityRegistry';
 import LineageExplorer from '../../../../lineage/LineageExplorer';
@@ -113,6 +114,24 @@ const defaultSidebarSection = {
 const INITIAL_SIDEBAR_WIDTH = 400;
 const MAX_SIDEBAR_WIDTH = 800;
 const MIN_SIDEBAR_WIDTH = 200;
+
+// Initial Privileges
+const PRIVILEGES = {
+    commonPrivileges: {
+        editOwners: true,
+        editDocumentation: false,
+        editGlossaryTerms: true,
+        editTags: true,
+        editDomain: false,
+        editLinks: true,
+        editDeprecation: false,
+    },
+    dataSets: {
+        editSchemaFieldDescription: true,
+        editSchemaFieldTags: true,
+        editSchemaFieldGlossaryTerms: false,
+    },
+};
 
 /**
  * Container for display of the Entity Page
@@ -243,7 +262,8 @@ export const EntityProfile = <T, U>({
                 lineage,
             }}
         >
-            <>
+            {/* TODO: Add EntityAuthorizationContext.Provider */}
+            <EntityAuthorizationContext.Provider value={PRIVILEGES}>
                 {showBrowseBar && <EntityProfileNavBar urn={urn} entityType={entityType} />}
                 {entityData?.status?.removed === true && (
                     <Alert
@@ -286,7 +306,7 @@ export const EntityProfile = <T, U>({
                         </>
                     )}
                 </ContentContainer>
-            </>
+            </EntityAuthorizationContext.Provider>
         </EntityContext.Provider>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -126,9 +126,12 @@ const PRIVILEGES = {
     editLinks: false,
     editDeprecation: false,
     // Datasets Privileges
-    editSchemaFieldDescription: true,
-    editSchemaFieldTags: true,
+    editSchemaFieldDescription: false,
+    editSchemaAddFieldDescription: false,
+    editSchemaFieldTags: false,
+    editSchemaAddFieldTags: false,
     editSchemaFieldGlossaryTerms: false,
+    editSchemaAddFieldGlossaryTerms: false,
 };
 
 /**
@@ -260,7 +263,6 @@ export const EntityProfile = <T, U>({
                 lineage,
             }}
         >
-            {/* TODO: Add EntityAuthorizationContext.Provider */}
             <EntityAuthorizationContext.Provider value={PRIVILEGES}>
                 {showBrowseBar && <EntityProfileNavBar urn={urn} entityType={entityType} />}
                 {entityData?.status?.removed === true && (

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -115,22 +115,20 @@ const INITIAL_SIDEBAR_WIDTH = 400;
 const MAX_SIDEBAR_WIDTH = 800;
 const MIN_SIDEBAR_WIDTH = 200;
 
-// Initial Privileges
+// Initial Privileges: Todo: get these details from graphAPI
 const PRIVILEGES = {
-    commonPrivileges: {
-        editOwners: false,
-        editDocumentation: false,
-        editGlossaryTerms: false,
-        editTags: false,
-        editDomain: false,
-        editLinks: false,
-        editDeprecation: false,
-    },
-    dataSets: {
-        editSchemaFieldDescription: true,
-        editSchemaFieldTags: true,
-        editSchemaFieldGlossaryTerms: false,
-    },
+    // Common Privileges
+    editOwners: false,
+    editDocumentation: false,
+    editGlossaryTerms: false,
+    editTags: false,
+    editDomain: false,
+    editLinks: false,
+    editDeprecation: false,
+    // Datasets Privileges
+    editSchemaFieldDescription: true,
+    editSchemaFieldTags: true,
+    editSchemaFieldGlossaryTerms: false,
 };
 
 /**

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SidebarDomainSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SidebarDomainSection.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { EditOutlined } from '@ant-design/icons';
 import { EMPTY_MESSAGES } from '../../../../constants';
 import { useEntityData, useRefetch } from '../../../../EntityContext';
+import { useEntityCommonPrivileges } from '../../../../EntityAuthorizationContext';
 import { SidebarHeader } from '../SidebarHeader';
 import { SetDomainModal } from './SetDomainModal';
 import { useEntityRegistry } from '../../../../../../useEntityRegistry';
@@ -16,6 +17,9 @@ export const SidebarDomainSection = () => {
     const refetch = useRefetch();
     const [unsetDomainMutation] = useUnsetDomainMutation();
     const [showModal, setShowModal] = useState(false);
+    const { commonPrivileges } = useEntityCommonPrivileges();
+
+    const { editDomain } = commonPrivileges;
     const domain = entityData?.domain;
 
     const removeDomain = () => {
@@ -54,7 +58,7 @@ export const SidebarDomainSection = () => {
                     <DomainLink
                         urn={domain.urn}
                         name={entityRegistry.getDisplayName(EntityType.Domain, domain)}
-                        closable
+                        closable={editDomain}
                         onClose={(e) => {
                             e.preventDefault();
                             onRemoveDomain();
@@ -66,9 +70,11 @@ export const SidebarDomainSection = () => {
                         <Typography.Paragraph type="secondary">
                             {EMPTY_MESSAGES.domain.title}. {EMPTY_MESSAGES.domain.description}
                         </Typography.Paragraph>
-                        <Button type="default" onClick={() => setShowModal(true)}>
-                            <EditOutlined /> Set Domain
-                        </Button>
+                        {editDomain && (
+                            <Button type="default" onClick={() => setShowModal(true)}>
+                                <EditOutlined /> Set Domain
+                            </Button>
+                        )}
                     </>
                 )}
             </div>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SidebarDomainSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SidebarDomainSection.tsx
@@ -17,9 +17,9 @@ export const SidebarDomainSection = () => {
     const refetch = useRefetch();
     const [unsetDomainMutation] = useUnsetDomainMutation();
     const [showModal, setShowModal] = useState(false);
-    const { commonPrivileges } = useEntityCommonPrivileges();
+    // Privileges
+    const { editDomain } = useEntityCommonPrivileges();
 
-    const { editDomain } = commonPrivileges;
     const domain = entityData?.domain;
 
     const removeDomain = () => {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/SidebarOwnerSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/SidebarOwnerSection.tsx
@@ -13,9 +13,8 @@ export const SidebarOwnerSection = ({ properties }: { properties?: any }) => {
     const refetch = useRefetch();
     const [showAddModal, setShowAddModal] = useState(false);
     const ownersEmpty = !entityData?.ownership?.owners?.length;
-    const { commonPrivileges } = useEntityCommonPrivileges();
-
-    const { editOwners } = commonPrivileges;
+    // Privileges
+    const { editOwners } = useEntityCommonPrivileges();
 
     return (
         <div>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/SidebarOwnerSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/SidebarOwnerSection.tsx
@@ -4,6 +4,7 @@ import { PlusOutlined } from '@ant-design/icons';
 import { ExpandedOwner } from '../../../../components/styled/ExpandedOwner';
 import { EMPTY_MESSAGES } from '../../../../constants';
 import { useEntityData, useRefetch } from '../../../../EntityContext';
+import { useEntityCommonPrivileges } from '../../../../EntityAuthorizationContext';
 import { SidebarHeader } from '../SidebarHeader';
 import { AddOwnerModal } from './AddOwnerModal';
 
@@ -12,13 +13,22 @@ export const SidebarOwnerSection = ({ properties }: { properties?: any }) => {
     const refetch = useRefetch();
     const [showAddModal, setShowAddModal] = useState(false);
     const ownersEmpty = !entityData?.ownership?.owners?.length;
+    const { commonPrivileges } = useEntityCommonPrivileges();
+
+    const { editOwners } = commonPrivileges;
 
     return (
         <div>
             <SidebarHeader title="Owners" />
             <div>
                 {entityData?.ownership?.owners?.map((owner) => (
-                    <ExpandedOwner key={owner.owner.urn} entityUrn={urn} owner={owner} refetch={refetch} />
+                    <ExpandedOwner
+                        key={owner.owner.urn}
+                        entityUrn={urn}
+                        owner={owner}
+                        refetch={refetch}
+                        isEditOwner={editOwners}
+                    />
                 ))}
                 {ownersEmpty && (
                     <Typography.Paragraph type="secondary">
@@ -26,9 +36,11 @@ export const SidebarOwnerSection = ({ properties }: { properties?: any }) => {
                     </Typography.Paragraph>
                 )}
 
-                <Button type={ownersEmpty ? 'default' : 'text'} onClick={() => setShowAddModal(true)}>
-                    <PlusOutlined /> Add Owner
-                </Button>
+                {editOwners && (
+                    <Button type={ownersEmpty ? 'default' : 'text'} onClick={() => setShowAddModal(true)}>
+                        <PlusOutlined /> Add Owner
+                    </Button>
+                )}
             </div>
             <AddOwnerModal
                 urn={urn}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
@@ -6,6 +6,7 @@ import StripMarkdownText from '../../../components/styled/StripMarkdownText';
 
 import { EMPTY_MESSAGES } from '../../../constants';
 import { useEntityData, useRefetch, useRouteToTab } from '../../../EntityContext';
+import { useEntityCommonPrivileges } from '../../../EntityAuthorizationContext';
 import { SidebarHeader } from './SidebarHeader';
 import { AddLinkModal } from '../../../components/styled/AddLinkModal';
 
@@ -40,7 +41,9 @@ export const SidebarAboutSection = () => {
     const { entityData } = useEntityData();
     const refetch = useRefetch();
     const routeToTab = useRouteToTab();
+    const { commonPrivileges } = useEntityCommonPrivileges();
 
+    const { editDocumentation } = commonPrivileges;
     const description = entityData?.editableProperties?.description || entityData?.properties?.description;
     const links = entityData?.institutionalMemory?.elements || [];
 
@@ -51,7 +54,8 @@ export const SidebarAboutSection = () => {
             <SidebarHeader
                 title="About"
                 actions={
-                    !isUntouched && (
+                    !isUntouched &&
+                    editDocumentation && (
                         <Button
                             onClick={() => routeToTab({ tabName: 'Documentation', tabParams: { editing: true } })}
                             type="text"
@@ -103,11 +107,13 @@ export const SidebarAboutSection = () => {
                             {link.description || link.label}
                         </LinkButton>
                     ))}
-                    <AddLinkModal buttonProps={{ type: 'text' }} refetch={refetch} />
+                    {editDocumentation && <AddLinkModal buttonProps={{ type: 'text' }} refetch={refetch} />}
                 </SidebarLinkList>
             ) : (
                 <SidebarLinkList>
-                    {!isUntouched && <AddLinkModal buttonProps={{ type: 'text' }} refetch={refetch} />}
+                    {!isUntouched && editDocumentation && (
+                        <AddLinkModal buttonProps={{ type: 'text' }} refetch={refetch} />
+                    )}
                 </SidebarLinkList>
             )}
         </div>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
@@ -41,9 +41,9 @@ export const SidebarAboutSection = () => {
     const { entityData } = useEntityData();
     const refetch = useRefetch();
     const routeToTab = useRouteToTab();
-    const { commonPrivileges } = useEntityCommonPrivileges();
+    // Privileges
+    const { editDocumentation } = useEntityCommonPrivileges();
 
-    const { editDocumentation } = commonPrivileges;
     const description = entityData?.editableProperties?.description || entityData?.properties?.description;
     const links = entityData?.institutionalMemory?.elements || [];
 

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import TagTermGroup from '../../../../../shared/tags/TagTermGroup';
 import { SidebarHeader } from './SidebarHeader';
 import { useEntityData, useRefetch } from '../../../EntityContext';
+import { useEntityCommonPrivileges } from '../../../EntityAuthorizationContext';
 
 const TermSection = styled.div`
     margin-top: 20px;
@@ -14,6 +15,9 @@ export const SidebarTagsSection = ({ properties }: { properties?: any }) => {
     const canAddTerm = properties?.hasTerms;
 
     const { urn, entityType, entityData } = useEntityData();
+    const { commonPrivileges } = useEntityCommonPrivileges();
+
+    const { editTags, editGlossaryTerms } = commonPrivileges;
     const refetch = useRefetch();
 
     return (
@@ -21,8 +25,8 @@ export const SidebarTagsSection = ({ properties }: { properties?: any }) => {
             <SidebarHeader title="Tags" />
             <TagTermGroup
                 editableTags={entityData?.globalTags}
-                canAddTag={canAddTag}
-                canRemove
+                canAddTag={editTags && canAddTag}
+                canRemove={editTags}
                 showEmptyMessage
                 entityUrn={urn}
                 entityType={entityType}
@@ -32,8 +36,8 @@ export const SidebarTagsSection = ({ properties }: { properties?: any }) => {
                 <SidebarHeader title="Glossary Terms" />
                 <TagTermGroup
                     editableGlossaryTerms={entityData?.glossaryTerms}
-                    canAddTerm={canAddTerm}
-                    canRemove
+                    canAddTerm={editGlossaryTerms && canAddTerm}
+                    canRemove={editGlossaryTerms}
                     showEmptyMessage
                     entityUrn={urn}
                     entityType={entityType}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
@@ -15,9 +15,9 @@ export const SidebarTagsSection = ({ properties }: { properties?: any }) => {
     const canAddTerm = properties?.hasTerms;
 
     const { urn, entityType, entityData } = useEntityData();
-    const { commonPrivileges } = useEntityCommonPrivileges();
+    // Privileges
+    const { editTags, editGlossaryTerms } = useEntityCommonPrivileges();
 
-    const { editTags, editGlossaryTerms } = commonPrivileges;
     const refetch = useRefetch();
 
     return (

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -21,6 +21,7 @@ import { SchemaRow } from './components/SchemaRow';
 import { FkContext } from './utils/selectedFkContext';
 import useSchemaBlameRenderer from './utils/useSchemaBlameRenderer';
 import { ANTD_GRAY } from '../../../constants';
+import { useEntitySchemaPrivileges } from '../../../EntityAuthorizationContext';
 
 const TableContainer = styled.div`
     &&& .ant-table-tbody > tr > .ant-table-cell-with-append {
@@ -60,16 +61,26 @@ export default function SchemaTable({
     const [tagHoveredIndex, setTagHoveredIndex] = useState<string | undefined>(undefined);
     const [selectedFkFieldPath, setSelectedFkFieldPath] =
         useState<null | { fieldPath: string; constraint?: ForeignKeyConstraint | null }>(null);
+    const {
+        editSchemaFieldTags,
+        editSchemaAddFieldTags,
+        editSchemaFieldGlossaryTerms,
+        editSchemaAddFieldGlossaryTerms,
+    } = useEntitySchemaPrivileges();
 
     const descriptionRender = useDescriptionRenderer(editableSchemaMetadata);
     const usageStatsRenderer = useUsageStatsRenderer(usageStats);
     const tagRenderer = useTagsAndTermsRenderer(editableSchemaMetadata, tagHoveredIndex, setTagHoveredIndex, {
         showTags: true,
         showTerms: false,
+        canRemove: editSchemaFieldTags,
+        canAddTag: editSchemaAddFieldTags,
     });
     const termRenderer = useTagsAndTermsRenderer(editableSchemaMetadata, tagHoveredIndex, setTagHoveredIndex, {
         showTags: false,
         showTerms: true,
+        canRemove: editSchemaFieldGlossaryTerms,
+        canAddTerm: editSchemaAddFieldGlossaryTerms,
     });
     const schemaTitleRenderer = useSchemaTitleRenderer(schemaMetadata, setSelectedFkFieldPath);
     const schemaBlameRenderer = useSchemaBlameRenderer(schemaFieldBlameList);
@@ -98,7 +109,7 @@ export default function SchemaTable({
 
     const tagColumn = {
         width: 125,
-        title: 'Tags',
+        title: 'Tags2',
         dataIndex: 'globalTags',
         key: 'tag',
         render: tagRenderer,
@@ -107,7 +118,7 @@ export default function SchemaTable({
 
     const termColumn = {
         width: 125,
-        title: 'Terms',
+        title: 'Terms2',
         dataIndex: 'globalTags',
         key: 'tag',
         render: termRenderer,

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
@@ -8,7 +8,7 @@ export default function useTagsAndTermsRenderer(
     editableSchemaMetadata: EditableSchemaMetadata | null | undefined,
     tagHoveredIndex: string | undefined,
     setTagHoveredIndex: (index: string | undefined) => void,
-    options: { showTags: boolean; showTerms: boolean },
+    options: { showTags: boolean; showTerms: boolean; canRemove?: boolean; canAddTerm?: boolean; canAddTag?: boolean },
 ) {
     const { urn } = useEntityData();
     const refetch = useRefetch();
@@ -25,10 +25,14 @@ export default function useTagsAndTermsRenderer(
                     editableTags={options.showTags ? relevantEditableFieldInfo?.globalTags : null}
                     uneditableGlossaryTerms={options.showTerms ? record.glossaryTerms : null}
                     editableGlossaryTerms={options.showTerms ? relevantEditableFieldInfo?.glossaryTerms : null}
-                    canRemove
+                    canRemove={options.canRemove}
                     buttonProps={{ size: 'small' }}
-                    canAddTag={tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTags}
-                    canAddTerm={tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTerms}
+                    canAddTag={
+                        options.canAddTag && tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTags
+                    }
+                    canAddTerm={
+                        options.canAddTerm && tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTerms
+                    }
                     onOpenModal={() => setTagHoveredIndex(undefined)}
                     entityUrn={urn}
                     entityType={EntityType.Dataset}

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -14,6 +14,7 @@ import { DescriptionEditor } from './components/DescriptionEditor';
 import { LinkList } from './components/LinkList';
 
 import { useEntityData, useRefetch, useRouteToTab } from '../../EntityContext';
+import { useEntityCommonPrivileges } from '../../EntityAuthorizationContext';
 import { EDITED_DESCRIPTIONS_CACHE_NAME } from '../../utils';
 
 const DocumentationContainer = styled.div`
@@ -33,6 +34,9 @@ export const DocumentationTab = () => {
     const routeToTab = useRouteToTab();
     const isEditing = queryString.parse(useLocation().search, { parseBooleans: true }).editing;
 
+    const { commonPrivileges } = useEntityCommonPrivileges();
+    const { editDocumentation } = commonPrivileges;
+
     useEffect(() => {
         const editedDescriptions = (localStorageDictionary && JSON.parse(localStorageDictionary)) || {};
         if (editedDescriptions.hasOwnProperty(urn)) {
@@ -48,17 +52,21 @@ export const DocumentationTab = () => {
         <>
             {description || links.length ? (
                 <>
-                    <TabToolbar>
-                        <div>
-                            <Button
-                                type="text"
-                                onClick={() => routeToTab({ tabName: 'Documentation', tabParams: { editing: true } })}
-                            >
-                                <EditOutlined /> Edit
-                            </Button>
-                            <AddLinkModal buttonProps={{ type: 'text' }} refetch={refetch} />
-                        </div>
-                    </TabToolbar>
+                    {editDocumentation && (
+                        <TabToolbar>
+                            <div>
+                                <Button
+                                    type="text"
+                                    onClick={() =>
+                                        routeToTab({ tabName: 'Documentation', tabParams: { editing: true } })
+                                    }
+                                >
+                                    <EditOutlined /> Edit
+                                </Button>
+                                <AddLinkModal buttonProps={{ type: 'text' }} refetch={refetch} />
+                            </div>
+                        </TabToolbar>
+                    )}
                     <DocumentationContainer>
                         {description ? (
                             <MDEditor.Markdown style={{ fontWeight: 400 }} source={description} />

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -33,9 +33,8 @@ export const DocumentationTab = () => {
 
     const routeToTab = useRouteToTab();
     const isEditing = queryString.parse(useLocation().search, { parseBooleans: true }).editing;
-
-    const { commonPrivileges } = useEntityCommonPrivileges();
-    const { editDocumentation } = commonPrivileges;
+    // Privileges
+    const { editDocumentation } = useEntityCommonPrivileges();
 
     useEffect(() => {
         const editedDescriptions = (localStorageDictionary && JSON.parse(localStorageDictionary)) || {};


### PR DESCRIPTION

## Checklist
- For datasets, added the another level of user privileges, so that every user can edit/add features as per the privileges assign to them. 
- This POC completed on Datasets page only.
- User can restricted to add/edit/remove the information like- edit about, tags, glossary terms, owner, domain, description etc. 
- We need to update the privileges once for user with the backend GraphQL API


<img width="1495" alt="Screenshot 2022-05-31 at 9 53 22 PM" src="https://user-images.githubusercontent.com/29713365/171273853-1afb2a1f-55ad-4e50-809c-208f6da49d65.png">


@jjoyce0510 @chriscollins3456 



