### PR TITLE
fix(ui): Support deleting references to glossary terms / nodes, users, assertions, and groups

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
@@ -14,6 +14,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -46,7 +47,16 @@ public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Bo
       if (isAuthorizedToDeleteAssertion(context, assertionUrn)) {
           try {
             _entityClient.deleteEntity(assertionUrn, context.getAuthentication());
-            _entityClient.deleteEntityReferences(assertionUrn, context.getAuthentication());
+
+            // Asynchronously Delete all references to the entity (to return quickly)
+            CompletableFuture.runAsync(() -> {
+              try {
+                _entityClient.deleteEntityReferences(assertionUrn, context.getAuthentication());
+              } catch (RemoteInvocationException e) {
+                log.error(String.format("Caught exception while attempting to clear all entity references for assertion with urn %s", urn), e);
+              }
+            });
+
             return true;
           } catch (Exception e) {
             throw new RuntimeException(String.format("Failed to perform delete against assertion with urn %s", assertionUrn), e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
@@ -46,6 +46,7 @@ public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Bo
       if (isAuthorizedToDeleteAssertion(context, assertionUrn)) {
           try {
             _entityClient.deleteEntity(assertionUrn, context.getAuthentication());
+            _entityClient.deleteEntityReferences(assertionUrn, context.getAuthentication());
             return true;
           } catch (Exception e) {
             throw new RuntimeException(String.format("Failed to perform delete against assertion with urn %s", assertionUrn), e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
@@ -18,11 +18,13 @@ import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
  * GraphQL Resolver that deletes an Assertion.
  */
+@Slf4j
 public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Boolean>>  {
 
   private final EntityClient _entityClient;
@@ -53,7 +55,7 @@ public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Bo
               try {
                 _entityClient.deleteEntityReferences(assertionUrn, context.getAuthentication());
               } catch (RemoteInvocationException e) {
-                log.error(String.format("Caught exception while attempting to clear all entity references for assertion with urn %s", urn), e);
+                log.error(String.format("Caught exception while attempting to clear all entity references for assertion with urn %s", assertionUrn), e);
               }
             });
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -38,12 +38,12 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
         try {
           _entityClient.deleteEntity(entityUrn, context.getAuthentication());
 
-          // Asynchronously Delete all references to the term (to return quickly)
+          // Asynchronously Delete all references to the entity (to return quickly)
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(entityUrn, context.getAuthentication());
             } catch (RemoteInvocationException e) {
-              log.error(String.format("Caught exception while attempting to clear all entity references for glossary term with urn %s", entityUrn), e);
+              log.error(String.format("Caught exception while attempting to clear all entity references for glossary entity with urn %s", entityUrn), e);
             }
           });
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -6,11 +6,14 @@ import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 
 
+@Slf4j
 public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
@@ -34,6 +37,16 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
 
         try {
           _entityClient.deleteEntity(entityUrn, context.getAuthentication());
+
+          // Asynchronously Delete all references to the term (to return quickly)
+          CompletableFuture.runAsync(() -> {
+            try {
+              _entityClient.deleteEntityReferences(entityUrn, context.getAuthentication());
+            } catch (RemoteInvocationException e) {
+              log.error(String.format("Caught exception while attempting to clear all entity references for glossary term with urn %s", entityUrn), e);
+            }
+          });
+
           return true;
         } catch (Exception e) {
           throw new RuntimeException(String.format("Failed to perform delete against glossary entity with urn %s", entityUrn), e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/RemoveGroupResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/RemoveGroupResolver.java
@@ -34,7 +34,7 @@ public class RemoveGroupResolver implements DataFetcher<CompletableFuture<Boolea
         try {
           _entityClient.deleteEntity(urn, context.getAuthentication());
 
-          // Asynchronously Delete all references to the term (to return quickly)
+          // Asynchronously Delete all references to the entity (to return quickly)
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(urn, context.getAuthentication());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/RemoveGroupResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/RemoveGroupResolver.java
@@ -5,13 +5,17 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+
 
 /**
  * Resolver responsible for hard deleting a particular DataHub Corp Group
  */
+@Slf4j
 public class RemoveGroupResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
@@ -28,8 +32,17 @@ public class RemoveGroupResolver implements DataFetcher<CompletableFuture<Boolea
       final Urn urn = Urn.createFromString(groupUrn);
       return CompletableFuture.supplyAsync(() -> {
         try {
-          // TODO: Remove all dangling references to this group.
           _entityClient.deleteEntity(urn, context.getAuthentication());
+
+          // Asynchronously Delete all references to the term (to return quickly)
+          CompletableFuture.runAsync(() -> {
+            try {
+              _entityClient.deleteEntityReferences(urn, context.getAuthentication());
+            } catch (RemoteInvocationException e) {
+              log.error(String.format("Caught exception while attempting to clear all entity references for group with urn %s", urn), e);
+            }
+          });
+
           return true;
         } catch (Exception e) {
           throw new RuntimeException(String.format("Failed to perform delete against group with urn %s", groupUrn), e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/RemoveUserResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/RemoveUserResolver.java
@@ -5,14 +5,17 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
  * Resolver responsible for hard deleting a particular DataHub Corp User
  */
+@Slf4j
 public class RemoveUserResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
@@ -30,6 +33,16 @@ public class RemoveUserResolver implements DataFetcher<CompletableFuture<Boolean
       return CompletableFuture.supplyAsync(() -> {
         try {
           _entityClient.deleteEntity(urn, context.getAuthentication());
+
+          // Asynchronously Delete all references to the term (to return quickly)
+          CompletableFuture.runAsync(() -> {
+            try {
+              _entityClient.deleteEntityReferences(urn, context.getAuthentication());
+            } catch (RemoteInvocationException e) {
+              log.error(String.format("Caught exception while attempting to clear all entity references for user with urn %s", urn), e);
+            }
+          });
+
           return true;
         } catch (Exception e) {
           throw new RuntimeException(String.format("Failed to perform delete against user with urn %s", userUrn), e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/RemoveUserResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/RemoveUserResolver.java
@@ -34,7 +34,7 @@ public class RemoveUserResolver implements DataFetcher<CompletableFuture<Boolean
         try {
           _entityClient.deleteEntity(urn, context.getAuthentication());
 
-          // Asynchronously Delete all references to the term (to return quickly)
+          // Asynchronously Delete all references to the entity (to return quickly)
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(urn, context.getAuthentication());

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/DeleteEntityUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/DeleteEntityUtils.java
@@ -50,6 +50,10 @@ public class DeleteEntityUtils {
     try {
       final DataMap copy = aspect.copy().data();
       final DataComplex newValue = removeValueBasedOnPath(value, schema, copy, aspectPath.getPathComponents(), 0);
+      if (newValue == null) {
+        // If the new value is null, we should remove the aspect.
+        return null;
+      }
       return new Aspect((DataMap) newValue);
     } catch (CloneNotSupportedException e) {
       return new Aspect();
@@ -106,6 +110,7 @@ public class DeleteEntityUtils {
         if (canDelete) {
           record.remove(pathComponents.get(index));
         } else {
+          // If the field is required, then we need to remove the entire record (if possible)
           return null;
         }
       } else {
@@ -126,6 +131,10 @@ public class DeleteEntityUtils {
             record.remove(key);
           } else if (record.size() == 1) {
             return null;
+          } else {
+            // Not optional and not the only field, then this is a bad delete. Need to throw.
+            throw new UnsupportedOperationException(
+                String.format("Delete failed! Failed to field with name %s from DataMap. The field is required!", key));
           }
         } else {
           record.put(key, result);

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/DeleteEntityUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/DeleteEntityUtils.java
@@ -105,7 +105,7 @@ public class DeleteEntityUtils {
       if (valueExistsInRecord) {
         if (canDelete) {
           record.remove(pathComponents.get(index));
-        } else if (record.size() == 1) {
+        } else {
           return null;
         }
       } else {

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/DeleteEntityUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/DeleteEntityUtilsTest.java
@@ -73,18 +73,12 @@ public class DeleteEntityUtilsTest extends TestCase {
         + "}");
 
     final DataSchema schema = pdlSchemaParser.lookupName("simple_record");
-    final Aspect updatedAspect = DeleteEntityUtils.getAspectWithReferenceRemoved("hello", aspect, schema,
-        new PathSpec("key_a"));
-
-    assertTrue(updatedAspect.data().containsKey("key_a"));
-    assertEquals("hello", updatedAspect.data().get("key_a"));
-    assertTrue(updatedAspect.data().containsKey("key_b"));
-    assertEquals("world", updatedAspect.data().get("key_b"));
-    assertEquals(aspect, updatedAspect);
+    assertNull(DeleteEntityUtils.getAspectWithReferenceRemoved("hello", aspect, schema,
+        new PathSpec("key_a")));
   }
 
   /**
-   * Tests that Aspect Processor does not delete a non-optional value from a record referenced by another record.
+   * Tests that Aspect Processor deletes a required value from a record referenced by another record.
    */
   @Test
   public void testNestedFieldRemoval() {
@@ -98,15 +92,14 @@ public class DeleteEntityUtilsTest extends TestCase {
         + "}");
 
     pdlSchemaParser.parse("record complex_record {\n"
-        + "key_c: simple_record\n"
+        + "key_c: optional simple_record\n"
         + "}");
 
     final DataSchema schema = pdlSchemaParser.lookupName("complex_record");
     final Aspect updatedAspect = DeleteEntityUtils.getAspectWithReferenceRemoved("hello", aspect, schema,
         new PathSpec("key_c", "key_a"));
 
-    assertTrue(updatedAspect.data().containsKey("key_c"));
-    assertEquals(aspect.data().get("key_c"), updatedAspect.data().get("key_c"));
+    assertFalse(updatedAspect.data().containsKey("key_c"));
   }
 
   /**

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/JavaEntityClientFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/JavaEntityClientFactory.java
@@ -2,6 +2,7 @@ package com.linkedin.gms.factory.entity;
 
 import com.linkedin.entity.client.JavaEntityClient;
 import com.linkedin.gms.factory.kafka.DataHubKafkaProducerFactory;
+import com.linkedin.metadata.entity.DeleteEntityService;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.search.EntitySearchService;
@@ -21,6 +22,10 @@ public class JavaEntityClientFactory {
   @Autowired
   @Qualifier("entityService")
   private EntityService _entityService;
+
+  @Autowired
+  @Qualifier("deleteEntityService")
+  private DeleteEntityService _deleteEntityService;
 
   @Autowired
   @Qualifier("searchService")
@@ -46,6 +51,7 @@ public class JavaEntityClientFactory {
   public JavaEntityClient getJavaEntityClient() {
     return new JavaEntityClient(
         _entityService,
+        _deleteEntityService,
         _eventProducer,
         _entitySearchService,
         _searchService,

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -230,6 +230,12 @@ public interface EntityClient {
       throws RemoteInvocationException;
 
   /**
+   * Delete all references to an entity with a particular urn.
+   */
+  public void deleteEntityReferences(@Nonnull final Urn urn, @Nonnull final Authentication authentication)
+      throws RemoteInvocationException;
+
+  /**
    * Filters entities based on a particular Filter and Sort criterion
    *
    * @param entity filter entity

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -21,7 +21,6 @@ import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.entity.DeleteEntityService;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.event.EventProducer;
-import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.LineageDirection;
 import com.linkedin.metadata.query.AutoCompleteResult;
 import com.linkedin.metadata.query.ListResult;

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -18,8 +18,10 @@ import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.aspect.EnvelopedAspectArray;
 import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.browse.BrowseResult;
+import com.linkedin.metadata.entity.DeleteEntityService;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.event.EventProducer;
+import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.LineageDirection;
 import com.linkedin.metadata.query.AutoCompleteResult;
 import com.linkedin.metadata.query.ListResult;
@@ -63,6 +65,7 @@ public class JavaEntityClient implements EntityClient {
     private final Clock _clock = Clock.systemUTC();
 
     private final EntityService _entityService;
+    private final DeleteEntityService _deleteEntityService;
     private final EventProducer _eventProducer;
     private final EntitySearchService _entitySearchService;
     private final SearchService _searchService;
@@ -348,6 +351,12 @@ public class JavaEntityClient implements EntityClient {
      */
     public void deleteEntity(@Nonnull final Urn urn, @Nonnull final Authentication authentication) throws RemoteInvocationException {
         _entityService.deleteUrn(urn);
+    }
+
+    @Override
+    public void deleteEntityReferences(@Nonnull Urn urn, @Nonnull Authentication authentication)
+        throws RemoteInvocationException {
+        _deleteEntityService.deleteReferencesTo(urn, false);
     }
 
     @Nonnull

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -18,6 +18,7 @@ import com.linkedin.entity.EntitiesDoAutocompleteRequestBuilder;
 import com.linkedin.entity.EntitiesDoBatchGetTotalEntityCountRequestBuilder;
 import com.linkedin.entity.EntitiesDoBatchIngestRequestBuilder;
 import com.linkedin.entity.EntitiesDoBrowseRequestBuilder;
+import com.linkedin.entity.EntitiesDoDeleteReferencesRequestBuilder;
 import com.linkedin.entity.EntitiesDoDeleteRequestBuilder;
 import com.linkedin.entity.EntitiesDoFilterRequestBuilder;
 import com.linkedin.entity.EntitiesDoGetBrowsePathsRequestBuilder;
@@ -484,6 +485,16 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   public void deleteEntity(@Nonnull final Urn urn, @Nonnull final Authentication authentication)
       throws RemoteInvocationException {
     EntitiesDoDeleteRequestBuilder requestBuilder = ENTITIES_REQUEST_BUILDERS.actionDelete().urnParam(urn.toString());
+    sendClientRequest(requestBuilder, authentication);
+  }
+
+  /**
+   * Delete all references to a particular entity.
+   */
+  @Override
+  public void deleteEntityReferences(@Nonnull Urn urn, @Nonnull Authentication authentication)
+      throws RemoteInvocationException {
+    EntitiesDoDeleteReferencesRequestBuilder requestBuilder = ENTITIES_REQUEST_BUILDERS.actionDeleteReferences().urnParam(urn.toString());
     sendClientRequest(requestBuilder, authentication);
   }
 

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -97,6 +97,10 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
   private EntityService _entityService;
 
   @Inject
+  @Named("deleteEntityService")
+  private DeleteEntityService _deleteEntityService;
+
+  @Inject
   @Named("searchService")
   private SearchService _searchService;
 
@@ -119,10 +123,6 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
   @Inject
   @Named("graphService")
   private GraphService _graphService;
-
-  @Inject
-  @Named("deleteEntityService")
-  private DeleteEntityService _deleteEntityService;
 
   /**
    * Retrieves the value for an entity that is made up of latest versions of specified aspects.


### PR DESCRIPTION
**Summary**
In this PR we add support for maintaining referential integrity when deleting users, groups, assertions, and groups. Prior to this change, deleting these entities would result in dangling pointers to that entity. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)