### PR TITLE
fix(ingest) redshift: Adding missing dependencies and relaxing sqlalchemy dependency

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -171,7 +171,7 @@ iceberg_common = {
     "azure-identity==1.10.0",
 }
 
-s3_base = {*data_lake_base, "moto[s3]", path_spec_common}
+s3_base = {*data_lake_base, "moto[s3]", *path_spec_common}
 
 delta_lake = {
     *s3_base,
@@ -259,11 +259,8 @@ plugins: Dict[str, Set[str]] = {
     | {"psycopg2-binary", "acryl-pyhive[hive]>=0.6.12", "pymysql>=1.0.2"},
     "pulsar": {"requests"},
     "redash": {"redash-toolbelt", "sql-metadata", "sqllineage==1.3.5"},
-    "redshift": sql_common
-    | redshift_common,
-    "redshift-usage": sql_common
-    | usage_common
-    | redshift_common,
+    "redshift": sql_common | redshift_common,
+    "redshift-usage": sql_common | usage_common | redshift_common,
     "sagemaker": aws_common,
     "snowflake": snowflake_common,
     "snowflake-usage": snowflake_common

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -107,6 +107,11 @@ aws_common = {
     "botocore!=1.23.0",
 }
 
+path_spec_common = {
+    "parse>=1.19.0",
+    "wcmatch",
+}
+
 looker_common = {
     # Looker Python SDK
     "looker-sdk==22.2.1"
@@ -119,6 +124,14 @@ bigquery_common = {
     "more-itertools>=8.12.0",
     # we do not use protobuf directly but newer version caused bigquery connector to fail
     "protobuf<=3.20.1",
+}
+
+redshift_common = {
+    "sqlalchemy-redshift",
+    "psycopg2-binary",
+    "GeoAlchemy2",
+    "sqllineage==1.3.5",
+    *path_spec_common,
 }
 
 snowflake_common = {
@@ -156,11 +169,6 @@ iceberg_common = {
     # Iceberg Python SDK
     "acryl-iceberg-legacy==0.0.4",
     "azure-identity==1.10.0",
-}
-
-path_spec_common = {
-    "parse>=1.19.0",
-    "wcmatch",
 }
 
 s3_base = {*data_lake_base, "moto[s3]", path_spec_common}
@@ -252,22 +260,10 @@ plugins: Dict[str, Set[str]] = {
     "pulsar": {"requests"},
     "redash": {"redash-toolbelt", "sql-metadata", "sqllineage==1.3.5"},
     "redshift": sql_common
-    | {
-        "sqlalchemy-redshift",
-        "psycopg2-binary",
-        "GeoAlchemy2",
-        "sqllineage==1.3.5",
-        path_spec_common,
-    },
+    | redshift_common,
     "redshift-usage": sql_common
     | usage_common
-    | {
-        "sqlalchemy-redshift",
-        "psycopg2-binary",
-        "GeoAlchemy2",
-        "sqllineage==1.3.5",
-        path_spec_common,
-    },
+    | redshift_common,
     "sagemaker": aws_common,
     "snowflake": snowflake_common,
     "snowflake-usage": snowflake_common

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -88,7 +88,7 @@ kafka_protobuf = (
 
 sql_common = {
     # Required for all SQL sources.
-    "sqlalchemy==1.3.24",
+    "sqlalchemy>=1.3.24,<2.0.0",
     # Required for SQL profiling.
     "great-expectations>=0.14.11,<0.15.3",
     # datahub does not depend on Jinja2 directly but great expectations does. With Jinja2 3.1.0 GE 0.14.11 is breaking
@@ -250,7 +250,14 @@ plugins: Dict[str, Set[str]] = {
     "pulsar": {"requests"},
     "redash": {"redash-toolbelt", "sql-metadata", "sqllineage==1.3.5"},
     "redshift": sql_common
-    | {"sqlalchemy-redshift", "psycopg2-binary", "GeoAlchemy2", "sqllineage==1.3.5"},
+    | {
+        "sqlalchemy-redshift",
+        "psycopg2-binary",
+        "GeoAlchemy2",
+        "sqllineage==1.3.5",
+        "parse>=1.19.0",
+        "wcmatch",
+    },
     "redshift-usage": sql_common
     | usage_common
     | {
@@ -258,6 +265,8 @@ plugins: Dict[str, Set[str]] = {
         "psycopg2-binary",
         "GeoAlchemy2",
         "sqllineage==1.3.5",
+        "parse>=1.19.0",
+        "wcmatch",
     },
     "sagemaker": aws_common,
     "snowflake": snowflake_common,
@@ -454,7 +463,7 @@ if is_py37_or_newer:
 entry_points = {
     "console_scripts": ["datahub = datahub.entrypoints:main"],
     "datahub.ingestion.source.plugins": [
-	 "csv-enricher = datahub.ingestion.source.csv_enricher:CSVEnricherSource",
+        "csv-enricher = datahub.ingestion.source.csv_enricher:CSVEnricherSource",
         "file = datahub.ingestion.source.file:GenericFileSource",
         "sqlalchemy = datahub.ingestion.source.sql.sql_generic:SQLAlchemyGenericSource",
         "athena = datahub.ingestion.source.sql.athena:AthenaSource",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -158,11 +158,12 @@ iceberg_common = {
     "azure-identity==1.10.0",
 }
 
-s3_base = {
-    *data_lake_base,
-    "moto[s3]",
+path_spec_common = {
+    "parse>=1.19.0",
     "wcmatch",
 }
+
+s3_base = {*data_lake_base, "moto[s3]", path_spec_common}
 
 delta_lake = {
     *s3_base,
@@ -172,6 +173,7 @@ delta_lake = {
 usage_common = {
     "sqlparse",
 }
+
 
 # Note: for all of these, framework_common will be added.
 plugins: Dict[str, Set[str]] = {
@@ -255,8 +257,7 @@ plugins: Dict[str, Set[str]] = {
         "psycopg2-binary",
         "GeoAlchemy2",
         "sqllineage==1.3.5",
-        "parse>=1.19.0",
-        "wcmatch",
+        path_spec_common,
     },
     "redshift-usage": sql_common
     | usage_common
@@ -265,8 +266,7 @@ plugins: Dict[str, Set[str]] = {
         "psycopg2-binary",
         "GeoAlchemy2",
         "sqllineage==1.3.5",
-        "parse>=1.19.0",
-        "wcmatch",
+        path_spec_common,
     },
     "sagemaker": aws_common,
     "snowflake": snowflake_common,


### PR DESCRIPTION
Adding missing redshift dependencies
Relaxing sqlalchemy deps to make our plugins work with Airflow 2.3 -> This should fix https://github.com/datahub-project/datahub/issues/4809 



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)