### PR TITLE
feat(upgrades) Create new DataHubUpgrade + Restore Glossary Entities Bootstrap step

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DataHubUpgradeKey.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DataHubUpgradeKey.pdl
@@ -1,0 +1,15 @@
+namespace com.linkedin.metadata.key
+
+import com.linkedin.common.Urn
+
+/**
+ * Key for a DataHubUpgrade
+ */
+@Aspect = {
+  "name": "dataHubUpgradeKey"
+}
+record DataHubUpgradeKey {
+
+  id: string
+
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/upgrade/DataHubUpgradeRequest.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/upgrade/DataHubUpgradeRequest.pdl
@@ -1,0 +1,20 @@
+namespace com.linkedin.upgrade
+
+/**
+ * Information collected when kicking off a DataHubUpgrade
+ */
+@Aspect = {
+   "name": "dataHubUpgradeRequest"
+}
+record DataHubUpgradeRequest {
+
+    /**
+     * Timestamp when we started this DataHubUpgrade
+     */
+    timestampMs: long
+
+    /**
+     * Version of this upgrade
+     */
+    version: string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/upgrade/DataHubUpgradeResult.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/upgrade/DataHubUpgradeResult.pdl
@@ -1,0 +1,20 @@
+namespace com.linkedin.upgrade
+
+/**
+ * Information collected when a DataHubUpgrade successfully finishes
+ */
+@Aspect = {
+   "name": "dataHubUpgradeResult"
+}
+record DataHubUpgradeResult {
+
+    /**
+     * Timestamp when we started this DataHubUpgrade
+     */
+    timestampMs: long
+
+    /**
+     * Result map to place helpful information about this upgrade job
+     */
+    result: optional map[string, string]
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -226,4 +226,10 @@ entities:
     keyAspect: testKey
     aspects:
       - testInfo
+  - name: dataHubUpgrade
+    category: internal
+    keyAspect: dataHubUpgradeKey
+    aspects:
+      - dataHubUpgradeRequest
+      - dataHubUpgradeResult
 events:

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.boot.steps.IngestDataPlatformsStep;
 import com.linkedin.metadata.boot.steps.IngestPoliciesStep;
 import com.linkedin.metadata.boot.steps.IngestRetentionPoliciesStep;
 import com.linkedin.metadata.boot.steps.IngestRootUserStep;
+import com.linkedin.metadata.boot.steps.RestoreGlossaryIndices;
 import com.linkedin.metadata.entity.AspectMigrationsDao;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -65,7 +66,8 @@ public class BootstrapManagerFactory {
     final IngestDataPlatformsStep ingestDataPlatformsStep = new IngestDataPlatformsStep(_entityService);
     final IngestDataPlatformInstancesStep ingestDataPlatformInstancesStep =
         new IngestDataPlatformInstancesStep(_entityService, _migrationsDao);
+    final RestoreGlossaryIndices restoreGlossaryIndicesStep = new RestoreGlossaryIndices(_entityService, _entitySearchService, _entityRegistry);
     return new BootstrapManager(ImmutableList.of(ingestRootUserStep, ingestPoliciesStep, ingestDataPlatformsStep,
-        ingestDataPlatformInstancesStep, _ingestRetentionPoliciesStep));
+        ingestDataPlatformInstancesStep, _ingestRetentionPoliciesStep, restoreGlossaryIndicesStep));
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
@@ -1,0 +1,205 @@
+package com.linkedin.metadata.boot.steps;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.glossary.GlossaryNodeInfo;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.boot.BootstrapStep;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
+import com.linkedin.metadata.key.DataHubUpgradeKey;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.upgrade.DataHubUpgradeRequest;
+import com.linkedin.upgrade.DataHubUpgradeResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class RestoreGlossaryIndices implements BootstrapStep {
+  private static final String VERSION = "0";
+  private static final String UPGRADE_ID = "restore-glossary-indices-ui";
+  private static final Urn GLOSSARY_UPGRADE_URN = EntityKeyUtils.convertEntityKeyToUrn(new DataHubUpgradeKey().setId(UPGRADE_ID), Constants.DATA_HUB_UPGRADE_ENTITY_NAME);
+  private static final Integer BATCH_SIZE = 1000;
+
+  private final EntityService _entityService;
+  private final EntitySearchService _entitySearchService;
+  private final EntityRegistry _entityRegistry;
+
+  @Override
+  public String name() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Nonnull
+  @Override
+  public ExecutionMode getExecutionMode() {
+    return ExecutionMode.BLOCKING;
+  }
+
+  @Override
+  public void execute() throws Exception {
+    log.info("Attempting to run RestoreGlossaryIndices upgrade..");
+    try {
+      if (_entityService.exists(GLOSSARY_UPGRADE_URN)) {
+        log.info("Glossary Upgrade has run before. Skipping");
+        return;
+      }
+
+      final AspectSpec termAspectSpec = _entityRegistry.getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME).getAspectSpec(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME);
+      final AspectSpec nodeAspectSpec = _entityRegistry.getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME).getAspectSpec(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME);
+      final AuditStamp auditStamp = new AuditStamp().setActor(Urn.createFromString(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis());
+
+      final DataHubUpgradeRequest upgradeRequest = new DataHubUpgradeRequest().setTimestampMs(System.currentTimeMillis()).setVersion(VERSION);
+      ingestUpgradeAspect(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME, upgradeRequest, auditStamp);
+
+      final int totalTermsCount = getAndRestoreTermAspectIndices(0, auditStamp, termAspectSpec);
+      int termsCount = BATCH_SIZE;
+      while (termsCount < totalTermsCount) {
+        getAndRestoreTermAspectIndices(termsCount, auditStamp, termAspectSpec);
+        termsCount += BATCH_SIZE;
+      }
+
+      final int totalNodesCount = getAndRestoreNodeAspectIndices(0, auditStamp, nodeAspectSpec);
+      int nodesCount = BATCH_SIZE;
+      while (nodesCount < totalNodesCount) {
+        getAndRestoreNodeAspectIndices(nodesCount, auditStamp, nodeAspectSpec);
+        nodesCount += BATCH_SIZE;
+      }
+
+      final DataHubUpgradeResult upgradeResult = new DataHubUpgradeResult().setTimestampMs(System.currentTimeMillis());
+      ingestUpgradeAspect(Constants.DATA_HUB_UPGRADE_RESULT_ASPECT_NAME, upgradeResult, auditStamp);
+
+      log.info("Successfully restored glossary index");
+    } catch (Exception e) {
+      log.error("Error when running the RestoreGlossaryIndices Bootstrap Step", e);
+      _entityService.deleteUrn(GLOSSARY_UPGRADE_URN);
+      throw new RuntimeException("Error when running the RestoreGlossaryIndices Bootstrap Step", e);
+    }
+  }
+
+  private void ingestUpgradeAspect(String aspectName, RecordTemplate aspect, AuditStamp auditStamp) {
+    final MetadataChangeProposal upgradeProposal = new MetadataChangeProposal();
+    upgradeProposal.setEntityUrn(GLOSSARY_UPGRADE_URN);
+    upgradeProposal.setEntityType(Constants.DATA_HUB_UPGRADE_ENTITY_NAME);
+    upgradeProposal.setAspectName(aspectName);
+    upgradeProposal.setAspect(GenericRecordUtils.serializeAspect(aspect));
+    upgradeProposal.setChangeType(ChangeType.UPSERT);
+
+    _entityService.ingestProposal(upgradeProposal, auditStamp);
+  }
+
+  private int getAndRestoreTermAspectIndices(int start, AuditStamp auditStamp, AspectSpec termAspectSpec) throws Exception {
+    SearchResult termsResult = _entitySearchService.search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, start, BATCH_SIZE);
+    List<Urn> termUrns = termsResult.getEntities().stream().map(SearchEntity::getEntity).collect(Collectors.toList());
+    final Map<Urn, EntityResponse> termInfoResponses = _entityService.getEntitiesV2(
+        Constants.GLOSSARY_TERM_ENTITY_NAME,
+        new HashSet<>(termUrns),
+        Collections.singleton(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)
+    );
+
+    //  Loop over Terms and produce changelog
+    for (Urn termUrn: termUrns) {
+      EntityResponse termEntityResponse = termInfoResponses.get(termUrn);
+      if (termEntityResponse == null) {
+        log.info("Term not in set of entity responses {}", termUrn);
+        continue;
+      }
+      GlossaryTermInfo termInfo = mapTermInfo(termEntityResponse);
+      if (termInfo == null) {
+        log.info("Received null termInfo for urn {}", termUrn);
+        continue;
+      }
+
+      _entityService.produceMetadataChangeLog(
+          termUrn,
+          Constants.GLOSSARY_TERM_ENTITY_NAME,
+          Constants.GLOSSARY_TERM_INFO_ASPECT_NAME,
+          termAspectSpec,
+          null,
+          termInfo,
+          null,
+          null,
+          auditStamp,
+          ChangeType.RESTATE);
+    }
+
+    return termsResult.getNumEntities();
+  }
+
+  private int getAndRestoreNodeAspectIndices(int start, AuditStamp auditStamp, AspectSpec nodeAspectSpec) throws Exception {
+    SearchResult nodesResult = _entitySearchService.search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, start, BATCH_SIZE);
+    List<Urn> nodeUrns = nodesResult.getEntities().stream().map(SearchEntity::getEntity).collect(Collectors.toList());
+    final Map<Urn, EntityResponse> nodeInfoResponses = _entityService.getEntitiesV2(
+        Constants.GLOSSARY_NODE_ENTITY_NAME,
+        new HashSet<>(nodeUrns),
+        Collections.singleton(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)
+    );
+
+    //  Loop over Nodes and produce changelog
+    for (Urn nodeUrn: nodeUrns) {
+      EntityResponse nodeEntityResponse = nodeInfoResponses.get(nodeUrn);
+      if (nodeEntityResponse == null) {
+        log.info("Node not in set of entity responses {}", nodeUrn);
+        continue;
+      }
+      GlossaryNodeInfo nodeInfo = mapNodeInfo(nodeEntityResponse);
+      if (nodeInfo == null) {
+        log.info("Received null nodeInfo for urn {}", nodeUrn);
+        continue;
+      }
+
+      _entityService.produceMetadataChangeLog(
+          nodeUrn,
+          Constants.GLOSSARY_NODE_ENTITY_NAME,
+          Constants.GLOSSARY_NODE_INFO_ASPECT_NAME,
+          nodeAspectSpec,
+          null,
+          nodeInfo,
+          null,
+          null,
+          auditStamp,
+          ChangeType.RESTATE);
+    }
+
+    return nodesResult.getNumEntities();
+  }
+
+  private GlossaryTermInfo mapTermInfo(EntityResponse entityResponse) {
+    EnvelopedAspectMap aspectMap = entityResponse.getAspects();
+    if (!aspectMap.containsKey(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)) {
+      return null;
+    }
+
+    return new GlossaryTermInfo(aspectMap.get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME).getValue().data());
+  }
+
+  private GlossaryNodeInfo mapNodeInfo(EntityResponse entityResponse) {
+    EnvelopedAspectMap aspectMap = entityResponse.getAspects();
+    if (!aspectMap.containsKey(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)) {
+      return null;
+    }
+
+    return new GlossaryNodeInfo(aspectMap.get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME).getValue().data());
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
@@ -112,6 +112,9 @@ public class RestoreGlossaryIndices implements BootstrapStep {
   private int getAndRestoreTermAspectIndices(int start, AuditStamp auditStamp, AspectSpec termAspectSpec) throws Exception {
     SearchResult termsResult = _entitySearchService.search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, start, BATCH_SIZE);
     List<Urn> termUrns = termsResult.getEntities().stream().map(SearchEntity::getEntity).collect(Collectors.toList());
+    if (termUrns.size() == 0) {
+      return 0;
+    }
     final Map<Urn, EntityResponse> termInfoResponses = _entityService.getEntitiesV2(
         Constants.GLOSSARY_TERM_ENTITY_NAME,
         new HashSet<>(termUrns),
@@ -150,6 +153,9 @@ public class RestoreGlossaryIndices implements BootstrapStep {
   private int getAndRestoreNodeAspectIndices(int start, AuditStamp auditStamp, AspectSpec nodeAspectSpec) throws Exception {
     SearchResult nodesResult = _entitySearchService.search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, start, BATCH_SIZE);
     List<Urn> nodeUrns = nodesResult.getEntities().stream().map(SearchEntity::getEntity).collect(Collectors.toList());
+    if (nodeUrns.size() == 0) {
+      return 0;
+    }
     final Map<Urn, EntityResponse> nodeInfoResponses = _entityService.getEntitiesV2(
         Constants.GLOSSARY_NODE_ENTITY_NAME,
         new HashSet<>(nodeUrns),

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
@@ -11,7 +11,6 @@ import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.boot.BootstrapStep;
 import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.key.DataHubUpgradeKey;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -39,7 +38,8 @@ import java.util.stream.Collectors;
 public class RestoreGlossaryIndices implements BootstrapStep {
   private static final String VERSION = "0";
   private static final String UPGRADE_ID = "restore-glossary-indices-ui";
-  private static final Urn GLOSSARY_UPGRADE_URN = EntityKeyUtils.convertEntityKeyToUrn(new DataHubUpgradeKey().setId(UPGRADE_ID), Constants.DATA_HUB_UPGRADE_ENTITY_NAME);
+  private static final Urn GLOSSARY_UPGRADE_URN =
+      EntityKeyUtils.convertEntityKeyToUrn(new DataHubUpgradeKey().setId(UPGRADE_ID), Constants.DATA_HUB_UPGRADE_ENTITY_NAME);
   private static final Integer BATCH_SIZE = 1000;
 
   private final EntityService _entityService;
@@ -66,8 +66,10 @@ public class RestoreGlossaryIndices implements BootstrapStep {
         return;
       }
 
-      final AspectSpec termAspectSpec = _entityRegistry.getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME).getAspectSpec(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME);
-      final AspectSpec nodeAspectSpec = _entityRegistry.getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME).getAspectSpec(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME);
+      final AspectSpec termAspectSpec =
+          _entityRegistry.getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME).getAspectSpec(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME);
+      final AspectSpec nodeAspectSpec =
+          _entityRegistry.getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME).getAspectSpec(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME);
       final AuditStamp auditStamp = new AuditStamp().setActor(Urn.createFromString(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis());
 
       final DataHubUpgradeRequest upgradeRequest = new DataHubUpgradeRequest().setTimestampMs(System.currentTimeMillis()).setVersion(VERSION);

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
@@ -127,12 +127,12 @@ public class RestoreGlossaryIndices implements BootstrapStep {
     for (Urn termUrn: termUrns) {
       EntityResponse termEntityResponse = termInfoResponses.get(termUrn);
       if (termEntityResponse == null) {
-        log.info("Term not in set of entity responses {}", termUrn);
+        log.warn("Term not in set of entity responses {}", termUrn);
         continue;
       }
       GlossaryTermInfo termInfo = mapTermInfo(termEntityResponse);
       if (termInfo == null) {
-        log.info("Received null termInfo for urn {}", termUrn);
+        log.warn("Received null termInfo for urn {}", termUrn);
         continue;
       }
 
@@ -168,12 +168,12 @@ public class RestoreGlossaryIndices implements BootstrapStep {
     for (Urn nodeUrn: nodeUrns) {
       EntityResponse nodeEntityResponse = nodeInfoResponses.get(nodeUrn);
       if (nodeEntityResponse == null) {
-        log.info("Node not in set of entity responses {}", nodeUrn);
+        log.warn("Node not in set of entity responses {}", nodeUrn);
         continue;
       }
       GlossaryNodeInfo nodeInfo = mapNodeInfo(nodeEntityResponse);
       if (nodeInfo == null) {
-        log.info("Received null nodeInfo for urn {}", nodeUrn);
+        log.warn("Received null nodeInfo for urn {}", nodeUrn);
         continue;
       }
 

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndicesTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndicesTest.java
@@ -20,8 +20,6 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.mxe.MetadataChangeProposal;
-import com.linkedin.upgrade.DataHubUpgradeRequest;
-import com.linkedin.upgrade.DataHubUpgradeResult;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndicesTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndicesTest.java
@@ -1,0 +1,160 @@
+package com.linkedin.metadata.boot.steps;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.glossary.GlossaryNodeInfo;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.upgrade.DataHubUpgradeRequest;
+import com.linkedin.upgrade.DataHubUpgradeResult;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class RestoreGlossaryIndicesTest {
+
+  private static final String GLOSSARY_UPGRADE_URN = String.format("urn:li:%s:%s", Constants.DATA_HUB_UPGRADE_ENTITY_NAME, "restore-glossary-indices-ui");
+
+  @Test
+  public void testExecuteFirstTime() throws Exception {
+    final Urn glossaryTermUrn = Urn.createFromString("urn:li:glossaryTerm:11115397daf94708a8822b8106cfd451");
+    final Urn glossaryNodeUrn = Urn.createFromString("urn:li:glossaryNode:22225397daf94708a8822b8106cfd451");
+    final EntityService mockService = Mockito.mock(EntityService.class);
+    final EntitySearchService mockSearchService = Mockito.mock(EntitySearchService.class);
+    final EntityRegistry mockRegistry = Mockito.mock(EntityRegistry.class);
+
+    final Urn upgradeEntityUrn = Urn.createFromString(GLOSSARY_UPGRADE_URN);
+    Mockito.when(mockService.exists(upgradeEntityUrn)).thenReturn(false);
+
+
+    //  Mock termInfoResponses and getting aspectSpec
+    Map<String, EnvelopedAspect> termInfoAspects = new HashMap<>();
+    termInfoAspects.put(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(new GlossaryTermInfo().setName("test").data())));
+    Map<Urn, EntityResponse> termInfoResponses = new HashMap<>();
+    termInfoResponses.put(glossaryTermUrn, new EntityResponse().setUrn(glossaryTermUrn).setAspects(new EnvelopedAspectMap(termInfoAspects)));
+    Mockito.when(mockSearchService.search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, 0, 1000))
+        .thenReturn(new SearchResult().setNumEntities(1).setEntities(new SearchEntityArray(ImmutableList.of(new SearchEntity().setEntity(glossaryTermUrn)))));
+    Mockito.when(mockService.getEntitiesV2(
+        Constants.GLOSSARY_TERM_ENTITY_NAME,
+            new HashSet<>(Collections.singleton(glossaryTermUrn)),
+            Collections.singleton(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)))
+        .thenReturn(termInfoResponses);
+
+    //  Mock nodeInfoResponses and getting aspectSpec
+    Map<String, EnvelopedAspect> nodeInfoAspects = new HashMap<>();
+    nodeInfoAspects.put(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(new GlossaryNodeInfo().setName("test").data())));
+    Map<Urn, EntityResponse> nodeInfoResponses = new HashMap<>();
+    nodeInfoResponses.put(glossaryNodeUrn, new EntityResponse().setUrn(glossaryNodeUrn).setAspects(new EnvelopedAspectMap(nodeInfoAspects)));
+    Mockito.when(mockSearchService.search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, 0, 1000))
+        .thenReturn(new SearchResult().setNumEntities(1).setEntities(new SearchEntityArray(ImmutableList.of(new SearchEntity().setEntity(glossaryNodeUrn)))));
+    Mockito.when(mockService.getEntitiesV2(
+        Constants.GLOSSARY_NODE_ENTITY_NAME,
+            new HashSet<>(Collections.singleton(glossaryNodeUrn)),
+            Collections.singleton(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)
+        ))
+        .thenReturn(nodeInfoResponses);
+
+    EntitySpec entitySpec = Mockito.mock(EntitySpec.class);
+    AspectSpec aspectSpec = Mockito.mock(AspectSpec.class);
+    //  Mock for Terms
+    Mockito.when(mockRegistry.getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME)).thenReturn(entitySpec);
+    Mockito.when(entitySpec.getAspectSpec(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)).thenReturn(aspectSpec);
+    //  Mock for Nodes
+    Mockito.when(mockRegistry.getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME)).thenReturn(entitySpec);
+    Mockito.when(entitySpec.getAspectSpec(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)).thenReturn(aspectSpec);
+
+    RestoreGlossaryIndices restoreIndicesStep = new RestoreGlossaryIndices(mockService, mockSearchService, mockRegistry);
+    restoreIndicesStep.execute();
+
+
+    Mockito.verify(mockService, Mockito.times(2)).ingestProposal(
+        Mockito.any(MetadataChangeProposal.class),
+        Mockito.any(AuditStamp.class)
+        );
+    Mockito.verify(mockService, Mockito.times(1)).produceMetadataChangeLog(
+        Mockito.eq(glossaryTermUrn),
+        Mockito.eq(Constants.GLOSSARY_TERM_ENTITY_NAME),
+        Mockito.eq(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME),
+        Mockito.eq(aspectSpec),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(ChangeType.RESTATE)
+    );
+    Mockito.verify(mockService, Mockito.times(1)).produceMetadataChangeLog(
+        Mockito.eq(glossaryNodeUrn),
+        Mockito.eq(Constants.GLOSSARY_NODE_ENTITY_NAME),
+        Mockito.eq(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME),
+        Mockito.eq(aspectSpec),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(ChangeType.RESTATE)
+    );
+  }
+
+  @Test
+  public void testDoesNotRunWhenAlreadyExecuted() throws Exception {
+    final Urn glossaryTermUrn = Urn.createFromString("urn:li:glossaryTerm:11115397daf94708a8822b8106cfd451");
+    final Urn glossaryNodeUrn = Urn.createFromString("urn:li:glossaryNode:22225397daf94708a8822b8106cfd451");
+    final EntityService mockService = Mockito.mock(EntityService.class);
+    final EntitySearchService mockSearchService = Mockito.mock(EntitySearchService.class);
+
+    final Urn upgradeEntityUrn = Urn.createFromString(GLOSSARY_UPGRADE_URN);
+    Mockito.when(mockService.exists(upgradeEntityUrn)).thenReturn(true);
+
+    Mockito.verify(mockSearchService, Mockito.times(0)).search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, 0, 1000);
+    Mockito.verify(mockSearchService, Mockito.times(0)).search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, 0, 1000);
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(MetadataChangeProposal.class),
+        Mockito.any(AuditStamp.class)
+    );
+    Mockito.verify(mockService, Mockito.times(0)).produceMetadataChangeLog(
+        Mockito.eq(glossaryTermUrn),
+        Mockito.eq(Constants.GLOSSARY_TERM_ENTITY_NAME),
+        Mockito.eq(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(ChangeType.RESTATE)
+    );
+    Mockito.verify(mockService, Mockito.times(0)).produceMetadataChangeLog(
+        Mockito.eq(glossaryNodeUrn),
+        Mockito.eq(Constants.GLOSSARY_NODE_ENTITY_NAME),
+        Mockito.eq(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(ChangeType.RESTATE)
+    );
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -44,6 +44,7 @@ public class Constants {
   public static final String NOTEBOOK_ENTITY_NAME = "notebook";
   public static final String DATA_PLATFORM_INSTANCE_ENTITY_NAME = "dataPlatformInstance";
   public static final String ACCESS_TOKEN_ENTITY_NAME = "dataHubAccessToken";
+  public static final String DATA_HUB_UPGRADE_ENTITY_NAME = "dataHubUpgrade";
 
   /**
    * Aspects
@@ -209,6 +210,11 @@ public class Constants {
   // DataHub Access Token
   public static final String ACCESS_TOKEN_KEY_ASPECT_NAME = "dataHubAccessTokenKey";
   public static final String ACCESS_TOKEN_INFO_NAME = "dataHubAccessTokenInfo";
+
+  // DataHub Upgrade
+  public static final String DATA_HUB_UPGRADE_KEY_ASPECT_NAME = "dataHubUpgradeKey";
+  public static final String DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME = "dataHubUpgradeRequest";
+  public static final String DATA_HUB_UPGRADE_RESULT_ASPECT_NAME = "dataHubUpgradeResult";
 
 
   public static final String CHANGE_EVENT_PLATFORM_EVENT_NAME = "entityChangeEvent";


### PR DESCRIPTION
Creates a new entity called DataHubUpgrade which will be used in order to keep track of who has run what upgrade steps.

I'm creating a specific instance for `glossary-upgrade` where we will restore indices of Glossary Nodes Info aspects and Glossary Term Info aspects. Once a user boots up GMS, if they haven't run this bootstrap step they will get all of their Terms and nodes and restore their indices. All following times on bootup they will not run this step if there is already a `glossary-upgrade` DataHubUpgrade entity in mysql.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)