### PR TITLE
fix(siblings): fixing lineage fetching for siblings & sources

### DIFF
--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -212,7 +212,7 @@ fragment lineageNodeProperties on EntityWithRelationships {
     }
 }
 
-fragment relationshipFields on EntityWithRelationships {
+fragment lineageFields on EntityWithRelationships {
     ...lineageNodeProperties
     ... on Dataset {
         siblings {
@@ -224,10 +224,10 @@ fragment relationshipFields on EntityWithRelationships {
             }
         }
     }
-    upstream: lineage(input: { direction: UPSTREAM, start: 0, count: 100 }) {
+    upstream: lineage(input: { direction: UPSTREAM, start: 0, count: 100, separateSiblings: $separateSiblings }) {
         ...leafLineageResults
     }
-    downstream: lineage(input: { direction: DOWNSTREAM, start: 0, count: 100 }) {
+    downstream: lineage(input: { direction: DOWNSTREAM, start: 0, count: 100, separateSiblings: $separateSiblings }) {
         ...leafLineageResults
     }
 }
@@ -239,7 +239,7 @@ fragment fullLineageResults on EntityLineageResult {
     relationships {
         type
         entity {
-            ...relationshipFields
+            ...lineageFields
         }
     }
 }

--- a/datahub-web-react/src/graphql/relationships.graphql
+++ b/datahub-web-react/src/graphql/relationships.graphql
@@ -23,3 +23,23 @@ fragment leafRelationshipResults on EntityRelationshipsResult {
         }
     }
 }
+
+fragment relationshipFields on EntityWithRelationships {
+    ...lineageNodeProperties
+    ... on Dataset {
+        siblings {
+            isPrimary
+            siblings {
+                urn
+                type
+                ...lineageNodeProperties
+            }
+        }
+    }
+    upstream: lineage(input: { direction: UPSTREAM, start: 0, count: 100 }) {
+        ...leafLineageResults
+    }
+    downstream: lineage(input: { direction: DOWNSTREAM, start: 0, count: 100 }) {
+        ...leafLineageResults
+    }
+}

--- a/smoke-test/tests/cypress/cypress/integration/siblings/siblings.js
+++ b/smoke-test/tests/cypress/cypress/integration/siblings/siblings.js
@@ -31,6 +31,15 @@ describe('siblings', () => {
 
   it('can view individual nodes', () => {
     cy.login();
+
+    const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
+    cy.on('uncaught:exception', (err) => {
+        /* returning false here prevents Cypress from failing the test */
+        if (resizeObserverLoopErrRe.test(err.message)) {
+            return false
+        }
+    })
+
     cy.visit('/dataset/urn:li:dataset:(urn:li:dataPlatform:dbt,cypress_project.jaffle_shop.customers,PROD)/?is_lineage_mode=false');
 
     // navigate to the bq entity


### PR DESCRIPTION
Makes sure sibling logic is also skipped when testing for upstreams/downstream of newly expanded nodes. This usually won't make a difference unless your only upstream/downstream is also your sibling (e.g., sources).

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)