### PR TITLE
feat(glossary) Hide self and children from select when moving a GlossaryNode

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/NodeParentSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/NodeParentSelect.tsx
@@ -29,7 +29,7 @@ function NodeParentSelect(props: Props) {
     const [isFocusedOnInput, setIsFocusedOnInput] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const entityRegistry = useEntityRegistry();
-    const { entityData, urn: entityDataUrn } = useEntityData();
+    const { entityData, urn: entityDataUrn, entityType } = useEntityData();
 
     const [nodeSearch, { data: nodeData }] = useGetSearchResultsLazyQuery();
     let nodeSearchResults = nodeData?.search?.searchResults || [];
@@ -82,6 +82,7 @@ function NodeParentSelect(props: Props) {
     }
 
     const isShowingGlossaryBrowser = !searchQuery && isFocusedOnInput;
+    const shouldHideSelf = isMoving && entityType === EntityType.GlossaryNode;
 
     return (
         <ClickOutside onClickOutside={() => setIsFocusedOnInput(false)}>
@@ -103,7 +104,12 @@ function NodeParentSelect(props: Props) {
                 ))}
             </Select>
             <BrowserWrapper isHidden={!isShowingGlossaryBrowser}>
-                <GlossaryBrowser isSelecting hideTerms selectNode={selectNodeFromBrowser} />
+                <GlossaryBrowser
+                    isSelecting
+                    hideTerms
+                    selectNode={selectNodeFromBrowser}
+                    nodeUrnToHide={shouldHideSelf ? entityData?.urn : undefined}
+                />
             </BrowserWrapper>
         </ClickOutside>
     );

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
@@ -20,13 +20,23 @@ interface Props {
     hideTerms?: boolean;
     openToEntity?: boolean;
     refreshBrowser?: boolean;
+    nodeUrnToHide?: string;
     selectTerm?: (urn: string, displayName: string) => void;
     selectNode?: (urn: string, displayName: string) => void;
 }
 
 function GlossaryBrowser(props: Props) {
-    const { rootNodes, rootTerms, isSelecting, hideTerms, refreshBrowser, openToEntity, selectTerm, selectNode } =
-        props;
+    const {
+        rootNodes,
+        rootTerms,
+        isSelecting,
+        hideTerms,
+        refreshBrowser,
+        openToEntity,
+        nodeUrnToHide,
+        selectTerm,
+        selectNode,
+    } = props;
 
     const { data: nodesData, refetch: refetchNodes } = useGetRootGlossaryNodesQuery({ skip: !!rootNodes });
     const { data: termsData, refetch: refetchTerms } = useGetRootGlossaryTermsQuery({ skip: !!rootTerms });
@@ -51,6 +61,7 @@ function GlossaryBrowser(props: Props) {
                     hideTerms={hideTerms}
                     openToEntity={openToEntity}
                     refreshBrowser={refreshBrowser}
+                    nodeUrnToHide={nodeUrnToHide}
                     selectTerm={selectTerm}
                     selectNode={selectNode}
                 />

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/NodeItem.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/NodeItem.tsx
@@ -49,17 +49,22 @@ interface Props {
     hideTerms?: boolean;
     openToEntity?: boolean;
     refreshBrowser?: boolean;
+    nodeUrnToHide?: string;
     selectTerm?: (urn: string, displayName: string) => void;
     selectNode?: (urn: string, displayName: string) => void;
 }
 
 function NodeItem(props: Props) {
-    const { node, isSelecting, hideTerms, openToEntity, refreshBrowser, selectTerm, selectNode } = props;
+    const { node, isSelecting, hideTerms, openToEntity, refreshBrowser, nodeUrnToHide, selectTerm, selectNode } = props;
+    const shouldHideNode = nodeUrnToHide === node.urn;
 
     const [areChildrenVisible, setAreChildrenVisible] = useState(false);
     const entityRegistry = useEntityRegistry();
     const { entityData } = useEntityData();
-    const { data } = useGetGlossaryNodeQuery({ variables: { urn: node.urn }, skip: !areChildrenVisible });
+    const { data } = useGetGlossaryNodeQuery({
+        variables: { urn: node.urn },
+        skip: !areChildrenVisible || shouldHideNode,
+    });
 
     useEffect(() => {
         if (openToEntity && entityData && entityData.parentNodes?.nodes.some((parent) => parent.urn === node.urn)) {
@@ -94,6 +99,8 @@ function NodeItem(props: Props) {
             ?.filter((child) => child.entity?.type === EntityType.GlossaryTerm)
             .map((child) => child.entity) || [];
 
+    if (shouldHideNode) return null;
+
     return (
         <ItemWrapper>
             <NodeWrapper>
@@ -123,6 +130,7 @@ function NodeItem(props: Props) {
                             isSelecting={isSelecting}
                             hideTerms={hideTerms}
                             openToEntity={openToEntity}
+                            nodeUrnToHide={nodeUrnToHide}
                             selectTerm={selectTerm}
                             selectNode={selectNode}
                         />


### PR DESCRIPTION
When moving a Glossary Node, we don't even want to show them the option to move the Node to itself or any of its children. So now pass in an optional `nodeUrnToHide` which will hide the Node and therefore all of its children as well. We do this when we are moving a Node only (Terms can move wherever they want).


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)