### PR TITLE
refactor(ui): Use createTag mutation for creating new tags from the UI

### DIFF
--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -49,7 +49,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
     if (graphQLErrors && graphQLErrors.length) {
         const firstError = graphQLErrors[0];
         const { extensions } = firstError;
-        console.log(firstError);
+        console.error(firstError);
         const errorCode = extensions && (extensions.code as number);
         // Fallback in case the calling component does not handle.
         message.error(`${firstError.message} (code ${errorCode})`, 3);

--- a/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
@@ -120,6 +120,7 @@ export class ContainerEntity implements Entity<Container> {
                 container={data.container}
                 entityCount={data.entities?.total}
                 domain={data.domain}
+                tags={data.tags}
             />
         );
     };

--- a/datahub-web-react/src/app/entity/container/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/container/preview/Preview.tsx
@@ -11,6 +11,7 @@ import {
 import DefaultPreviewCard from '../../../preview/DefaultPreviewCard';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { IconStyleType } from '../../Entity';
+import useTagsAndTermsRenderer from '../../shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer';
 
 export const Preview = ({
     urn,
@@ -62,6 +63,7 @@ export const Preview = ({
             entityCount={entityCount}
             domain={domain || undefined}
             parentContainers={parentContainers}
+            tags={}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/container/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/container/preview/Preview.tsx
@@ -7,11 +7,11 @@ import {
     SubTypes,
     Domain,
     ParentContainersResult,
+    GlobalTags,
 } from '../../../../types.generated';
 import DefaultPreviewCard from '../../../preview/DefaultPreviewCard';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { IconStyleType } from '../../Entity';
-import useTagsAndTermsRenderer from '../../shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer';
 
 export const Preview = ({
     urn,
@@ -21,6 +21,7 @@ export const Preview = ({
     platformInstanceId,
     description,
     owners,
+    tags,
     insights,
     subTypes,
     logoComponent,
@@ -36,6 +37,7 @@ export const Preview = ({
     platformInstanceId?: string;
     description?: string | null;
     owners?: Array<Owner> | null;
+    tags?: GlobalTags | null;
     insights?: Array<SearchInsight> | null;
     subTypes?: SubTypes | null;
     logoComponent?: JSX.Element;
@@ -63,7 +65,7 @@ export const Preview = ({
             entityCount={entityCount}
             domain={domain || undefined}
             parentContainers={parentContainers}
-            tags={}
+            tags={tags || undefined}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -65,3 +65,5 @@ export function getPlatformName(entityData: GenericEntityProperties | null) {
 }
 
 export const EDITED_DESCRIPTIONS_CACHE_NAME = 'editedDescriptions';
+
+export const FORBIDDEN_URN_CHARS_REGEX = /.*[(),\\].*/;

--- a/datahub-web-react/src/app/shared/tags/AddTagsTermsModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagsTermsModal.tsx
@@ -168,7 +168,7 @@ export default function AddTagsTermsModal({
         querySelectorToExecuteClick: '#addTagButton',
     });
 
-    if (showCreateModal && isValidInput) {
+    if (showCreateModal) {
         return (
             <CreateTagModal
                 visible={visible}

--- a/datahub-web-react/src/app/shared/tags/AddTagsTermsModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagsTermsModal.tsx
@@ -14,6 +14,7 @@ import GlossaryBrowser from '../../glossary/GlossaryBrowser/GlossaryBrowser';
 import ClickOutside from '../ClickOutside';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { useGetRecommendations } from '../recommendation';
+import { FORBIDDEN_URN_CHARS_REGEX } from '../../entity/shared/utils';
 
 type AddTagsModalProps = {
     visible: boolean;
@@ -58,6 +59,10 @@ export const BrowserWrapper = styled.div<{ isHidden: boolean }>`
 `;
 
 const CREATE_TAG_VALUE = '____reserved____.createTagValue';
+
+const isValidTagName = (tagName: string) => {
+    return tagName && tagName.length > 0 && !FORBIDDEN_URN_CHARS_REGEX.test(tagName);
+};
 
 export default function AddTagsTermsModal({
     visible,
@@ -131,7 +136,7 @@ export default function AddTagsTermsModal({
         return displayName.toLowerCase() === inputValue.toLowerCase();
     });
 
-    if (!inputExistsInTagSearch && inputValue.length > 0 && type === EntityType.Tag && urns.length === 0) {
+    if (!inputExistsInTagSearch && isValidTagName(inputValue) && type === EntityType.Tag && urns.length === 0) {
         tagSearchOptions?.push(
             <Select.Option value={CREATE_TAG_VALUE} key={CREATE_TAG_VALUE}>
                 <Typography.Link> Create {inputValue}</Typography.Link>
@@ -163,7 +168,7 @@ export default function AddTagsTermsModal({
         querySelectorToExecuteClick: '#addTagButton',
     });
 
-    if (showCreateModal) {
+    if (showCreateModal && isValidInput) {
         return (
             <CreateTagModal
                 visible={visible}
@@ -179,7 +184,9 @@ export default function AddTagsTermsModal({
     // When a Tag or term search result is selected, add the urn to the Urns
     const onSelectValue = (urn: string) => {
         if (urn === CREATE_TAG_VALUE) {
-            setShowCreateModal(true);
+            if (isValidTagName(inputValue)) {
+                setShowCreateModal(true);
+            }
             return;
         }
         const newUrns = [...(urns || []), urn];

--- a/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { message, Button, Input, Modal, Space } from 'antd';
 import styled from 'styled-components';
-
-import { useUpdateTagMutation } from '../../../graphql/tag.generated';
 import { useAddTagMutation } from '../../../graphql/mutations.generated';
+import { useCreateTagMutation } from '../../../graphql/tag.generated';
 import { SubResourceType } from '../../../types.generated';
 import { useEnterKeyListener } from '../useEnterKeyListener';
 
@@ -31,18 +30,17 @@ export default function CreateTagModal({
     const [stagedDescription, setStagedDescription] = useState('');
     const [addTagMutation] = useAddTagMutation();
 
-    const [updateTagMutation] = useUpdateTagMutation();
+    const [createTagMutation] = useCreateTagMutation();
     const [disableCreate, setDisableCreate] = useState(false);
 
     const onOk = () => {
         setDisableCreate(true);
         // first create the new tag
         const tagUrn = `urn:li:tag:${tagName}`;
-        updateTagMutation({
+        createTagMutation({
             variables: {
-                urn: tagUrn,
                 input: {
-                    urn: tagUrn,
+                    id: tagName,
                     name: tagName,
                     description: stagedDescription,
                 },

--- a/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
@@ -57,15 +57,21 @@ export default function CreateTagModal({
                             subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
                         },
                     },
-                }).finally(() => {
-                    // and finally close the modal
-                    setDisableCreate(false);
-                    onClose();
-                });
+                })
+                    .catch((e) => {
+                        message.destroy();
+                        message.error({ content: `Failed to add tag: \n ${e.message || ''}`, duration: 3 });
+                        onClose();
+                    })
+                    .finally(() => {
+                        // and finally close the modal
+                        setDisableCreate(false);
+                        onClose();
+                    });
             })
             .catch((e) => {
                 message.destroy();
-                message.error({ content: `Failed to create & add tag: \n ${e.message || ''}`, duration: 3 });
+                message.error({ content: `Failed to create tag: \n ${e.message || ''}`, duration: 3 });
                 onClose();
             });
     };

--- a/datahub-web-react/src/graphql/tag.graphql
+++ b/datahub-web-react/src/graphql/tag.graphql
@@ -28,3 +28,7 @@ mutation updateTag($urn: String!, $input: TagUpdateInput!) {
 mutation deleteTag($urn: String!) {
     deleteTag(urn: $urn)
 }
+
+mutation createTag($input: CreateTagInput!) {
+    createTag(input: $input)
+}

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -6,6 +6,9 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Breaking Changes
 - The `should_overwrite` flag in `csv-enricher` has been replaced with `write_semantics` to match the format used for other sources. See the [documentation](https://datahubproject.io/docs/generated/ingestion/sources/csv/) for more details
+- Closing an authorization hole in creating tags adding a Platform Privilege called `Create Tags` for creating tags. This is assigned to `datahub` root user, along 
+with default All Users policy. Notice: You may need to add this privilege (or `Manage Tags`) to existing users that need the ability to create tags on the platform. 
+  
 ### Potential Downtime
 
 ### Deprecations


### PR DESCRIPTION
**Summary**

In this PR, we migrate to using the new createTag GraphQL API for creating tags via the UI. This API requires that the `Create Tags` platform privilege has been granted to the user, which is a net-new requirement.

**Changes**

- Migrate from updateTag to createTag mutation to make creating tags behind the Create Tag privilege. This should simplify recent confusion over tag privileges.
- [minor fix] Show tags in the Container entity previews
- Add validation for new tag names (no urn-invalid characters like parens, commas) 




## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)