### PR TITLE
fix(ui-ingestion): show warning banner when configuring looker ui-ingestion for the first time

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/DefineRecipeStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/DefineRecipeStep.tsx
@@ -1,4 +1,4 @@
-import { Button, message, Typography } from 'antd';
+import { Alert, Button, message, Typography } from 'antd';
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { StepProps } from './types';
@@ -6,6 +6,8 @@ import { getSourceConfigs, jsonToYaml, yamlToJson } from '../utils';
 import { YamlEditor } from './YamlEditor';
 import { ANTD_GRAY } from '../../../entity/shared/constants';
 import { IngestionSourceBuilderStep } from './steps';
+
+const LOOKML_DOC_LINK = 'https://datahubproject.io/docs/generated/ingestion/sources/looker#module-lookml';
 
 const Section = styled.div`
     display: flex;
@@ -46,15 +48,20 @@ export const DefineRecipeStep = ({ state, updateState, goTo, prev }: StepProps) 
 
     const { type } = state;
     const sourceConfigs = getSourceConfigs(type as string);
+    const isEditing: boolean = prev === undefined;
     const displayRecipe = stagedRecipeYml || sourceConfigs.placeholderRecipe;
     const sourceDisplayName = sourceConfigs.displayName;
     const sourceDocumentationUrl = sourceConfigs.docsUrl; // Maybe undefined (in case of "custom")
 
+    // LookML banner specific code
+    const isSourceLooker: boolean = sourceConfigs.type === 'looker';
+    const [showLookerBanner, setShowLookerBanner] = useState(isSourceLooker && !isEditing);
+
     useEffect(() => {
-        if (stagedRecipeYml && stagedRecipeYml.length > 0) {
+        if (stagedRecipeYml && stagedRecipeYml.length > 0 && !showLookerBanner) {
             setStepComplete(true);
         }
-    }, [stagedRecipeYml]);
+    }, [stagedRecipeYml, showLookerBanner]);
 
     const onClickNext = () => {
         // Convert the recipe into it's json representation, and catch + report exceptions while we do it.
@@ -82,7 +89,37 @@ export const DefineRecipeStep = ({ state, updateState, goTo, prev }: StepProps) 
         <>
             <Section>
                 <SelectTemplateHeader level={5}>Configure {sourceDisplayName} Recipe</SelectTemplateHeader>
+                {showLookerBanner && (
+                    <Alert
+                        type="warning"
+                        banner
+                        closable
+                        message={
+                            <>
+                                <big>
+                                    <i>
+                                        <b>You must close this banner to proceed!</b>
+                                    </i>
+                                </big>
+                                <br />
+                                <br />
+                                To get complete Looker metadata integration (including Looker views and lineage to the
+                                underlying warehouse tables), you must <b>also</b> use the{' '}
+                                <a href={LOOKML_DOC_LINK} target="_blank" rel="noopener noreferrer">
+                                    DataHub lookml module
+                                </a>
+                                .
+                                <br />
+                                <br />
+                                LookML ingestion <b>cannot</b> currently be performed via UI-based ingestion. This is a
+                                known problem the DataHub team is working to solve!
+                            </>
+                        }
+                        afterClose={() => setShowLookerBanner(false)}
+                    />
+                )}
                 <Typography.Text>
+                    {showLookerBanner && <br />}
                     For more information about how to configure a recipe, see the{' '}
                     <a href={sourceDocumentationUrl} target="_blank" rel="noopener noreferrer">
                         {sourceDisplayName} source docs.
@@ -93,7 +130,7 @@ export const DefineRecipeStep = ({ state, updateState, goTo, prev }: StepProps) 
                 <YamlEditor initialText={displayRecipe} onChange={setStagedRecipeYml} />
             </BorderedSection>
             <ControlsContainer>
-                <Button disabled={prev === undefined} onClick={prev}>
+                <Button disabled={isEditing} onClick={prev}>
                     Previous
                 </Button>
                 <Button disabled={!stepComplete} onClick={onClickNext}>


### PR DESCRIPTION
## Screenshots

**Cannot proceed to next step for Looker ingestion without closing banner**
<img width="858" alt="image" src="https://user-images.githubusercontent.com/19418814/172934263-274bbe6a-e3cd-49cd-b4ee-da818d313edd.png">

**Can proceed to next step for Looker ingestion when banner is closed**
<img width="868" alt="image" src="https://user-images.githubusercontent.com/19418814/172934311-9bbc419f-a332-4d81-a408-7552aa1164f6.png">

**Banner is not shown when editing Looker recipe**
<img width="864" alt="image" src="https://user-images.githubusercontent.com/19418814/172934589-cf48aa5f-4784-4f63-b7c3-8c96b63a7b2a.png">

**Banner is not shown when creating a new recipe for other sources**
<img width="859" alt="image" src="https://user-images.githubusercontent.com/19418814/172934640-dcabea3d-f4f8-4da2-b7c2-12fb771ba239.png">

**Banner is not shown when editing an existing recipe for other sources**
![Uploading image.png…]()


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)