### PR TITLE
feat(cli): delete - make delete easier to use

### DIFF
--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -38,6 +38,7 @@ For now, this behaviour must be opted into by a prompt that will appear for you 
 
 You can optionally add `-n` or `--dry-run` to execute a dry run before issuing the final delete command.
 You can optionally add `-f` or `--force` to skip confirmations
+You can optionally add `--only-removed` flag to remove soft-deleted items only.
 
  :::note
 

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -38,7 +38,7 @@ For now, this behaviour must be opted into by a prompt that will appear for you 
 
 You can optionally add `-n` or `--dry-run` to execute a dry run before issuing the final delete command.
 You can optionally add `-f` or `--force` to skip confirmations
-You can optionally add `--only-removed` flag to remove soft-deleted items only.
+You can optionally add `--only-soft-deleted` flag to remove soft-deleted items only.
 
  :::note
 

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -366,10 +366,11 @@ def post_delete_endpoint_with_session_and_url(
 
 def get_urns_by_filter(
     platform: Optional[str],
-    env: Optional[str],
+    env: Optional[str] = None,
     entity_type: str = "dataset",
     search_query: str = "*",
     include_removed: bool = False,
+    only_removed: Optional[bool] = None,
 ) -> Iterable[str]:
     session, gms_host = get_session_and_host()
     endpoint: str = "/entities?action=search"
@@ -401,7 +402,15 @@ def get_urns_by_filter(
             }
         )
 
-    if include_removed:
+    if only_removed:
+        filter_criteria.append(
+            {
+                "field": "removed",
+                "value": "true",
+                "condition": "EQUAL",
+            }
+        )
+    elif include_removed:
         filter_criteria.append(
             {
                 "field": "removed",

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -370,7 +370,7 @@ def get_urns_by_filter(
     entity_type: str = "dataset",
     search_query: str = "*",
     include_removed: bool = False,
-    only_removed: Optional[bool] = None,
+    only_soft_deleted: Optional[bool] = None,
 ) -> Iterable[str]:
     session, gms_host = get_session_and_host()
     endpoint: str = "/entities?action=search"
@@ -402,7 +402,7 @@ def get_urns_by_filter(
             }
         )
 
-    if only_removed:
+    if only_soft_deleted:
         filter_criteria.append(
             {
                 "field": "removed",

--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -94,8 +94,7 @@ def delete_for_registry(
 @click.option("--query", required=False, type=str)
 @click.option("--registry-id", required=False, type=str)
 @click.option("-n", "--dry-run", required=False, is_flag=True)
-@click.option("--include-removed", required=False, is_flag=True)
-@click.option("--only-removed", required=False, is_flag=True, default=False)
+@click.option("--only-soft-deleted", required=False, is_flag=True, default=False)
 @upgrade.check_upgrade
 @telemetry.with_telemetry
 def delete(
@@ -108,8 +107,7 @@ def delete(
     query: str,
     registry_id: str,
     dry_run: bool,
-    include_removed: bool,
-    only_removed: bool,
+    only_soft_deleted: bool,
 ) -> None:
     """Delete metadata from datahub using a single urn or a combination of filters"""
 
@@ -120,6 +118,7 @@ def delete(
             "You must provide either an urn or a platform or an env or a query for me to delete anything"
         )
 
+    include_removed: bool
     if soft:
         # For soft-delete include-removed does not make any sense
         include_removed = False
@@ -199,7 +198,7 @@ def delete(
             search_query=query,
             force=force,
             include_removed=include_removed,
-            only_removed=only_removed,
+            only_soft_deleted=only_soft_deleted,
         )
 
     if not dry_run:
@@ -231,7 +230,7 @@ def delete_with_filters(
     entity_type: str = "dataset",
     env: Optional[str] = None,
     platform: Optional[str] = None,
-    only_removed: Optional[bool] = False,
+    only_soft_deleted: Optional[bool] = False,
 ) -> DeletionResult:
 
     session, gms_host = cli_utils.get_session_and_host()
@@ -242,7 +241,7 @@ def delete_with_filters(
     batch_deletion_result = DeletionResult()
 
     urns: List[str] = []
-    if not only_removed:
+    if not only_soft_deleted:
         urns = list(
             cli_utils.get_urns_by_filter(
                 env=env,
@@ -254,14 +253,14 @@ def delete_with_filters(
         )
 
     soft_deleted_urns: List[str] = []
-    if include_removed or only_removed:
+    if include_removed or only_soft_deleted:
         soft_deleted_urns = list(
             cli_utils.get_urns_by_filter(
                 env=env,
                 platform=platform,
                 search_query=search_query,
                 entity_type=entity_type,
-                only_removed=True,
+                only_soft_deleted=True,
             )
         )
 

--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -254,7 +254,7 @@ def delete_with_filters(
         )
 
     soft_deleted_urns: List[str] = []
-    if include_removed:
+    if include_removed or only_removed:
         soft_deleted_urns = list(
             cli_utils.get_urns_by_filter(
                 env=env,


### PR DESCRIPTION
Add new flag `--only-soft-deleted` to allow soft-deleting soft-deleting entities only and removed `--include-removed` arg which was redundant now.

Workflow now

<img width="1725" alt="image" src="https://user-images.githubusercontent.com/4127841/181039689-7e3143d6-0bab-46dc-9b63-855d1fe2b64c.png">

Refactoring done so dry-run of hard-delete for soft-deleted entities should be faster now.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)