### PR TITLE
fix(validation) Fail validation error silently instead of crashing

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
@@ -45,7 +45,8 @@ const getSchemaAggregationText = (
             );
         }
         default:
-            throw new Error(`Unsupported schema aggregation assertion ${aggregation} provided.`);
+            console.error(`Unsupported schema aggregation assertion ${aggregation} provided.`);
+            return <Typography.Text>Dataset columns are</Typography.Text>;
     }
 };
 
@@ -62,7 +63,8 @@ const getRowsAggregationText = (aggregation: AssertionStdAggregation | undefined
         case AssertionStdAggregation.Native:
             return <Typography.Text>Dataset rows are</Typography.Text>;
         default:
-            throw new Error(`Unsupported Dataset Rows Aggregation ${aggregation} provided`);
+            console.error(`Unsupported Dataset Rows Aggregation ${aggregation} provided`);
+            return <Typography.Text>Dataset rows are</Typography.Text>;
     }
 };
 
@@ -179,7 +181,8 @@ const getAggregationText = (
         case DatasetAssertionScope.DatasetColumn:
             return getColumnAggregationText(aggregation, fields?.length === 1 ? fields[0] : undefined);
         default:
-            throw new Error(`Unsupported Dataset Assertion scope ${scope} provided`);
+            console.error(`Unsupported Dataset Assertion scope ${scope} provided`);
+            return 'Dataset is';
     }
 };
 

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
@@ -74,36 +74,38 @@ const getColumnAggregationText = (
     aggregation: AssertionStdAggregation | undefined | null,
     field: SchemaFieldRef | undefined,
 ) => {
+    let columnText = field?.path;
     if (field === undefined) {
-        throw new Error(`Invalid field provided for Dataset Assertion with scope Column ${JSON.stringify(field)}`);
+        columnText = 'undefined';
+        console.error(`Invalid field provided for Dataset Assertion with scope Column ${JSON.stringify(field)}`);
     }
     switch (aggregation) {
         // Hybrid Aggregations
         case AssertionStdAggregation.UniqueCount: {
             return (
                 <Typography.Text>
-                    Unique value count for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Unique value count for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.UniquePropotion: {
             return (
                 <Typography.Text>
-                    Unique value proportion for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Unique value proportion for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.NullCount: {
             return (
                 <Typography.Text>
-                    Null count for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Null count for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.NullProportion: {
             return (
                 <Typography.Text>
-                    Null proportion for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Null proportion for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
@@ -111,35 +113,35 @@ const getColumnAggregationText = (
         case AssertionStdAggregation.Min: {
             return (
                 <Typography.Text>
-                    Minimum value for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Minimum value for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.Max: {
             return (
                 <Typography.Text>
-                    Maximum value for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Maximum value for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.Mean: {
             return (
                 <Typography.Text>
-                    Mean value for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Mean value for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.Median: {
             return (
                 <Typography.Text>
-                    Median value for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Median value for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
         case AssertionStdAggregation.Stddev: {
             return (
                 <Typography.Text>
-                    Standard deviation for column <Typography.Text strong>{field.path}</Typography.Text> is
+                    Standard deviation for column <Typography.Text strong>{columnText}</Typography.Text> is
                 </Typography.Text>
             );
         }
@@ -147,7 +149,7 @@ const getColumnAggregationText = (
         case AssertionStdAggregation.Native: {
             return (
                 <Typography.Text>
-                    Column <Typography.Text strong>{field.path}</Typography.Text> values are
+                    Column <Typography.Text strong>{columnText}</Typography.Text> values are
                 </Typography.Text>
             );
         }
@@ -155,7 +157,7 @@ const getColumnAggregationText = (
             // No aggregation on the column at hand. Treat the column as a set of values.
             return (
                 <Typography.Text>
-                    Column <Typography.Text strong>{field.path}</Typography.Text> values are
+                    Column <Typography.Text strong>{columnText}</Typography.Text> values are
                 </Typography.Text>
             );
     }


### PR DESCRIPTION
Some users were having issues with the Validation tab throwing an error and crashing the app because `getColumnAggregationText` was receiving `undefined` for the `field` arg. Instead of throwing an error, I'm now  tossing a `console.error` and then setting the default text to be "undefined" so the Validations tab at least shows up.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)