### PR TITLE
fix(ingestion): bigquery-usage - Only send operational metadata for allowed tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
@@ -926,7 +926,11 @@ class BigQueryUsageSource(Source):
     def _create_operation_aspect_work_unit(
         self, event: QueryEvent
     ) -> Optional[MetadataWorkUnit]:
-        if event.statementType in OPERATION_STATEMENT_TYPES and event.destinationTable:
+        if (
+            event.statementType in OPERATION_STATEMENT_TYPES
+            and event.destinationTable
+            and self._is_table_allowed(event.destinationTable)
+        ):
             destination_table: BigQueryTableRef
             try:
                 destination_table = event.destinationTable.remove_extras()


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)