### PR TITLE
fix(ui) Fix entity profile sidebar width issues

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -90,7 +90,8 @@ const HeaderAndTabsFlex = styled.div`
 const Sidebar = styled.div<{ $width: number }>`
     max-height: 100%;
     overflow: auto;
-    flex-basis: ${(props) => props.$width}px;
+    width: ${(props) => props.$width}px;
+    min-width: ${(props) => props.$width}px;
     padding-left: 20px;
     padding-right: 20px;
 `;
@@ -117,7 +118,6 @@ const defaultSidebarSection = {
     visible: (_, _1) => true,
 };
 
-const INITIAL_SIDEBAR_WIDTH = 400;
 const MAX_SIDEBAR_WIDTH = 800;
 const MIN_SIDEBAR_WIDTH = 200;
 
@@ -147,7 +147,7 @@ export const EntityProfile = <T, U>({
         display: { ...defaultSidebarSection, ...sidebarSection.display },
     }));
 
-    const [sidebarWidth, setSidebarWidth] = useState(INITIAL_SIDEBAR_WIDTH);
+    const [sidebarWidth, setSidebarWidth] = useState(window.innerWidth * 0.25);
     const [browserWidth, setBrowserWith] = useState(window.innerWidth * 0.2);
     const [shouldUpdateBrowser, setShouldUpdateBrowser] = useState(false);
 


### PR DESCRIPTION
The sidebar width on entity profiles will sometimes shrink if the content of the page is wide enough. It ends up looking bad and even as you switch between tabs on the entity page it will grow and shrink. This change sets the width to be 25% of the view width, and that's how it will stay unless the user drags the sidebar to expand or shrink it.

**Before**:
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/28656603/176752755-cd61b428-ed84-459f-9b39-c673c6f8c33a.png">

**After**:
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/28656603/176752802-c54fb03c-0e3b-4646-8945-3e1289d30cfb.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)