### PR TITLE
feat(frontend) Allow overriding akka-max-header-value-length

### DIFF
--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -36,6 +36,8 @@ play.allowGlobalApplication = true
 play.server.provider = server.CustomAkkaHttpServerProvider
 play.http.server.akka.max-header-count = 64
 play.http.server.akka.max-header-count = ${?DATAHUB_AKKA_MAX_HEADER_COUNT}
+play.server.akka.max-header-value-length = 8k
+play.server.akka.max-header-value-length = ${?DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH}
 
 # Database configuration
 # ~~~~~

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -48,3 +48,6 @@ METADATA_SERVICE_AUTH_ENABLED=true
 
 # Change to override max header count defaults
 DATAHUB_AKKA_MAX_HEADER_COUNT=64
+
+# Change to override max header value length defaults
+DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH=8k


### PR DESCRIPTION
Allows overriding `max-header-value-length` via environment variables. This should enable users to solve the following issue:
```akka.actor.ActorSystemImpl - Illegal request, responding with status '431 Request Header Fields Too Large': HTTP header value exceeds the configured limit of 8192 characters``` 