### PR TITLE
Show message when related glossary terms are empty.

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components/macro';
 import { TermRelationshipType } from '../../../../types.generated';
 import { Message } from '../../../shared/Message';
+import { EmptyTab } from '../../shared/components/styled/EmptyTab';
 import { ANTD_GRAY } from '../../shared/constants';
 import AddRelatedTermsModal from './AddRelatedTermsModal';
 import RelatedTerm from './RelatedTerm';
@@ -45,6 +46,7 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
             ? TermRelationshipType.HasA
             : TermRelationshipType.IsA;
 
+    console.log('relationshipType:: ', glossaryRelatedTermType);
     return (
         <>
             {contentLoading ? (
@@ -62,6 +64,9 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
                     {glossaryRelatedTermUrns.map((urn) => (
                         <RelatedTerm key={urn} urn={urn} relationshipType={relationshipType} />
                     ))}
+                    {glossaryRelatedTermUrns.length === 0 && (
+                        <EmptyTab tab={glossaryRelatedTermType.toLocaleLowerCase()} />
+                    )}
                 </ListContainer>
             )}
             {isShowingAddModal && (

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -47,4 +47,12 @@ export const EMPTY_MESSAGES = {
         title: 'No domain set',
         description: 'Group related entities based on your organizational structure using by adding them to a Domain.',
     },
+    contains: {
+        title: 'No contain yet',
+        description: 'Share your knowledge by adding contain.',
+    },
+    inherits: {
+        title: 'No inherit yet',
+        description: 'Share your knowledge by adding inherit.',
+    },
 };


### PR DESCRIPTION
- Added a message when glossary-related term type is empty.

![Glossary_Related_Term_Type](https://user-images.githubusercontent.com/86347578/176463105-4214a79d-a5a5-4b4f-9149-3c8f6f692ab6.png)





## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)