### PR TITLE
fix(jaas): fixed auth.jaas.enabled option parsing

### DIFF
--- a/datahub-frontend/app/auth/JAASConfigs.java
+++ b/datahub-frontend/app/auth/JAASConfigs.java
@@ -11,9 +11,7 @@ public class JAASConfigs {
     private Boolean _isEnabled = true;
 
     public JAASConfigs(final com.typesafe.config.Config configs) {
-        if (configs.hasPath(JAAS_ENABLED_CONFIG_PATH)
-                && Boolean.FALSE.equals(
-                        Boolean.parseBoolean(configs.getValue(JAAS_ENABLED_CONFIG_PATH).toString()))) {
+        if (configs.hasPath(JAAS_ENABLED_CONFIG_PATH) && !configs.getBoolean(JAAS_ENABLED_CONFIG_PATH)) {
             _isEnabled = false;
         }
     }


### PR DESCRIPTION
Previous implementation rendered config value as "Quoted(true)", thus value never could be interpreted as true

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)