### PR TITLE
feat(ingest): SQL- Add schema_aliases functionality

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -725,10 +725,8 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
             profile_requests: List["GEProfilerRequest"] = []
             if sql_config.profiling.enabled:
                 profiler = self.get_profiler_instance(inspector)
-            print("Entering DB Name")
+
             db_name = self.get_db_name(inspector)
-            print("DB NAME")
-            print(db_name)
             yield from self.gen_database_containers(db_name)
 
             for schema in self.get_schema_names(inspector):


### PR DESCRIPTION
The goal of this PR is to:
- use the `database_alias` field in the naming of database containers
- add an optional `schema_aliases` dictionary field to SQL recipes to use in the naming of schema containers

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)