### PR TITLE
fix(ingest): use temp dir for file generated during test

### DIFF
--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -109,7 +109,7 @@ class TestPipeline(object):
 
     @freeze_time(FROZEN_TIME)
     @patch("datahub.ingestion.source.kafka.KafkaSource.get_workunits", autospec=True)
-    def test_configure_with_file_sink_does_not_init_graph(self, mock_source):
+    def test_configure_with_file_sink_does_not_init_graph(self, mock_source, tmp_path):
         pipeline = Pipeline.create(
             {
                 "source": {
@@ -119,7 +119,7 @@ class TestPipeline(object):
                 "sink": {
                     "type": "file",
                     "config": {
-                        "filename": "test.json",
+                        "filename": str(tmp_path / "test.json"),
                     },
                 },
             }
@@ -127,7 +127,7 @@ class TestPipeline(object):
         # assert that the default sink config is for a DatahubRestSink
         assert isinstance(pipeline.config.sink, DynamicTypedConfig)
         assert pipeline.config.sink.type == "file"
-        assert pipeline.config.sink.config == {"filename": "test.json"}
+        assert pipeline.config.sink.config == {"filename": str(tmp_path / "test.json")}
         assert pipeline.ctx.graph is None, "DataHubGraph should not be initialized"
 
     @freeze_time(FROZEN_TIME)


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)