### PR TITLE
fix(tokens): Reduce cache timeout for access tokens + fix listing owner tokens

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/ListAccessTokensResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/ListAccessTokensResolver.java
@@ -101,6 +101,6 @@ public class ListAccessTokensResolver implements DataFetcher<CompletableFuture<L
    */
   private boolean isListingSelfTokens(final List<FacetFilterInput> filters, final QueryContext context) {
     return AuthorizationUtils.canGeneratePersonalAccessToken(context) && filters.stream()
-        .anyMatch(filter -> filter.getField().equals("actorUrn") && filter.getValue().equals(context.getActorUrn()));
+        .anyMatch(filter -> filter.getField().equals("ownerUrn") && filter.getValue().equals(context.getActorUrn()));
   }
 }

--- a/metadata-service/auth-api/src/main/java/com/datahub/authentication/AuthenticationConstants.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authentication/AuthenticationConstants.java
@@ -30,6 +30,8 @@ public class AuthenticationConstants {
   public static final String SYSTEM_CLIENT_SECRET_CONFIG = "systemClientSecret";
 
   public static final String ENTITY_SERVICE = "entityService";
+  public static final String TOKEN_SERVICE = "tokenService";
+
 
   private AuthenticationConstants() { }
 }

--- a/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
+++ b/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
@@ -11,6 +11,7 @@ import com.datahub.authentication.AuthenticatorContext;
 import com.datahub.authentication.authenticator.AuthenticatorChain;
 import com.datahub.authentication.authenticator.DataHubSystemAuthenticator;
 import com.datahub.authentication.authenticator.NoOpAuthenticator;
+import com.datahub.authentication.token.StatefulTokenService;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.metadata.entity.EntityService;
@@ -48,6 +49,10 @@ public class AuthenticationFilter implements Filter {
   @Inject
   @Named("entityService")
   private EntityService _entityService;
+
+  @Inject
+  @Named("dataHubTokenService")
+  private StatefulTokenService _tokenService;
 
   private AuthenticatorChain authenticatorChain;
 
@@ -109,8 +114,12 @@ public class AuthenticationFilter implements Filter {
     boolean isAuthEnabled = this.configurationProvider.getAuthentication().isEnabled();
 
     // Create authentication context object to pass to authenticator instances. They can use it as needed.
-    final AuthenticatorContext authenticatorContext = new AuthenticatorContext(ImmutableMap.of(ENTITY_SERVICE,
-        this._entityService));
+    final AuthenticatorContext authenticatorContext = new AuthenticatorContext(ImmutableMap.of(
+        ENTITY_SERVICE,
+        this._entityService,
+        TOKEN_SERVICE,
+        this._tokenService
+    ));
 
     if (isAuthEnabled) {
       log.info("Auth is enabled. Building authenticator chain...");

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
@@ -56,7 +56,7 @@ public class StatefulTokenService extends StatelessTokenService {
     this._entityService = entityService;
     this._revokedTokenCache = CacheBuilder.newBuilder()
         .maximumSize(10000)
-        .expireAfterWrite(6, TimeUnit.HOURS)
+        .expireAfterWrite(1, TimeUnit.MINUTES)
         .build(new CacheLoader<String, Boolean>() {
           @Override
           public Boolean load(final String key) {

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -131,7 +131,7 @@ def test_non_admin_can_create_list_revoke_tokens():
     user_tokenId = res_data["data"]["createAccessToken"]["metadata"]["id"]
 
     # User should be able to list his own token
-    res_data = listAccessTokens(user_session, [{"field": "actorUrn","value": "urn:li:corpuser:user"}])
+    res_data = listAccessTokens(user_session, [{"field": "ownerUrn","value": "urn:li:corpuser:user"}])
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None
@@ -148,7 +148,7 @@ def test_non_admin_can_create_list_revoke_tokens():
     assert res_data["data"]["revokeAccessToken"] == True
 
     # Using a normal account, check that all its tokens where removed.
-    res_data = listAccessTokens(user_session, [{"field": "actorUrn","value": "urn:li:corpuser:user"}])
+    res_data = listAccessTokens(user_session, [{"field": "ownerUrn","value": "urn:li:corpuser:user"}])
     assert res_data
     assert res_data["data"]
     assert res_data["data"]["listAccessTokens"]["total"] is not None


### PR DESCRIPTION
In this PR we fix 2 issues:

1. Reduce the cache timeout for access tokens - this means that once a token is revoked it will more quickly begin being rejected. Previous cache timeout was 6 hours which can cause problems when multiple instances are in play (or even in same instance), new one set to 1 minute.
2. Fix the ListAccessTokensResolver to correctly check the "owner" filter instead of the actor filter for fetching tokens owned by a particular user (used to display access tokens in the UI)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)