### PR TITLE
refactor(ui): Misc improvements to Dataset Assertions UI

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetHealthResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetHealthResolver.java
@@ -124,7 +124,7 @@ public class DatasetHealthResolver implements DataFetcher<CompletableFuture<Heal
 
       final GenericTable assertionRunResults = getAssertionRunsTable(datasetUrn);
 
-      if (!assertionRunResults.hasRows()) {
+      if (!assertionRunResults.hasRows() || assertionRunResults.getRows().size() == 0) {
         // No assertion run results found. Return empty health!
         return null;
       }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetHealthResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetHealthResolver.java
@@ -28,7 +28,6 @@ import com.linkedin.timeseries.GroupingBucketType;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetHealthResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetHealthResolver.java
@@ -122,7 +122,14 @@ public class DatasetHealthResolver implements DataFetcher<CompletableFuture<Heal
           .stream()
           .map(relationship -> relationship.getEntity().toString()).collect(Collectors.toSet());
 
-      final List<String> failingAssertionUrns = getFailingAssertionUrns(datasetUrn, activeAssertionUrns);
+      final GenericTable assertionRunResults = getAssertionRunsTable(datasetUrn);
+
+      if (!assertionRunResults.hasRows()) {
+        // No assertion run results found. Return empty health!
+        return null;
+      }
+
+      final List<String> failingAssertionUrns = getFailingAssertionUrns(assertionRunResults, activeAssertionUrns);
 
       // Finally compute & return the health.
       final Health health = new Health();
@@ -141,20 +148,18 @@ public class DatasetHealthResolver implements DataFetcher<CompletableFuture<Heal
     return null;
   }
 
