### PR TITLE
perf(siblings): reduce data fetched by siblings in lineage

### DIFF
--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -141,25 +141,6 @@ fragment lineageNodeProperties on EntityWithRelationships {
     }
 }
 
-fragment relationshipFieldsWithoutSiblings on EntityWithRelationships {
-    ...lineageNodeProperties
-    ... on Dataset {
-        siblings {
-            isPrimary
-            siblings {
-                urn
-                type
-            }
-        }
-    }
-    upstream: lineage(input: { direction: UPSTREAM, start: 0, count: 100 }) {
-        ...leafLineageResults
-    }
-    downstream: lineage(input: { direction: DOWNSTREAM, start: 0, count: 100 }) {
-        ...leafLineageResults
-    }
-}
-
 fragment relationshipFields on EntityWithRelationships {
     ...lineageNodeProperties
     ... on Dataset {
@@ -168,7 +149,7 @@ fragment relationshipFields on EntityWithRelationships {
             siblings {
                 urn
                 type
-                ...relationshipFieldsWithoutSiblings
+                ...lineageNodeProperties
             }
         }
     }
@@ -222,7 +203,7 @@ query getEntityLineage($urn: String!) {
                 siblings {
                     urn
                     type
-                    ...relationshipFieldsWithoutSiblings
+                    ...lineageNodeProperties
                 }
             }
         }


### PR DESCRIPTION
We no longer need sibling's lineage, so we can avoid fetching that.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)