### PR TITLE
fix(ui) Correct show/hide tabs in Settings based on privileges

### DIFF
--- a/datahub-web-react/src/app/settings/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settings/SettingsPage.tsx
@@ -101,13 +101,13 @@ export const SettingsPage = () => {
                     </Menu.ItemGroup>
                     {(showPolicies || showUsersGroups) && (
                         <Menu.ItemGroup title="Access">
-                            {showPolicies && (
+                            {showUsersGroups && (
                                 <Menu.Item key="identities">
                                     <UsergroupAddOutlined />
                                     <ItemTitle>Users & Groups</ItemTitle>
                                 </Menu.Item>
                             )}
-                            {showUsersGroups && (
+                            {showPolicies && (
                                 <Menu.Item key="policies">
                                     <BankOutlined />
                                     <ItemTitle>Privileges</ItemTitle>


### PR DESCRIPTION
Fix mixup where we were showing and hiding Policies/Users and Groups tabs incorrectly.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)