### PR TITLE
fix(ingest/trino): Avoid exception if $properties table empty or not readable

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
@@ -71,8 +71,9 @@ def get_table_comment(self, connection, table_name: str, schema: str = None, **k
 
         # Generate properties dictionary.
         properties = {}
-        for col_name, col_value in row.items():
-            properties[col_name] = col_value
+        if row:
+            for col_name, col_value in row.items():
+                properties[col_name] = col_value
 
         return {"text": properties.get("comment", None), "properties": properties}
     except TrinoQueryError as e:


### PR DESCRIPTION
Under some configuration of access rules in Trino, the user may not have
read access to the content of the table, which will result in an exception
(`fetchone()` returns `None`)

This commit ensures no exception are raised and the ingestion can proceed.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)