### PR TITLE
feat(upgrade) Check version when determining to run RestoreGlossaryIndices step

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.boot.steps;
 
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspectMap;
@@ -36,7 +37,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor
 public class RestoreGlossaryIndices implements BootstrapStep {
-  private static final String VERSION = "0";
+  private static final String VERSION = "1";
   private static final String UPGRADE_ID = "restore-glossary-indices-ui";
   private static final Urn GLOSSARY_UPGRADE_URN =
       EntityKeyUtils.convertEntityKeyToUrn(new DataHubUpgradeKey().setId(UPGRADE_ID), Constants.DATA_HUB_UPGRADE_ENTITY_NAME);
@@ -67,9 +68,18 @@ public class RestoreGlossaryIndices implements BootstrapStep {
     Thread.sleep(SLEEP_SECONDS * 1000);
 
     try {
-      if (_entityService.exists(GLOSSARY_UPGRADE_URN)) {
-        log.info("Glossary Upgrade has run before. Skipping");
-        return;
+      EntityResponse response = _entityService.getEntityV2(
+          Constants.DATA_HUB_UPGRADE_ENTITY_NAME,
+          GLOSSARY_UPGRADE_URN,
+          Collections.singleton(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME)
+      );
+      if (response != null && response.getAspects().containsKey(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME)) {
+        DataMap dataMap = response.getAspects().get(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME).getValue().data();
+        DataHubUpgradeRequest request = new DataHubUpgradeRequest(dataMap);
+        if (request.hasVersion() && request.getVersion().equals(VERSION)) {
+          log.info("Glossary Upgrade has run before with this version. Skipping");
+          return;
+        }
       }
 
       final AspectSpec termAspectSpec =
@@ -130,7 +140,7 @@ public class RestoreGlossaryIndices implements BootstrapStep {
     );
 
     //  Loop over Terms and produce changelog
-    for (Urn termUrn: termUrns) {
+    for (Urn termUrn : termUrns) {
       EntityResponse termEntityResponse = termInfoResponses.get(termUrn);
       if (termEntityResponse == null) {
         log.warn("Term not in set of entity responses {}", termUrn);
@@ -171,7 +181,7 @@ public class RestoreGlossaryIndices implements BootstrapStep {
     );
 
     //  Loop over Nodes and produce changelog
-    for (Urn nodeUrn: nodeUrns) {
+    for (Urn nodeUrn : nodeUrns) {
       EntityResponse nodeEntityResponse = nodeInfoResponses.get(nodeUrn);
       if (nodeEntityResponse == null) {
         log.warn("Node not in set of entity responses {}", nodeUrn);

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndices.java
@@ -42,7 +42,7 @@ public class RestoreGlossaryIndices implements BootstrapStep {
   private static final Urn GLOSSARY_UPGRADE_URN =
       EntityKeyUtils.convertEntityKeyToUrn(new DataHubUpgradeKey().setId(UPGRADE_ID), Constants.DATA_HUB_UPGRADE_ENTITY_NAME);
   private static final Integer BATCH_SIZE = 1000;
-  private static final Integer SLEEP_SECONDS = 30;
+  private static final Integer SLEEP_SECONDS = 120;
 
   private final EntityService _entityService;
   private final EntitySearchService _entitySearchService;
@@ -56,7 +56,7 @@ public class RestoreGlossaryIndices implements BootstrapStep {
   @Nonnull
   @Override
   public ExecutionMode getExecutionMode() {
-    return ExecutionMode.BLOCKING;
+    return ExecutionMode.ASYNC;
   }
 
   @Override

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndicesTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreGlossaryIndicesTest.java
@@ -30,7 +30,51 @@ import java.util.Map;
 
 public class RestoreGlossaryIndicesTest {
 
+  private static final String VERSION_1 = "1";
+  private static final String VERSION_2 = "2";
   private static final String GLOSSARY_UPGRADE_URN = String.format("urn:li:%s:%s", Constants.DATA_HUB_UPGRADE_ENTITY_NAME, "restore-glossary-indices-ui");
+
+  private void mockGetTermInfo(Urn glossaryTermUrn, EntitySearchService mockSearchService, EntityService mockService) throws Exception {
+    Map<String, EnvelopedAspect> termInfoAspects = new HashMap<>();
+    termInfoAspects.put(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(new GlossaryTermInfo().setName("test").data())));
+    Map<Urn, EntityResponse> termInfoResponses = new HashMap<>();
+    termInfoResponses.put(glossaryTermUrn, new EntityResponse().setUrn(glossaryTermUrn).setAspects(new EnvelopedAspectMap(termInfoAspects)));
+    Mockito.when(mockSearchService.search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, 0, 1000))
+        .thenReturn(new SearchResult().setNumEntities(1).setEntities(new SearchEntityArray(ImmutableList.of(new SearchEntity().setEntity(glossaryTermUrn)))));
+    Mockito.when(mockService.getEntitiesV2(
+            Constants.GLOSSARY_TERM_ENTITY_NAME,
+            new HashSet<>(Collections.singleton(glossaryTermUrn)),
+            Collections.singleton(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)))
+        .thenReturn(termInfoResponses);
+  }
+
+  private void mockGetNodeInfo(Urn glossaryNodeUrn, EntitySearchService mockSearchService, EntityService mockService) throws Exception {
+    Map<String, EnvelopedAspect> nodeInfoAspects = new HashMap<>();
+    nodeInfoAspects.put(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(new GlossaryNodeInfo().setName("test").data())));
+    Map<Urn, EntityResponse> nodeInfoResponses = new HashMap<>();
+    nodeInfoResponses.put(glossaryNodeUrn, new EntityResponse().setUrn(glossaryNodeUrn).setAspects(new EnvelopedAspectMap(nodeInfoAspects)));
+    Mockito.when(mockSearchService.search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, 0, 1000))
+        .thenReturn(new SearchResult().setNumEntities(1).setEntities(new SearchEntityArray(ImmutableList.of(new SearchEntity().setEntity(glossaryNodeUrn)))));
+    Mockito.when(mockService.getEntitiesV2(
+            Constants.GLOSSARY_NODE_ENTITY_NAME,
+            new HashSet<>(Collections.singleton(glossaryNodeUrn)),
+            Collections.singleton(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)
+        ))
+        .thenReturn(nodeInfoResponses);
+  }
+
+  private AspectSpec mockGlossaryAspectSpecs(EntityRegistry mockRegistry) {
+    EntitySpec entitySpec = Mockito.mock(EntitySpec.class);
+    AspectSpec aspectSpec = Mockito.mock(AspectSpec.class);
+    //  Mock for Terms
+    Mockito.when(mockRegistry.getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME)).thenReturn(entitySpec);
+    Mockito.when(entitySpec.getAspectSpec(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)).thenReturn(aspectSpec);
+    //  Mock for Nodes
+    Mockito.when(mockRegistry.getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME)).thenReturn(entitySpec);
+    Mockito.when(entitySpec.getAspectSpec(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)).thenReturn(aspectSpec);
+
+    return aspectSpec;
+  }
 
   @Test
   public void testExecuteFirstTime() throws Exception {
@@ -41,49 +85,83 @@ public class RestoreGlossaryIndicesTest {
     final EntityRegistry mockRegistry = Mockito.mock(EntityRegistry.class);
 
     final Urn upgradeEntityUrn = Urn.createFromString(GLOSSARY_UPGRADE_URN);
-    Mockito.when(mockService.exists(upgradeEntityUrn)).thenReturn(false);
+    Mockito.when(mockService.getEntityV2(
+        Constants.DATA_HUB_UPGRADE_ENTITY_NAME,
+        upgradeEntityUrn,
+        Collections.singleton(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME)
+    )).thenReturn(null);
 
+    mockGetTermInfo(glossaryTermUrn, mockSearchService, mockService);
+    mockGetNodeInfo(glossaryNodeUrn, mockSearchService, mockService);
 
-    //  Mock termInfoResponses and getting aspectSpec
-    Map<String, EnvelopedAspect> termInfoAspects = new HashMap<>();
-    termInfoAspects.put(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(new GlossaryTermInfo().setName("test").data())));
-    Map<Urn, EntityResponse> termInfoResponses = new HashMap<>();
-    termInfoResponses.put(glossaryTermUrn, new EntityResponse().setUrn(glossaryTermUrn).setAspects(new EnvelopedAspectMap(termInfoAspects)));
-    Mockito.when(mockSearchService.search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, 0, 1000))
-        .thenReturn(new SearchResult().setNumEntities(1).setEntities(new SearchEntityArray(ImmutableList.of(new SearchEntity().setEntity(glossaryTermUrn)))));
-    Mockito.when(mockService.getEntitiesV2(
-        Constants.GLOSSARY_TERM_ENTITY_NAME,
-            new HashSet<>(Collections.singleton(glossaryTermUrn)),
-            Collections.singleton(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)))
-        .thenReturn(termInfoResponses);
-
-    //  Mock nodeInfoResponses and getting aspectSpec
-    Map<String, EnvelopedAspect> nodeInfoAspects = new HashMap<>();
-    nodeInfoAspects.put(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(new GlossaryNodeInfo().setName("test").data())));
-    Map<Urn, EntityResponse> nodeInfoResponses = new HashMap<>();
-    nodeInfoResponses.put(glossaryNodeUrn, new EntityResponse().setUrn(glossaryNodeUrn).setAspects(new EnvelopedAspectMap(nodeInfoAspects)));
-    Mockito.when(mockSearchService.search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, 0, 1000))
-        .thenReturn(new SearchResult().setNumEntities(1).setEntities(new SearchEntityArray(ImmutableList.of(new SearchEntity().setEntity(glossaryNodeUrn)))));
-    Mockito.when(mockService.getEntitiesV2(
-        Constants.GLOSSARY_NODE_ENTITY_NAME,
-            new HashSet<>(Collections.singleton(glossaryNodeUrn)),
-            Collections.singleton(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)
-        ))
-        .thenReturn(nodeInfoResponses);
-
-    EntitySpec entitySpec = Mockito.mock(EntitySpec.class);
-    AspectSpec aspectSpec = Mockito.mock(AspectSpec.class);
-    //  Mock for Terms
-    Mockito.when(mockRegistry.getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME)).thenReturn(entitySpec);
-    Mockito.when(entitySpec.getAspectSpec(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME)).thenReturn(aspectSpec);
-    //  Mock for Nodes
-    Mockito.when(mockRegistry.getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME)).thenReturn(entitySpec);
-    Mockito.when(entitySpec.getAspectSpec(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME)).thenReturn(aspectSpec);
+    AspectSpec aspectSpec = mockGlossaryAspectSpecs(mockRegistry);
 
     RestoreGlossaryIndices restoreIndicesStep = new RestoreGlossaryIndices(mockService, mockSearchService, mockRegistry);
     restoreIndicesStep.execute();
 
 
+    Mockito.verify(mockRegistry, Mockito.times(1)).getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME);
+    Mockito.verify(mockRegistry, Mockito.times(1)).getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME);
+    Mockito.verify(mockService, Mockito.times(2)).ingestProposal(
+        Mockito.any(MetadataChangeProposal.class),
+        Mockito.any(AuditStamp.class)
+        );
+    Mockito.verify(mockService, Mockito.times(1)).produceMetadataChangeLog(
+        Mockito.eq(glossaryTermUrn),
+        Mockito.eq(Constants.GLOSSARY_TERM_ENTITY_NAME),
+        Mockito.eq(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME),
+        Mockito.eq(aspectSpec),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(ChangeType.RESTATE)
+    );
+    Mockito.verify(mockService, Mockito.times(1)).produceMetadataChangeLog(
+        Mockito.eq(glossaryNodeUrn),
+        Mockito.eq(Constants.GLOSSARY_NODE_ENTITY_NAME),
+        Mockito.eq(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME),
+        Mockito.eq(aspectSpec),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(null),
+        Mockito.eq(null),
+        Mockito.any(),
+        Mockito.eq(ChangeType.RESTATE)
+    );
+  }
+
+  @Test
+  public void testExecutesWithNewVersion() throws Exception {
+    final Urn glossaryTermUrn = Urn.createFromString("urn:li:glossaryTerm:11115397daf94708a8822b8106cfd451");
+    final Urn glossaryNodeUrn = Urn.createFromString("urn:li:glossaryNode:22225397daf94708a8822b8106cfd451");
+    final EntityService mockService = Mockito.mock(EntityService.class);
+    final EntitySearchService mockSearchService = Mockito.mock(EntitySearchService.class);
+    final EntityRegistry mockRegistry = Mockito.mock(EntityRegistry.class);
+
+    final Urn upgradeEntityUrn = Urn.createFromString(GLOSSARY_UPGRADE_URN);
+    com.linkedin.upgrade.DataHubUpgradeRequest upgradeRequest = new com.linkedin.upgrade.DataHubUpgradeRequest().setVersion(VERSION_2);
+    Map<String, EnvelopedAspect> upgradeRequestAspects = new HashMap<>();
+    upgradeRequestAspects.put(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(upgradeRequest.data())));
+    EntityResponse response = new EntityResponse().setAspects(new EnvelopedAspectMap(upgradeRequestAspects));
+    Mockito.when(mockService.getEntityV2(
+        Constants.DATA_HUB_UPGRADE_ENTITY_NAME,
+        upgradeEntityUrn,
+        Collections.singleton(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME)
+    )).thenReturn(response);
+
+    mockGetTermInfo(glossaryTermUrn, mockSearchService, mockService);
+    mockGetNodeInfo(glossaryNodeUrn, mockSearchService, mockService);
+
+    AspectSpec aspectSpec = mockGlossaryAspectSpecs(mockRegistry);
+
+    RestoreGlossaryIndices restoreIndicesStep = new RestoreGlossaryIndices(mockService, mockSearchService, mockRegistry);
+    restoreIndicesStep.execute();
+
+
+    Mockito.verify(mockRegistry, Mockito.times(1)).getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME);
+    Mockito.verify(mockRegistry, Mockito.times(1)).getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME);
     Mockito.verify(mockService, Mockito.times(2)).ingestProposal(
         Mockito.any(MetadataChangeProposal.class),
         Mockito.any(AuditStamp.class)
@@ -120,10 +198,24 @@ public class RestoreGlossaryIndicesTest {
     final Urn glossaryNodeUrn = Urn.createFromString("urn:li:glossaryNode:22225397daf94708a8822b8106cfd451");
     final EntityService mockService = Mockito.mock(EntityService.class);
     final EntitySearchService mockSearchService = Mockito.mock(EntitySearchService.class);
+    final EntityRegistry mockRegistry = Mockito.mock(EntityRegistry.class);
 
     final Urn upgradeEntityUrn = Urn.createFromString(GLOSSARY_UPGRADE_URN);
-    Mockito.when(mockService.exists(upgradeEntityUrn)).thenReturn(true);
+    com.linkedin.upgrade.DataHubUpgradeRequest upgradeRequest = new com.linkedin.upgrade.DataHubUpgradeRequest().setVersion(VERSION_1);
+    Map<String, EnvelopedAspect> upgradeRequestAspects = new HashMap<>();
+    upgradeRequestAspects.put(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME, new EnvelopedAspect().setValue(new Aspect(upgradeRequest.data())));
+    EntityResponse response = new EntityResponse().setAspects(new EnvelopedAspectMap(upgradeRequestAspects));
+    Mockito.when(mockService.getEntityV2(
+        Constants.DATA_HUB_UPGRADE_ENTITY_NAME,
+        upgradeEntityUrn,
+        Collections.singleton(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME)
+    )).thenReturn(response);
 
+    RestoreGlossaryIndices restoreIndicesStep = new RestoreGlossaryIndices(mockService, mockSearchService, mockRegistry);
+    restoreIndicesStep.execute();
+
+    Mockito.verify(mockRegistry, Mockito.times(0)).getEntitySpec(Constants.GLOSSARY_TERM_ENTITY_NAME);
+    Mockito.verify(mockRegistry, Mockito.times(0)).getEntitySpec(Constants.GLOSSARY_NODE_ENTITY_NAME);
     Mockito.verify(mockSearchService, Mockito.times(0)).search(Constants.GLOSSARY_TERM_ENTITY_NAME, "", null, null, 0, 1000);
     Mockito.verify(mockSearchService, Mockito.times(0)).search(Constants.GLOSSARY_NODE_ENTITY_NAME, "", null, null, 0, 1000);
     Mockito.verify(mockService, Mockito.times(0)).ingestProposal(


### PR DESCRIPTION
Previously, we would only check that the datahub upgrade urn existed for the restore glossary indices step to determine if we should run the step. If it existed we did not run, and if not, we ran it.

Now, we may have situations where someone may have run the upgrade step but we want them to run it again, so we can check a version! The `DataHubUpgradeRequest` aspect was already storing a version, and for this step we previously set it to `0`. Now we check to get that aspect, and if it exists, and it has the same version as the const at the top of the file, skip the step. If it doesn't exist or the version is different, run the step.

Now to have users re-run the step we just need to change the `VERSION` at the top of the file. I do so here as we know we want some users to re-run this step.

Adds a new test for running with a new version (the diff looks confusing there)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)