### PR TITLE
fix(me) Cache the me query for performance reasons

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -88,6 +88,13 @@ const user2 = {
     editableInfo: {
         pictureLink: null,
     },
+    editableProperties: {
+        displayName: 'Test',
+        title: 'test',
+        pictureLink: null,
+        teams: [],
+        skills: [],
+    },
     globalTags: {
         tags: [
             {

--- a/datahub-web-react/src/app/useGetAuthenticatedUser.tsx
+++ b/datahub-web-react/src/app/useGetAuthenticatedUser.tsx
@@ -10,7 +10,7 @@ export function useGetAuthenticatedUser(skip?: boolean) {
     if (!userUrn) {
         throw new Error('Could not find logged in user.');
     }
-    const { data, error } = useGetMeQuery({ skip });
+    const { data, error } = useGetMeQuery({ skip, fetchPolicy: 'cache-first' });
     if (error) {
         console.error(`Could not fetch logged in user from cache. + ${error.message}`);
     }


### PR DESCRIPTION
We call this query on almost every new page or tag, let's cache it.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)