### PR TITLE
fix(ingest): pass transport options to usage history looker api calls

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -1053,7 +1053,11 @@ class LookerDashboardSource(Source):
 
     def _populate_userwise_runs_counts(self, dashboard_usages):
         userwise_count_rows = LookerUtil.run_inline_query(
-            self.client, usage_queries["counts_per_day_per_user_per_dashboard"]
+            self.client,
+            usage_queries["counts_per_day_per_user_per_dashboard"],
+            transport_options=self.source_config.transport_options.get_transport_options()
+            if self.source_config.transport_options is not None
+            else None,
         )
 
         for row in userwise_count_rows:
@@ -1108,6 +1112,9 @@ class LookerDashboardSource(Source):
         count_rows = LookerUtil.run_inline_query(
             self.client,
             usage_queries["counts_per_day_per_dashboard"],
+            transport_options=self.source_config.transport_options.get_transport_options()
+            if self.source_config.transport_options is not None
+            else None,
         )
         for row in count_rows:
             dashboard_usages[

--- a/metadata-ingestion/src/datahub/ingestion/source/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker_common.py
@@ -476,11 +476,14 @@ class LookerUtil:
         )
 
     @staticmethod
-    def run_inline_query(client: Looker31SDK, q: dict) -> List:
+    def run_inline_query(
+        client: Looker31SDK, q: dict, transport_options: Optional[TransportOptions]
+    ) -> List:
 
         response_sql = client.run_inline_query(
             result_format="sql",
             body=LookerUtil.create_query_request(q),
+            transport_options=transport_options,
         )
         logger.debug("=================Query=================")
         logger.debug(response_sql)
@@ -488,6 +491,7 @@ class LookerUtil:
         response_json = client.run_inline_query(
             result_format="json",
             body=LookerUtil.create_query_request(q),
+            transport_options=transport_options,
         )
 
         logger.debug("=================Response=================")

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -1,9 +1,11 @@
 import json
 import time
 from datetime import datetime
+from typing import Optional
 from unittest import mock
 
 from freezegun import freeze_time
+from looker_sdk.rtl.transport import TransportOptions
 from looker_sdk.sdk.api31.models import (
     Dashboard,
     DashboardElement,
@@ -294,7 +296,9 @@ def setup_mock_user(mocked_client):
     mocked_client.user.return_value = User(id=1, email="test@looker.com")
 
 
-def side_effect_query_inline(result_format: str, body: WriteQuery) -> str:
+def side_effect_query_inline(
+    result_format: str, body: WriteQuery, transport_options: Optional[TransportOptions]
+) -> str:
     query_type = None
     if result_format == "sql":
         return ""  # Placeholder for sql text


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)