### PR TITLE
test(ingest): limit GMS retries in test

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import os
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -34,7 +35,9 @@ class DataHubRestEmitter:
         504,
     ]
     DEFAULT_RETRY_METHODS = ["HEAD", "GET", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"]
-    DEFAULT_RETRY_MAX_TIMES = 3
+    DEFAULT_RETRY_MAX_TIMES = int(
+        os.getenv("DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES", "3")
+    )
 
     _gms_server: str
     _token: Optional[str]

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import unittest.mock
 
 import pytest
 
@@ -29,6 +30,14 @@ def mock_time(monkeypatch):
     monkeypatch.setattr(time, "time", fake_time)
 
     yield
+
+
+@pytest.fixture(autouse=True, scope="session")
+def reduce_gms_retries():
+    with unittest.mock.patch(
+        "datahub.emitter.rest_emitter.DataHubRestEmitter._retry_max_times", 1
+    ):
+        yield
 
 
 def pytest_addoption(parser):

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -1,25 +1,30 @@
 import logging
 import os
 import time
-import unittest.mock
 
 import pytest
 
-from tests.test_helpers.docker_helpers import docker_compose_runner  # noqa: F401
-from tests.test_helpers.state_helpers import mock_datahub_graph  # noqa: F401
+# Enable debug logging.
+logging.getLogger().setLevel(logging.DEBUG)
+os.environ["DATAHUB_DEBUG"] = "1"
+
+# Disable telemetry
+os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
+
+# Reduce retries on GMS, because this causes tests to hang while sleeping
+# between retries.
+os.environ["DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES"] = "1"
+
+# We need our imports to go below the os.environ updates, since mere act
+# of importing some datahub modules will load env variables.
+from tests.test_helpers.docker_helpers import docker_compose_runner  # noqa: F401,E402
+from tests.test_helpers.state_helpers import mock_datahub_graph  # noqa: F401,E402
 
 try:
     # See https://github.com/spulec/freezegun/issues/98#issuecomment-590553475.
     import pandas  # noqa: F401
 except ImportError:
     pass
-
-# Enable debug logging.
-logging.getLogger().setLevel(logging.DEBUG)
-os.putenv("DATAHUB_DEBUG", "1")
-
-# Disable telemetry
-os.putenv("DATAHUB_TELEMETRY_ENABLED", "false")
 
 
 @pytest.fixture
@@ -30,14 +35,6 @@ def mock_time(monkeypatch):
     monkeypatch.setattr(time, "time", fake_time)
 
     yield
-
-
-@pytest.fixture(autouse=True, scope="session")
-def reduce_gms_retries():
-    with unittest.mock.patch(
-        "datahub.emitter.rest_emitter.DataHubRestEmitter._retry_max_times", 1
-    ):
-        yield
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
The tests were previously hanging for a bit of time because of the retries. With these changes, running `pytest -v
tests/unit/test_pipeline.py` went from ~31s to ~4s on my machine.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)