### PR TITLE
fix(business glossary): setting properties to be empty if the node has no properties aspect

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryNodeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryNodeMapper.java
@@ -54,6 +54,11 @@ public class GlossaryNodeMapper implements ModelMapper<EntityResponse, GlossaryN
 
   private void mapGlossaryNodeKey(@Nonnull GlossaryNode glossaryNode, @Nonnull DataMap dataMap) {
     GlossaryNodeKey glossaryNodeKey = new GlossaryNodeKey(dataMap);
+
+    if (glossaryNode.getProperties() == null) {
+      glossaryNode.setProperties(new GlossaryNodeProperties());
+    }
+
     if (glossaryNode.getProperties().getName() == null) {
       glossaryNode.getProperties().setName(glossaryNodeKey.getName());
     }


### PR DESCRIPTION
If the node has no properties aspect, it will reach the key mapper with a null `properties` field. This fix prevents an NPE.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)