### PR TITLE
feat(ui): add copy function for stats table sample value

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/ColumnStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/ColumnStats.tsx
@@ -1,10 +1,11 @@
-import { Tag, Typography } from 'antd';
+import { Typography } from 'antd';
 import { ColumnsType, ColumnType } from 'antd/lib/table';
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { DatasetFieldProfile } from '../../../../../../../types.generated';
 import { StyledTable } from '../../../../components/styled/StyledTable';
 import { ANTD_GRAY } from '../../../../constants';
+import SampleValueTag from './SampleValueTag';
 
 type Props = {
     columnStats: Array<DatasetFieldProfile>;
@@ -128,7 +129,7 @@ export default function ColumnStats({ columnStats }: Props) {
                         (sampleValues &&
                             sampleValues
                                 .slice(0, sampleValues.length < 3 ? sampleValues?.length : 3)
-                                .map((value) => <Tag>{value}</Tag>)) ||
+                                .map((value) => <SampleValueTag value={value} />)) ||
                         unknownValue()
                     );
                 },

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/SampleValueTag.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/SampleValueTag.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Tag, Tooltip } from 'antd';
+import styled from 'styled-components';
+
+const StyledTag = styled(Tag)`
+    cursor: pointer;
+    max-width: 250px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &&:hover {
+        color: ${(props) => props.theme.styles['primary-color']};
+        border-color: ${(props) => props.theme.styles['primary-color']};
+    }
+`;
+
+type Props = {
+    value: string;
+};
+
+export default function SampleValueTag({ value }: Props) {
+    const [copied, setCopied] = useState(false);
+
+    const onClick = () => {
+        setCopied(true);
+        navigator.clipboard.writeText(value);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+        <Tooltip title={copied ? 'Copied' : 'Click to copy'}>
+            <StyledTag onClick={onClick}>{value}</StyledTag>
+        </Tooltip>
+    );
+}


### PR DESCRIPTION
Add capability for users to copy sample values in the stats table
Feature request: https://feature-requests.datahubproject.io/p/improve-table-stats-sample-value-ux

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)