### PR TITLE
feat(ingest) Allow ingestion of Elasticsearch index template

### DIFF
--- a/metadata-ingestion/archived/source_docs/elastic_search.md
+++ b/metadata-ingestion/archived/source_docs/elastic_search.md
@@ -41,6 +41,9 @@ source:
     index_pattern:
       allow: [".*some_index_name_pattern*"]
       deny: [".*skip_index_name_pattern*"]
+    ingest_index_template: False
+    template_pattern:
+      allow: [".*some_index_name_pattern*"]
 
 sink:
 # sink configs
@@ -62,6 +65,9 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `index_pattern.allow`       |          |                    | List of regex patterns for indexes to include in ingestion.   |
 | `index_pattern.deny`        |          |                    | List of regex patterns for indexes to exclude from ingestion. |
 | `index_pattern.ignoreCase`  |          | `True`             | Whether regex matching should ignore case or not              |
+| `ingest_index_template`     |          | `False`            | Whether index templates should be ingested                    |
+| `template_pattern.allow`    |          |                    | List of regex patterns for index templates to include in ingestion.   |
+| `template_pattern.deny`    |          |                    | List of regex patterns for index templates to exclude in ingestion.   |
 
 ## Compatibility
 

--- a/metadata-ingestion/archived/source_docs/elastic_search.md
+++ b/metadata-ingestion/archived/source_docs/elastic_search.md
@@ -41,9 +41,9 @@ source:
     index_pattern:
       allow: [".*some_index_name_pattern*"]
       deny: [".*skip_index_name_pattern*"]
-    ingest_index_template: False
-    template_pattern:
-      allow: [".*some_index_name_pattern*"]
+    ingest_index_templates: False
+    index_template_pattern:
+      allow: [".*some_index_template_name_pattern*"]
 
 sink:
 # sink configs
@@ -54,20 +54,20 @@ sink:
 Note that a `.` is used to denote nested fields in the YAML recipe.
 
 
-| Field                       | Required | Default            | Description                                                   |
-| --------------------------- | -------- |--------------------|---------------------------------------------------------------|
-| `host`                      | ✅       | `"localhost:9092"` | The elastic search host URI.                                  |
-| `username`                  |          | None               | The username credential.                                      |
-| `password`                  |          | None               | The password credential.                                      |
-| `url_prefix`                |          | ""                 | There are cases where an enterprise would have multiple elastic search clusters. One way for them to manage is to have a single endpoint for all the elastic search clusters and use url_prefix for routing requests to different clusters.                            |
-| `env`                       |          | `"PROD"`           | Environment to use in namespace when constructing URNs.       |
-| `platform_instance`         |          | None               | The Platform instance to use while constructing URNs.         |
-| `index_pattern.allow`       |          |                    | List of regex patterns for indexes to include in ingestion.   |
-| `index_pattern.deny`        |          |                    | List of regex patterns for indexes to exclude from ingestion. |
-| `index_pattern.ignoreCase`  |          | `True`             | Whether regex matching should ignore case or not              |
-| `ingest_index_template`     |          | `False`            | Whether index templates should be ingested                    |
-| `template_pattern.allow`    |          |                    | List of regex patterns for index templates to include in ingestion.   |
-| `template_pattern.deny`    |          |                    | List of regex patterns for index templates to exclude in ingestion.   |
+| Field                          | Required | Default            | Description                                                                                                                                                                                                                                 |
+|--------------------------------| -------- |--------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `host`                         | ✅       | `"localhost:9092"` | The elastic search host URI.                                                                                                                                                                                                                |
+| `username`                     |          | None               | The username credential.                                                                                                                                                                                                                    |
+| `password`                     |          | None               | The password credential.                                                                                                                                                                                                                    |
+| `url_prefix`                   |          | ""                 | There are cases where an enterprise would have multiple elastic search clusters. One way for them to manage is to have a single endpoint for all the elastic search clusters and use url_prefix for routing requests to different clusters. |
+| `env`                          |          | `"PROD"`           | Environment to use in namespace when constructing URNs.                                                                                                                                                                                     |
+| `platform_instance`            |          | None               | The Platform instance to use while constructing URNs.                                                                                                                                                                                       |
+| `index_pattern.allow`          |          |                    | List of regex patterns for indexes to include in ingestion.                                                                                                                                                                                 |
+| `index_pattern.deny`           |          |                    | List of regex patterns for indexes to exclude from ingestion.                                                                                                                                                                               |
+| `index_pattern.ignoreCase`     |          | `True`             | Whether regex matching should ignore case or not                                                                                                                                                                                            |
+| `ingest_index_templates`       |          | `False`            | Whether index templates should be ingested                                                                                                                                                                                                  |
+| `index_template_pattern.allow` |          |                    | List of regex patterns for index templates to include in ingestion.                                                                                                                                                                         |
+| `index_template_pattern.deny`  |          |                    | List of regex patterns for index templates to exclude from ingestion.                                                                                                                                                                       |
 
 ## Compatibility
 

