### PR TITLE
feat(impact) Move Impact Analysis to its own Entity tab

### DIFF
--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -18,6 +18,7 @@ import { capitalizeFirstLetter } from '../../shared/textUtil';
 import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { RunsTab } from './tabs/RunsTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
+import { ImpactAnalysis } from '../shared/tabs/ImpactAnalysis/ImpactAnalysis';
 
 /**
  * Definition of the DataHub DataJob entity.
@@ -84,6 +85,18 @@ export class DataJobEntity implements Entity<DataJob> {
                     component: LineageTab,
                     display: {
                         visible: (_, _1) => true,
+                        enabled: (_, dataJob: GetDataJobQuery) =>
+                            (dataJob?.dataJob?.incoming?.count || 0) !== 0 ||
+                            (dataJob?.dataJob?.outgoing?.count || 0) !== 0,
+                    },
+                },
+                {
+                    name: 'Impact',
+                    component: ImpactAnalysis,
+                    display: {
+                        visible: (_, _1, config) => {
+                            return !!config && config.lineageConfig.supportsImpactAnalysis;
+                        },
                         enabled: (_, dataJob: GetDataJobQuery) =>
                             (dataJob?.dataJob?.incoming?.count || 0) !== 0 ||
                             (dataJob?.dataJob?.outgoing?.count || 0) !== 0,

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -27,6 +27,7 @@ import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domai
 import { ValidationsTab } from '../shared/tabs/Dataset/Validations/ValidationsTab';
 import { OperationsTab } from './profile/OperationsTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
+import { ImpactAnalysis } from '../shared/tabs/ImpactAnalysis/ImpactAnalysis';
 
 const SUBTYPES = {
     VIEW: 'view',
@@ -118,6 +119,18 @@ export class DatasetEntity implements Entity<Dataset> {
                                 (dataset?.dataset?.upstream?.total || 0) > 0 ||
                                 (dataset?.dataset?.downstream?.total || 0) > 0
                             );
+                        },
+                    },
+                },
+                {
+                    name: 'Impact',
+                    component: ImpactAnalysis,
+                    display: {
+                        visible: (_, _1, config) => {
+                            return !!config && config.lineageConfig.supportsImpactAnalysis;
+                        },
+                        enabled: (_, dataset: GetDatasetQuery) => {
+                            return (dataset?.dataset?.downstream?.total || 0) > 0;
                         },
                     },
                 },

--- a/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeature/MLFeatureEntity.tsx
@@ -15,6 +15,7 @@ import { DocumentationTab } from '../shared/tabs/Documentation/DocumentationTab'
 import { FeatureTableTab } from '../shared/tabs/ML/MlFeatureFeatureTableTab';
 import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
+import { ImpactAnalysis } from '../shared/tabs/ImpactAnalysis/ImpactAnalysis';
 
 /**
  * Definition of the DataHub MLFeature entity.
@@ -89,6 +90,18 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                                 (result?.mlFeature?.upstream?.total || 0) > 0 ||
                                 (result?.mlFeature?.downstream?.total || 0) > 0
                             );
+                        },
+                    },
+                },
+                {
+                    name: 'Impact',
+                    component: ImpactAnalysis,
+                    display: {
+                        visible: (_, _1, config) => {
+                            return !!config && config.lineageConfig.supportsImpactAnalysis;
+                        },
+                        enabled: (_, result: GetMlFeatureQuery) => {
+                            return (result?.mlFeature?.downstream?.total || 0) > 0;
                         },
                     },
                 },

--- a/datahub-web-react/src/app/entity/mlPrimaryKey/MLPrimaryKeyEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlPrimaryKey/MLPrimaryKeyEntity.tsx
@@ -14,6 +14,7 @@ import { SidebarAboutSection } from '../shared/containers/profile/sidebar/Sideba
 import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { SidebarOwnerSection } from '../shared/containers/profile/sidebar/Ownership/SidebarOwnerSection';
 import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
+import { ImpactAnalysis } from '../shared/tabs/ImpactAnalysis/ImpactAnalysis';
 
 /**
  * Definition of the DataHub MLPrimaryKey entity.
@@ -87,6 +88,18 @@ export class MLPrimaryKeyEntity implements Entity<MlPrimaryKey> {
                                 (result?.mlPrimaryKey?.upstream?.total || 0) > 0 ||
                                 (result?.mlPrimaryKey?.downstream?.total || 0) > 0
                             );
+                        },
+                    },
+                },
+                {
+                    name: 'Impact',
+                    component: ImpactAnalysis,
+                    display: {
+                        visible: (_, _1, config) => {
+                            return !!config && config.lineageConfig.supportsImpactAnalysis;
+                        },
+                        enabled: (_, result: GetMlPrimaryKeyQuery) => {
+                            return (result?.mlPrimaryKey?.downstream?.total || 0) > 0;
                         },
                     },
                 },

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityTabs.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityTabs.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { EntityTab } from '../../../types';
 import { useBaseEntity, useEntityData, useRouteToTab } from '../../../EntityContext';
+import { useAppConfig } from '../../../../../useAppConfig';
 
 type Props = {
     tabs: EntityTab[];
@@ -25,6 +26,7 @@ const Tab = styled(Tabs.TabPane)`
 `;
 
 export const EntityTabs = <T,>({ tabs, selectedTab }: Props) => {
+    const appConfig = useAppConfig();
     const { entityData } = useEntityData();
     const routeToTab = useRouteToTab();
     const baseEntity = useBaseEntity<T>();
@@ -37,7 +39,7 @@ export const EntityTabs = <T,>({ tabs, selectedTab }: Props) => {
         }
     }, [tabs, selectedTab, routeToTab]);
 
-    const visibleTabs = tabs.filter((tab) => tab.display?.visible(entityData, baseEntity));
+    const visibleTabs = tabs.filter((tab) => tab.display?.visible(entityData, baseEntity, appConfig.config));
 
     return (
         <UnborderedTabs

--- a/datahub-web-react/src/app/entity/shared/tabs/ImpactAnalysis/ImpactAnalysis.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/ImpactAnalysis/ImpactAnalysis.tsx
@@ -10,17 +10,15 @@ import useFilters from '../../../../search/utils/useFilters';
 import { SearchCfg } from '../../../../../conf';
 import analytics, { EventType } from '../../../../analytics';
 import { EmbeddedListSearch } from '../../components/styled/search/EmbeddedListSearch';
-import generateUseSearchResultsViaRelationshipHook from './generateUseSearchResultsViaRelationshipHook';
+import generateUseSearchResultsViaRelationshipHook from '../Lineage/generateUseSearchResultsViaRelationshipHook';
+import { useEntityData } from '../../EntityContext';
 
 const ImpactAnalysisWrapper = styled.div`
     flex: 1;
 `;
 
-type Props = {
-    urn: string;
-};
-
-export const ImpactAnalysis = ({ urn }: Props) => {
+export const ImpactAnalysis = () => {
+    const { urn } = useEntityData();
     const location = useLocation();
 
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTab.tsx
@@ -1,30 +1,19 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { Button } from 'antd';
 import { useHistory } from 'react-router';
-import { BarsOutlined, PartitionOutlined } from '@ant-design/icons';
-import { VscGraphLeft } from 'react-icons/vsc';
-import styled from 'styled-components';
+import { PartitionOutlined } from '@ant-design/icons';
 
 import { useEntityData, useLineageData } from '../../EntityContext';
 import TabToolbar from '../../components/styled/TabToolbar';
 import { getEntityPath } from '../../containers/profile/utils';
 import { useEntityRegistry } from '../../../../useEntityRegistry';
 import { LineageTable } from './LineageTable';
-import { ImpactAnalysis } from './ImpactAnalysis';
-import { useAppConfig } from '../../../../useAppConfig';
-
-const ImpactAnalysisIcon = styled(VscGraphLeft)`
-    transform: scaleX(-1);
-    font-size: 18px;
-`;
 
 export const LineageTab = () => {
     const { urn, entityType } = useEntityData();
     const history = useHistory();
     const entityRegistry = useEntityRegistry();
     const lineage = useLineageData();
-    const [showImpactAnalysis, setShowImpactAnalysis] = useState(false);
-    const appConfig = useAppConfig();
 
     const routeToLineage = useCallback(() => {
         history.push(getEntityPath(entityType, urn, entityRegistry, true));
@@ -35,37 +24,13 @@ export const LineageTab = () => {
     return (
         <>
             <TabToolbar>
-                <div>
-                    <Button type="text" onClick={routeToLineage}>
-                        <PartitionOutlined />
-                        Visualize Lineage
-                    </Button>
-                    {appConfig.config.lineageConfig.supportsImpactAnalysis &&
-                        (showImpactAnalysis ? (
-                            <Button type="text" onClick={() => setShowImpactAnalysis(false)}>
-                                <span className="anticon">
-                                    <BarsOutlined />
-                                </span>
-                                Direct Dependencies
-                            </Button>
-                        ) : (
-                            <Button type="text" onClick={() => setShowImpactAnalysis(true)}>
-                                <span className="anticon">
-                                    <ImpactAnalysisIcon />
-                                </span>
-                                Impact Analysis
-                            </Button>
-                        ))}
-                </div>
+                <Button type="text" onClick={routeToLineage}>
+                    <PartitionOutlined />
+                    Visualize Lineage
+                </Button>
             </TabToolbar>
-            {showImpactAnalysis ? (
-                <ImpactAnalysis urn={urn} />
-            ) : (
-                <>
-                    <LineageTable data={upstreamEntities} title={`${upstreamEntities?.length || 0} Upstream`} />
-                    <LineageTable data={downstreamEntities} title={`${downstreamEntities?.length || 0} Downstream`} />
-                </>
-            )}
+            <LineageTable data={upstreamEntities} title={`${upstreamEntities?.length || 0} Upstream`} />
+            <LineageTable data={downstreamEntities} title={`${downstreamEntities?.length || 0} Downstream`} />
         </>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -29,6 +29,7 @@ import {
     ParentContainersResult,
     EntityRelationshipsResult,
     ParentNodesResult,
+    AppConfig,
 } from '../../../types.generated';
 import { FetchedEntity } from '../../lineage/types';
 
@@ -36,7 +37,7 @@ export type EntityTab = {
     name: string;
     component: React.FunctionComponent<{ properties?: any }>;
     display?: {
-        visible: (GenericEntityProperties, T) => boolean; // Whether the tab is visible on the UI. Defaults to true.
+        visible: (GenericEntityProperties, T, config?: AppConfig) => boolean; // Whether the tab is visible on the UI. Defaults to true.
         enabled: (GenericEntityProperties, T) => boolean; // Whether the tab is enabled on the UI. Defaults to true.
     };
     properties?: any;


### PR DESCRIPTION
Moves Impact Analysis out of the Lineage tab into its own tab called "Impact". Will only be shows for the entities that already show the Lineage tab, and is also only shows if the appConfig allows it.

Here we are:
<img width="1412" alt="image" src="https://user-images.githubusercontent.com/28656603/172243161-c5cfd196-46c5-4e06-b76d-fa8b88aa1135.png">

And what the Lineage tab looks like without Impact Analysis
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/28656603/172243259-06b5e561-6ff4-4d5b-a0fa-552ab63ae8ec.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)