### PR TITLE
docs: fix docsearch config

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -6,7 +6,7 @@ module.exports = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
   favicon: "img/favicon.ico",
-  organizationName: "linkedin", // Usually your GitHub org/user name.
+  organizationName: "datahub-project", // Usually your GitHub org/user name.
   projectName: "datahub", // Usually your repo name.
   stylesheets: [
     "https://fonts.googleapis.com/css2?family=Manrope:wght@400;600&display=swap",
@@ -172,7 +172,8 @@ module.exports = {
       additionalLanguages: ["ini"],
     },
     algolia: {
-      apiKey: "26a4b687e96e7476b5a6f11365a83336",
+      appId: "RK0UG797F3",
+      apiKey: "39d7eb90d8b31d464e309375a52d674f",
       indexName: "datahubproject",
       // contextualSearch: true,
       // searchParameters: {},


### PR DESCRIPTION
Migrating to the new crawler config as per https://docsearch.algolia.com/docs/migrating-from-legacy/ and https://docusaurus.io/blog/2021/11/21/algolia-docsearch-migration.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)