### PR TITLE
[bug fix]: disabled create buttons

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -106,8 +106,8 @@ function EntityDropdown(props: Props) {
     };
 
     const canManageGlossaries = platformPrivileges
-        ? platformPrivileges.manageDomains
-        : me?.platformPrivileges.manageDomains;
+        ? platformPrivileges.manageGlossaries
+        : me?.platformPrivileges.manageGlossaries;
     const pageUrl = window.location.href;
     const isDeleteDisabled = !!entityData?.children?.count;
 


### PR DESCRIPTION
if you do not have the MANAGE DOMAINS privilege, the button to create new term/term group is grayed out:
![image](https://user-images.githubusercontent.com/50935738/175325536-4ca9ef7b-b818-4307-acf4-3f30bf073466.png)
It should have checked the MANAGE GLOSSARIES privilege instead.

