### PR TITLE
chore(deps): Bump Nimbus Jose JWT dependency

### DIFF
--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -41,7 +41,9 @@ dependencies {
 
   implementation(externalDependency.pac4j) {
     exclude group: "net.minidev", module: "json-smart"
+    exclude group: "com.nimbusds", module: "nimbus-jose-jwt"
   }
+  implementation "com.nimbusds:nimbus-jose-jwt:7.9"
   implementation externalDependency.jsonSmart
   implementation externalDependency.playPac4j
   implementation externalDependency.shiroCore


### PR DESCRIPTION
Attempts to fix CVE-2019-17195 which comes from com.nimbusds:nimbus-jose-jwt dependency transitively from Pac4J. Fix is to exclude jar and include a specific version.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)