--- a/metadata-ingestion/docs/sources/elastic-search/elasticsearch_recipe.yml
+++ b/metadata-ingestion/docs/sources/elastic-search/elasticsearch_recipe.yml
@@ -23,9 +23,9 @@ source:
     index_pattern:
       allow: [".*some_index_name_pattern*"]
       deny: [".*skip_index_name_pattern*"]
-    ingest_index_template: False
-    template_pattern:
-      allow: [".*some_index_name_pattern*"]
+    ingest_index_templates: False
+    index_template_pattern:
+      allow: [".*some_index_template_name_pattern*"]
 
 sink:
 # sink configs

--- a/metadata-ingestion/docs/sources/elastic-search/elasticsearch_recipe.yml
+++ b/metadata-ingestion/docs/sources/elastic-search/elasticsearch_recipe.yml
@@ -23,6 +23,9 @@ source:
     index_pattern:
       allow: [".*some_index_name_pattern*"]
       deny: [".*skip_index_name_pattern*"]
+    ingest_index_template: False
+    template_pattern:
+      allow: [".*some_index_name_pattern*"]
 
 sink:
 # sink configs

--- a/metadata-ingestion/examples/recipes/elasticsearch_to_datahub.dhub.yaml
+++ b/metadata-ingestion/examples/recipes/elasticsearch_to_datahub.dhub.yaml
@@ -11,8 +11,8 @@ source:
     client_key: "./path/client.key"
     ssl_assert_hostname: False
     ssl_assert_fingerprint: "./path/cert.fingerprint"
-    ingest_index_template: False
-    # template_pattern:
+    ingest_index_templates: False
+    # index_template_pattern:
     #   allow:
     #     - "^.+"
     

--- a/metadata-ingestion/examples/recipes/elasticsearch_to_datahub.dhub.yaml
+++ b/metadata-ingestion/examples/recipes/elasticsearch_to_datahub.dhub.yaml
@@ -11,7 +11,11 @@ source:
     client_key: "./path/client.key"
     ssl_assert_hostname: False
     ssl_assert_fingerprint: "./path/cert.fingerprint"
-
+    ingest_index_template: False
+    # template_pattern:
+    #   allow:
+    #     - "^.+"
+    
 sink:
   type: "datahub-rest"
   config:


### PR DESCRIPTION
So this enhancement to the existing ES connector is driven by my company's current practice of using Index Templates as the basis for daily created indices. We don't use the Datastreams feature in ES to automatically rollover the index. As a result, if i use the default ES connector, i get thousands of identical datasets, differing by date, which is not very helpful for finding documentation (can't really expect every index to be populated) So we decided to ingest the index template instead.   

Based on my checks in [Slack](https://datahubspace.slack.com/archives/CUMUWQU66/p1657880726234279), it doesn't seem to be a popular use case, but i thought i will just put it up all the same.   


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)