### PR TITLE
feat(ui) Update the max text length of Terms/Term Groups

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
@@ -104,7 +104,7 @@ function CreateGlossaryEntityModal(props: Props) {
                                 message: `Enter a ${entityRegistry.getEntityName(entityType)} name.`,
                             },
                             { whitespace: true },
-                            { min: 1, max: 50 },
+                            { min: 1, max: 100 },
                         ]}
                         hasFeedback
                     >


### PR DESCRIPTION
Updates the max Term and Term Group text length to be 100 instead of 50. 50 was unnecessarily constrictive for our users who may want rather long Term or Term Group names.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)