### PR TITLE
fix(glossary) Fix dropdown where disabled buttons are still clickable

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -162,35 +162,51 @@ function EntityDropdown(props: Props) {
                             </Menu.Item>
                         )}
                         {menuItems.has(EntityMenuItems.ADD_TERM) && (
-                            <StyledMenuItem key="2" disabled={!canManageGlossaries}>
-                                <MenuItem onClick={() => setIsCreateTermModalVisible(true)}>
+                            <StyledMenuItem
+                                key="2"
+                                disabled={!canManageGlossaries}
+                                onClick={() => setIsCreateTermModalVisible(true)}
+                            >
+                                <MenuItem>
                                     <PlusOutlined /> &nbsp;Add Term
                                 </MenuItem>
                             </StyledMenuItem>
                         )}
                         {menuItems.has(EntityMenuItems.ADD_TERM_GROUP) && (
-                            <StyledMenuItem key="3" disabled={!canManageGlossaries}>
-                                <MenuItem onClick={() => setIsCreateNodeModalVisible(true)}>
+                            <StyledMenuItem
+                                key="3"
+                                disabled={!canManageGlossaries}
+                                onClick={() => setIsCreateNodeModalVisible(true)}
+                            >
+                                <MenuItem>
                                     <FolderAddOutlined /> &nbsp;Add Term Group
                                 </MenuItem>
                             </StyledMenuItem>
                         )}
                         {menuItems.has(EntityMenuItems.MOVE) && (
-                            <StyledMenuItem key="4" disabled={!canManageGlossaries}>
-                                <MenuItem onClick={() => setIsMoveModalVisible(true)}>
+                            <StyledMenuItem
+                                key="4"
+                                disabled={!canManageGlossaries}
+                                onClick={() => setIsMoveModalVisible(true)}
+                            >
+                                <MenuItem>
                                     <FolderOpenOutlined /> &nbsp;Move
                                 </MenuItem>
                             </StyledMenuItem>
                         )}
                         {menuItems.has(EntityMenuItems.DELETE) && (
-                            <StyledMenuItem key="5" disabled={isDeleteDisabled || !canManageGlossaries}>
+                            <StyledMenuItem
+                                key="5"
+                                disabled={isDeleteDisabled || !canManageGlossaries}
+                                onClick={onDeleteEntity}
+                            >
                                 <Tooltip
                                     title={`Can't delete ${entityRegistry.getEntityName(
                                         entityType,
                                     )} with child entities.`}
                                     overlayStyle={isDeleteDisabled ? {} : { display: 'none' }}
                                 >
-                                    <MenuItem onClick={onDeleteEntity}>
+                                    <MenuItem>
                                         <DeleteOutlined /> &nbsp;Delete
                                     </MenuItem>
                                 </Tooltip>


### PR DESCRIPTION
Fixes an issue where disabled buttons were not truly disabled (although they looked like it). 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)