### PR TITLE
<fix>[analytics-tab] fix analytics tab config variable for gms

### DIFF
--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -64,7 +64,7 @@ UI_INGESTION_DEFAULT_CLI_VERSION=0.8.41
 # ELASTICSEARCH_PASSWORD=
 
 # To disable Analytics on the UI
-# ANALYTICS_ENABLED=false
+# DATAHUB_ANALYTICS_ENABLED=false
 
 # Encryption of DataHub Secrets
 # SECRET_SERVICE_ENCRYPTION_KEY=<your-AES-encryption-key>

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -8,6 +8,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 - #5451 `GMS_HOST` and `GMS_PORT` environment variables deprecated in `v0.8.39` have been removed. Use `DATAHUB_GMS_HOST` and `DATAHUB_GMS_PORT` instead.
 - #5478 DataHub CLI `delete` command when used with `--hard` option will delete soft-deleted entities which match the other filters given.
 - #5471 Looker now populates `userEmail` in dashboard user usage stats. This version of looker connnector will not work with older version of  **datahub-gms** if you have `extract_usage_history` looker config enabled.
+- #5529 - `ANALYTICS_ENABLED` environment variable in **datahub-gms** is now deprecated. Use `DATAHUB_ANALYTICS_ENABLED` instead.
 
 ### Potential Downtime
 

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -85,7 +85,7 @@ configEntityRegistry:
   path: ${ENTITY_REGISTRY_CONFIG_PATH:../../metadata-models/src/main/resources/entity-registry.yml}
 
 platformAnalytics:
-  enabled: ${ANALYTICS_ENABLED:true}
+  enabled: ${DATAHUB_ANALYTICS_ENABLED:true}
 
 visualConfig:
   assets:


### PR DESCRIPTION
This PR fixes the usage of **the boolean analytics tab config** in the gms. Most of the services follow the convention of `DATAHUB_ANALYTICS_ENABLED` usage. 

Also, [the env var in the helm charts of gms](https://github.com/acryldata/datahub-helm/blob/a8f5da4da9197f514ae02ebd4a77708ecf256488/charts/datahub/subcharts/datahub-gms/templates/deployment.yaml#L98) is defined as `DATAHUB_ANALYTICS_ENABLED` which conflicts with `ANALYTIS_ENABLED` env var defined in the source code of gms 😬. After this PR is merged, it should be correctly resolved. So there is no change needed for the helm charts.

---

I tested on my local computer and see that the analytics tab is correctly disabled in the UI. 
![image](https://user-images.githubusercontent.com/19890112/181854292-57c34e9d-d80b-4121-b395-b4d19c8efa9e.png)

---

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)