### PR TITLE
fix(bigquery): handling of empty partitioned tables, improve report message

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -324,6 +324,12 @@ class Pipeline:
             self.ctx.graph,
         )
 
+    def _count_all_vals(self, d: Dict[str, List]) -> int:
+        result = 0
+        for val in d.values():
+            result += len(val)
+        return result
+
     def pretty_print_summary(self, warnings_as_failure: bool = False) -> int:
         click.echo()
         click.secho(f"Source ({self.config.source.type}) report:", bold=True)
@@ -331,12 +337,29 @@ class Pipeline:
         click.secho(f"Sink ({self.config.sink.type}) report:", bold=True)
         click.echo(self.sink.get_report().as_string())
         click.echo()
+        workunits_produced = self.source.get_report().workunits_produced
         if self.source.get_report().failures or self.sink.get_report().failures:
-            click.secho("Pipeline finished with failures", fg="bright_red", bold=True)
+            num_failures_source = self._count_all_vals(
+                self.source.get_report().failures
+            )
+            click.secho(
+                f"Pipeline finished with {num_failures_source} failures in source producing {workunits_produced} workunits",
+                fg="bright_red",
+                bold=True,
+            )
             return 1
         elif self.source.get_report().warnings or self.sink.get_report().warnings:
-            click.secho("Pipeline finished with warnings", fg="yellow", bold=True)
+            num_warn_source = self._count_all_vals(self.source.get_report().warnings)
+            click.secho(
+                f"Pipeline finished with {num_warn_source} warnings in source producing {workunits_produced} workunits",
+                fg="yellow",
+                bold=True,
+            )
             return 1 if warnings_as_failure else 0
         else:
-            click.secho("Pipeline finished successfully", fg="green", bold=True)
+            click.secho(
+                f"Pipeline finished successfully producing {workunits_produced} workunits",
+                fg="green",
+                bold=True,
+            )
             return 0


### PR DESCRIPTION
- no error when profiling bigquery partitioned table which is empty
- minor perf improvement so we don't run query for every table to find the partitioned table
- improve final error messages as sometimes it gets hard to find number of workunit, error, warnings in big reports
- do not attempt to profile tables when we were not able to get column information

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)