### PR TITLE
fix(ui): Enable previews properly when browsing for DataJob

### DIFF
--- a/datahub-web-react/src/graphql/browse.graphql
+++ b/datahub-web-react/src/graphql/browse.graphql
@@ -152,6 +152,33 @@ query getBrowseResults($input: BrowseInput!) {
                     ...entityDomain
                 }
             }
+            ... on DataJob {
+                urn
+                type
+                dataFlow {
+                    ...nonRecursiveDataFlowFields
+                }
+                jobId
+                ownership {
+                    ...ownershipFields
+                }
+                properties {
+                    name
+                    description
+                }
+                globalTags {
+                    ...globalTagsFields
+                }
+                glossaryTerms {
+                    ...glossaryTerms
+                }
+                editableProperties {
+                    description
+                }
+                domain {
+                    ...entityDomain
+                }
+            }
             ... on MLFeatureTable {
                 urn
                 type


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


When working locally, I couldnt get anything to show up on the when browsing at `browse/tasks`(no name, owners, description, etc), even though I had all the entities and could see them getting set in the GraphQL resolvers.

I then checked the demo https://demo.datahubproject.io/browse/tasks/airflow/datahub_really_large_dag and noticed they are all the same. 

This change resolves it for me locally -

<img width="748" alt="Screen Shot 2022-06-25 at 12 00 12 PM" src="https://user-images.githubusercontent.com/7296539/175783470-3cf39e7b-90ad-4acf-ab4a-e86a534ace17.png">
 