### PR TITLE
fix(ui): add dataset qualifiedName parameter to lineage query

### DIFF
--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -81,6 +81,7 @@ fragment lineageNodeProperties on EntityWithRelationships {
         properties {
             name
             description
+            qualifiedName
         }
         editableProperties {
             description


### PR DESCRIPTION
`Show full titles` button on Lineage page does not display dataset `qualifiedName`, because it's missing in `GetEntityLineageQuery` result

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)