### PR TITLE
fix(ui) Display Term Group name properly in Recently Viewed

### DIFF
--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -220,6 +220,12 @@ fragment entityPreview on Entity {
             ...deprecationFields
         }
     }
+    ... on GlossaryNode {
+        properties {
+            name
+            description
+        }
+    }
     ... on MLFeatureTable {
         urn
         type


### PR DESCRIPTION
Fixes a bug where we weren't displaying the name of a Term Group properly in the Recently Viewed recommendation module. This is because we weren't querying for the name on the graphql side!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)