### PR TITLE
fix(glue): fix glue profiling config option

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -716,7 +716,7 @@ class GlueSource(Source):
             dataset_profile.rowCount = int(
                 float(table_stats[self.source_config.profiling.row_count])
             )
-        if self.source_config.profiling.row_count in table_stats:
+        if self.source_config.profiling.column_count in table_stats:
             dataset_profile.columnCount = int(
                 float(table_stats[self.source_config.profiling.column_count])
             )


### PR DESCRIPTION
I am trying to modify the line because it seems strange to check the row_count value when allocating the column_count value.

Please let me know if there is anything I'm doing wrong


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)