### PR TITLE
feat(schema-history): remove blame language for the schema history feature

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -143,9 +143,9 @@ import com.linkedin.datahub.graphql.resolvers.mutate.RemoveOwnerResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.RemoveTagResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.RemoveTermResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateDescriptionResolver;
-import com.linkedin.datahub.graphql.resolvers.operation.ReportOperationResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateNameResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateParentNodeResolver;
+import com.linkedin.datahub.graphql.resolvers.operation.ReportOperationResolver;
 import com.linkedin.datahub.graphql.resolvers.policy.DeletePolicyResolver;
 import com.linkedin.datahub.graphql.resolvers.policy.GetGrantedPrivilegesResolver;
 import com.linkedin.datahub.graphql.resolvers.policy.ListPoliciesResolver;
@@ -165,6 +165,7 @@ import com.linkedin.datahub.graphql.resolvers.test.ListTestsResolver;
 import com.linkedin.datahub.graphql.resolvers.test.TestResultsResolver;
 import com.linkedin.datahub.graphql.resolvers.test.UpdateTestResolver;
 import com.linkedin.datahub.graphql.resolvers.timeline.GetSchemaBlameResolver;
+import com.linkedin.datahub.graphql.resolvers.timeline.GetSchemaVersionListResolver;
 import com.linkedin.datahub.graphql.resolvers.type.AspectInterfaceTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.type.EntityInterfaceTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.type.HyperParameterValueTypeResolver;
@@ -214,8 +215,8 @@ import com.linkedin.datahub.graphql.types.usage.UsageType;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.config.DatahubConfiguration;
 import com.linkedin.metadata.config.IngestionConfiguration;
-import com.linkedin.metadata.config.VisualConfiguration;
 import com.linkedin.metadata.config.TestsConfiguration;
+import com.linkedin.metadata.config.VisualConfiguration;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.graph.SiblingGraphService;
@@ -232,12 +233,6 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.StaticDataFetcher;
 import graphql.schema.idl.RuntimeWiring;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.IOUtils;
-import org.dataloader.BatchLoaderContextProvider;
-import org.dataloader.DataLoader;
-import org.dataloader.DataLoaderOptions;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -250,10 +245,15 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+import org.dataloader.BatchLoaderContextProvider;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderOptions;
 
 import static com.linkedin.datahub.graphql.Constants.*;
-import static com.linkedin.metadata.Constants.DATA_PROCESS_INSTANCE_RUN_EVENT_ASPECT_NAME;
-import static graphql.Scalars.GraphQLLong;
+import static com.linkedin.metadata.Constants.*;
+import static graphql.Scalars.*;
 
 
 /**
@@ -635,6 +635,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("ingestionSource", new GetIngestionSourceResolver(this.entityClient))
             .dataFetcher("executionRequest", new GetIngestionExecutionRequestResolver(this.entityClient))
             .dataFetcher("getSchemaBlame", new GetSchemaBlameResolver(this.timelineService))
+            .dataFetcher("getSchemaVersionList", new GetSchemaVersionListResolver(this.timelineService))
             .dataFetcher("test", getResolver(testType))
             .dataFetcher("listTests", new ListTestsResolver(entityClient))
             .dataFetcher("getRootGlossaryTerms", new GetRootGlossaryTermsResolver(this.entityClient))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/timeline/GetSchemaVersionListResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/timeline/GetSchemaVersionListResolver.java
@@ -1,9 +1,9 @@
 package com.linkedin.datahub.graphql.resolvers.timeline;
 
 import com.linkedin.common.urn.Urn;
-import com.linkedin.datahub.graphql.generated.GetSchemaBlameInput;
-import com.linkedin.datahub.graphql.generated.GetSchemaBlameResult;
-import com.linkedin.datahub.graphql.types.timeline.mappers.SchemaBlameMapper;
+import com.linkedin.datahub.graphql.generated.GetSchemaVersionListInput;
+import com.linkedin.datahub.graphql.generated.GetSchemaVersionListResult;
+import com.linkedin.datahub.graphql.types.timeline.mappers.SchemaVersionListMapper;
 import com.linkedin.metadata.timeline.TimelineService;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeTransaction;
@@ -23,21 +23,21 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 Returns the most recent changes made to each column in a dataset at each dataset version.
  */
 @Slf4j
