### PR TITLE
fix(bigquery): multi-project GCP setup run query through correct project

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -343,7 +343,7 @@ class BigQuerySource(SQLAlchemySource):
         self, inspector: Optional[Inspector] = None, run_on_compute: bool = False
     ) -> Optional[str]:
         """
-        Use run_on_compute = true when running queries on storage project 
+        Use run_on_compute = true when running queries on storage project
         where you don't have job create rights
         """
         if self.config.storage_project_id and (not run_on_compute):
@@ -358,7 +358,7 @@ class BigQuerySource(SQLAlchemySource):
 
     def get_db_name(self, inspector: Inspector) -> str:
         """
-        DO NOT USE this to get project name when running queries. 
+        DO NOT USE this to get project name when running queries.
             That can cause problems with multi-project setups.
             Use get_multiproject_project_id with run_on_compute = True
         """

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -342,6 +342,10 @@ class BigQuerySource(SQLAlchemySource):
     def get_multiproject_project_id(
         self, inspector: Optional[Inspector] = None, run_on_compute: bool = False
     ) -> Optional[str]:
+        """
+        Use run_on_compute = true when running queries on storage project 
+        where you don't have job create rights
+        """
         if self.config.storage_project_id and (not run_on_compute):
             return self.config.storage_project_id
         elif self.config.project_id:
@@ -353,6 +357,11 @@ class BigQuerySource(SQLAlchemySource):
                 return None
 
     def get_db_name(self, inspector: Inspector) -> str:
+        """
+        DO NOT USE this to get project name when running queries. 
+            That can cause problems with multi-project setups.
+            Use get_multiproject_project_id with run_on_compute = True
+        """
         db_name = self.get_multiproject_project_id(inspector)
         # db name can't be empty here as we pass in inpector to get_multiproject_project_id
         assert db_name
@@ -458,7 +467,7 @@ class BigQuerySource(SQLAlchemySource):
         profile_clause = c if c == "" else f" WHERE {c}"[:-4]
         if profile_clause == "":
             return None
-        project_id = self.get_db_name(inspector)
+        project_id = self.get_multiproject_project_id(inspector, run_on_compute=True)
         _client: BigQueryClient = BigQueryClient(project=project_id)
         # Reading all tables' metadata to report
         base_query = (


### PR DESCRIPTION
Change done in https://github.com/datahub-project/datahub/pull/5329 broke multi-project setup. Fixing that.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)