### PR TITLE
fix(siblings): Force merged urn to viewed entity urn

### DIFF
--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -89,7 +89,7 @@ export const combineEntityDataWithSiblings = <T>(baseEntity: T): T => {
 
     // eslint-disable-next-line @typescript-eslint/dot-notation
     const siblings: T[] = siblingAspect?.siblings || [];
-    const isPrimary = !!extractedBaseEntity?.siblings?.isPrimary; // curr base entity is primary?
+    const isPrimary = !!extractedBaseEntity?.siblings?.isPrimary;
 
     const combinedBaseEntity: any = siblings.reduce(
         (prev, current) =>

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -89,7 +89,7 @@ export const combineEntityDataWithSiblings = <T>(baseEntity: T): T => {
 
     // eslint-disable-next-line @typescript-eslint/dot-notation
     const siblings: T[] = siblingAspect?.siblings || [];
-    const isPrimary = !!extractedBaseEntity?.siblings?.isPrimary;
+    const isPrimary = !!extractedBaseEntity?.siblings?.isPrimary; // curr base entity is primary?
 
     const combinedBaseEntity: any = siblings.reduce(
         (prev, current) =>
@@ -99,6 +99,9 @@ export const combineEntityDataWithSiblings = <T>(baseEntity: T): T => {
             }),
         extractedBaseEntity,
     ) as T;
+
+    // Force the urn of the combined entity to the current entity urn.
+    combinedBaseEntity.urn = extractedBaseEntity.urn;
 
     return { [baseEntityKey]: combinedBaseEntity } as unknown as T;
 };


### PR DESCRIPTION
In recent work for siblings feature, we've mis-merged the URN field of the siblings by taking whichever is the primary. This does not make sense. This PR fixes this feature.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)