### PR TITLE
fix(ingest): fix table urn for athena connectionType

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -412,6 +412,9 @@ def make_table_urn(
         platform = "teradata"
     elif connection_type in ("sqlserver"):
         platform = "mssql"
+    elif connection_type in ("athena"):
+        platform = "athena"
+        upstream_db = ""
     else:
         platform = connection_type
 


### PR DESCRIPTION
As per [Common Tableau + Amazon Athena Errors](https://tableaulove.com/common-athena-tableau-errors/) linked in [this tableau blog](https://www.tableau.com/about/blog/2017/5/connect-your-s3-data-amazon-athena-connector-tableau-103-71105) , athena databases (equivalent to schemas in tableau) are grouped under AwsDataCatalog catalog(equivalent to database in tableau). 
In this PR, we ignore tableau upstream db and consider only schema and table name when generating table urn for athena, in order to create urn consistent with other places such as athena source. 


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)