### PR TITLE
build(ingest): make gradle build less chatty

### DIFF
--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -65,13 +65,13 @@ task lint(type: Exec, dependsOn: installDev) {
     The find/sed combo below is a temporary work-around for the following mypy issue with airflow 2.2.0:
    "venv/lib/python3.8/site-packages/airflow/_vendor/connexion/spec.py:169: error: invalid syntax".
    */
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "find ${venv_name}/lib -path *airflow/_vendor/connexion/spec.py -exec sed -i.bak -e '169,169s/  # type: List\\[str\\]//g' {} \\; && " +
-    "source ${venv_name}/bin/activate && black --check --diff src/ tests/ examples/ && isort --check --diff src/ tests/ examples/ && flake8 --count --statistics src/ tests/ examples/ && mypy src/ tests/ examples/"
+    "source ${venv_name}/bin/activate && set -x && black --check --diff src/ tests/ examples/ && isort --check --diff src/ tests/ examples/ && flake8 --count --statistics src/ tests/ examples/ && mypy src/ tests/ examples/"
 }
 task lintFix(type: Exec, dependsOn: installDev) {
-  commandLine 'bash', '-x', '-c',
-    "source ${venv_name}/bin/activate && " +
+  commandLine 'bash', '-c',
+    "source ${venv_name}/bin/activate && set -x && " +
     "black src/ tests/ examples/ && " +
     "isort src/ tests/ examples/ && " +
     "flake8 src/ tests/ examples/ && " +
@@ -83,7 +83,7 @@ task testQuick(type: Exec, dependsOn: installDev) {
   inputs.files(project.fileTree(dir: "src/", include: "**/*.py"))
   inputs.files(project.fileTree(dir: "tests/"))
   outputs.dir("${venv_name}")
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "source ${venv_name}/bin/activate && pytest --durations=20 -m 'not integration and not integration_batch_1 and not slow_integration' -vv --continue-on-collection-errors --junit-xml=junit.quick.xml"
 }
 
@@ -91,7 +91,7 @@ task installDevTest(type: Exec, dependsOn: [install]) {
   inputs.file file('setup.py')
   outputs.dir("${venv_name}")
   outputs.file("${venv_name}/.build_install_dev_test_sentinel")
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "${venv_name}/bin/pip install -e .[dev,integration-tests] && touch ${venv_name}/.build_install_dev_test_sentinel"
 }
 
@@ -99,9 +99,9 @@ def testFile = hasProperty('testFile') ? testFile : 'unknown'
 task testSingle(dependsOn: [installDevTest]) {
   doLast {
   if (testFile != 'unknown')  {
-  exec {
-    commandLine 'bash', '-x', '-c',
-     "source ${venv_name}/bin/activate && pytest ${testFile}"
+    exec {
+      commandLine 'bash', '-c',
+        "source ${venv_name}/bin/activate && pytest ${testFile}"
     }
   } else {
    throw new GradleException("No file provided. Use -PtestFile=<test_file>")
@@ -118,22 +118,22 @@ task installAirflow1(type: Exec, dependsOn: [install]) {
 }
 
 task testIntegration(type: Exec, dependsOn: [installDevTest]) {
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "source ${venv_name}/bin/activate && pytest --durations=50 -m 'integration' -vv --continue-on-collection-errors --junit-xml=junit.integration.xml"
 }
 
 task testIntegrationBatch1(type: Exec, dependsOn: [installDevTest]) {
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "source ${venv_name}/bin/activate && pytest --durations=50 -m 'integration_batch_1' -vv --continue-on-collection-errors --junit-xml=junit.integrationbatch1.xml"
 }
 
 task testFull(type: Exec, dependsOn: [installDevTest]) {
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "source ${venv_name}/bin/activate && pytest --durations=50 -vv --continue-on-collection-errors --junit-xml=junit.full.xml"
 }
 
 task testSlowIntegration(type: Exec, dependsOn: [installDevTest]) {
-  commandLine 'bash', '-x', '-c',
+  commandLine 'bash', '-c',
     "source ${venv_name}/bin/activate && pytest --durations=20 -m 'slow_integration' -vv --continue-on-collection-errors --junit-xml=junit.slow.integration.xml"
 }
 


### PR DESCRIPTION
Using `set -x` with `source venv/bin/activate` produces a ton of extra messages during the build process.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)