### PR TITLE
fix(ui) Make profile icon clickable to expand header menu

### DIFF
--- a/datahub-web-react/src/app/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/app/shared/ManageAccount.tsx
@@ -34,6 +34,12 @@ const DownArrow = styled(CaretDownOutlined)`
     color: ${ANTD_GRAY[7]};
 `;
 
+const DropdownWrapper = styled.div`
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+`;
+
 interface Props {
     urn: string;
     pictureLink?: string;
@@ -102,12 +108,12 @@ export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink, name }: Pr
     );
 
     return (
-        <>
-            <CustomAvatar photoUrl={_pictureLink} style={{ marginRight: 4 }} name={name} />
-            <Dropdown overlay={menu} trigger={['click']}>
+        <Dropdown overlay={menu} trigger={['click']}>
+            <DropdownWrapper>
+                <CustomAvatar photoUrl={_pictureLink} style={{ marginRight: 4 }} name={name} />
                 <DownArrow />
-            </Dropdown>
-        </>
+            </DropdownWrapper>
+        </Dropdown>
     );
 };
 


### PR DESCRIPTION
Makes the profile icon clickable to expand or contract the header menu. This was a recent regression.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)