### PR TITLE
fix(bootstrap): skip ingesting data platforms that already exist

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestDataPlatformsStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestDataPlatformsStep.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.boot.steps;
 
+import com.datahub.util.RecordUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.AuditStamp;
@@ -7,12 +8,9 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.dataplatform.DataPlatformInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.boot.BootstrapStep;
-import com.datahub.util.RecordUtils;
 import com.linkedin.metadata.entity.EntityService;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
@@ -46,13 +44,24 @@ public class IngestDataPlatformsStep implements BootstrapStep {
 
     // 2. For each JSON object, cast into a DataPlatformSnapshot object.
     for (final JsonNode dataPlatform : dataPlatforms) {
+      final String urnString;
       final Urn urn;
       try {
-        urn = Urn.createFromString(dataPlatform.get("urn").asText());
+        urnString = dataPlatform.get("urn").asText();
+        urn = Urn.createFromString(urnString);
       } catch (URISyntaxException e) {
         log.error("Malformed urn: {}", dataPlatform.get("urn").asText());
         throw new RuntimeException("Malformed urn", e);
       }
+
+      final DataPlatformInfo existingInfo =
+          (DataPlatformInfo) _entityService.getLatestAspect(urn, PLATFORM_ASPECT_NAME);
+      // Skip ingesting for this JSON object if info already exists.
+      if (existingInfo != null) {
+        log.debug(String.format("%s already exists for %s. Skipping...", PLATFORM_ASPECT_NAME, urnString));
+        continue;
+      }
+
       final DataPlatformInfo info =
           RecordUtils.toRecordTemplate(DataPlatformInfo.class, dataPlatform.get("aspect").toString());
 


### PR DESCRIPTION
## Screenshots
![image](https://user-images.githubusercontent.com/19418814/178614358-ac55fcc9-88a7-4d24-a6a7-d3059584ab55.png)
**Skipped for existing platforms**

![image](https://user-images.githubusercontent.com/19418814/178614462-7ef4259d-2747-4fc9-b52b-e053830a87e4.png)
**Ingested for new Test Data Platform**

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)