-  private List<String> getFailingAssertionUrns(final String asserteeUrn, final Set<String> candidateAssertionUrns) {
-    // Query timeseries backend
-    GenericTable result = _timeseriesAspectService.getAggregatedStats(
+  private GenericTable getAssertionRunsTable(final String asserteeUrn) {
+    return _timeseriesAspectService.getAggregatedStats(
         Constants.ASSERTION_ENTITY_NAME,
         Constants.ASSERTION_RUN_EVENT_ASPECT_NAME,
         createAssertionAggregationSpecs(),
         createAssertionsFilter(asserteeUrn),
         createAssertionGroupingBuckets());
-    if (!result.hasRows()) {
-      // No completed assertion runs found. Return empty list.
-      return Collections.emptyList();
-    }
+  }
+
+  private List<String> getFailingAssertionUrns(final GenericTable assertionRunsResult, final Set<String> candidateAssertionUrns) {
     // Create the buckets based on the result
-    return resultToFailedAssertionUrns(result.getRows(), candidateAssertionUrns);
+    return resultToFailedAssertionUrns(assertionRunsResult.getRows(), candidateAssertionUrns);
   }
 
   private Filter createAssertionsFilter(final String datasetUrn) {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHealthStatus.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHealthStatus.tsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import { Tooltip } from 'antd';
+import styled from 'styled-components';
 import { getHealthIcon } from '../../../../../shared/health/healthUtils';
 import { HealthStatus } from '../../../../../../types.generated';
+
+const StatusContainer = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-left: 8px;
+`;
 
 type Props = {
     status: HealthStatus;
@@ -11,8 +19,8 @@ type Props = {
 export const EntityHealthStatus = ({ status, message }: Props) => {
     const icon = getHealthIcon(status, 18);
     return (
-        <div style={{ paddingLeft: 12, paddingRight: 12, paddingTop: 4, paddingBottom: 4 }}>
+        <StatusContainer>
             <Tooltip title={message}>{icon}</Tooltip>
-        </div>
+        </StatusContainer>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
@@ -1,5 +1,5 @@
-import { Popover, Typography } from 'antd';
-import React from 'react';
+import { Popover, Typography, Button } from 'antd';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import {
     AssertionStdAggregation,
@@ -10,10 +10,11 @@ import {
     SchemaFieldRef,
 } from '../../../../../../types.generated';
 import { getFormattedParameterValue } from './assertionUtils';
+import { DatasetAssertionLogicModal } from './DatasetAssertionLogicModal';
 
-const SqlText = styled.pre`
-    margin: 0px;
+const ViewLogicButton = styled(Button)`
     padding: 0px;
+    margin: 0px;
 `;
 
 type Props = {
@@ -314,7 +315,7 @@ const TOOLTIP_MAX_WIDTH = 440;
  */
 export const DatasetAssertionDescription = ({ assertionInfo }: Props) => {
     const { scope, aggregation, fields, operator, parameters, nativeType, nativeParameters, logic } = assertionInfo;
-
+    const [isLogicVisible, setIsLogicVisible] = useState(false);
     /**
      * Build a description component from a) input (aggregation, inputs) b) the operator text
      */
@@ -342,7 +343,19 @@ export const DatasetAssertionDescription = ({ assertionInfo }: Props) => {
                 </>
             }
         >
-            <div>{(logic && <SqlText>{logic}</SqlText>) || description}</div>
+            <div>{description}</div>
+            {logic && (
+                <div>
+                    <ViewLogicButton onClick={() => setIsLogicVisible(true)} type="link">
+                        View Logic
+                    </ViewLogicButton>
+                </div>
+            )}
+            <DatasetAssertionLogicModal
+                logic={logic || 'N/A'}
+                visible={isLogicVisible}
+                onClose={() => setIsLogicVisible(false)}
+            />
         </Popover>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionLogicModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionLogicModal.tsx
@@ -1,0 +1,24 @@
+import { Modal, Button } from 'antd';
+import React from 'react';
+import Query from '../Queries/Query';
+
+export type AssertionsSummary = {
+    totalAssertions: number;
+    totalRuns: number;
+    failedRuns: number;
+    succeededRuns: number;
+};
+
+type Props = {
+    logic: string;
+    visible: boolean;
+    onClose: () => void;
+};
+
+export const DatasetAssertionLogicModal = ({ logic, visible, onClose }: Props) => {
+    return (
+        <Modal visible={visible} onCancel={onClose} footer={<Button onClick={onClose}>Close</Button>}>
+            <Query query={logic} />
+        </Modal>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionsSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionsSummary.tsx
@@ -23,7 +23,7 @@ const SummaryMessage = styled.div`
 
 const SummaryTitle = styled(Typography.Title)`
     && {
-        padding-bottom: 00px;
+        padding-bottom: 0px;
         margin-bottom: 0px;
     }
 `;

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionsSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionsSummary.tsx
@@ -6,9 +6,9 @@ import { ANTD_GRAY } from '../../../constants';
 
 const SummaryHeader = styled.div`
     width: 100%;
-    height: 80px;
     padding-left: 40px;
-    padding-top: 0px;
+    padding-top: 20px;
+    padding-bottom: 20px;
     display: flex;
     align-items: center;
     border-bottom: 1px solid ${ANTD_GRAY[4.5]};
@@ -23,7 +23,7 @@ const SummaryMessage = styled.div`
 
 const SummaryTitle = styled(Typography.Title)`
     && {
-        padding-bottom: 0px;
+        padding-bottom: 00px;
         margin-bottom: 0px;
     }
 `;

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/ValidationsTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/ValidationsTab.tsx
@@ -54,7 +54,8 @@ export const ValidationsTab = () => {
     const [view, setView] = useState(ViewType.ASSERTIONS);
 
     const assertions = (data && data.dataset?.assertions?.assertions?.map((assertion) => assertion as Assertion)) || [];
-    const totalAssertions = data?.dataset?.assertions?.total || undefined;
+    const maybeTotalAssertions = data?.dataset?.assertions?.total || undefined;
+    const effectiveTotalAssertions = maybeTotalAssertions || 0;
     const filteredAssertions = assertions.filter((assertion) => !removedUrns.includes(assertion.urn));
 
     const passingTests = (entityData as any)?.testResults?.passing || [];
@@ -62,12 +63,12 @@ export const ValidationsTab = () => {
     const totalTests = maybeFailingTests.length + passingTests.length;
 
     useEffect(() => {
-        if (totalTests > 0 && totalAssertions === 0) {
+        if (totalTests > 0 && maybeTotalAssertions === 0) {
             setView(ViewType.TESTS);
         } else {
             setView(ViewType.ASSERTIONS);
         }
-    }, [totalTests, totalAssertions]);
+    }, [totalTests, maybeTotalAssertions]);
 
     // Pre-sort the list of assertions based on which has been most recently executed.
     assertions.sort(sortAssertions);
@@ -76,9 +77,13 @@ export const ValidationsTab = () => {
         <>
             <TabToolbar>
                 <div>
-                    <Button type="text" disabled={totalAssertions === 0} onClick={() => setView(ViewType.ASSERTIONS)}>
+                    <Button
+                        type="text"
+                        disabled={effectiveTotalAssertions === 0}
+                        onClick={() => setView(ViewType.ASSERTIONS)}
+                    >
                         <FileProtectOutlined />
-                        Assertions ({totalAssertions})
+                        Assertions ({effectiveTotalAssertions})
                     </Button>
                     <Button type="text" disabled={totalTests === 0} onClick={() => setView(ViewType.TESTS)}>
                         <FileDoneOutlined />

--- a/metadata-ingestion/examples/recipes/file_to_datahub_rest.dhub.yaml
+++ b/metadata-ingestion/examples/recipes/file_to_datahub_rest.dhub.yaml
@@ -3,11 +3,10 @@
 source:
   type: "file"
   config:
-    filename: "./examples/mce_files/assertion_test.json"
+    filename: "./examples/mce_files/bootstrap_mce.json"
 
 # see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
 sink:
   type: "datahub-rest"
   config:
     server: "http://localhost:8080"
-    token: eyJhbGciOiJIUzI1NiJ9.eyJhY3RvclR5cGUiOiJVU0VSIiwiYWN0b3JJZCI6ImRhdGFodWIiLCJ0eXBlIjoiUEVSU09OQUwiLCJ2ZXJzaW9uIjoiMiIsImV4cCI6MTY1Nzc0NTAyOCwianRpIjoiNDNmMDEwNGUtNjg1Ni00MmNmLWJmOWItNzhjNGZhMzYzMTUxIiwic3ViIjoiZGF0YWh1YiIsImlzcyI6ImRhdGFodWItbWV0YWRhdGEtc2VydmljZSJ9.RCHm5Z1TtAbHKvUfzWpCcC4ZGEM7EvMg8LKLSZBxoqI

--- a/metadata-ingestion/examples/recipes/file_to_datahub_rest.dhub.yaml
+++ b/metadata-ingestion/examples/recipes/file_to_datahub_rest.dhub.yaml
@@ -3,10 +3,11 @@
 source:
   type: "file"
   config:
-    filename: "./examples/mce_files/bootstrap_mce.json"
+    filename: "./examples/mce_files/assertion_test.json"
 
 # see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
 sink:
   type: "datahub-rest"
   config:
     server: "http://localhost:8080"
+    token: eyJhbGciOiJIUzI1NiJ9.eyJhY3RvclR5cGUiOiJVU0VSIiwiYWN0b3JJZCI6ImRhdGFodWIiLCJ0eXBlIjoiUEVSU09OQUwiLCJ2ZXJzaW9uIjoiMiIsImV4cCI6MTY1Nzc0NTAyOCwianRpIjoiNDNmMDEwNGUtNjg1Ni00MmNmLWJmOWItNzhjNGZhMzYzMTUxIiwic3ViIjoiZGF0YWh1YiIsImlzcyI6ImRhdGFodWItbWV0YWRhdGEtc2VydmljZSJ9.RCHm5Z1TtAbHKvUfzWpCcC4ZGEM7EvMg8LKLSZBxoqI


### PR DESCRIPTION
**Summary**

This PR fixes and improves various aspects of the Assertions UI, including:

1. If you have no assertion runs, you will not see a pass or fail status next to dataset name
2. Default to the assertions tab when assertions are present (do not require an extra click) 
3. Support viewable logic along with an assertion definition (in a logic modal)
4. Fix inconsistent remove assertions flow 

**Screenshots**

<img width="1074" alt="Screen Shot 2022-06-13 at 2 56 25 PM" src="https://user-images.githubusercontent.com/17549204/173452111-39675c43-3405-489f-ba47-51fd06e5ebe2.png">
<img width="1081" alt="Screen Shot 2022-06-13 at 2 56 43 PM" src="https://user-images.githubusercontent.com/17549204/173452121-04e29cdf-e2b2-49b7-975c-d780186c4cca.png">
<img width="703" alt="Screen Shot 2022-06-13 at 2 56 48 PM" src="https://user-images.githubusercontent.com/17549204/173452125-b0bc0521-ce83-4cba-a26f-65419d6a1891.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)