### PR TITLE
fix(cli): suppress secrets in stacktraces

### DIFF
--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -170,8 +170,8 @@ def main(**kwargs):
                     line_wrap=MAX_CONTENT_WIDTH,
                     truncate_vals=10 * MAX_CONTENT_WIDTH,
                     suppressed_vars=[
-                        r"password",
-                        r".*secret",
+                        r".*password.*",
+                        r".*secret.*",
                         r".*key.*",
                         r".*access.*",
                         # needed because sometimes secrets are in url

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -169,6 +169,17 @@ def main(**kwargs):
                     exc,
                     line_wrap=MAX_CONTENT_WIDTH,
                     truncate_vals=10 * MAX_CONTENT_WIDTH,
+                    suppressed_vars=[
+                        r"password",
+                        r".*secret",
+                        r".*key.*",
+                        r".*access.*",
+                        # needed because sometimes secrets are in url
+                        r".*url.*",
+                        # needed because sqlalchemy uses it underneath
+                        # and passes all params
+                        r".*cparams.*",
+                    ],
                     suppressed_paths=[r"lib/python.*/site-packages/click/"],
                     **kwargs,
                 )


### PR DESCRIPTION
Before
<img width="490" alt="image" src="https://user-images.githubusercontent.com/4127841/176729498-3dfb970b-34cd-4531-b046-1154d0209856.png">

After
<img width="490" alt="image" src="https://user-images.githubusercontent.com/4127841/176729248-3e55c91b-7ce9-4333-9dae-22ea3481690d.png">

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)