### PR TITLE
fix(gms) Remove auto-creating status aspect if not present when ingesting

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -1070,11 +1070,6 @@ private Map<Urn, List<EnvelopedAspect>> getCorrespondingAspects(Set<EntityAspect
       aspectsToGet.add(DATA_PLATFORM_INSTANCE);
     }
 
-    boolean shouldHaveStatusSet = isAspectMissing(entityType, STATUS, includedAspects);
-    if (shouldHaveStatusSet) {
-      aspectsToGet.add(STATUS);
-    }
-
     List<Pair<String, RecordTemplate>> aspects = new ArrayList<>();
     final String keyAspectName = getKeyAspectName(urn);
     aspectsToGet.add(keyAspectName);
@@ -1101,12 +1096,6 @@ private Map<Urn, List<EnvelopedAspect>> getCorrespondingAspects(Set<EntityAspect
     if (shouldCheckDataPlatform && latestAspects.get(DATA_PLATFORM_INSTANCE) == null) {
       DataPlatformInstanceUtils.buildDataPlatformInstance(entityType, keyAspect)
           .ifPresent(aspect -> aspects.add(Pair.of(DATA_PLATFORM_INSTANCE, aspect)));
-    }
-
-    if (shouldHaveStatusSet && latestAspects.get(STATUS) != null) {
-      Status status = new Status();
-      status.setRemoved(false);
-      aspects.add(Pair.of(STATUS, status));
     }
 
     return aspects;


### PR DESCRIPTION
Removes auto-creation of Status aspect when ingesting metadata snapshots that do not include. 
Historically this behaviour was used to ensure that re-ingesting some metadata that was soft deleted would be resurfaced. The typical scenario being to fix an incorrect ingestion recipe.

This approach caused issues in usage ingestion where soft deleted entities come back to life because any sort of associated metadata was ingested.
The correct approach is to have our connectors explicitly send a Status aspect with `removed=false` to re-enable the soft delete entity.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)