### PR TITLE
fix(siblings) Display sibling assertions in Validations tab

### DIFF
--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -48,7 +48,7 @@ const customMerge = (isPrimary, key) => {
     if (key === 'platform') {
         return (a, b) => (isPrimary ? b : a);
     }
-    if (key === 'tags' || key === 'terms') {
+    if (key === 'tags' || key === 'terms' || key === 'assertions') {
         return (a, b) => {
             return merge(a, b, {
                 customMerge: customMerge.bind({}, isPrimary),

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/ValidationsTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/ValidationsTab.tsx
@@ -9,6 +9,7 @@ import { DatasetAssertionsList } from './DatasetAssertionsList';
 import { DatasetAssertionsSummary } from './DatasetAssertionsSummary';
 import { sortAssertions } from './assertionUtils';
 import { TestResults } from './TestResults';
+import { combineEntityDataWithSiblings } from '../../../siblingUtils';
 
 /**
  * Returns a status summary for the assertions associated with a Dataset.
@@ -47,28 +48,30 @@ enum ViewType {
 export const ValidationsTab = () => {
     const { urn, entityData } = useEntityData();
     const { data, refetch } = useGetDatasetAssertionsQuery({ variables: { urn } });
+    const combinedData = combineEntityDataWithSiblings(data);
     const [removedUrns, setRemovedUrns] = useState<string[]>([]);
     /**
      * Determines which view should be visible: assertions or tests.
      */
     const [view, setView] = useState(ViewType.ASSERTIONS);
 
-    const assertions = (data && data.dataset?.assertions?.assertions?.map((assertion) => assertion as Assertion)) || [];
-    const maybeTotalAssertions = data?.dataset?.assertions?.total || undefined;
-    const effectiveTotalAssertions = maybeTotalAssertions || 0;
+    const assertions =
+        (combinedData && combinedData.dataset?.assertions?.assertions?.map((assertion) => assertion as Assertion)) ||
+        [];
     const filteredAssertions = assertions.filter((assertion) => !removedUrns.includes(assertion.urn));
+    const numAssertions = filteredAssertions.length;
 
     const passingTests = (entityData as any)?.testResults?.passing || [];
     const maybeFailingTests = (entityData as any)?.testResults?.failing || [];
     const totalTests = maybeFailingTests.length + passingTests.length;
 
     useEffect(() => {
-        if (totalTests > 0 && maybeTotalAssertions === 0) {
+        if (totalTests > 0 && numAssertions === 0) {
             setView(ViewType.TESTS);
         } else {
             setView(ViewType.ASSERTIONS);
         }
-    }, [totalTests, maybeTotalAssertions]);
+    }, [totalTests, numAssertions]);
 
     // Pre-sort the list of assertions based on which has been most recently executed.
     assertions.sort(sortAssertions);
@@ -77,13 +80,9 @@ export const ValidationsTab = () => {
         <>
             <TabToolbar>
                 <div>
-                    <Button
-                        type="text"
-                        disabled={effectiveTotalAssertions === 0}
-                        onClick={() => setView(ViewType.ASSERTIONS)}
-                    >
+                    <Button type="text" disabled={numAssertions === 0} onClick={() => setView(ViewType.ASSERTIONS)}>
                         <FileProtectOutlined />
-                        Assertions ({effectiveTotalAssertions})
+                        Assertions ({numAssertions})
                     </Button>
                     <Button type="text" disabled={totalTests === 0} onClick={() => setView(ViewType.TESTS)}>
                         <FileDoneOutlined />

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -198,22 +198,34 @@ fragment viewProperties on Dataset {
     }
 }
 
+fragment assertionsQuery on Dataset {
+    assertions(start: 0, count: 100) {
+        start
+        count
+        total
+        assertions {
+            ...assertionDetails
+            runEvents(status: COMPLETE, limit: 1) {
+                total
+                failed
+                succeeded
+                runEvents {
+                    ...assertionRunEventDetails
+                }
+            }
+        }
+    }
+}
+
 query getDatasetAssertions($urn: String!) {
     dataset(urn: $urn) {
-        assertions(start: 0, count: 100) {
-            start
-            count
-            total
-            assertions {
-                ...assertionDetails
-                runEvents(status: COMPLETE, limit: 1) {
-                    total
-                    failed
-                    succeeded
-                    runEvents {
-                        ...assertionRunEventDetails
-                    }
-                }
+        ...assertionsQuery
+        siblings {
+            isPrimary
+            siblings {
+                urn
+                type
+                ...assertionsQuery
             }
         }
     }


### PR DESCRIPTION
Updates the get assertions query to also get all assertions for siblings, then combine that data to show all assertions in the Validation tab for all siblings.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)