### PR TITLE
feat(ingest): add deprecation warning for Python 3.6

### DIFF
--- a/metadata-ingestion/src/datahub/__init__.py
+++ b/metadata-ingestion/src/datahub/__init__.py
@@ -1,3 +1,6 @@
+import sys
+import warnings
+
 # Published at https://pypi.org/project/acryl-datahub/.
 __package_name__ = "acryl-datahub"
 __version__ = "0.0.0.dev0"
@@ -11,3 +14,11 @@ def nice_version_name() -> str:
     if is_dev_mode():
         return "unavailable (installed in develop mode)"
     return __version__
+
+
+if sys.version_info < (3, 10):
+    warnings.warn(
+        "DataHub will require Python 3.7 or newer in a future release. "
+        "Please upgrade your Python version to continue using DataHub.",
+        FutureWarning,
+    )

--- a/metadata-ingestion/src/datahub/__init__.py
+++ b/metadata-ingestion/src/datahub/__init__.py
@@ -16,7 +16,7 @@ def nice_version_name() -> str:
     return __version__
 
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 7):
     warnings.warn(
         "DataHub will require Python 3.7 or newer in a future release. "
         "Please upgrade your Python version to continue using DataHub.",


### PR DESCRIPTION
Not 100% sure if this is the best place to put the warning - let me know if there's a different place that we should put this or if we should change the messaging (e.g. maybe we should say which version/date will drop support?)

It'll make sense to deploy this change in a CLI release and give it a week or so, and then drop Python 3.6 in a subsequent release.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)