### PR TITLE
feat(ui) Show Glossary and Domains header links to everyone

### DIFF
--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../graphql/search.generated';
 import { EntityType } from '../../types.generated';
 import analytics, { EventType } from '../analytics';
-import { AdminHeaderLinks } from '../shared/admin/AdminHeaderLinks';
+import { HeaderLinks } from '../shared/admin/HeaderLinks';
 import { ANTD_GRAY } from '../entity/shared/constants';
 import { useAppConfig } from '../useAppConfig';
 import { DEFAULT_APP_CONFIG } from '../../appConfigContext';
@@ -188,7 +188,7 @@ export const HomePageHeader = () => {
                     )}
                 </WelcomeText>
                 <NavGroup>
-                    <AdminHeaderLinks />
+                    <HeaderLinks />
                     <ManageAccount
                         urn={user?.urn || ''}
                         pictureLink={user?.editableProperties?.pictureLink || ''}

--- a/datahub-web-react/src/app/search/SearchHeader.tsx
+++ b/datahub-web-react/src/app/search/SearchHeader.tsx
@@ -8,7 +8,7 @@ import { ManageAccount } from '../shared/ManageAccount';
 import { AutoCompleteResultForEntity, EntityType } from '../../types.generated';
 import EntityRegistry from '../entity/EntityRegistry';
 import { ANTD_GRAY } from '../entity/shared/constants';
-import { AdminHeaderLinks } from '../shared/admin/AdminHeaderLinks';
+import { HeaderLinks } from '../shared/admin/HeaderLinks';
 import { useAppConfig } from '../useAppConfig';
 import { DEFAULT_APP_CONFIG } from '../../appConfigContext';
 
@@ -104,7 +104,7 @@ export const SearchHeader = ({
                 />
             </LogoSearchContainer>
             <NavGroup>
-                <AdminHeaderLinks areLinksHidden={isSearchBarFocused} />
+                <HeaderLinks areLinksHidden={isSearchBarFocused} />
                 <ManageAccount urn={authenticatedUserUrn} pictureLink={authenticatedUserPictureLink || ''} />
             </NavGroup>
         </Header>

--- a/datahub-web-react/src/app/shared/admin/HeaderLinks.tsx
+++ b/datahub-web-react/src/app/shared/admin/HeaderLinks.tsx
@@ -14,7 +14,7 @@ import { Button, Dropdown, Menu } from 'antd';
 import { useAppConfig } from '../../useAppConfig';
 import { useGetAuthenticatedUser } from '../../useGetAuthenticatedUser';
 
-const AdminLink = styled.span`
+const LinkWrapper = styled.span`
     margin-right: 0px;
 `;
 
@@ -40,7 +40,7 @@ interface Props {
     areLinksHidden?: boolean;
 }
 
-export function AdminHeaderLinks(props: Props) {
+export function HeaderLinks(props: Props) {
     const { areLinksHidden } = props;
     const me = useGetAuthenticatedUser();
     const { config } = useAppConfig();
@@ -52,66 +52,58 @@ export function AdminHeaderLinks(props: Props) {
     const showSettings = true;
     const showIngestion =
         isIngestionEnabled && me && me.platformPrivileges.manageIngestion && me.platformPrivileges.manageSecrets;
-    const showDomains = me?.platformPrivileges?.manageDomains || false;
-    const showGlossary = me?.platformPrivileges?.manageGlossaries || false;
 
     return (
         <LinksWrapper areLinksHidden={areLinksHidden}>
             {showAnalytics && (
-                <AdminLink>
+                <LinkWrapper>
                     <Link to="/analytics">
                         <Button type="text">
                             <BarChartOutlined /> Analytics
                         </Button>
                     </Link>
-                </AdminLink>
+                </LinkWrapper>
             )}
             {showIngestion && (
-                <AdminLink>
+                <LinkWrapper>
                     <Link to="/ingestion">
                         <Button type="text">
                             <ApiOutlined /> Ingestion
                         </Button>
                     </Link>
-                </AdminLink>
+                </LinkWrapper>
             )}
-            {(showGlossary || showDomains) && (
-                <Dropdown
-                    trigger={['click']}
-                    overlay={
-                        <Menu>
-                            {showGlossary && (
-                                <MenuItem key="0">
-                                    <Link to="/glossary">
-                                        <BookOutlined style={{ fontSize: '14px', fontWeight: 'bold' }} /> Glossary
-                                    </Link>
-                                </MenuItem>
-                            )}
-                            {showDomains && (
-                                <MenuItem key="1">
-                                    <Link to="/domains">
-                                        <FolderOutlined style={{ fontSize: '14px', fontWeight: 'bold' }} /> Domains
-                                    </Link>
-                                </MenuItem>
-                            )}
-                        </Menu>
-                    }
-                >
-                    <AdminLink>
-                        <Button type="text">
-                            <SolutionOutlined /> Govern <DownOutlined style={{ fontSize: '6px' }} />
-                        </Button>
-                    </AdminLink>
-                </Dropdown>
-            )}
+            <Dropdown
+                trigger={['click']}
+                overlay={
+                    <Menu>
+                        <MenuItem key="0">
+                            <Link to="/glossary">
+                                <BookOutlined style={{ fontSize: '14px', fontWeight: 'bold' }} /> Glossary
+                            </Link>
+                        </MenuItem>
+                        <MenuItem key="1">
+                            <Link to="/domains">
+                                <FolderOutlined style={{ fontSize: '14px', fontWeight: 'bold' }} /> Domains
+                            </Link>
+                        </MenuItem>
+                    </Menu>
+                }
+            >
+                <LinkWrapper>
+                    <Button type="text">
+                        <SolutionOutlined /> Govern <DownOutlined style={{ fontSize: '6px' }} />
+                    </Button>
+                </LinkWrapper>
+            </Dropdown>
             {showSettings && (
-                <AdminLink style={{ marginRight: 12 }}>
+                <LinkWrapper style={{ marginRight: 12 }}>
                     <Link to="/settings">
                         <Button type="text">
                             <SettingOutlined />
                         </Button>
                     </Link>
-                </AdminLink>
+                </LinkWrapper>
             )}
         </LinksWrapper>
     );


### PR DESCRIPTION
No longer hide the "Govern" header dropdown that contains links to Glossary and Domains. These should be available to everyone especially since we have privileges to prevent users from editing that shouldn't. But anyone should be able to see the Glossary and the Domains.

Involved some renaming now that these links aren't exclusively "Admin".

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)