### PR TITLE
fix(ingest): If there is no manager for a LDAP user (example: system account)

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -207,8 +207,10 @@ class LDAPSource(Source):
                     self.config.filter,
                     serverctrls=[self.lc],
                 )
-                _m_dn, m_attrs = self.ldap_client.result3(manager_msgid)[1][0]
-                manager_ldap = guess_person_ldap(m_attrs)
+                result = self.ldap_client.result3(manager_msgid)
+                if result[1]:
+                    _m_dn, m_attrs = result[1][0]
+                    manager_ldap = guess_person_ldap(m_attrs)
             except ldap.LDAPError as e:
                 self.report.report_warning(
                     dn, "manager LDAP search failed: {}".format(e)


### PR DESCRIPTION
The first element of the results3 tuple could be an empty array [], for example, if it is a system account and it has no managers. Thus, the the current code is failing with "out of range" error. I added a quick check if array is not empty which has fixed this error. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)