### PR TITLE
fix(glossary) Fixes a bug for yaml ingested terms without source_url

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
@@ -134,9 +134,7 @@ export const SidebarAboutSection = ({ properties }: { properties?: Props }) => {
                                 {sourceRef}
                             </SourceButton>
                         ) : (
-                            {
-                                sourceRef,
-                            }
+                            <span>{sourceRef}</span>
                         )}
                     </Typography.Paragraph>
                 </>


### PR DESCRIPTION
If you ingest your glossary via yaml and don't have a `source_url` defined, react throws and error on your page because `sourceRef` wasn't surrounded by html tags.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)