### PR TITLE
feat(ui): Adding Statistics Summary to Dataset + Dashboard Profiles 

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -225,6 +225,7 @@ export const dataset1 = {
     assertions: null,
     deprecation: null,
     testResults: null,
+    statsSummary: null,
 };
 
 export const dataset2 = {
@@ -309,6 +310,7 @@ export const dataset2 = {
     status: null,
     deprecation: null,
     testResults: null,
+    statsSummary: null,
 };
 
 export const dataset3 = {
@@ -524,6 +526,7 @@ export const dataset3 = {
     writeRuns: null,
     testResults: null,
     siblings: null,
+    statsSummary: null,
 } as Dataset;
 
 export const dataset4 = {

--- a/datahub-web-react/src/app/entity/container/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/container/preview/Preview.tsx
@@ -79,7 +79,7 @@ export const Preview = ({
             parentContainers={parentContainers}
             tags={tags || undefined}
             externalUrl={externalUrl}
-            stats={
+            subHeader={
                 (entityCount && [
                     <StatText>
                         <b>{entityCount}</b> {entityCount === 1 ? 'entity' : 'entities'}

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -21,6 +21,7 @@ import { getDataForEntityType } from '../shared/containers/profile/utils';
 import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
+import { DashboardStatsSummarySubHeader } from './profile/DashboardStatsSummarySubHeader';
 
 /**
  * Definition of the DataHub Dashboard entity.
@@ -75,6 +76,9 @@ export class DashboardEntity implements Entity<Dashboard> {
             useUpdateQuery={useUpdateDashboardMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
             headerDropdownItems={new Set([EntityMenuItems.COPY_URL, EntityMenuItems.UPDATE_DEPRECATION])}
+            subHeader={{
+                component: DashboardStatsSummarySubHeader,
+            }}
             tabs={[
                 {
                     name: 'Documentation',
@@ -164,6 +168,12 @@ export class DashboardEntity implements Entity<Dashboard> {
                 logoUrl={data?.platform?.properties?.logoUrl}
                 domain={data.domain?.domain}
                 container={data.container}
+                parentContainers={data.parentContainers}
+                deprecation={data.deprecation}
+                externalUrl={data.properties?.externalUrl}
+                statsSummary={data.statsSummary}
+                lastUpdatedMs={data.properties?.lastModified?.time}
+                createdMs={data.properties?.created?.time}
             />
         );
     };
@@ -190,6 +200,7 @@ export class DashboardEntity implements Entity<Dashboard> {
                 externalUrl={data.properties?.externalUrl}
                 statsSummary={data.statsSummary}
                 lastUpdatedMs={data.properties?.lastModified?.time}
+                createdMs={data.properties?.created?.time}
             />
         );
     };

--- a/datahub-web-react/src/app/entity/dashboard/preview/DashboardPreview.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/preview/DashboardPreview.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
-import { ClockCircleOutlined, EyeOutlined, TeamOutlined } from '@ant-design/icons';
 import {
     AccessLevel,
     Domain,
@@ -18,13 +16,7 @@ import DefaultPreviewCard from '../../../preview/DefaultPreviewCard';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { capitalizeFirstLetter } from '../../../shared/textUtil';
 import { IconStyleType } from '../../Entity';
-import { ANTD_GRAY } from '../../shared/constants';
-import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
-import { toRelativeTimeString } from '../../../shared/time/timeUtils';
-
-const StatText = styled.span`
-    color: ${ANTD_GRAY[8]};
-`;
+import { DashboardStatsSummary as DashboardStatsSummaryView } from '../shared/DashboardStatsSummary';
 
 export const DashboardPreview = ({
     urn,
@@ -43,6 +35,7 @@ export const DashboardPreview = ({
     chartCount,
     statsSummary,
     lastUpdatedMs,
+    createdMs,
     externalUrl,
     parentContainers,
     deprecation,
@@ -64,6 +57,7 @@ export const DashboardPreview = ({
     chartCount?: number | null;
     statsSummary?: DashboardStatsSummary | null;
     lastUpdatedMs?: number | null;
+    createdMs?: number | null;
     externalUrl?: string | null;
     parentContainers?: ParentContainersResult | null;
 }): JSX.Element => {
@@ -91,35 +85,15 @@ export const DashboardPreview = ({
             parentContainers={parentContainers}
             externalUrl={externalUrl}
             topUsers={statsSummary?.topUsersLast30Days}
-            stats={[
-                (chartCount && (
-                    <StatText>
-                        <b>{chartCount}</b> charts
-                    </StatText>
-                )) ||
-                    undefined,
-                (statsSummary?.viewCount && (
-                    <StatText>
-                        <EyeOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        <b>{formatNumberWithoutAbbreviation(statsSummary.viewCount)}</b> views
-                    </StatText>
-                )) ||
-                    undefined,
-                (statsSummary?.uniqueUserCountLast30Days && (
-                    <StatText>
-                        <TeamOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        <b>{formatNumberWithoutAbbreviation(statsSummary?.uniqueUserCountLast30Days)}</b> unique users
-                    </StatText>
-                )) ||
-                    undefined,
-                (lastUpdatedMs && (
-                    <StatText>
-                        <ClockCircleOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        Changed {toRelativeTimeString(lastUpdatedMs)}
-                    </StatText>
-                )) ||
-                    undefined,
-            ].filter((stat) => stat !== undefined)}
+            subHeader={
+                <DashboardStatsSummaryView
+                    chartCount={chartCount}
+                    viewCount={statsSummary?.viewCount}
+                    uniqueUserCountLast30Days={statsSummary?.uniqueUserCountLast30Days}
+                    lastUpdatedMs={lastUpdatedMs}
+                    createdMs={createdMs}
+                />
+            }
         />
     );
 };

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardStatsSummarySubHeader.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardStatsSummarySubHeader.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { DashboardStatsSummary as DashboardStatsSummaryObj } from '../../../../types.generated';
+import { useBaseEntity } from '../../shared/EntityContext';
+import { GetDashboardQuery } from '../../../../graphql/dashboard.generated';
+import { DashboardStatsSummary } from '../shared/DashboardStatsSummary';
+
+export const DashboardStatsSummarySubHeader = () => {
+    const result = useBaseEntity<GetDashboardQuery>();
+    const dashboard = result?.dashboard;
+    const maybeStatsSummary = dashboard?.statsSummary as DashboardStatsSummaryObj;
+    const chartCount = dashboard?.charts?.total;
+    const viewCount = maybeStatsSummary?.viewCount;
+    const uniqueUserCountLast30Days = maybeStatsSummary?.uniqueUserCountLast30Days;
+    const lastUpdatedMs = dashboard?.properties?.lastModified?.time;
+    const createdMs = dashboard?.properties?.created?.time;
+
+    return (
+        <DashboardStatsSummary
+            chartCount={chartCount}
+            viewCount={viewCount}
+            uniqueUserCountLast30Days={uniqueUserCountLast30Days}
+            lastUpdatedMs={lastUpdatedMs}
+            createdMs={createdMs}
+        />
+    );
+};

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Popover } from 'antd';
-import { ClockCircleOutlined, EyeOutlined, TeamOutlined } from '@ant-design/icons';
+import { Popover, Tooltip } from 'antd';
+import { ClockCircleOutlined, EyeOutlined, TeamOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
@@ -9,6 +9,11 @@ import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
+`;
+
+const HelpIcon = styled(QuestionCircleOutlined)`
+    color: ${ANTD_GRAY[7]};
+    padding-left: 4px;
 `;
 
 type Props = {
@@ -52,7 +57,12 @@ export const DashboardStatsSummary = ({
                 content={
                     <>
                         {createdMs && <div>Created on {toLocalDateTimeString(createdMs)}.</div>}
-                        <div>Changed on {toLocalDateTimeString(lastUpdatedMs)}.</div>
+                        <div>
+                            Changed on {toLocalDateTimeString(lastUpdatedMs)}.{' '}
+                            <Tooltip title="The time at which the dashboard was last changed in the source platform">
+                                <HelpIcon />
+                            </Tooltip>
+                        </div>
                     </>
                 }
             >

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Popover } from 'antd';
+import { ClockCircleOutlined, EyeOutlined, TeamOutlined } from '@ant-design/icons';
+import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
+import { ANTD_GRAY } from '../../shared/constants';
+import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
+import { StatsSummary } from '../../shared/components/styled/StatsSummary';
+
+const StatText = styled.span`
+    color: ${ANTD_GRAY[8]};
+`;
+
+type Props = {
+    chartCount?: number | null;
+    viewCount?: number | null;
+    uniqueUserCountLast30Days?: number | null;
+    lastUpdatedMs?: number | null;
+    createdMs?: number | null;
+};
+
+export const DashboardStatsSummary = ({
+    chartCount,
+    viewCount,
+    uniqueUserCountLast30Days,
+    lastUpdatedMs,
+    createdMs,
+}: Props) => {
+    const statsViews = [
+        (!!chartCount && (
+            <StatText>
+                <b>{chartCount}</b> charts
+            </StatText>
+        )) ||
+            undefined,
+        (!!viewCount && (
+            <StatText>
+                <EyeOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                <b>{formatNumberWithoutAbbreviation(viewCount)}</b> views
+            </StatText>
+        )) ||
+            undefined,
+        (!!uniqueUserCountLast30Days && (
+            <StatText>
+                <TeamOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                <b>{formatNumberWithoutAbbreviation(uniqueUserCountLast30Days)}</b> unique users
+            </StatText>
+        )) ||
+            undefined,
+        (!!lastUpdatedMs && (
+            <Popover
+                content={
+                    <>
+                        {createdMs && <div>Created on {toLocalDateTimeString(createdMs)}.</div>}
+                        <div>Changed on {toLocalDateTimeString(lastUpdatedMs)}.</div>
+                    </>
+                }
+            >
+                <StatText>
+                    <ClockCircleOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                    Changed {toRelativeTimeString(lastUpdatedMs)}
+                </StatText>
+            </Popover>
+        )) ||
+            undefined,
+    ].filter((stat) => stat !== undefined);
+
+    return <>{statsViews.length > 0 && <StatsSummary stats={statsViews} />}</>;
+};

--- a/datahub-web-react/src/app/entity/dataFlow/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/dataFlow/preview/Preview.tsx
@@ -62,7 +62,7 @@ export const Preview = ({
             insights={insights}
             externalUrl={externalUrl}
             deprecation={deprecation}
-            stats={
+            subHeader={
                 (jobCount && [
                     <StatText>
                         <b>{jobCount}</b> {entityRegistry.getCollectionName(EntityType.DataJob)}

--- a/datahub-web-react/src/app/entity/dataJob/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/preview/Preview.tsx
@@ -66,7 +66,7 @@ export const Preview = ({
             dataTestID="datajob-item-preview"
             insights={insights}
             externalUrl={externalUrl}
-            stats={
+            subHeader={
                 (lastRunTimeMs && [
                     <StatText>
                         <ClockCircleOutlined style={{ paddingRight: 8 }} />

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -15,7 +15,6 @@ import QueriesTab from '../shared/tabs/Dataset/Queries/QueriesTab';
 import { SidebarAboutSection } from '../shared/containers/profile/sidebar/SidebarAboutSection';
 import { SidebarOwnerSection } from '../shared/containers/profile/sidebar/Ownership/SidebarOwnerSection';
 import { SidebarTagsSection } from '../shared/containers/profile/sidebar/SidebarTagsSection';
-import { SidebarStatsSection } from '../shared/containers/profile/sidebar/Dataset/StatsSidebarSection';
 import StatsTab from '../shared/tabs/Dataset/Stats/StatsTab';
 import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
 import { capitalizeFirstLetter } from '../../shared/textUtil';
@@ -28,6 +27,7 @@ import { ValidationsTab } from '../shared/tabs/Dataset/Validations/ValidationsTa
 import { OperationsTab } from './profile/OperationsTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { SidebarSiblingsSection } from '../shared/containers/profile/sidebar/SidebarSiblingsSection';
+import { DatasetStatsSummarySubHeader } from './profile/stats/stats/DatasetStatsSummarySubHeader';
 
 const SUBTYPES = {
     VIEW: 'view',
@@ -86,6 +86,9 @@ export class DatasetEntity implements Entity<Dataset> {
             useUpdateQuery={useUpdateDatasetMutation}
             getOverrideProperties={this.getOverridePropertiesFromEntity}
             headerDropdownItems={new Set([EntityMenuItems.COPY_URL, EntityMenuItems.UPDATE_DEPRECATION])}
+            subHeader={{
+                component: DatasetStatsSummarySubHeader,
+            }}
             tabs={[
                 {
                     name: 'Schema',
@@ -176,6 +179,12 @@ export class DatasetEntity implements Entity<Dataset> {
                     component: SidebarAboutSection,
                 },
                 {
+                    component: SidebarOwnerSection,
+                    properties: {
+                        defaultOwnerType: OwnershipType.TechnicalOwner,
+                    },
+                },
+                {
                     component: SidebarSiblingsSection,
                     display: {
                         visible: (_, dataset: GetDatasetQuery) =>
@@ -190,24 +199,10 @@ export class DatasetEntity implements Entity<Dataset> {
                     },
                 },
                 {
-                    component: SidebarStatsSection,
-                    display: {
-                        visible: (_, dataset: GetDatasetQuery) =>
-                            (dataset?.dataset?.datasetProfiles?.length || 0) > 0 ||
-                            (dataset?.dataset?.usageStats?.buckets?.length || 0) > 0,
-                    },
-                },
-                {
                     component: SidebarTagsSection,
                     properties: {
                         hasTags: true,
                         hasTerms: true,
-                    },
-                },
-                {
-                    component: SidebarOwnerSection,
-                    properties: {
-                        defaultOwnerType: OwnershipType.TechnicalOwner,
                     },
                 },
                 {

--- a/datahub-web-react/src/app/entity/dataset/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/dataset/preview/Preview.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import styled from 'styled-components';
-import { ClockCircleOutlined, ConsoleSqlOutlined, TableOutlined, TeamOutlined } from '@ant-design/icons';
 import {
     EntityType,
     FabricType,
@@ -19,13 +17,7 @@ import DefaultPreviewCard from '../../../preview/DefaultPreviewCard';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { capitalizeFirstLetterOnly } from '../../../shared/textUtil';
 import { IconStyleType } from '../../Entity';
-import { ANTD_GRAY } from '../../shared/constants';
-import { toRelativeTimeString } from '../../../shared/time/timeUtils';
-import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
-
-const StatText = styled.span`
-    color: ${ANTD_GRAY[8]};
-`;
+import { DatasetStatsSummary as DatasetStatsSummaryView } from '../shared/DatasetStatsSummary';
 
 export const Preview = ({
     urn,
@@ -102,36 +94,14 @@ export const Preview = ({
             parentContainers={parentContainers}
             externalUrl={externalUrl}
             topUsers={statsSummary?.topUsersLast30Days}
-            stats={[
-                (rowCount && (
-                    <StatText>
-                        <TableOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        <b>{formatNumberWithoutAbbreviation(rowCount)}</b> rows
-                    </StatText>
-                )) ||
-                    undefined,
-                (statsSummary?.queryCountLast30Days && (
-                    <StatText>
-                        <ConsoleSqlOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        <b>{formatNumberWithoutAbbreviation(statsSummary?.queryCountLast30Days)}</b> queries last month
-                    </StatText>
-                )) ||
-                    undefined,
-                (statsSummary?.uniqueUserCountLast30Days && (
-                    <StatText>
-                        <TeamOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        <b>{formatNumberWithoutAbbreviation(statsSummary?.uniqueUserCountLast30Days)}</b> unique users
-                    </StatText>
-                )) ||
-                    undefined,
-                (lastUpdatedMs && (
-                    <StatText>
-                        <ClockCircleOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                        Changed {toRelativeTimeString(lastUpdatedMs)}
-                    </StatText>
-                )) ||
-                    undefined,
-            ].filter((stat) => stat !== undefined)}
+            subHeader={
+                <DatasetStatsSummaryView
+                    rowCount={rowCount}
+                    queryCountLast30Days={statsSummary?.queryCountLast30Days}
+                    uniqueUserCountLast30Days={statsSummary?.uniqueUserCountLast30Days}
+                    lastUpdatedMs={lastUpdatedMs}
+                />
+            }
         />
     );
 };

--- a/datahub-web-react/src/app/entity/dataset/profile/stats/stats/DatasetStatsSummarySubHeader.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/stats/stats/DatasetStatsSummarySubHeader.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+    DatasetStatsSummary as DatasetStatsSummaryObj,
+    DatasetProfile,
+    Operation,
+} from '../../../../../../types.generated';
+import { useBaseEntity } from '../../../../shared/EntityContext';
+import { GetDatasetQuery } from '../../../../../../graphql/dataset.generated';
+import { DatasetStatsSummary } from '../../../shared/DatasetStatsSummary';
+
+export const DatasetStatsSummarySubHeader = () => {
+    const result = useBaseEntity<GetDatasetQuery>();
+    const dataset = result?.dataset;
+
+    const maybeStatsSummary = dataset?.statsSummary as DatasetStatsSummaryObj;
+    const maybeLastProfile =
+        ((dataset?.datasetProfiles?.length || 0) > 0 && (dataset?.datasetProfiles![0] as DatasetProfile)) || undefined;
+    const maybeLastOperation =
+        ((dataset?.operations?.length || 0) > 0 && (dataset?.operations![0] as Operation)) || undefined;
+
+    const rowCount = maybeLastProfile?.rowCount;
+    const queryCountLast30Days = maybeStatsSummary?.queryCountLast30Days;
+    const uniqueUserCountLast30Days = maybeStatsSummary?.uniqueUserCountLast30Days;
+    const lastUpdatedMs = maybeLastOperation?.lastUpdatedTimestamp;
+
+    return (
+        <DatasetStatsSummary
+            rowCount={rowCount}
+            queryCountLast30Days={queryCountLast30Days}
+            uniqueUserCountLast30Days={uniqueUserCountLast30Days}
+            lastUpdatedMs={lastUpdatedMs}
+        />
+    );
+};

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Popover } from 'antd';
+import { ClockCircleOutlined, ConsoleSqlOutlined, TableOutlined, TeamOutlined } from '@ant-design/icons';
+import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
+import { ANTD_GRAY } from '../../shared/constants';
+import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
+import { StatsSummary } from '../../shared/components/styled/StatsSummary';
+
+const StatText = styled.span`
+    color: ${ANTD_GRAY[8]};
+`;
+
+type Props = {
+    rowCount?: number | null;
+    queryCountLast30Days?: number | null;
+    uniqueUserCountLast30Days?: number | null;
+    lastUpdatedMs?: number | null;
+};
+
+export const DatasetStatsSummary = ({
+    rowCount,
+    queryCountLast30Days,
+    uniqueUserCountLast30Days,
+    lastUpdatedMs,
+}: Props) => {
+    const statsViews = [
+        (!!rowCount && (
+            <StatText>
+                <TableOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                <b>{formatNumberWithoutAbbreviation(rowCount)}</b> rows
+            </StatText>
+        )) ||
+            undefined,
+        (!!queryCountLast30Days && (
+            <StatText>
+                <ConsoleSqlOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                <b>{formatNumberWithoutAbbreviation(queryCountLast30Days)}</b> queries last month
+            </StatText>
+        )) ||
+            undefined,
+        (!!uniqueUserCountLast30Days && (
+            <StatText>
+                <TeamOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                <b>{formatNumberWithoutAbbreviation(uniqueUserCountLast30Days)}</b> unique users
+            </StatText>
+        )) ||
+            undefined,
+        (!!lastUpdatedMs && (
+            <Popover content={<div>Changed on {toLocalDateTimeString(lastUpdatedMs)}.</div>}>
+                <StatText>
+                    <ClockCircleOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+                    Changed {toRelativeTimeString(lastUpdatedMs)}
+                </StatText>
+            </Popover>
+        )) ||
+            undefined,
+    ].filter((stat) => stat !== undefined);
+
+    return <>{statsViews.length > 0 && <StatsSummary stats={statsViews} />}</>;
+};

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Popover } from 'antd';
-import { ClockCircleOutlined, ConsoleSqlOutlined, TableOutlined, TeamOutlined } from '@ant-design/icons';
+import { Popover, Tooltip } from 'antd';
+import {
+    ClockCircleOutlined,
+    ConsoleSqlOutlined,
+    TableOutlined,
+    TeamOutlined,
+    QuestionCircleOutlined,
+} from '@ant-design/icons';
 import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
@@ -9,6 +15,11 @@ import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
+`;
+
+const HelpIcon = styled(QuestionCircleOutlined)`
+    color: ${ANTD_GRAY[7]};
+    padding-left: 4px;
 `;
 
 type Props = {
@@ -47,7 +58,16 @@ export const DatasetStatsSummary = ({
         )) ||
             undefined,
         (!!lastUpdatedMs && (
-            <Popover content={<div>Changed on {toLocalDateTimeString(lastUpdatedMs)}.</div>}>
+            <Popover
+                content={
+                    <div>
+                        Changed on {toLocalDateTimeString(lastUpdatedMs)}.{' '}
+                        <Tooltip title="The time at which the data was last changed in the source platform">
+                            <HelpIcon />
+                        </Tooltip>
+                    </div>
+                }
+            >
                 <StatText>
                     <ClockCircleOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
                     Changed {toRelativeTimeString(lastUpdatedMs)}

--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActor.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActor.tsx
@@ -22,8 +22,6 @@ const ActorTag = styled(Tag)`
 `;
 
 export const ExpandedActor = ({ actor, popOver, closable, onClose }: Props) => {
-    console.log(actor);
-
     const entityRegistry = useEntityRegistry();
 
     let name = '';

--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
@@ -23,11 +23,12 @@ type Props = {
     actors: Array<CorpUser | CorpGroup>;
     max: number;
     onClose?: (actor: CorpUser | CorpGroup) => void;
+    containerStyle?: any;
 };
 
 const DEFAULT_MAX = 10;
 
-export const ExpandedActorGroup = ({ actors, max = DEFAULT_MAX, onClose }: Props) => {
+export const ExpandedActorGroup = ({ actors, max = DEFAULT_MAX, onClose, containerStyle }: Props) => {
     const finalActors = actors.length > max ? actors.slice(0, max) : actors;
     const remainder = actors.length > max ? actors.length - max : undefined;
 
@@ -42,7 +43,7 @@ export const ExpandedActorGroup = ({ actors, max = DEFAULT_MAX, onClose }: Props
                 </PopoverActors>
             }
         >
-            <ActorsContainer>
+            <ActorsContainer style={containerStyle}>
                 {finalActors.map((actor) => (
                     <ExpandedActor key={actor.urn} actor={actor} onClose={() => onClose?.(actor)} />
                 ))}

--- a/datahub-web-react/src/app/entity/shared/components/styled/StatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/StatsSummary.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ANTD_GRAY } from '../../constants';
+
+type Props = {
+    stats: Array<React.ReactNode>;
+};
+
+const StatsContainer = styled.div`
+    margin-top: 8px;
+`;
+
+const StatDivider = styled.div`
+    display: inline-block;
+    padding-left: 10px;
+    margin-right: 10px;
+    border-right: 1px solid ${ANTD_GRAY[4]};
+    height: 21px;
+    vertical-align: text-top;
+`;
+
+export const StatsSummary = ({ stats }: Props) => {
+    return (
+        <>
+            {stats && stats.length > 0 && (
+                <StatsContainer>
+                    {stats.map((statView, index) => (
+                        <span>
+                            {statView}
+                            {index < stats.length - 1 && <StatDivider />}
+                        </span>
+                    ))}
+                </StatsContainer>
+            )}
+        </>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -6,7 +6,13 @@ import { useHistory } from 'react-router';
 import { EntityType, Exact } from '../../../../../types.generated';
 import { Message } from '../../../../shared/Message';
 import { getDataForEntityType, getEntityPath, useRoutedTab } from './utils';
-import { EntitySidebarSection, EntityTab, GenericEntityProperties, GenericEntityUpdate } from '../../types';
+import {
+    EntitySidebarSection,
+    EntitySubHeaderSection,
+    EntityTab,
+    GenericEntityProperties,
+    GenericEntityUpdate,
+} from '../../types';
 import { EntityProfileNavBar } from './nav/EntityProfileNavBar';
 import { ANTD_GRAY } from '../../constants';
 import { EntityHeader } from './header/EntityHeader';
@@ -49,6 +55,7 @@ type Props<T, U> = {
     tabs: EntityTab[];
     sidebarSections: EntitySidebarSection[];
     customNavBar?: React.ReactNode;
+    subHeader?: EntitySubHeaderSection;
     headerDropdownItems?: Set<EntityMenuItems>;
     displayGlossaryBrowser?: boolean;
     isNameEditable?: boolean;
@@ -136,6 +143,7 @@ export const EntityProfile = <T, U>({
     headerDropdownItems,
     displayGlossaryBrowser,
     isNameEditable,
+    subHeader,
 }: Props<T, U>): JSX.Element => {
     const isLineageMode = useIsLineageMode();
     const isHideSiblingMode = useIsSeparateSiblingsMode();
@@ -254,7 +262,7 @@ export const EntityProfile = <T, U>({
                     )}
                     {!loading && (
                         <>
-                            <EntityHeader headerDropdownItems={headerDropdownItems} />
+                            <EntityHeader headerDropdownItems={headerDropdownItems} subHeader={subHeader} />
                             <Divider />
                             <EntitySidebar sidebarSections={sideBarSectionsWithDefaults} />
                         </>
@@ -323,6 +331,7 @@ export const EntityProfile = <T, U>({
                                         <EntityHeader
                                             headerDropdownItems={headerDropdownItems}
                                             isNameEditable={isNameEditable}
+                                            subHeader={subHeader}
                                             refreshBrowser={refreshBrowser}
                                         />
                                         <EntityTabs

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -16,6 +16,7 @@ import EntityName from './EntityName';
 import CopyUrn from '../../../../../shared/CopyUrn';
 import { DeprecationPill } from '../../../components/styled/DeprecationPill';
 import CompactContext from '../../../../../shared/CompactContext';
+import { EntitySubHeaderSection } from '../../../types';
 
 const TitleWrapper = styled.div`
     display: flex;
@@ -83,9 +84,10 @@ type Props = {
     refreshBrowser?: () => void;
     headerDropdownItems?: Set<EntityMenuItems>;
     isNameEditable?: boolean;
+    subHeader?: EntitySubHeaderSection;
 };
 
-export const EntityHeader = ({ refreshBrowser, headerDropdownItems, isNameEditable }: Props) => {
+export const EntityHeader = ({ refreshBrowser, headerDropdownItems, isNameEditable, subHeader }: Props) => {
     const { urn, entityType, entityData } = useEntityData();
     const refetch = useRefetch();
     const me = useGetAuthenticatedUser();
@@ -108,47 +110,55 @@ export const EntityHeader = ({ refreshBrowser, headerDropdownItems, isNameEditab
     const canEditName = isNameEditable && getCanEditName(entityType, me?.platformPrivileges as PlatformPrivileges);
 
     return (
-        <HeaderContainer data-testid="entity-header-test-id">
-            <MainHeaderContent>
-                <PlatformContent />
-                <TitleWrapper>
-                    <EntityName isNameEditable={canEditName} />
-                    {entityData?.deprecation?.deprecated && (
-                        <DeprecationPill deprecation={entityData?.deprecation} preview={isCompact} />
-                    )}
-                    {entityData?.health?.map((health) => (
-                        <EntityHealthStatus
-                            type={health.type}
-                            status={health.status}
-                            message={health.message || undefined}
-                        />
-                    ))}
-                </TitleWrapper>
-                <EntityCount entityCount={entityCount} />
-            </MainHeaderContent>
-            <SideHeaderContent>
-                <TopButtonsWrapper>
-                    {externalUrl && (
-                        <ExternalUrlContainer>
-                            <ExternalUrlButton type="link" href={externalUrl} target="_blank" onClick={sendAnalytics}>
-                                View in {platformName} <ArrowRightOutlined style={{ fontSize: 12 }} />
-                            </ExternalUrlButton>
-                        </ExternalUrlContainer>
-                    )}
-                    <CopyUrn urn={urn} isActive={copiedUrn} onClick={() => setCopiedUrn(true)} />
-                    {headerDropdownItems && (
-                        <EntityDropdown
-                            urn={urn}
-                            entityType={entityType}
-                            entityData={entityData}
-                            menuItems={headerDropdownItems}
-                            refetchForEntity={refetch}
-                            refreshBrowser={refreshBrowser}
-                            platformPrivileges={me?.platformPrivileges as PlatformPrivileges}
-                        />
-                    )}
-                </TopButtonsWrapper>
-            </SideHeaderContent>
-        </HeaderContainer>
+        <>
+            <HeaderContainer data-testid="entity-header-test-id">
+                <MainHeaderContent>
+                    <PlatformContent />
+                    <TitleWrapper>
+                        <EntityName isNameEditable={canEditName} />
+                        {entityData?.deprecation?.deprecated && (
+                            <DeprecationPill deprecation={entityData?.deprecation} preview={isCompact} />
+                        )}
+                        {entityData?.health?.map((health) => (
+                            <EntityHealthStatus
+                                type={health.type}
+                                status={health.status}
+                                message={health.message || undefined}
+                            />
+                        ))}
+                    </TitleWrapper>
+                    <EntityCount entityCount={entityCount} />
+                </MainHeaderContent>
+                <SideHeaderContent>
+                    <TopButtonsWrapper>
+                        {externalUrl && (
+                            <ExternalUrlContainer>
+                                <ExternalUrlButton
+                                    type="link"
+                                    href={externalUrl}
+                                    target="_blank"
+                                    onClick={sendAnalytics}
+                                >
+                                    View in {platformName} <ArrowRightOutlined style={{ fontSize: 12 }} />
+                                </ExternalUrlButton>
+                            </ExternalUrlContainer>
+                        )}
+                        <CopyUrn urn={urn} isActive={copiedUrn} onClick={() => setCopiedUrn(true)} />
+                        {headerDropdownItems && (
+                            <EntityDropdown
+                                urn={urn}
+                                entityType={entityType}
+                                entityData={entityData}
+                                menuItems={headerDropdownItems}
+                                refetchForEntity={refetch}
+                                refreshBrowser={refreshBrowser}
+                                platformPrivileges={me?.platformPrivileges as PlatformPrivileges}
+                            />
+                        )}
+                    </TopButtonsWrapper>
+                </SideHeaderContent>
+            </HeaderContainer>
+            {subHeader && <subHeader.component />}
+        </>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
@@ -1,11 +1,11 @@
 import { Tooltip, Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
-import { Maybe, UserUsageCounts } from '../../../../../../../types.generated';
-import UsageFacepile from '../../../../../dataset/profile/UsageFacepile';
+import { CorpUser, Maybe, UserUsageCounts } from '../../../../../../../types.generated';
 import { InfoItem } from '../../../../components/styled/InfoItem';
 import { ANTD_GRAY } from '../../../../constants';
 import { countFormatter, countSeparator } from '../../../../../../../utils/formatter/index';
+import { ExpandedActorGroup } from '../../../../components/styled/ExpandedActorGroup';
 
 type Props = {
     rowCount?: number;
@@ -67,10 +67,20 @@ export default function TableStats({
                         </Typography.Text>
                     </InfoItem>
                 )}
-                {users && (
+                {users && users.length > 0 && (
                     <InfoItem title="Top Users">
                         <div style={{ paddingTop: 8 }}>
-                            <UsageFacepile users={users} maxNumberDisplayed={10} />
+                            <ExpandedActorGroup
+                                containerStyle={{
+                                    justifyContent: 'left',
+                                }}
+                                actors={
+                                    users
+                                        .filter((user) => user && user?.user !== undefined && user?.user !== null)
+                                        .map((user) => user?.user as CorpUser) || []
+                                }
+                                max={4}
+                            />
                         </div>
                     </InfoItem>
                 )}

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -51,6 +51,10 @@ export type EntitySidebarSection = {
     properties?: any;
 };
 
+export type EntitySubHeaderSection = {
+    component: React.FunctionComponent<{ properties?: any }>;
+};
+
 export type GenericEntityProperties = {
     urn?: string;
     name?: Maybe<string>;

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -105,10 +105,6 @@ const TagSeparator = styled.div`
     border-right: 1px solid #cccccc;
 `;
 
-const StatsContainer = styled.div`
-    margin-top: 8px;
-`;
-
 const InsightContainer = styled.div`
     margin-top: 12px;
 `;
@@ -175,7 +171,7 @@ interface Props {
     deprecation?: Deprecation | null;
     topUsers?: Array<CorpUser> | null;
     externalUrl?: string | null;
-    stats?: Array<React.ReactNode> | null;
+    subHeader?: React.ReactNode;
     snippet?: React.ReactNode;
     insights?: Array<SearchInsight> | null;
     glossaryTerms?: GlossaryTerms;
@@ -207,7 +203,7 @@ export default function DefaultPreviewCard({
     tags,
     owners,
     topUsers,
-    stats,
+    subHeader,
     snippet,
     insights,
     glossaryTerms,
@@ -302,16 +298,7 @@ export default function DefaultPreviewCard({
                         {hasTags && <TagTermGroup uneditableTags={tags} maxShow={3} />}
                     </TagContainer>
                 )}
-                {stats && stats.length > 0 && (
-                    <StatsContainer>
-                        {stats.map((statView, index) => (
-                            <span>
-                                {statView}
-                                {index < stats.length - 1 && <PlatformDivider />}
-                            </span>
-                        ))}
-                    </StatsContainer>
-                )}
+                {subHeader}
                 {insightViews.length > 0 && (
                     <InsightContainer>
                         {insightViews.map((insightView, index) => (

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -176,6 +176,25 @@ fragment nonSiblingDatasetFields on Dataset {
             type
         }
     }
+    statsSummary {
+        queryCountLast30Days
+        uniqueUserCountLast30Days
+        topUsersLast30Days {
+            urn
+            type
+            username
+            properties {
+                displayName
+                firstName
+                lastName
+                fullName
+            }
+            editableProperties {
+                displayName
+                pictureLink
+            }
+        }
+    }
 }
 
 mutation updateDataset($urn: String!, $input: DatasetUpdateInput!) {

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -91,7 +91,18 @@ fragment nonSiblingDatasetFields on Dataset {
             users {
                 user {
                     urn
+                    type
                     username
+                    properties {
+                        displayName
+                        firstName
+                        lastName
+                        fullName
+                    }
+                    editableProperties {
+                        displayName
+                        pictureLink
+                    }
                 }
                 count
                 userEmail

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -389,6 +389,25 @@ fragment dashboardFields on Dashboard {
     dataPlatformInstance {
         ...dataPlatformInstanceFields
     }
+    statsSummary {
+        viewCount
+        uniqueUserCountLast30Days
+        topUsersLast30Days {
+            urn
+            type
+            username
+            properties {
+                displayName
+                firstName
+                lastName
+                fullName
+            }
+            editableProperties {
+                displayName
+                pictureLink
+            }
+        }
+    }
 }
 
 fragment nonRecursiveMLFeature on MLFeature {


### PR DESCRIPTION
**Summary**

In this PR, we do a few things:

1. Refactor the search preview stats into a shared compont for datasets and dashboards (DatasetStatsSummary, DashboardStatsSummary) 
2. Add a customizable "subheader" to render on the Entity Profile, which reuses these components to show statistics preview on the entity profile
3. Remove the sidebar stats section for datasets
4. Move owners sidebar section up 
5. Fix rendering of Top Users in the Dataset stats tab to show clickable resolved users (not just emails) 

**Status**
Ready for review

**Screenshots**
<img width="1303" alt="Screen Shot 2022-07-19 at 2 54 05 PM" src="https://user-images.githubusercontent.com/17549204/179855207-3a56a631-cf37-4d19-a491-5f70743c3e1a.png">
<img width="1332" alt="Screen Shot 2022-07-19 at 2 54 51 PM" src="https://user-images.githubusercontent.com/17549204/179855246-62bb8f2c-1f39-4e79-9a20-1e8931cdcc48.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)