### PR TITLE
fix(hive): add column comment as a column description

### DIFF
--- a/metadata-ingestion/docs/sources/hive/hive_recipe.yml
+++ b/metadata-ingestion/docs/sources/hive/hive_recipe.yml
@@ -59,8 +59,8 @@ source:
   type: hive
   config:
     host_port: <databricks workspace URL>:443
-    username: token
-    password: <api token>
+    username: token / username
+    password: <api token> / password
     scheme: 'databricks+pyhive'
 
     options:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/hive.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/hive.py
@@ -79,6 +79,7 @@ try:
                     "nullable": True,
                     "default": None,
                     "full_type": orig_col_type,  # pass it through
+                    "comment": _comment,
                 }
             )
         return result


### PR DESCRIPTION
This PR extracts column comments and populates in column description. Previously this was being kept empty.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)