### PR TITLE
fix(ui): load monaco-editor as a dependency and not from a third party CDN

### DIFF
--- a/datahub-web-react/craco.config.js
+++ b/datahub-web-react/craco.config.js
@@ -21,6 +21,13 @@ module.exports = {
                 new CopyWebpackPlugin({
                     patterns: [{ from: 'src/images', to: 'platforms' }],
                 }),
+                // Copy monaco-editor files to the build directory
+                new CopyWebpackPlugin({
+                    patterns: [
+                        { from: "node_modules/monaco-editor/min/vs/", to: "monaco-editor/vs" },
+                        { from: "node_modules/monaco-editor/min-maps/vs/", to: "monaco-editor/min-maps/vs" },
+                    ],
+                }),
             ],
         },
     },

--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -64,6 +64,7 @@
         "lodash.debounce": "^4.0.8",
         "miragejs": "^0.1.41",
         "moment-timezone": "^0.5.34",
+        "monaco-editor": "^0.28.1",
         "monaco-yaml": "^3.2.1",
         "query-string": "^6.13.8",
         "rc-table": "^7.13.1",

--- a/datahub-web-react/src/app/ingest/source/builder/YamlEditor.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/YamlEditor.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import Editor from '@monaco-editor/react';
+import Editor, { loader } from '@monaco-editor/react';
+
+loader.config({
+    paths: {
+        vs: `${process.env.PUBLIC_URL}/monaco-editor/vs`,
+    },
+});
 
 type Props = {
     initialText: string;

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -11575,6 +11575,11 @@ moment-timezone@^0.5.34:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+monaco-editor@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.28.1.tgz#732788ff2172d59e6d436b206da8cac715413940"
+  integrity sha512-P1vPqxB4B1ZFzTeR1ScggSp9/5NoQrLCq88fnlNUsuRAP1usEBN4TIpI2lw0AYIZNVIanHk0qwjze2uJwGOHUw==
+
 monaco-yaml@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/monaco-yaml/-/monaco-yaml-3.2.1.tgz#45ce9f7f8140dc26249ac99eb0a9e5a9ab9beb87"


### PR DESCRIPTION
This PR adds the monaco-editor as a dependency and loads the editor from the local directory and not from a third party CDN. This fixes potential issues where the CDN is not reachable (see also #4955) and of course it is better to have all dependencies in one place and not relying on a third party service.

As it is quite hard (to not say impossible?) to import the monaco-editor in a Create React App (there are many issues, comments, etc. which describes the issues with it), the files are copied from the monaco-editor package to the build directory using the CopyWebpackPlugin and are then loaded by the @monaco-editor/react package from there.

The version of the added monaco-editor package is exactly the version which is loaded by the current version of the @monaco-editor/react package, therefore there shouldn't be any differences.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)