### PR TITLE
fix(glossary) Two quick followup fixes around the new Glossary updates

### DIFF
--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components/macro';
 import { useGetRootGlossaryNodesQuery, useGetRootGlossaryTermsQuery } from '../../../graphql/glossary.generated';
 import { GlossaryNode, GlossaryTerm } from '../../../types.generated';
@@ -28,11 +28,18 @@ function GlossaryBrowser(props: Props) {
     const { rootNodes, rootTerms, isSelecting, hideTerms, refreshBrowser, openToEntity, selectTerm, selectNode } =
         props;
 
-    const { data: nodesData } = useGetRootGlossaryNodesQuery({ skip: !!rootNodes });
-    const { data: termsData } = useGetRootGlossaryTermsQuery({ skip: !!rootTerms });
+    const { data: nodesData, refetch: refetchNodes } = useGetRootGlossaryNodesQuery({ skip: !!rootNodes });
+    const { data: termsData, refetch: refetchTerms } = useGetRootGlossaryTermsQuery({ skip: !!rootTerms });
 
     const displayedNodes = rootNodes || nodesData?.getRootGlossaryNodes?.nodes || [];
     const displayedTerms = rootTerms || termsData?.getRootGlossaryTerms?.terms || [];
+
+    useEffect(() => {
+        if (refreshBrowser) {
+            refetchNodes();
+            refetchTerms();
+        }
+    }, [refreshBrowser, refetchNodes, refetchTerms]);
 
     return (
         <BrowserWrapper>

--- a/datahub-web-react/src/app/glossary/GlossarySearch.tsx
+++ b/datahub-web-react/src/app/glossary/GlossarySearch.tsx
@@ -70,6 +70,7 @@ function GlossarySearch() {
                     initialQuery={query || ''}
                     placeholderText="Search Glossary"
                     suggestions={[]}
+                    hideRecommendations
                     style={{
                         padding: 12,
                         paddingBottom: 5,

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -170,6 +170,7 @@ interface Props {
     autoCompleteStyle?: React.CSSProperties;
     entityRegistry: EntityRegistry;
     fixAutoComplete?: boolean;
+    hideRecommendations?: boolean;
     setIsSearchBarFocused?: (isSearchBarFocused: boolean) => void;
     onFocus?: () => void;
     onBlur?: () => void;
@@ -193,6 +194,7 @@ export const SearchBar = ({
     inputStyle,
     autoCompleteStyle,
     fixAutoComplete,
+    hideRecommendations,
     setIsSearchBarFocused,
     onFocus,
     onBlur,
@@ -213,6 +215,7 @@ export const SearchBar = ({
                 limit: 1,
             },
         },
+        skip: hideRecommendations,
     });
 
     const effectiveQuery = searchQuery !== undefined ? searchQuery : initialQuery || '';


### PR DESCRIPTION
We noticed two small issues around the Glossary updates:
1. The Glossary search bar would show search recommendations such as most recent search which hid actual search results.
2. Moving a Node or Term from the root level would not update in the Glossary Browser (the file nav on the left) until you refresh

Here's how I fix them:
1. Pass in an optional prop to skip the request to get search recommendations so we never show them if that prop is passed in.
2. Use the same state system used for updating the browser when moving terms/nodes not in root to also refetch the root nodes and terms when you move something.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)