### PR TITLE
fix(ui): Fixing unreleased search preview bugs 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -885,9 +885,14 @@ public class GmsGraphQLEngine {
             )
             .type("DatasetStatsSummary", typeWiring -> typeWiring
                 .dataFetcher("topUsersLast30Days", new LoadableTypeBatchResolver<>(corpUserType,
-                    (env) -> ((DatasetStatsSummary) env.getSource()).getTopUsersLast30Days().stream()
-                        .map(CorpUser::getUrn)
-                        .collect(Collectors.toList())))
+                    (env) -> {
+                        DatasetStatsSummary summary = ((DatasetStatsSummary) env.getSource());
+                        return summary.getTopUsersLast30Days() != null
+                            ? summary.getTopUsersLast30Days().stream()
+                            .map(CorpUser::getUrn)
+                            .collect(Collectors.toList())
+                            : null;
+                    }))
             );
     }
 
@@ -1039,9 +1044,14 @@ public class GmsGraphQLEngine {
         );
         builder.type("DashboardStatsSummary", typeWiring -> typeWiring
             .dataFetcher("topUsersLast30Days", new LoadableTypeBatchResolver<>(corpUserType,
-                (env) -> ((DashboardStatsSummary) env.getSource()).getTopUsersLast30Days().stream()
-                    .map(CorpUser::getUrn)
-                    .collect(Collectors.toList())))
+                (env) -> {
+                DashboardStatsSummary summary = ((DashboardStatsSummary) env.getSource());
+                return summary.getTopUsersLast30Days() != null
+                    ? summary.getTopUsersLast30Days().stream()
+                        .map(CorpUser::getUrn)
+                        .collect(Collectors.toList())
+                    : null;
+                }))
         );
     }
 

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -5279,7 +5279,7 @@ type DatasetStatsSummary {
     """
     The top users in the past 30 days
     """
-    topUsersLast30Days: [CorpUser!]!
+    topUsersLast30Days: [CorpUser!]
 }
 
 """
@@ -5456,7 +5456,7 @@ type DashboardStatsSummary {
     """
     The top users in the past 30 days
     """
-    topUsersLast30Days: [CorpUser!]!
+    topUsersLast30Days: [CorpUser!]
 }
 
 

--- a/datahub-web-react/src/app/entity/shared/components/styled/DeprecationPill.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/DeprecationPill.tsx
@@ -64,7 +64,6 @@ export const DeprecationPill = ({ deprecation, preview }: Props) => {
     /**
      * Deprecation Decommission Timestamp
      */
-
     const localeTimezone = getLocaleTimezone();
     const decommissionTimeLocal =
         (deprecation.decommissionTime &&

--- a/datahub-web-react/src/app/entity/shared/components/styled/DeprecationPill.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/DeprecationPill.tsx
@@ -64,6 +64,7 @@ export const DeprecationPill = ({ deprecation, preview }: Props) => {
     /**
      * Deprecation Decommission Timestamp
      */
+
     const localeTimezone = getLocaleTimezone();
     const decommissionTimeLocal =
         (deprecation.decommissionTime &&

--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
@@ -9,10 +9,26 @@ type Props = {
 
 export const ExpandedActorGroup = ({ actors, onClose }: Props) => {
     return (
-        <>
-            {actors.map((actor) => (
-                <ExpandedActor key={actor.urn} actor={actor} onClose={() => onClose?.(actor)} />
-            ))}
-        </>
+        <Popover
+            placement="left"
+            content={
+                <PopoverActors>
+                    {actors.map((actor) => (
+                        <ExpandedActor key={actor.urn} actor={actor} onClose={() => onClose?.(actor)} />
+                    ))}
+                </PopoverActors>
+            }
+        >
+            <div style={{ display: 'flex', justifyContent: 'right', flexWrap: 'wrap', alignItems: 'center' }}>
+                {finalActors.map((actor) => (
+                    <ExpandedActor key={actor.urn} actor={actor} onClose={() => onClose?.(actor)} />
+                ))}
+                {remainder && (
+                    <Typography.Text style={{ marginBottom: 8 }} type="secondary">
+                        + {remainder} more
+                    </Typography.Text>
+                )}
+            </div>
+        </Popover>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
@@ -4,9 +4,7 @@ import styled from 'styled-components';
 import { CorpGroup, CorpUser } from '../../../../../types.generated';
 import { ExpandedActor } from './ExpandedActor';
 
-const PopoverActors = styled.div`
-    max-width: 260px;
-`;
+const PopoverActors = styled.div``;
 
 type Props = {
     actors: Array<CorpUser | CorpGroup>;
@@ -36,12 +34,12 @@ export const ExpandedActorGroup = ({ actors, max, onClose }: Props) => {
                 {finalActors.map((actor) => (
                     <ExpandedActor key={actor.urn} actor={actor} onClose={() => onClose?.(actor)} />
                 ))}
-                {remainder && (
-                    <Typography.Text style={{ marginBottom: 8 }} type="secondary">
-                        + {remainder} more
-                    </Typography.Text>
-                )}
             </div>
+            {remainder && (
+                <Typography.Text style={{ display: 'flex', justifyContent: 'right', marginRight: 8 }} type="secondary">
+                    + {remainder} more
+                </Typography.Text>
+            )}
         </Popover>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
@@ -1,13 +1,26 @@
+import { Popover, Typography } from 'antd';
 import React from 'react';
+import styled from 'styled-components';
 import { CorpGroup, CorpUser } from '../../../../../types.generated';
 import { ExpandedActor } from './ExpandedActor';
 
+const PopoverActors = styled.div`
+    max-width: 260px;
+`;
+
 type Props = {
     actors: Array<CorpUser | CorpGroup>;
+    max?: number | null;
     onClose?: (actor: CorpUser | CorpGroup) => void;
 };
 
-export const ExpandedActorGroup = ({ actors, onClose }: Props) => {
+const DEFAULT_MAX = 10;
+
+export const ExpandedActorGroup = ({ actors, max, onClose }: Props) => {
+    const finalMax = max || DEFAULT_MAX;
+    const finalActors = actors.length > finalMax ? actors.slice(0, finalMax) : actors;
+    const remainder = actors.length > finalMax ? actors.length - finalMax : undefined;
+
     return (
         <Popover
             placement="left"

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -113,7 +113,7 @@ export const EntityHeader = ({ refreshBrowser, headerDropdownItems, isNameEditab
                 <PlatformContent />
                 <TitleWrapper>
                     <EntityName isNameEditable={canEditName} />
-                    {entityData?.deprecation && (
+                    {entityData?.deprecation?.deprecated && (
                         <DeprecationPill deprecation={entityData?.deprecation} preview={isCompact} />
                     )}
                     {entityData?.health?.map((health) => (

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -148,7 +148,7 @@ const UserListContainer = styled.div`
 
 const UserListDivider = styled(Divider)`
     padding: 4px;
-    height: 60px;
+    height: auto;
 `;
 
 const UserListTitle = styled(Typography.Text)`
@@ -324,22 +324,22 @@ export default function DefaultPreviewCard({
                 )}
             </LeftColumn>
             <RightColumn>
-                {topUsers && topUsers.length > 0 && (
+                {topUsers && topUsers?.length > 0 && (
                     <>
                         <UserListContainer>
                             <UserListTitle strong>Top Users</UserListTitle>
                             <div>
-                                <ExpandedActorGroup actors={topUsers} />
+                                <ExpandedActorGroup actors={topUsers} max={2} />
                             </div>
                         </UserListContainer>
-                        <UserListDivider type="vertical" />
                     </>
                 )}
-                {owners && owners.length > 0 && (
+                {(topUsers?.length || 0) > 0 && (owners?.length || 0) > 0 && <UserListDivider type="vertical" />}
+                {owners && owners?.length > 0 && (
                     <UserListContainer>
                         <UserListTitle strong>Owners</UserListTitle>
                         <div>
-                            <ExpandedActorGroup actors={owners.map((owner) => owner.owner)} />
+                            <ExpandedActorGroup actors={owners.map((owner) => owner.owner)} max={2} />
                         </div>
                     </UserListContainer>
                 )}

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -266,7 +266,7 @@ export default function DefaultPreviewCard({
                                 {name || ' '}
                             </EntityTitle>
                         </Link>
-                        {deprecation && <DeprecationPill deprecation={deprecation} preview />}
+                        {deprecation?.deprecated && <DeprecationPill deprecation={deprecation} preview />}
                         {externalUrl && (
                             <ExternalUrlContainer>
                                 <ExternalUrlButton type="link" href={externalUrl} target="_blank">


### PR DESCRIPTION
**Summary**

In this PR, we address a few minor search preview related bugs. These include

- Condensing top users + owners in search preview card, with left alignment and a max number to show of 2 (with popover) 
- Fixing a misbehaving deprecated label
- allow topUsers field to be null if it doesn't exist 

**Status**
Ready for review


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)