### PR TITLE
fix(documentation) Fix erratic cursor in documentation editor bug

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -141,7 +141,7 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
                 </Button>
             </TabToolbar>
             <StyledMDEditor
-                value={description}
+                value={updatedDescription}
                 onChange={(v) => handleEditorChange(v || '')}
                 preview="live"
                 visiableDragbar={false}


### PR DESCRIPTION
Fixes a bug we've been hearing about but been having a hard time to reproduce. What happens is while you're editing documentation, if you pause for at least 5 seconds after making an edit, then try to make another edit, your cursor jumps to the end of the content. This makes editing existing documentation nearly impossible if you're editing anything in the middle of the documentation content.

The issue was that we have a debounced function that sets the text content in localStorage after 5 seconds go without making a change. Once we set the value in localStorage, this changes the root `description` value that we get (defaults to what's in localStorage if it exists). We were setting this `description` as the default state for `updatedDescription` (what we pass into our mutation functions) but we were setting the `value` prop of the editor to be `description` - not `updatedDescription`. This means that when `description` changes due to localStorage changes, your cursor jumps as the value gets reset unexpectedly. If we use `updatedDescription`, `value` is getting updated synchronously with the state of the editor itself, and we're all good to go. No more cursor jumping issues!


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)