### PR TITLE
feat(search) Allow users to update the number of search results per page

### DIFF
--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as QueryString from 'query-string';
 import { useHistory, useLocation, useParams } from 'react-router';
 import { Alert } from 'antd';
@@ -39,13 +39,15 @@ export const SearchPage = () => {
         .filter((filter) => filter.field === ENTITY_FILTER_NAME)
         .map((filter) => filter.value.toUpperCase() as EntityType);
 
+    const [numResultsPerPage, setNumResultsPerPage] = useState(SearchCfg.RESULTS_PER_PAGE);
+
     const { data, loading, error } = useGetSearchResultsForMultipleQuery({
         variables: {
             input: {
                 types: entityFilters,
                 query,
-                start: (page - 1) * SearchCfg.RESULTS_PER_PAGE,
-                count: SearchCfg.RESULTS_PER_PAGE,
+                start: (page - 1) * numResultsPerPage,
+                count: numResultsPerPage,
                 filters: filtersWithoutEntities,
             },
         },
@@ -118,6 +120,8 @@ export const SearchPage = () => {
                 loading={loading}
                 onChangeFilters={onChangeFilters}
                 onChangePage={onChangePage}
+                numResultsPerPage={numResultsPerPage}
+                setNumResultsPerPage={setNumResultsPerPage}
             />
         </SearchablePage>
     );

--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -131,6 +131,8 @@ interface Props {
     }) => Promise<SearchResultsInterface | null | undefined>;
     entityFilters: EntityType[];
     filtersWithoutEntities: FacetFilterInput[];
+    numResultsPerPage: number;
+    setNumResultsPerPage: (numResults: number) => void;
 }
 
 export const SearchResults = ({
@@ -145,6 +147,8 @@ export const SearchResults = ({
     callSearchOnVariables,
     entityFilters,
     filtersWithoutEntities,
+    numResultsPerPage,
+    setNumResultsPerPage,
 }: Props) => {
     const pageStart = searchResponse?.start || 0;
     const pageSize = searchResponse?.count || 0;
@@ -167,6 +171,10 @@ export const SearchResults = ({
 
     const onFilterSelect = (newFilters) => {
         onChangeFilters(newFilters);
+    };
+
+    const updateNumResults = (_currentNum: number, newNum: number) => {
+        setNumResultsPerPage(newNum);
     };
 
     const history = useHistory();
@@ -242,11 +250,13 @@ export const SearchResults = ({
                                 <PaginationControlContainer>
                                     <Pagination
                                         current={page}
-                                        pageSize={SearchCfg.RESULTS_PER_PAGE}
+                                        pageSize={numResultsPerPage}
                                         total={totalResults}
                                         showLessItems
                                         onChange={onChangePage}
-                                        showSizeChanger={false}
+                                        showSizeChanger={totalResults > SearchCfg.RESULTS_PER_PAGE}
+                                        onShowSizeChange={updateNumResults}
+                                        pageSizeOptions={['10', '20', '50']}
                                     />
                                 </PaginationControlContainer>
                                 {authenticatedUserUrn && (


### PR DESCRIPTION
Previously we were hardcoding the number of search results per page to be 10. Now it's dynamic and leverages Ant designs existing component to allow users to set how many results they want to see per page.

Here's what it looks like:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/28656603/174855543-dc6490c7-196d-4b31-8044-b616869a82fb.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)