### PR TITLE
fix(gms): Change MessageDigest to be thread safe

### DIFF
--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
@@ -16,13 +16,6 @@ import com.linkedin.metadata.resources.entity.AspectUtils;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.ArrayUtils;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
@@ -31,11 +24,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.ArrayUtils;
 
-import static com.datahub.authentication.token.TokenClaims.ACTOR_ID_CLAIM_NAME;
-import static com.datahub.authentication.token.TokenClaims.ACTOR_TYPE_CLAIM_NAME;
-import static com.datahub.authentication.token.TokenClaims.TOKEN_TYPE_CLAIM_NAME;
-import static com.datahub.authentication.token.TokenClaims.TOKEN_VERSION_CLAIM_NAME;
+import static com.datahub.authentication.token.TokenClaims.*;
 
 
 /**
@@ -48,7 +43,6 @@ public class StatefulTokenService extends StatelessTokenService {
   private final EntityService _entityService;
   private final LoadingCache<String, Boolean> _revokedTokenCache;
   private final String salt;
-  private final MessageDigest sha256;
 
   public StatefulTokenService(@Nonnull final String signingKey, @Nonnull final String signingAlgorithm,
       @Nullable final String iss, @Nonnull final EntityService entityService, @Nonnull final String salt) {
@@ -65,11 +59,6 @@ public class StatefulTokenService extends StatelessTokenService {
           }
         });
     this.salt = salt;
-    try {
-      this.sha256 = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Unable to get SHA-256 algorithm.");
-    }
   }
 
   /**
@@ -179,14 +168,6 @@ public class StatefulTokenService extends StatelessTokenService {
     throw new TokenException("Access token no longer exists");
   }
 
-  public boolean isTokenRevoked(@Nonnull String hashToken) {
-    try {
-      return _revokedTokenCache.get(hashToken);
-    } catch (ExecutionException e) {
-      return false;
-    }
-  }
-
   /**
    * Hashes the input after salting it.
    */
@@ -194,7 +175,7 @@ public class StatefulTokenService extends StatelessTokenService {
     final byte[] saltingKeyBytes = this.salt.getBytes();
     final byte[] inputBytes = input.getBytes();
     final byte[] concatBytes = ArrayUtils.addAll(inputBytes, saltingKeyBytes);
-    final byte[] bytes = sha256.digest(concatBytes);
+    final byte[] bytes = DigestUtils.sha256(concatBytes);
     return Base64.getEncoder().encodeToString(bytes);
   }
 }


### PR DESCRIPTION
This PR fixes an issue on StatefulTokenService where the use of a single instance of `MessageDigest.getInstance("SHA-256");` was causing intermittent failures especially visible during ingestion. 

Root cause is that MessageDigest is not thread safe.
To fix this the PR uses instead Apache Commons utility which is thread safe.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)