-public class GetSchemaBlameResolver implements DataFetcher<CompletableFuture<GetSchemaBlameResult>> {
+public class GetSchemaVersionListResolver implements DataFetcher<CompletableFuture<GetSchemaVersionListResult>> {
   private final TimelineService _timelineService;
 
-  public GetSchemaBlameResolver(TimelineService timelineService) {
+  public GetSchemaVersionListResolver(TimelineService timelineService) {
     _timelineService = timelineService;
   }
 
   @Override
-  public CompletableFuture<GetSchemaBlameResult> get(final DataFetchingEnvironment environment) throws Exception {
-    final GetSchemaBlameInput input = bindArgument(environment.getArgument("input"), GetSchemaBlameInput.class);
+  public CompletableFuture<GetSchemaVersionListResult> get(final DataFetchingEnvironment environment) throws Exception {
+    final GetSchemaVersionListInput input =
+        bindArgument(environment.getArgument("input"), GetSchemaVersionListInput.class);
 
     final String datasetUrnString = input.getDatasetUrn();
     final long startTime = 0;
     final long endTime = 0;
-    final String version = input.getVersion() == null ? null : input.getVersion();
 
     return CompletableFuture.supplyAsync(() -> {
       try {
@@ -46,7 +46,7 @@ public class GetSchemaBlameResolver implements DataFetcher<CompletableFuture<Get
         Urn datasetUrn = Urn.createFromString(datasetUrnString);
         List<ChangeTransaction> changeTransactionList =
             _timelineService.getTimeline(datasetUrn, changeCategorySet, startTime, endTime, null, null, false);
-        return SchemaBlameMapper.map(changeTransactionList, version);
+        return SchemaVersionListMapper.map(changeTransactionList);
       } catch (URISyntaxException u) {
         log.error(
             String.format("Failed to list schema blame data, likely due to the Urn %s being invalid", datasetUrnString),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/timeline/mappers/SchemaVersionListMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/timeline/mappers/SchemaVersionListMapper.java
@@ -1,0 +1,56 @@
+package com.linkedin.datahub.graphql.types.timeline.mappers;
+
+import com.linkedin.datahub.graphql.generated.GetSchemaVersionListResult;
+import com.linkedin.datahub.graphql.generated.SemanticVersionStruct;
+import com.linkedin.datahub.graphql.types.timeline.utils.TimelineUtils;
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.util.Pair;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.linkedin.datahub.graphql.types.timeline.utils.TimelineUtils.*;
+
+
+// Class for converting ChangeTransactions received from the Timeline API to list of schema versions.
+@Slf4j
+public class SchemaVersionListMapper {
+
+  public static GetSchemaVersionListResult map(List<ChangeTransaction> changeTransactions) {
+    if (changeTransactions.isEmpty()) {
+      log.debug("Change transactions are empty");
+      return null;
+    }
+
+    GetSchemaVersionListResult result = new GetSchemaVersionListResult();
+
+    String latestSemanticVersionString =
+        truncateSemanticVersion(changeTransactions.get(changeTransactions.size() - 1).getSemVer());
+    long latestSemanticVersionTimestamp = changeTransactions.get(changeTransactions.size() - 1).getTimestamp();
+    String latestVersionStamp = changeTransactions.get(changeTransactions.size() - 1).getVersionStamp();
+    result.setLatestVersion(
+        new SemanticVersionStruct(latestSemanticVersionString, latestSemanticVersionTimestamp, latestVersionStamp));
+
+    List<ChangeTransaction> reversedChangeTransactions = changeTransactions.stream()
+        .map(TimelineUtils::semanticVersionChangeTransactionPair)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .sorted(Collections.reverseOrder(Comparator.comparing(Pair::getFirst)))
+        .map(Pair::getSecond)
+        .collect(Collectors.toList());
+
+    List<SemanticVersionStruct> semanticVersionStructList = reversedChangeTransactions.stream()
+        .map(changeTransaction -> new SemanticVersionStruct(truncateSemanticVersion(changeTransaction.getSemVer()),
+            changeTransaction.getTimestamp(), changeTransaction.getVersionStamp()))
+        .collect(Collectors.toList());
+
+    result.setSemanticVersionList(semanticVersionStructList);
+    return result;
+  }
+
+  private SchemaVersionListMapper() {
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/timeline/utils/TimelineUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/timeline/utils/TimelineUtils.java
@@ -1,0 +1,79 @@
+package com.linkedin.datahub.graphql.types.timeline.utils;
+
+import com.linkedin.datahub.graphql.generated.ChangeOperationType;
+import com.linkedin.datahub.graphql.generated.SchemaFieldChange;
+import com.linkedin.metadata.timeline.data.ChangeEvent;
+import com.linkedin.metadata.timeline.data.ChangeTransaction;
+import com.linkedin.util.Pair;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.parquet.SemanticVersion;
+
+
+@Slf4j
+public class TimelineUtils {
+
+  public static Optional<Pair<SemanticVersion, ChangeTransaction>> semanticVersionChangeTransactionPair(
+      ChangeTransaction changeTransaction) {
+    Optional<SemanticVersion> semanticVersion = createSemanticVersion(changeTransaction.getSemVer());
+    return semanticVersion.map(version -> Pair.of(version, changeTransaction));
+  }
+
+  public static Optional<SemanticVersion> createSemanticVersion(String semanticVersionString) {
+    String truncatedSemanticVersion = truncateSemanticVersion(semanticVersionString);
+    try {
+      SemanticVersion semanticVersion = SemanticVersion.parse(truncatedSemanticVersion);
+      return Optional.of(semanticVersion);
+    } catch (SemanticVersion.SemanticVersionParseException e) {
+      return Optional.empty();
+    }
+  }
+
+  // The SemanticVersion is currently returned from the ChangeTransactions in the format "x.y.z-computed". This function
+  // removes the suffix "computed".
+  public static String truncateSemanticVersion(String semanticVersion) {
+    String suffix = "-computed";
+    return semanticVersion.endsWith(suffix) ? semanticVersion.substring(0, semanticVersion.lastIndexOf(suffix))
+        : semanticVersion;
+  }
+
+  public static SchemaFieldChange getLastSchemaFieldChange(ChangeEvent changeEvent, long timestamp,
+      String semanticVersion, String versionStamp) {
+    SchemaFieldChange schemaFieldChange = new SchemaFieldChange();
+    schemaFieldChange.setTimestampMillis(timestamp);
+    schemaFieldChange.setLastSemanticVersion(truncateSemanticVersion(semanticVersion));
+    schemaFieldChange.setChangeType(
+        ChangeOperationType.valueOf(ChangeOperationType.class, changeEvent.getOperation().toString()));
+    schemaFieldChange.setVersionStamp(versionStamp);
+
+    String translatedChangeOperationType;
+    switch (changeEvent.getOperation()) {
+      case ADD:
+        translatedChangeOperationType = "Added";
+        break;
+      case MODIFY:
+        translatedChangeOperationType = "Modified";
+        break;
+      case REMOVE:
+        translatedChangeOperationType = "Removed";
+        break;
+      default:
+        translatedChangeOperationType = "Unknown change made";
+        log.warn(translatedChangeOperationType);
+        break;
+    }
+
+    String suffix = "-computed";
+    String translatedSemanticVersion =
+        semanticVersion.endsWith(suffix) ? semanticVersion.substring(0, semanticVersion.lastIndexOf(suffix))
+            : semanticVersion;
+
+    String lastSchemaFieldChange = String.format("%s in v%s", translatedChangeOperationType, translatedSemanticVersion);
+    schemaFieldChange.setLastSchemaFieldChange(lastSchemaFieldChange);
+
+    return schemaFieldChange;
+  }
+
+  private TimelineUtils() {
+  }
+}

--- a/datahub-graphql-core/src/main/resources/timeline.graphql
+++ b/datahub-graphql-core/src/main/resources/timeline.graphql
@@ -3,6 +3,11 @@ extend type Query {
     Returns the most recent changes made to each column in a dataset at each dataset version.
     """
     getSchemaBlame(input: GetSchemaBlameInput!): GetSchemaBlameResult
+
+    """
+    Returns the list of schema versions for a dataset.
+    """
+    getSchemaVersionList(input: GetSchemaVersionListInput!): GetSchemaVersionListResult
 }
 
 """
@@ -50,27 +55,19 @@ enum ChangeCategoryType {
 }
 
 """
-Input for getting schema changes computed at a specific version.
+Input for getting list of schema versions.
 """
-input GetSchemaBlameInput {
+input GetSchemaVersionListInput {
     """
     The dataset urn
     """
     datasetUrn: String!
-    """
-    Categories to filter on. By default, will just be TECHNICAL_SCHEMA.
-    """
-    categories: [ChangeCategoryType!]
-    """
-    Changes after this version are not shown. If not provided, this is the latestVersion.
-    """
-    version: String
 }
 
 """
 Schema changes computed at a specific version.
 """
-type GetSchemaBlameResult {
+type GetSchemaVersionListResult {
     """
     Latest and current semantic version
     """
@@ -83,6 +80,31 @@ type GetSchemaBlameResult {
     All semantic versions. Absent when there are no versions.
     """
     semanticVersionList: [SemanticVersionStruct!]
+}
+
+
+"""
+Input for getting schema changes computed at a specific version.
+"""
+input GetSchemaBlameInput {
+    """
+    The dataset urn
+    """
+    datasetUrn: String!
+    """
+    Changes after this version are not shown. If not provided, this is the latestVersion.
+    """
+    version: String
+}
+
+"""
+Schema changes computed at a specific version.
+"""
+type GetSchemaBlameResult {
+    """
+    Selected semantic version
+    """
+    version: SemanticVersionStruct
     """
     List of schema blame. Absent when there are no fields to return history for.
     """

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaHeader.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaHeader.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { Button, Popover, Radio, Select, Typography } from 'antd';
-import { CaretDownOutlined, FileTextOutlined, InfoCircleOutlined, TableOutlined } from '@ant-design/icons';
+import { Button, Popover, Select, Tooltip, Typography } from 'antd';
+import {
+    AuditOutlined,
+    CaretDownOutlined,
+    FileTextOutlined,
+    QuestionCircleOutlined,
+    TableOutlined,
+} from '@ant-design/icons';
 import styled from 'styled-components';
 import CustomPagination from './CustomPagination';
 import TabToolbar from '../../../../shared/components/styled/TabToolbar';
 import { SemanticVersionStruct } from '../../../../../../types.generated';
 import { toRelativeTimeString } from '../../../../../shared/time/timeUtils';
-import { SchemaViewType } from '../utils/types';
-import { ANTD_GRAY } from '../../../../shared/constants';
+import { ANTD_GRAY, REDESIGN_COLORS } from '../../../../shared/constants';
 import { navigateToVersionedDatasetUrl } from '../../../../shared/tabs/Dataset/Schema/utils/navigateToVersionedDatasetUrl';
 import SchemaTimeStamps from './SchemaTimeStamps';
 
@@ -86,24 +91,16 @@ const SchemaBlameSelectorOption = styled(Select.Option)`
     }
 `;
 
-const BlameRadio = styled(Radio.Group)`
+const SchemaAuditButton = styled(Button)`
     &&& {
         margin-top: 6px;
-        margin-right: 10px;
-        min-width: 140px;
     }
 `;
 
-const BlameRadioButton = styled(Radio.Button)`
+const StyledQuestionCircleOutlined = styled(QuestionCircleOutlined)`
     &&& {
-        min-width: 30px;
-    }
-`;
-
-const StyledInfoCircleOutlined = styled(InfoCircleOutlined)`
-    &&& {
-        margin-top: 12px;
-        font-size: 20px;
+        margin-top: 14px;
+        font-size: 16px;
         color: ${ANTD_GRAY[6]};
     }
 `;
@@ -129,8 +126,8 @@ type Props = {
     lastObserved?: number | null;
     selectedVersion: string;
     versionList: Array<SemanticVersionStruct>;
-    schemaView: SchemaViewType;
-    setSchemaView: any;
+    showSchemaAuditView: boolean;
+    setShowSchemaAuditView: any;
 };
 
 export default function SchemaHeader({
@@ -148,8 +145,8 @@ export default function SchemaHeader({
     lastObserved,
     selectedVersion,
     versionList,
-    schemaView,
-    setSchemaView,
+    showSchemaAuditView,
+    setShowSchemaAuditView,
 }: Props) {
     const history = useHistory();
     const location = useLocation();
@@ -167,6 +164,7 @@ export default function SchemaHeader({
             'unknown';
         return `${semanticVersion.semanticVersion} - ${semanticVersionTimestampString}`;
     };
+    const numVersions = versionList.length;
 
     const renderOptions = () => {
         return versionList.map(
@@ -182,10 +180,7 @@ export default function SchemaHeader({
                 ),
         );
     };
-
-    const onSchemaViewToggle = (e) => {
-        setSchemaView(e.target.value);
-    };
+    const schemaAuditToggleText = showSchemaAuditView ? 'Close column history' : 'View column history';
 
     const docLink = 'https://datahubproject.io/docs/dev-guides/timeline/';
     return (
@@ -227,45 +222,51 @@ export default function SchemaHeader({
                 </LeftButtonsGroup>
                 <RightButtonsGroup>
                     <SchemaTimeStamps lastObserved={lastObserved} lastUpdated={lastUpdated} />
-                    <BlameRadio value={schemaView} onChange={onSchemaViewToggle}>
-                        <BlameRadioButton value={SchemaViewType.NORMAL} data-testid="schema-normal-button">
-                            Normal
-                        </BlameRadioButton>
-                        <BlameRadioButton value={SchemaViewType.BLAME} data-testid="schema-blame-button">
-                            Blame
-                        </BlameRadioButton>
-                    </BlameRadio>
-                    <SchemaBlameSelector
-                        value={selectedVersion}
-                        onChange={(e) => {
-                            const datasetVersion: string = e as string;
-                            navigateToVersionedDatasetUrl({
-                                location,
-                                history,
-                                datasetVersion,
-                            });
-                        }}
-                        data-testid="schema-version-selector-dropdown"
-                        suffixIcon={<StyledCaretDownOutlined />}
-                    >
-                        {renderOptions()}
-                    </SchemaBlameSelector>
-                    <Popover
-                        overlayStyle={{ maxWidth: 240 }}
-                        placement="right"
-                        content={
-                            <div>
-                                Semantic versions for this view were computed using Technical Schema. You can find more
-                                info about how we compute versions
-                                <a target="_blank" rel="noreferrer noopener" href={docLink}>
-                                    {' '}
-                                    here.{' '}
-                                </a>
-                            </div>
-                        }
-                    >
-                        <StyledInfoCircleOutlined />
-                    </Popover>
+                    <Tooltip title={schemaAuditToggleText}>
+                        <SchemaAuditButton
+                            type="text"
+                            data-testid="schema-blame-button"
+                            onClick={() => setShowSchemaAuditView(!showSchemaAuditView)}
+                            style={{ color: showSchemaAuditView ? REDESIGN_COLORS.BLUE : ANTD_GRAY[7] }}
+                        >
+                            <AuditOutlined />
+                        </SchemaAuditButton>
+                    </Tooltip>
+                    {numVersions > 1 && (
+                        <>
+                            <SchemaBlameSelector
+                                value={selectedVersion}
+                                onChange={(e) => {
+                                    const datasetVersion: string = e as string;
+                                    navigateToVersionedDatasetUrl({
+                                        location,
+                                        history,
+                                        datasetVersion,
+                                    });
+                                }}
+                                data-testid="schema-version-selector-dropdown"
+                                suffixIcon={<StyledCaretDownOutlined />}
+                            >
+                                {renderOptions()}
+                            </SchemaBlameSelector>
+                            <Popover
+                                overlayStyle={{ maxWidth: 240 }}
+                                placement="right"
+                                content={
+                                    <div>
+                                        Semantic versions for this view were computed using Technical Schema. You can
+                                        find more info about how DataHub computes versions
+                                        <a target="_blank" rel="noreferrer noopener" href={docLink}>
+                                            {' '}
+                                            here.{' '}
+                                        </a>
+                                    </div>
+                                }
+                            >
+                                <StyledQuestionCircleOutlined />
+                            </Popover>
+                        </>
+                    )}
                 </RightButtonsGroup>
             </SchemaHeaderContainer>
         </TabToolbar>

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
@@ -2,10 +2,7 @@ import { Empty } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
 import styled from 'styled-components';
 import { GetDatasetQuery } from '../../../../../../graphql/dataset.generated';
-import {
-    useGetSchemaBlameQuery,
-    useGetSchemaBlameVersionsQuery,
-} from '../../../../../../graphql/schemaBlame.generated';
+import { useGetSchemaBlameQuery, useGetSchemaVersionListQuery } from '../../../../../../graphql/schemaBlame.generated';
 import SchemaEditableContext from '../../../../../shared/SchemaEditableContext';
 import SchemaHeader from '../../../../dataset/profile/schema/components/SchemaHeader';
 import SchemaRawView from '../../../../dataset/profile/schema/components/SchemaRawView';
@@ -13,8 +10,7 @@ import { KEY_SCHEMA_PREFIX } from '../../../../dataset/profile/schema/utils/cons
 import { groupByFieldPath } from '../../../../dataset/profile/schema/utils/utils';
 import { ANTD_GRAY } from '../../../constants';
 import { useBaseEntity, useEntityData } from '../../../EntityContext';
-import { ChangeCategoryType, SchemaFieldBlame, SemanticVersionStruct } from '../../../../../../types.generated';
-import { SchemaViewType } from '../../../../dataset/profile/schema/utils/types';
+import { SchemaFieldBlame, SemanticVersionStruct } from '../../../../../../types.generated';
 import SchemaTable from './SchemaTable';
 import useGetSemanticVersionFromUrlParams from './utils/useGetSemanticVersionFromUrlParams';
 import { useGetVersionedDatasetQuery } from '../../../../../../graphql/versionedDataset.generated';
@@ -54,22 +50,20 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
     );
 
     const [showKeySchema, setShowKeySchema] = useState(false);
-    const [schemaViewMode, setSchemaViewMode] = useState(SchemaViewType.NORMAL);
+    const [showSchemaAuditView, setShowSchemaAuditView] = useState(false);
 
-    const { data: getSchemaBlameVersionsData } = useGetSchemaBlameVersionsQuery({
+    const { data: getSchemaVersionListData } = useGetSchemaVersionListQuery({
         skip: !datasetUrn,
         variables: {
             input: {
                 datasetUrn,
-                categories: [ChangeCategoryType.TechnicalSchema],
             },
         },
     });
-    const latestVersion: string = getSchemaBlameVersionsData?.getSchemaBlame?.latestVersion?.semanticVersion || '';
+    const latestVersion: string = getSchemaVersionListData?.getSchemaVersionList?.latestVersion?.semanticVersion || '';
 
-    const showSchemaBlame: boolean = schemaViewMode === SchemaViewType.BLAME;
     const versionList: Array<SemanticVersionStruct> =
-        getSchemaBlameVersionsData?.getSchemaBlame?.semanticVersionList || [];
+        getSchemaVersionListData?.getSchemaVersionList?.semanticVersionList || [];
     const version = useGetSemanticVersionFromUrlParams();
     const selectedVersion = version || latestVersion;
 
@@ -77,9 +71,10 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
         (semanticVersion) => semanticVersion.semanticVersion === selectedVersion,
     );
     const selectedVersionStamp: string = selectedSemanticVersionStruct?.versionStamp || '';
+    const isVersionLatest = selectedVersion === latestVersion;
 
     let editMode = true;
-    if (selectedVersion !== latestVersion) {
+    if (!isVersionLatest) {
         editMode = false;
     } else if (properties && properties.hasOwnProperty('editMode')) {
         editMode = properties.editMode;
@@ -91,7 +86,6 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
             input: {
                 datasetUrn,
                 version: selectedVersion,
-                categories: [ChangeCategoryType.TechnicalSchema],
             },
         },
     });
@@ -139,8 +133,8 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
                 lastUpdated={lastUpdated}
                 selectedVersion={selectedVersion}
                 versionList={versionList}
-                schemaView={schemaViewMode}
-                setSchemaView={setSchemaViewMode}
+                showSchemaAuditView={showSchemaAuditView}
+                setShowSchemaAuditView={setShowSchemaAuditView}
             />
             {/* eslint-disable-next-line no-nested-ternary */}
             {showRaw ? (
@@ -159,7 +153,7 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
                             editableSchemaMetadata={editableSchemaMetadata}
                             usageStats={usageStats}
                             schemaFieldBlameList={schemaFieldBlameList}
-                            showSchemaBlame={showSchemaBlame}
+                            showSchemaAuditView={showSchemaAuditView}
                         />
                     </SchemaEditableContext.Provider>
                 </>

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -44,7 +44,7 @@ export type Props = {
     editMode?: boolean;
     usageStats?: UsageQueryResult | null;
     schemaFieldBlameList?: Array<SchemaFieldBlame> | null;
-    showSchemaBlame: boolean;
+    showSchemaAuditView: boolean;
 };
 export default function SchemaTable({
     rows,
@@ -53,7 +53,7 @@ export default function SchemaTable({
     usageStats,
     editMode = true,
     schemaFieldBlameList,
-    showSchemaBlame,
+    showSchemaAuditView,
 }: Props): JSX.Element {
     const hasUsageStats = useMemo(() => (usageStats?.aggregations?.fields?.length || 0) > 0, [usageStats]);
 
@@ -149,7 +149,7 @@ export default function SchemaTable({
         allColumns = [...allColumns, usageColumn];
     }
 
-    if (showSchemaBlame) {
+    if (showSchemaAuditView) {
         allColumns = [...allColumns, blameColumn];
     }
 

--- a/datahub-web-react/src/graphql/schemaBlame.graphql
+++ b/datahub-web-react/src/graphql/schemaBlame.graphql
@@ -17,8 +17,8 @@ query getSchemaBlame($input: GetSchemaBlameInput!) {
     }
 }
 
-query getSchemaBlameVersions($input: GetSchemaBlameInput!) {
-    getSchemaBlame(input: $input) {
+query getSchemaVersionList($input: GetSchemaVersionListInput!) {
+    getSchemaVersionList(input: $input) {
         latestVersion {
             semanticVersion
             semanticVersionTimestamp


### PR DESCRIPTION
## Summary of Changes
- Adds new getSchemaVersionsList GraphQL endpoint, which also reduces latency
- Instead of the Normal/Blame radio buttons, we have a simple Audit icon you can use to toggle schema history
- The version selector is only show if there is more than one version for a dataset

## Screenshots
**One version, schema history closed**
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/19418814/180084227-80fe4281-ccd3-4faf-bbe8-c4043b732a8a.png">
**One version, schema history visible**
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/19418814/180084262-8ca348d7-1cd4-4713-aee9-44222148dfa8.png">
**Multiple versions, schema history closed**
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/19418814/180084449-0f92af20-004d-4834-b9de-bb23bc438435.png">
**Multiple versions, schema history visible**
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/19418814/180084508-f2261065-8ee8-4695-8f51-e7892978191a.png">


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)