### PR TITLE
fix(restore-indices): Do not fail on MAE row count diff

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -100,8 +100,8 @@ public class SendMAEStep implements UpgradeStep {
           AspectSpec aspectSpec = entitySpec.getAspectSpec(aspectName);
           if (aspectSpec == null) {
             context.report()
-                .addLine(String.format("Failed to find aspect with name %s associated with entity named %s",
-                    aspectName, entityName));
+                .addLine(String.format("Failed to find aspect with name %s associated with entity named %s", aspectName,
+                    entityName));
             continue;
           }
 
@@ -135,11 +135,7 @@ public class SendMAEStep implements UpgradeStep {
         }
       }
       if (totalRowsMigrated != rowCount) {
-        context.report()
-            .addLine(
-                String.format("Number of MAEs sent %s does not equal the number of input rows %s...", totalRowsMigrated,
-                    rowCount));
-        return new DefaultUpgradeStepResult(id(), UpgradeStepResult.Result.FAILED);
+        context.report().addLine(String.format("Failed to send MAEs for %d rows...", rowCount - totalRowsMigrated));
       }
       return new DefaultUpgradeStepResult(id(), UpgradeStepResult.Result.SUCCEEDED);
     };


### PR DESCRIPTION
A few rows may fail to get restored (i.e. compatibility issues, deprecated aspects, etc.) 
Do not mark job as failed even if some rows fail to get restored. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)