### PR TITLE
fix(ingest/glue): handle error when generating s3 tags for virtual view tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1045,6 +1045,10 @@ class GlueSource(Source):
             )
 
         def get_s3_tags() -> Optional[GlobalTagsClass]:
+            # when TableType=VIRTUAL_VIEW the Location can be empty and we should 
+            # return no tags rather than fail the entire ingestion
+            if table.get("StorageDescriptor",{}).get("Location") is None:
+                return None
             bucket_name = s3_util.get_bucket_name(
                 table["StorageDescriptor"]["Location"]
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1045,9 +1045,9 @@ class GlueSource(Source):
             )
 
         def get_s3_tags() -> Optional[GlobalTagsClass]:
-            # when TableType=VIRTUAL_VIEW the Location can be empty and we should 
+            # when TableType=VIRTUAL_VIEW the Location can be empty and we should
             # return no tags rather than fail the entire ingestion
-            if table.get("StorageDescriptor",{}).get("Location") is None:
+            if table.get("StorageDescriptor", {}).get("Location") is None:
                 return None
             bucket_name = s3_util.get_bucket_name(
                 table["StorageDescriptor"]["Location"]


### PR DESCRIPTION
When using [Glue Virtual Views](https://aws.amazon.com/glue/features/elastic-views/) and tagging data with s3 bucket/object tags, the ingestion currently errors out when it finds a virtual view as there is no location set, and therefore the location doesnt being with s3:// or one of the other acceptable prefixes. This PR checks for the presence of a Location block and then returns `None` if one does not exist.


## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)