### PR TITLE
fix(siblings) Update the names of siblings utils args for readability

### DIFF
--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -43,20 +43,20 @@ const combineMerge = (target, source, options) => {
 
 const customMerge = (isPrimary, key) => {
     if (key === 'upstream' || key === 'downstream') {
-        return (a, _) => a;
+        return (_secondary, primary) => primary;
     }
     if (key === 'platform') {
-        return (a, b) => (isPrimary ? b : a);
+        return (secondary, primary) => (isPrimary ? primary : secondary);
     }
     if (key === 'tags' || key === 'terms' || key === 'assertions') {
-        return (a, b) => {
-            return merge(a, b, {
+        return (secondary, primary) => {
+            return merge(secondary, primary, {
                 customMerge: customMerge.bind({}, isPrimary),
             });
         };
     }
-    return (a, b) => {
-        return merge(a, b, {
+    return (secondary, primary) => {
+        return merge(secondary, primary, {
             arrayMerge: combineMerge,
             customMerge: customMerge.bind({}, isPrimary),
         });


### PR DESCRIPTION
After digging into it, we have confirmed that `a` is always the `secondary` sibling of the two and `b` is always the `primary` sibling of the two in the siblings utils comparator functions. This just updates those names appropriately.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)