### PR TITLE
feat(ui): Support batch adding / remove tags from search lists. 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -144,6 +144,8 @@ import com.linkedin.datahub.graphql.resolvers.mutate.AddTagResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.AddTagsResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.AddTermResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.AddTermsResolver;
+import com.linkedin.datahub.graphql.resolvers.mutate.BatchAddTagsResolver;
+import com.linkedin.datahub.graphql.resolvers.mutate.BatchRemoveTagsResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.MutableTypeResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.RemoveLinkResolver;
 import com.linkedin.datahub.graphql.resolvers.mutate.RemoveOwnerResolver;
@@ -686,7 +688,9 @@ public class GmsGraphQLEngine {
             .dataFetcher("updateCorpGroupProperties", new MutableTypeResolver<>(corpGroupType))
             .dataFetcher("addTag", new AddTagResolver(entityService))
             .dataFetcher("addTags", new AddTagsResolver(entityService))
+            .dataFetcher("batchAddTags", new BatchAddTagsResolver(entityService))
             .dataFetcher("removeTag", new RemoveTagResolver(entityService))
+            .dataFetcher("batchRemoveTags", new BatchRemoveTagsResolver(entityService))
             .dataFetcher("addTerm", new AddTermResolver(entityService))
             .dataFetcher("addTerms", new AddTermsResolver(entityService))
             .dataFetcher("removeTerm", new RemoveTermResolver(entityService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTagResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTagResolver.java
@@ -6,8 +6,10 @@ import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
 import com.linkedin.datahub.graphql.generated.TagAssociationInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -34,12 +36,12 @@ public class AddTagResolver implements DataFetcher<CompletableFuture<Boolean>> {
     }
 
     return CompletableFuture.supplyAsync(() -> {
-      LabelUtils.validateInput(
+      LabelUtils.validateResourceAndLabel(
           tagUrn,
           targetUrn,
           input.getSubResource(),
           input.getSubResourceType(),
-          "tag",
+          Constants.TAG_ENTITY_NAME,
           _entityService,
           false
       );
@@ -52,10 +54,9 @@ public class AddTagResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
         log.info("Adding Tag. input: {}", input.toString());
         Urn actor = CorpuserUrn.createFromString(((QueryContext) environment.getContext()).getActorUrn());
-        LabelUtils.addTagsToTarget(
+        LabelUtils.addTagsToResources(
             ImmutableList.of(tagUrn),
-            targetUrn,
-            input.getSubResource(),
+            ImmutableList.of(new ResourceRefInput(input.getResourceUrn(), input.getSubResourceType(), input.getSubResource())),
             actor,
             _entityService
         );

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTagsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTagsResolver.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.mutate;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.CorpuserUrn;
 
 import com.linkedin.common.urn.Urn;
@@ -7,7 +8,9 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.AddTagsInput;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -40,22 +43,21 @@ public class AddTagsResolver implements DataFetcher<CompletableFuture<Boolean>> 
         throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
       }
 
-      LabelUtils.validateInput(
+      LabelUtils.validateResourceAndLabel(
           tagUrns,
           targetUrn,
           input.getSubResource(),
           input.getSubResourceType(),
-          "tag",
+          Constants.TAG_ENTITY_NAME,
           _entityService,
           false
       );
       try {
         log.info("Adding Tags. input: {}", input.toString());
         Urn actor = CorpuserUrn.createFromString(((QueryContext) environment.getContext()).getActorUrn());
-        LabelUtils.addTagsToTarget(
+        LabelUtils.addTagsToResources(
             tagUrns,
-            targetUrn,
-            input.getSubResource(),
+            ImmutableList.of(new ResourceRefInput(input.getResourceUrn(), input.getSubResourceType(), input.getSubResource())),
             actor,
             _entityService
         );

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTermResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTermResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.TermAssociationInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -32,12 +33,12 @@ public class AddTermResolver implements DataFetcher<CompletableFuture<Boolean>> 
     }
 
     return CompletableFuture.supplyAsync(() -> {
-      LabelUtils.validateInput(
+      LabelUtils.validateResourceAndLabel(
           termUrn,
           targetUrn,
           input.getSubResource(),
           input.getSubResourceType(),
-          "glossaryTerm",
+          Constants.GLOSSARY_TERM_ENTITY_NAME,
           _entityService,
           false
       );
@@ -45,7 +46,7 @@ public class AddTermResolver implements DataFetcher<CompletableFuture<Boolean>> 
       try {
         log.info("Adding Term. input: {}", input);
         Urn actor = CorpuserUrn.createFromString(((QueryContext) environment.getContext()).getActorUrn());
-        LabelUtils.addTermsToTarget(
+        LabelUtils.addTermsToResource(
             ImmutableList.of(termUrn),
             targetUrn,
             input.getSubResource(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddTermsResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.AddTermsInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -37,12 +38,12 @@ public class AddTermsResolver implements DataFetcher<CompletableFuture<Boolean>>
         throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
       }
 
-      LabelUtils.validateInput(
+      LabelUtils.validateResourceAndLabel(
           termUrns,
           targetUrn,
           input.getSubResource(),
           input.getSubResourceType(),
-          "glossaryTerm",
+          Constants.GLOSSARY_TERM_ENTITY_NAME,
           _entityService,
           false
       );
@@ -50,7 +51,7 @@ public class AddTermsResolver implements DataFetcher<CompletableFuture<Boolean>>
       try {
         log.info("Adding Term. input: {}", input);
         Urn actor = CorpuserUrn.createFromString(((QueryContext) environment.getContext()).getActorUrn());
-        LabelUtils.addTermsToTarget(
+        LabelUtils.addTermsToResource(
             termUrns,
             targetUrn,
             input.getSubResource(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddTagsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddTagsResolver.java
@@ -1,0 +1,86 @@
+package com.linkedin.datahub.graphql.resolvers.mutate;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.BatchAddTagsInput;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class BatchAddTagsResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityService _entityService;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+    final BatchAddTagsInput input = bindArgument(environment.getArgument("input"), BatchAddTagsInput.class);
+    final List<Urn> tagUrns = input.getTagUrns().stream()
+        .map(UrnUtils::getUrn)
+        .collect(Collectors.toList());
+    final List<ResourceRefInput> resources = input.getResources();
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      // First, validate the batch
+      validateTags(tagUrns);
+      validateInputResources(resources, context);
+
+      try {
+        // Then execute the bulk add
+        batchAddTags(tagUrns, resources, context);
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to perform update against input {}, {}", input.toString(), e.getMessage());
+        throw new RuntimeException(String.format("Failed to perform update against input %s", input.toString()), e);
+      }
+    });
+  }
+
+  private void validateTags(List<Urn> tagUrns) {
+    for (Urn tagUrn : tagUrns) {
+      LabelUtils.validateLabel(tagUrn, Constants.TAG_ENTITY_NAME, _entityService);
+    }
+  }
+
+  private void validateInputResources(List<ResourceRefInput> resources, QueryContext context) {
+    for (ResourceRefInput resource : resources) {
+      validateInputResource(resource, context);
+    }
+  }
+
+  private void validateInputResource(ResourceRefInput resource, QueryContext context) {
+    final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
+    if (!LabelUtils.isAuthorizedToUpdateTags(context, resourceUrn, resource.getSubResource())) {
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    }
+    LabelUtils.validateResource(resourceUrn, resource.getSubResource(), resource.getSubResourceType(), _entityService);
+  }
+
+  private void batchAddTags(List<Urn> tagUrns, List<ResourceRefInput> resources, QueryContext context) {
+      log.debug("Batch adding Tags. tags: {}, resources: {}", resources, tagUrns);
+      try {
+        LabelUtils.addTagsToResources(tagUrns, resources, UrnUtils.getUrn(context.getActorUrn()), _entityService);
+      } catch (Exception e) {
+        throw new RuntimeException(String.format("Failed to batch add Tags %s to resources with urns %s!",
+            tagUrns,
+            resources.stream().map(ResourceRefInput::getResourceUrn).collect(Collectors.toList())),
+          e);
+      }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveTagsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveTagsResolver.java
@@ -1,0 +1,78 @@
+package com.linkedin.datahub.graphql.resolvers.mutate;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.BatchRemoveTagsInput;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.entity.EntityService;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class BatchRemoveTagsResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityService _entityService;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+    final QueryContext context = environment.getContext();
+    final BatchRemoveTagsInput input = bindArgument(environment.getArgument("input"), BatchRemoveTagsInput.class);
+    final List<Urn> tagUrns = input.getTagUrns().stream()
+      .map(UrnUtils::getUrn)
+      .collect(Collectors.toList());
+    final List<ResourceRefInput> resources = input.getResources();
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      // First, validate the batch
+      validateInputResources(resources, context);
+
+      try {
+        // Then execute the bulk add
+        batchRemoveTags(tagUrns, resources, context);
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to perform update against input {}, {}", input.toString(), e.getMessage());
+        throw new RuntimeException(String.format("Failed to perform update against input %s", input.toString()), e);
+      }
+    });
+  }
+
+  private void validateInputResources(List<ResourceRefInput> resources, QueryContext context) {
+    for (ResourceRefInput resource : resources) {
+      validateInputResource(resource, context);
+    }
+  }
+
+  private void validateInputResource(ResourceRefInput resource, QueryContext context) {
+    final Urn resourceUrn = UrnUtils.getUrn(resource.getResourceUrn());
+    if (!LabelUtils.isAuthorizedToUpdateTags(context, resourceUrn, resource.getSubResource())) {
+      throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+    }
+    LabelUtils.validateResource(resourceUrn, resource.getSubResource(), resource.getSubResourceType(), _entityService);
+  }
+
+  private void batchRemoveTags(List<Urn> tagUrns, List<ResourceRefInput> resources, QueryContext context) {
+    log.debug("Batch removing Tags. tags: {}, resources: {}", resources, tagUrns);
+    try {
+      LabelUtils.removeTagsFromResources(tagUrns, resources, UrnUtils.getUrn(context.getActorUrn()), _entityService);
+    } catch (Exception e) {
+      throw new RuntimeException(String.format("Failed to remove Tags %s to resources with urns %s!",
+          tagUrns,
+          resources.stream().map(ResourceRefInput::getResourceUrn).collect(Collectors.toList())),
+          e);
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
@@ -33,6 +33,16 @@ public class MutationUtils {
     entityService.ingestProposal(proposal, getAuditStamp(actor));
   }
 
+  public static MetadataChangeProposal buildMetadataChangeProposal(Urn urn, String aspectName, RecordTemplate aspect, Urn actor, EntityService entityService) {
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(urn);
+    proposal.setEntityType(urn.getEntityType());
+    proposal.setAspectName(aspectName);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(aspect));
+    proposal.setChangeType(ChangeType.UPSERT);
+    return proposal;
+  }
+
   public static RecordTemplate getAspectFromEntity(String entityUrn, String aspectName, EntityService entityService, RecordTemplate defaultValue) {
     try {
       RecordTemplate aspect = entityService.getAspect(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/RemoveTermResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/RemoveTermResolver.java
@@ -6,6 +6,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.TermAssociationInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -32,12 +33,12 @@ public class RemoveTermResolver implements DataFetcher<CompletableFuture<Boolean
     }
 
     return CompletableFuture.supplyAsync(() -> {
-      LabelUtils.validateInput(
+      LabelUtils.validateResourceAndLabel(
           termUrn,
           targetUrn,
           input.getSubResource(),
           input.getSubResourceType(),
-          "glossaryTerm",
+          Constants.GLOSSARY_TERM_ENTITY_NAME,
           _entityService,
           true
       );
@@ -51,7 +52,7 @@ public class RemoveTermResolver implements DataFetcher<CompletableFuture<Boolean
 
         log.info(String.format("Removing Term. input: {}", input));
         Urn actor = CorpuserUrn.createFromString(((QueryContext) environment.getContext()).getActorUrn());
-        LabelUtils.removeTermFromTarget(
+        LabelUtils.removeTermFromResource(
             termUrn,
             targetUrn,
             input.getSubResource(),

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
@@ -1,8 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.mutate.util;
 
 import com.google.common.collect.ImmutableList;
-
-
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTermAssociation;
 import com.linkedin.common.GlossaryTermAssociationArray;
@@ -12,14 +10,17 @@ import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.urn.GlossaryTermUrn;
 import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.authorization.ConjunctivePrivilegeGroup;
 import com.linkedin.datahub.graphql.authorization.DisjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
 import com.linkedin.datahub.graphql.generated.SubResourceType;
 import com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.schema.EditableSchemaFieldInfo;
 import com.linkedin.schema.EditableSchemaMetadata;
 import java.net.URISyntaxException;
@@ -43,9 +44,9 @@ public class LabelUtils {
   public static final String EDITABLE_SCHEMA_METADATA = "editableSchemaMetadata";
   public static final String TAGS_ASPECT_NAME = "globalTags";
 
-  public static void removeTermFromTarget(
+  public static void removeTermFromResource(
       Urn labelUrn,
-      Urn targetUrn,
+      Urn resourceUrn,
       String subResource,
       Urn actor,
       EntityService entityService
@@ -53,96 +54,61 @@ public class LabelUtils {
     if (subResource == null || subResource.equals("")) {
       com.linkedin.common.GlossaryTerms terms =
           (com.linkedin.common.GlossaryTerms) MutationUtils.getAspectFromEntity(
-              targetUrn.toString(), GLOSSARY_TERM_ASPECT_NAME, entityService, new GlossaryTerms());
+              resourceUrn.toString(), GLOSSARY_TERM_ASPECT_NAME, entityService, new GlossaryTerms());
       terms.setAuditStamp(getAuditStamp(actor));
 
       removeTermIfExists(terms, labelUrn);
-      persistAspect(targetUrn, GLOSSARY_TERM_ASPECT_NAME, terms, actor, entityService);
+      persistAspect(resourceUrn, GLOSSARY_TERM_ASPECT_NAME, terms, actor, entityService);
     } else {
       com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
           (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
-              targetUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
+              resourceUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
       EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, subResource);
       if (!editableFieldInfo.hasGlossaryTerms()) {
         editableFieldInfo.setGlossaryTerms(new GlossaryTerms());
       }
 
       removeTermIfExists(editableFieldInfo.getGlossaryTerms(), labelUrn);
-      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
+      persistAspect(resourceUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
     }
   }
 
-  public static void removeTagFromTarget(
-      Urn labelUrn,
-      Urn targetUrn,
-      String subResource,
+  public static void removeTagsFromResources(
+      List<Urn> tags,
+      List<ResourceRefInput> resources,
       Urn actor,
       EntityService entityService
-  ) {
-    if (subResource == null || subResource.equals("")) {
-      com.linkedin.common.GlobalTags tags =
-          (com.linkedin.common.GlobalTags) getAspectFromEntity(targetUrn.toString(), TAGS_ASPECT_NAME, entityService, new GlobalTags());
-
-      if (!tags.hasTags()) {
-        tags.setTags(new TagAssociationArray());
-      }
-      removeTagIfExists(tags, labelUrn);
-      persistAspect(targetUrn, TAGS_ASPECT_NAME, tags, actor, entityService);
-    } else {
-      com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
-          (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
-              targetUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
-      EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, subResource);
-
-      if (!editableFieldInfo.hasGlobalTags()) {
-        editableFieldInfo.setGlobalTags(new GlobalTags());
-      }
-      removeTagIfExists(editableFieldInfo.getGlobalTags(), labelUrn);
-      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
+  ) throws Exception {
+    final List<MetadataChangeProposal> changes = new ArrayList<>();
+    for (ResourceRefInput resource : resources) {
+      changes.add(buildRemoveTagsProposal(tags, resource, actor, entityService));
     }
+    ingestChangeProposals(changes, entityService, actor);
   }
 
-  public static void addTagsToTarget(
-      List<Urn> labelUrns,
-      Urn targetUrn,
-      String subResource,
+  public static void addTagsToResources(
+      List<Urn> tagUrns,
+      List<ResourceRefInput> resources,
       Urn actor,
       EntityService entityService
-  ) throws URISyntaxException {
-    if (subResource == null || subResource.equals("")) {
-      com.linkedin.common.GlobalTags tags =
-          (com.linkedin.common.GlobalTags) getAspectFromEntity(targetUrn.toString(), TAGS_ASPECT_NAME, entityService, new GlobalTags());
-
-      if (!tags.hasTags()) {
-        tags.setTags(new TagAssociationArray());
-      }
-      addTagsIfNotExists(tags, labelUrns);
-      persistAspect(targetUrn, TAGS_ASPECT_NAME, tags, actor, entityService);
-    } else {
-      com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
-          (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
-              targetUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
-      EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, subResource);
-
-      if (!editableFieldInfo.hasGlobalTags()) {
-        editableFieldInfo.setGlobalTags(new GlobalTags());
-      }
-
-      addTagsIfNotExists(editableFieldInfo.getGlobalTags(), labelUrns);
-      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
+  ) throws Exception {
+    final List<MetadataChangeProposal> changes = new ArrayList<>();
+    for (ResourceRefInput resource : resources) {
+      changes.add(buildAddTagsProposal(tagUrns, resource, actor, entityService));
     }
+    ingestChangeProposals(changes, entityService, actor);
   }
 
-  public static void addTermsToTarget(
+  public static void addTermsToResource(
       List<Urn> labelUrns,
-      Urn targetUrn,
+      Urn resourceUrn,
       String subResource,
       Urn actor,
       EntityService entityService
   ) throws URISyntaxException {
     if (subResource == null || subResource.equals("")) {
       com.linkedin.common.GlossaryTerms terms =
-          (com.linkedin.common.GlossaryTerms) getAspectFromEntity(targetUrn.toString(), GLOSSARY_TERM_ASPECT_NAME, entityService, new GlossaryTerms());
+          (com.linkedin.common.GlossaryTerms) getAspectFromEntity(resourceUrn.toString(), GLOSSARY_TERM_ASPECT_NAME, entityService, new GlossaryTerms());
       terms.setAuditStamp(getAuditStamp(actor));
 
       if (!terms.hasTerms()) {
@@ -150,12 +116,11 @@ public class LabelUtils {
       }
 
       addTermsIfNotExistsToEntity(terms, labelUrns);
-      System.out.println(String.format("Persisting terms! %s", terms.toString()));
-      persistAspect(targetUrn, GLOSSARY_TERM_ASPECT_NAME, terms, actor, entityService);
+      persistAspect(resourceUrn, GLOSSARY_TERM_ASPECT_NAME, terms, actor, entityService);
     } else {
       com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
           (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
-              targetUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
+              resourceUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
 
       EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, subResource);
       if (!editableFieldInfo.hasGlossaryTerms()) {
@@ -165,7 +130,7 @@ public class LabelUtils {
       editableFieldInfo.getGlossaryTerms().setAuditStamp(getAuditStamp(actor));
 
       addTermsIfNotExistsToEntity(editableFieldInfo.getGlossaryTerms(), labelUrns);
-      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
+      persistAspect(resourceUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
     }
   }
 
@@ -197,14 +162,14 @@ public class LabelUtils {
     }
   }
 
-  private static TagAssociationArray removeTagIfExists(GlobalTags tags, Urn tagUrn) {
+  private static TagAssociationArray removeTagsIfExists(GlobalTags tags, List<Urn> tagUrns) {
     if (!tags.hasTags()) {
       tags.setTags(new TagAssociationArray());
     }
-
     TagAssociationArray tagAssociationArray = tags.getTags();
-
-    tagAssociationArray.removeIf(association -> association.getTag().equals(tagUrn));
+    for (Urn tagUrn : tagUrns) {
+      tagAssociationArray.removeIf(association -> association.getTag().equals(tagUrn));
+    }
     return tagAssociationArray;
   }
 
@@ -217,33 +182,6 @@ public class LabelUtils {
 
     termArray.removeIf(association -> association.getUrn().equals(termUrn));
     return termArray;
-  }
-
-  private static void addTagsIfNotExists(GlobalTags tags, List<Urn> tagUrns) throws URISyntaxException {
-    if (!tags.hasTags()) {
-      tags.setTags(new TagAssociationArray());
-    }
-
-    TagAssociationArray tagAssociationArray = tags.getTags();
-
-    List<Urn> tagsToAdd = new ArrayList<>();
-    for (Urn tagUrn : tagUrns) {
-      if (tagAssociationArray.stream().anyMatch(association -> association.getTag().equals(tagUrn))) {
-        continue;
-      }
-      tagsToAdd.add(tagUrn);
-    }
-
-    // Check for no tags to add
-    if (tagsToAdd.size() == 0) {
-      return;
-    }
-
-    for (Urn tagUrn : tagsToAdd) {
-      TagAssociation newAssociation = new TagAssociation();
-      newAssociation.setTag(TagUrn.createFromUrn(tagUrn));
-      tagAssociationArray.add(newAssociation);
-    }
   }
 
   public static boolean isAuthorizedToUpdateTags(@Nonnull QueryContext context, Urn targetUrn, String subResource) {
@@ -288,9 +226,9 @@ public class LabelUtils {
         orPrivilegeGroups);
   }
 
-  public static Boolean validateInput(
+  public static void validateResourceAndLabel(
       List<Urn> labelUrns,
-      Urn targetUrn,
+      Urn resourceUrn,
       String subResource,
       SubResourceType subResourceType,
       String labelEntityType,
@@ -298,48 +236,186 @@ public class LabelUtils {
       Boolean isRemoving
   ) {
     for (Urn urn : labelUrns) {
-      boolean labelResult = validateInput(urn, targetUrn, subResource, subResourceType, labelEntityType, entityService, isRemoving);
-      if (!labelResult) {
-        return false;
-      }
+      validateResourceAndLabel(urn, resourceUrn, subResource, subResourceType, labelEntityType, entityService, isRemoving);
     }
-    return true;
   }
 
-  public static Boolean validateInput(
+  public static void validateLabel(Urn labelUrn, String labelEntityType, EntityService entityService) {
+    if (!labelUrn.getEntityType().equals(labelEntityType)) {
+      throw new IllegalArgumentException(String.format("Failed to validate label with urn %s. Urn type does not match entity type %s..",
+          labelUrn,
+          labelEntityType));
+    }
+    if (!entityService.exists(labelUrn)) {
+      throw new IllegalArgumentException(String.format("Failed to validate label with urn %s. Urn does not exist.", labelUrn));
+    }
+  }
+
+  public static void validateResource(Urn resourceUrn, String subResource, SubResourceType subResourceType, EntityService entityService) {
+    if (!entityService.exists(resourceUrn)) {
+      throw new IllegalArgumentException(String.format("Failed to update resource with urn %s. Entity does not exist.", resourceUrn));
+    }
+    if ((subResource != null && subResource.length() > 0) || subResourceType != null) {
+      if (subResource == null || subResource.length() == 0) {
+        throw new IllegalArgumentException(String.format(
+            "Failed to update resource with urn %s. SubResourceType (%s) provided without a subResource.", resourceUrn, subResourceType));
+      }
+      if (subResourceType == null) {
+        throw new IllegalArgumentException(String.format(
+            "Failed to updates resource with urn %s. SubResource (%s) provided without a subResourceType.",  resourceUrn, subResource));
+      }
+      validateSubresourceExists(resourceUrn, subResource, subResourceType, entityService);
+    }
+  }
+
+  public static void validateResourceAndLabel(
       Urn labelUrn,
-      Urn targetUrn,
+      Urn resourceUrn,
       String subResource,
       SubResourceType subResourceType,
       String labelEntityType,
       EntityService entityService,
       Boolean isRemoving
   ) {
-    if (!labelUrn.getEntityType().equals(labelEntityType)) {
-      throw new IllegalArgumentException(String.format("Failed to update %s on %s. Was expecting a %s.", labelUrn, targetUrn, labelEntityType));
+    if (!isRemoving) {
+      validateLabel(labelUrn, labelEntityType, entityService);
+    }
+    validateResource(resourceUrn, subResource, subResourceType, entityService);
+  }
+
+  private static MetadataChangeProposal buildAddTagsProposal(
+      List<Urn> tagUrns,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService entityService
+  ) throws URISyntaxException {
+    if (resource.getSubResource() == null || resource.getSubResource().equals("")) {
+      // Case 1: Adding tags to a top-level entity
+      return buildAddTagsToEntityProposal(tagUrns, resource, actor, entityService);
+    } else {
+      // Case 2: Adding tags to subresource (e.g. schema fields)
+      return buildAddTagsToSubResourceProposal(tagUrns, resource, actor, entityService);
+    }
+  }
+
+  private static MetadataChangeProposal buildRemoveTagsProposal(
+      List<Urn> tagUrns,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService entityService
+  ) throws URISyntaxException {
+    if (resource.getSubResource() == null || resource.getSubResource().equals("")) {
+      // Case 1: Adding tags to a top-level entity
+      return buildRemoveTagsToEntityProposal(tagUrns, resource, actor, entityService);
+    } else {
+      // Case 2: Adding tags to subresource (e.g. schema fields)
+      return buildRemoveTagsToSubResourceProposal(tagUrns, resource, actor, entityService);
+    }
+  }
+
+  private static MetadataChangeProposal buildRemoveTagsToEntityProposal(
+      List<Urn> tagUrns,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService entityService
+  ) {
+    com.linkedin.common.GlobalTags tags =
+        (com.linkedin.common.GlobalTags) getAspectFromEntity(resource.getResourceUrn(), TAGS_ASPECT_NAME, entityService, new GlobalTags());
+
+    if (!tags.hasTags()) {
+      tags.setTags(new TagAssociationArray());
+    }
+    removeTagsIfExists(tags, tagUrns);
+    return buildMetadataChangeProposal(UrnUtils.getUrn(resource.getResourceUrn()), TAGS_ASPECT_NAME, tags, actor, entityService);
+  }
+
+  private static MetadataChangeProposal buildRemoveTagsToSubResourceProposal(
+      List<Urn> tagUrns,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService entityService
+  ) {
+    com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
+        (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
+            resource.getResourceUrn(),
+            EDITABLE_SCHEMA_METADATA,
+            entityService,
+            new EditableSchemaMetadata());
+    EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, resource.getSubResource());
+
+    if (!editableFieldInfo.hasGlobalTags()) {
+      editableFieldInfo.setGlobalTags(new GlobalTags());
+    }
+    removeTagsIfExists(editableFieldInfo.getGlobalTags(), tagUrns);
+    return buildMetadataChangeProposal(UrnUtils.getUrn(resource.getResourceUrn()), EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
+  }
+
+  private static MetadataChangeProposal buildAddTagsToEntityProposal(
+      List<Urn> tagUrns,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService entityService
+  ) throws URISyntaxException {
+    com.linkedin.common.GlobalTags tags =
+        (com.linkedin.common.GlobalTags) getAspectFromEntity(resource.getResourceUrn(), TAGS_ASPECT_NAME, entityService, new GlobalTags());
+
+    if (!tags.hasTags()) {
+      tags.setTags(new TagAssociationArray());
+    }
+    addTagsIfNotExists(tags, tagUrns);
+    return buildMetadataChangeProposal(UrnUtils.getUrn(resource.getResourceUrn()), TAGS_ASPECT_NAME, tags, actor, entityService);
+  }
+
+  private static MetadataChangeProposal buildAddTagsToSubResourceProposal(
+      List<Urn> tagUrns,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService entityService
+  ) throws URISyntaxException {
+    com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
+        (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
+            resource.getResourceUrn(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
+    EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, resource.getSubResource());
+
+    if (!editableFieldInfo.hasGlobalTags()) {
+      editableFieldInfo.setGlobalTags(new GlobalTags());
     }
 
-    if (!entityService.exists(targetUrn)) {
-      throw new IllegalArgumentException(String.format("Failed to update %s on %s. %s does not exist.", labelUrn, targetUrn, targetUrn));
+    addTagsIfNotExists(editableFieldInfo.getGlobalTags(), tagUrns);
+    return buildMetadataChangeProposal(UrnUtils.getUrn(resource.getResourceUrn()), EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
+  }
+
+  private static void addTagsIfNotExists(GlobalTags tags, List<Urn> tagUrns) throws URISyntaxException {
+    if (!tags.hasTags()) {
+      tags.setTags(new TagAssociationArray());
     }
 
-    // Datahub allows removing tags & terms it is not familiar with- however these terms must exist to be added back
-    if (!entityService.exists(labelUrn) && !isRemoving) {
-      throw new IllegalArgumentException(String.format("Failed to update %s on %s. %s does not exist.", labelUrn, targetUrn, labelUrn));
-    }
+    TagAssociationArray tagAssociationArray = tags.getTags();
 
-    if ((subResource != null && subResource.length() > 0) || subResourceType != null) {
-      if (subResource == null || subResource.length() == 0) {
-        throw new IllegalArgumentException(String.format(
-            "Failed to update %s on %s. SubResourceType (%s) provided without a subResource.", labelUrn, targetUrn, subResourceType));
+    List<Urn> tagsToAdd = new ArrayList<>();
+    for (Urn tagUrn : tagUrns) {
+      if (tagAssociationArray.stream().anyMatch(association -> association.getTag().equals(tagUrn))) {
+        continue;
       }
-      if (subResourceType == null) {
-        throw new IllegalArgumentException(String.format(
-            "Failed to update %s on %s. SubResource (%s) provided without a subResourceType.", labelUrn, targetUrn, subResource));
-      }
-      validateSubresourceExists(targetUrn, subResource, subResourceType, entityService);
+      tagsToAdd.add(tagUrn);
     }
 
-    return true;
+    // Check for no tags to add
+    if (tagsToAdd.size() == 0) {
+      return;
+    }
+
+    for (Urn tagUrn : tagsToAdd) {
+      TagAssociation newAssociation = new TagAssociation();
+      newAssociation.setTag(TagUrn.createFromUrn(tagUrn));
+      tagAssociationArray.add(newAssociation);
+    }
+  }
+
+  private static void ingestChangeProposals(List<MetadataChangeProposal> changes, EntityService entityService, Urn actor) {
+    // TODO: Replace this with a batch ingest proposals endpoint.
+    for (MetadataChangeProposal change : changes) {
+      entityService.ingestProposal(change, getAuditStamp(actor));
+    }
   }
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -261,9 +261,19 @@ type Mutation {
     addTags(input: AddTagsInput!): Boolean
 
     """
+		Add tags to multiple Entity or subresource
+    """
+    batchAddTags(input: BatchAddTagsInput!): Boolean
+
+    """
 		Remove a tag from a particular Entity or subresource
     """
     removeTag(input: TagAssociationInput!): Boolean
+
+    """
+		Remove tags from multiple Entity or subresource
+    """
+    batchRemoveTags(input: BatchRemoveTagsInput!): Boolean
 
     """
 		Add a glossary term to a particular Entity or subresource
@@ -6550,6 +6560,56 @@ input AddTagsInput {
 
     """
     The target Metadata Entity to add or remove the Tag to
+    """
+    resourceUrn: String!
+
+    """
+    An optional type of a sub resource to attach the Tag to
+    """
+    subResourceType: SubResourceType
+
+    """
+    An optional sub resource identifier to attach the Tag to
+    """
+    subResource: String
+}
+
+"""
+Input provided when adding tags to a batch of assets
+"""
+input BatchAddTagsInput {
+    """
+    The primary key of the Tags
+    """
+    tagUrns: [String!]!
+
+    """
+    The target assets to attach the tags to
+    """
+    resources: [ResourceRefInput]!
+}
+
+"""
+Input provided when removing tags from a batch of assets
+"""
+input BatchRemoveTagsInput {
+    """
+    The primary key of the Tags
+    """
+    tagUrns: [String!]!
+
+    """
+    The target assets to remove the tags from
+    """
+    resources: [ResourceRefInput]!
+}
+
+"""
+Reference to a resource to apply an action to
+"""
+input ResourceRefInput {
+    """
+    The urn of the resource being referenced
     """
     resourceUrn: String!
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
@@ -1,0 +1,308 @@
+package com.linkedin.datahub.graphql.resolvers.tag;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.BatchAddTagsInput;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.BatchAddTagsResolver;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class BatchAddTagsResolverTest {
+
+  private static final String TEST_ENTITY_URN_1 = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
+  private static final String TEST_ENTITY_URN_2 = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test-2,PROD)";
+  private static final String TEST_TAG_1_URN = "urn:li:tag:test-id-1";
+  private static final String TEST_TAG_2_URN = "urn:li:tag:test-id-2";
+
+  @Test
+  public void testGetSuccessNoExistingTags() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+
+    BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchAddTagsInput input = new BatchAddTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    assertTrue(resolver.get(mockEnv).get());
+
+    final GlobalTags newTags = new GlobalTags().setTags(new TagAssociationArray(ImmutableList.of(
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN)),
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_2_URN))
+    )));
+
+    final MetadataChangeProposal proposal1 = new MetadataChangeProposal();
+    proposal1.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_1));
+    proposal1.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal1.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal1.setAspect(GenericRecordUtils.serializeAspect(newTags));
+    proposal1.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal1),
+        Mockito.any(AuditStamp.class)
+    );
+
+    final MetadataChangeProposal proposal2 = new MetadataChangeProposal();
+    proposal2.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_2));
+    proposal2.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal2.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal2.setAspect(GenericRecordUtils.serializeAspect(newTags));
+    proposal2.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal2),
+        Mockito.any(AuditStamp.class)
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+        Mockito.eq(Urn.createFromString(TEST_TAG_1_URN))
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+        Mockito.eq(Urn.createFromString(TEST_TAG_2_URN))
+    );
+  }
+
+  @Test
+  public void testGetSuccessExistingTags() throws Exception {
+    GlobalTags originalTags = new GlobalTags().setTags(new TagAssociationArray(ImmutableList.of(
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN))))
+    );
+
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(originalTags);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(originalTags);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+
+    BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchAddTagsInput input = new BatchAddTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    assertTrue(resolver.get(mockEnv).get());
+
+    final GlobalTags newTags = new GlobalTags().setTags(new TagAssociationArray(ImmutableList.of(
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN)),
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_2_URN))
+    )));
+
+    final MetadataChangeProposal proposal1 = new MetadataChangeProposal();
+    proposal1.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_1));
+    proposal1.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal1.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal1.setAspect(GenericRecordUtils.serializeAspect(newTags));
+    proposal1.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal1),
+        Mockito.any(AuditStamp.class)
+    );
+
+    final MetadataChangeProposal proposal2 = new MetadataChangeProposal();
+    proposal2.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_2));
+    proposal2.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal2.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal2.setAspect(GenericRecordUtils.serializeAspect(newTags));
+    proposal2.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal2),
+        Mockito.any(AuditStamp.class)
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+        Mockito.eq(Urn.createFromString(TEST_TAG_1_URN))
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+        Mockito.eq(Urn.createFromString(TEST_TAG_2_URN))
+    );
+  }
+
+  @Test
+  public void testGetFailureTagDoesNotExist() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(false);
+
+    BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchAddTagsInput input = new BatchAddTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+  }
+
+  @Test
+  public void testGetFailureResourceDoesNotExist() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+
+    BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchAddTagsInput input = new BatchAddTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchAddTagsInput input = new BatchAddTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.doThrow(RuntimeException.class).when(mockService).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+
+    BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    BatchAddTagsInput input = new BatchAddTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
@@ -1,0 +1,260 @@
+package com.linkedin.datahub.graphql.resolvers.tag;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.BatchRemoveTagsInput;
+import com.linkedin.datahub.graphql.generated.ResourceRefInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.BatchRemoveTagsResolver;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class BatchRemoveTagsResolverTest {
+
+  private static final String TEST_ENTITY_URN_1 = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
+  private static final String TEST_ENTITY_URN_2 = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test-2,PROD)";
+  private static final String TEST_TAG_1_URN = "urn:li:tag:test-id-1";
+  private static final String TEST_TAG_2_URN = "urn:li:tag:test-id-2";
+
+  @Test
+  public void testGetSuccessNoExistingTags() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+
+    BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchRemoveTagsInput input = new BatchRemoveTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    assertTrue(resolver.get(mockEnv).get());
+
+    final GlobalTags emptyTags = new GlobalTags().setTags(new TagAssociationArray(Collections.emptyList()));
+
+    final MetadataChangeProposal proposal1 = new MetadataChangeProposal();
+    proposal1.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_1));
+    proposal1.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal1.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal1.setAspect(GenericRecordUtils.serializeAspect(emptyTags));
+    proposal1.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal1),
+        Mockito.any(AuditStamp.class)
+    );
+
+    final MetadataChangeProposal proposal2 = new MetadataChangeProposal();
+    proposal2.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_2));
+    proposal2.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal2.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal2.setAspect(GenericRecordUtils.serializeAspect(emptyTags));
+    proposal2.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal2),
+        Mockito.any(AuditStamp.class)
+    );
+  }
+
+  @Test
+  public void testGetSuccessExistingTags() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    final GlobalTags oldTags1 = new GlobalTags().setTags(new TagAssociationArray(ImmutableList.of(
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN)),
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_2_URN))
+    )));
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(oldTags1);
+
+    final GlobalTags oldTags2 = new GlobalTags().setTags(new TagAssociationArray(ImmutableList.of(
+        new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN))
+    )));
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(oldTags2);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+
+    BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchRemoveTagsInput input = new BatchRemoveTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    assertTrue(resolver.get(mockEnv).get());
+
+    final GlobalTags emptyTags = new GlobalTags().setTags(new TagAssociationArray(Collections.emptyList()));
+
+    final MetadataChangeProposal proposal1 = new MetadataChangeProposal();
+    proposal1.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_1));
+    proposal1.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal1.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal1.setAspect(GenericRecordUtils.serializeAspect(emptyTags));
+    proposal1.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal1),
+        Mockito.any(AuditStamp.class)
+    );
+
+    final MetadataChangeProposal proposal2 = new MetadataChangeProposal();
+    proposal2.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN_2));
+    proposal2.setEntityType(Constants.DATASET_ENTITY_NAME);
+    proposal2.setAspectName(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    proposal2.setAspect(GenericRecordUtils.serializeAspect(emptyTags));
+    proposal2.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal2),
+        Mockito.any(AuditStamp.class)
+    );
+  }
+
+  @Test
+  public void testGetFailureResourceDoesNotExist() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+        Mockito.eq(Constants.GLOBAL_TAGS_ASPECT_NAME),
+        Mockito.eq(0L)))
+        .thenReturn(null);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+
+    BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchRemoveTagsInput input = new BatchRemoveTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    BatchRemoveTagsInput input = new BatchRemoveTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.doThrow(RuntimeException.class).when(mockService).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class));
+
+    BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    BatchRemoveTagsInput input = new BatchRemoveTagsInput(ImmutableList.of(
+        TEST_TAG_1_URN,
+        TEST_TAG_2_URN
+    ), ImmutableList.of(
+        new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
+        new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
@@ -142,6 +142,7 @@ export class ContainerEntity implements Entity<Container> {
                 domain={data.domain?.domain}
                 parentContainers={data.parentContainers}
                 externalUrl={data.properties?.externalUrl}
+                tags={data.tags}
             />
         );
     };

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -119,7 +119,12 @@ export const EmbeddedListSearch = ({
         return refetch(variables);
     };
 
-    const { data, loading, error } = useGetSearchResults({
+    const {
+        data,
+        loading,
+        error,
+        refetch: realRefetch,
+    } = useGetSearchResults({
         variables: {
             input: {
                 types: entityFilters,
@@ -231,6 +236,7 @@ export const EmbeddedListSearch = ({
                 setIsSelectMode={setIsSelectMode}
                 selectedEntities={selectedEntities}
                 onChangeSelectAll={onChangeSelectAll}
+                refetch={realRefetch as any}
             />
             <EmbeddedListSearchResults
                 loading={loading}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
@@ -43,6 +43,7 @@ type Props = {
     selectedEntities: EntityAndType[];
     setIsSelectMode: (showSelectMode: boolean) => any;
     onChangeSelectAll: (selected: boolean) => void;
+    refetch?: () => void;
 };
 
 export default function EmbeddedListSearchHeader({
@@ -58,6 +59,7 @@ export default function EmbeddedListSearchHeader({
     selectedEntities,
     setIsSelectMode,
     onChangeSelectAll,
+    refetch,
 }: Props) {
     const entityRegistry = useEntityRegistry();
 
@@ -92,7 +94,7 @@ export default function EmbeddedListSearchHeader({
                                 entityFilters={entityFilters}
                                 filters={filters}
                                 query={query}
-                                // setShowSelectMode={setIsSelectMode}
+                                setShowSelectMode={setIsSelectMode}
                             />
                         </SearchMenuContainer>
                     </SearchAndDownloadContainer>
@@ -107,6 +109,7 @@ export default function EmbeddedListSearchHeader({
                         onCancel={() => {
                             setIsSelectMode(false);
                         }}
+                        refetch={refetch}
                     />
                 </TabToolbar>
             )}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchExtendedMenu.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchExtendedMenu.tsx
@@ -18,6 +18,10 @@ const SelectButton = styled(Button)`
     padding-right: 12px;
 `;
 
+const MenuItem = styled(Menu.Item)`
+    padding: 0px;
+`;
+
 type Props = {
     callSearchOnVariables: (variables: {
         input: SearchAcrossEntitiesInput;
@@ -41,19 +45,19 @@ export default function SearchExtendedMenu({
 
     const menu = (
         <Menu>
-            <Menu.Item key="0">
+            <MenuItem key="0">
                 <DownloadAsCsvButton
                     isDownloadingCsv={isDownloadingCsv}
                     setShowDownloadAsCsvModal={setShowDownloadAsCsvModal}
                 />
-            </Menu.Item>
+            </MenuItem>
             {setShowSelectMode && (
-                <Menu.Item key="1">
+                <MenuItem key="1">
                     <SelectButton type="text" onClick={() => setShowSelectMode(true)}>
                         <FormOutlined />
                         Edit...
                     </SelectButton>
-                </Menu.Item>
+                </MenuItem>
             )}
         </Menu>
     );

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelect.tsx
@@ -71,7 +71,7 @@ export const SearchSelect = ({ fixedEntityTypes, placeholderText, selectedEntiti
     const finalEntityTypes = (entityFilters.length > 0 && entityFilters) || fixedEntityTypes || [];
 
     // Execute search
-    const { data, loading, error } = useGetSearchResultsForMultipleQuery({
+    const { data, loading, error, refetch } = useGetSearchResultsForMultipleQuery({
         variables: {
             input: {
                 types: finalEntityTypes,
@@ -154,6 +154,8 @@ export const SearchSelect = ({ fixedEntityTypes, placeholderText, selectedEntiti
                     onChangeSelectAll={onChangeSelectAll}
                     showCancel={false}
                     showActions={false}
+                    refetch={refetch}
+                    selectedEntities={selectedEntities}
                 />
             </TabToolbar>
             <EmbeddedListSearchResults

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelectActions.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelectActions.tsx
@@ -13,19 +13,15 @@ import { SelectActionGroups } from './types';
 
 /**
  * The set of action groups that are visible by default.
+ *
+ * Currently, only the change tags action is implemented.
  */
-const DEFAULT_ACTION_GROUPS = [
-    SelectActionGroups.CHANGE_OWNERS,
-    SelectActionGroups.CHANGE_TAGS,
-    SelectActionGroups.CHANGE_GLOSSARY_TERMS,
-    SelectActionGroups.CHANGE_DOMAINS,
-    SelectActionGroups.CHANGE_DEPRECATION,
-    SelectActionGroups.DELETE,
-];
+const DEFAULT_ACTION_GROUPS = [SelectActionGroups.CHANGE_TAGS];
 
 type Props = {
     selectedEntities: EntityAndType[];
     visibleActionGroups?: Set<SelectActionGroups>;
+    refetch?: () => void;
 };
 
 /**
@@ -35,6 +31,7 @@ type Props = {
 export const SearchSelectActions = ({
     selectedEntities,
     visibleActionGroups = new Set(DEFAULT_ACTION_GROUPS),
+    refetch,
 }: Props) => {
     const entityRegistry = useEntityRegistry();
 
@@ -81,6 +78,7 @@ export const SearchSelectActions = ({
                         selectedEntityUrns.length === 0 ||
                         !isEntityCapabilitySupported(EntityCapabilityType.TAGS, selectedEntityTypes)
                     }
+                    refetch={refetch}
                 />
             )}
             {visibleActionGroups.has(SelectActionGroups.CHANGE_DOMAINS) && (

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelectBar.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelectBar.tsx
@@ -36,6 +36,7 @@ type Props = {
     showActions?: boolean;
     onChangeSelectAll: (selected: boolean) => void;
     onCancel?: () => void;
+    refetch?: () => void;
 };
 
 /**
@@ -50,6 +51,7 @@ export const SearchSelectBar = ({
     showActions = true,
     onChangeSelectAll,
     onCancel,
+    refetch,
 }: Props) => {
     const selectedEntityCount = selectedEntities.length;
     const onClickCancel = () => {
@@ -82,7 +84,7 @@ export const SearchSelectBar = ({
                 </Typography.Text>
             </CheckboxContainer>
             <ActionsContainer>
-                {showActions && <SearchSelectActions selectedEntities={selectedEntities} />}
+                {showActions && <SearchSelectActions selectedEntities={selectedEntities} refetch={refetch} />}
                 {showCancel && (
                     <CancelButton onClick={onClickCancel} type="link">
                         Done

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/action/TagsDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/action/TagsDropdown.tsx
@@ -1,27 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { EntityType } from '../../../../../../../types.generated';
+import EditTagTermsModal, { OperationType } from '../../../../../../shared/tags/AddTagsTermsModal';
 import ActionDropdown from './ActionDropdown';
 
 type Props = {
     urns: Array<string>;
     disabled: boolean;
+    refetch?: () => void;
 };
 
 // eslint-disable-next-line
-export default function TagsDropdown({ urns, disabled = false }: Props) {
+export default function TagsDropdown({ urns, disabled = false, refetch }: Props) {
+    const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+    const [operationType, setOperationType] = useState(OperationType.ADD);
+
     return (
-        <ActionDropdown
-            name="Tags"
-            actions={[
-                {
-                    title: 'Add tags',
-                    onClick: () => null,
-                },
-                {
-                    title: 'Remove tags',
-                    onClick: () => null,
-                },
-            ]}
-            disabled={disabled}
-        />
+        <>
+            <ActionDropdown
+                name="Tags"
+                actions={[
+                    {
+                        title: 'Add tags',
+                        onClick: () => {
+                            setOperationType(OperationType.ADD);
+                            setIsEditModalVisible(true);
+                        },
+                    },
+                    {
+                        title: 'Remove tags',
+                        onClick: () => {
+                            setOperationType(OperationType.REMOVE);
+                            setIsEditModalVisible(true);
+                        },
+                    },
+                ]}
+                disabled={disabled}
+            />
+            {isEditModalVisible && (
+                <EditTagTermsModal
+                    type={EntityType.Tag}
+                    visible
+                    onCloseModal={() => {
+                        setIsEditModalVisible(false);
+                        refetch?.();
+                    }}
+                    resources={urns.map((urn) => ({
+                        resourceUrn: urn,
+                    }))}
+                    entityType={EntityType.DataFlow}
+                    operationType={operationType}
+                />
+            )}
+        </>
     );
 }

--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -42,7 +42,12 @@ export const SearchPage = () => {
     const [isSelectMode, setIsSelectMode] = useState(false);
     const [selectedEntities, setSelectedEntities] = useState<EntityAndType[]>([]);
 
-    const { data, loading, error } = useGetSearchResultsForMultipleQuery({
+    const {
+        data,
+        loading,
+        error,
+        refetch: realRefetch,
+    } = useGetSearchResultsForMultipleQuery({
         variables: {
             input: {
                 types: entityFilters,
@@ -154,6 +159,7 @@ export const SearchPage = () => {
                 setSelectedEntities={setSelectedEntities}
                 setIsSelectMode={setIsSelectMode}
                 onChangeSelectAll={onChangeSelectAll}
+                refetch={realRefetch}
             />
         </>
     );

--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -119,6 +119,7 @@ interface Props {
     setSelectedEntities: (entities: EntityAndType[]) => void;
     setIsSelectMode: (showSelectMode: boolean) => any;
     onChangeSelectAll: (selected: boolean) => void;
+    refetch: () => void;
 }
 
 export const SearchResults = ({
@@ -140,6 +141,7 @@ export const SearchResults = ({
     setIsSelectMode,
     setSelectedEntities,
     onChangeSelectAll,
+    refetch,
 }: Props) => {
     const pageStart = searchResponse?.start || 0;
     const pageSize = searchResponse?.count || 0;
@@ -183,7 +185,7 @@ export const SearchResults = ({
                                         entityFilters={entityFilters}
                                         filters={filtersWithoutEntities}
                                         query={query}
-                                        // setShowSelectMode={setIsSelectMode}
+                                        setShowSelectMode={setIsSelectMode}
                                     />
                                 </SearchMenuContainer>
                             </>
@@ -198,6 +200,7 @@ export const SearchResults = ({
                                     selectedEntities={selectedEntities}
                                     onChangeSelectAll={onChangeSelectAll}
                                     onCancel={() => setIsSelectMode(false)}
+                                    refetch={refetch}
                                 />
                             </StyledTabToolbar>
                         )}

--- a/datahub-web-react/src/app/shared/tags/AddTagsTermsModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagsTermsModal.tsx
@@ -3,10 +3,13 @@ import { message, Button, Modal, Select, Typography, Tag as CustomTag } from 'an
 import styled from 'styled-components';
 
 import { useGetSearchResultsLazyQuery } from '../../../graphql/search.generated';
-import { EntityType, SubResourceType, Tag, Entity } from '../../../types.generated';
+import { EntityType, SubResourceType, Tag, Entity, ResourceRefInput } from '../../../types.generated';
 import CreateTagModal from './CreateTagModal';
-import { useAddTagsMutation, useAddTermsMutation } from '../../../graphql/mutations.generated';
-import analytics, { EventType, EntityActionType } from '../../analytics';
+import {
+    useAddTermsMutation,
+    useBatchAddTagsMutation,
+    useBatchRemoveTagsMutation,
+} from '../../../graphql/mutations.generated';
 import { useEnterKeyListener } from '../useEnterKeyListener';
 import TermLabel from '../TermLabel';
 import TagLabel from '../TagLabel';
@@ -16,13 +19,18 @@ import { useEntityRegistry } from '../../useEntityRegistry';
 import { useGetRecommendations } from '../recommendation';
 import { FORBIDDEN_URN_CHARS_REGEX } from '../../entity/shared/utils';
 
-type AddTagsModalProps = {
+export enum OperationType {
+    ADD,
+    REMOVE,
+}
+
+type EditTagsModalProps = {
     visible: boolean;
     onCloseModal: () => void;
-    entityUrn: string;
+    resources: ResourceRefInput[];
     entityType: EntityType;
-    entitySubresource?: string;
     type?: EntityType;
+    operationType?: OperationType; // Whether to allow creating a new Tag
 };
 
 const TagSelect = styled(Select)`
@@ -64,24 +72,25 @@ const isValidTagName = (tagName: string) => {
     return tagName && tagName.length > 0 && !FORBIDDEN_URN_CHARS_REGEX.test(tagName);
 };
 
-export default function AddTagsTermsModal({
+export default function EditTagTermsModal({
     visible,
     onCloseModal,
-    entityUrn,
+    resources,
     entityType,
-    entitySubresource,
     type = EntityType.Tag,
-}: AddTagsModalProps) {
+    operationType = OperationType.ADD,
+}: EditTagsModalProps) {
     const entityRegistry = useEntityRegistry();
     const [inputValue, setInputValue] = useState('');
     const [showCreateModal, setShowCreateModal] = useState(false);
-    const [disableAdd, setDisableAdd] = useState(false);
+    const [disableAction, setDisableAction] = useState(false);
     const [urns, setUrns] = useState<string[]>([]);
     const [selectedTerms, setSelectedTerms] = useState<any[]>([]);
     const [selectedTags, setSelectedTags] = useState<any[]>([]);
     const [isFocusedOnInput, setIsFocusedOnInput] = useState(false);
 
-    const [addTagsMutation] = useAddTagsMutation();
+    const [batchAddTagsMutation] = useBatchAddTagsMutation();
+    const [batchRemoveTagsMutation] = useBatchRemoveTagsMutation();
     const [addTermsMutation] = useAddTermsMutation();
 
     const [tagTermSearch, { data: tagTermSearchData }] = useGetSearchResultsLazyQuery();
@@ -136,7 +145,13 @@ export default function AddTagsTermsModal({
         return displayName.toLowerCase() === inputValue.toLowerCase();
     });
 
-    if (!inputExistsInTagSearch && isValidTagName(inputValue) && type === EntityType.Tag && urns.length === 0) {
+    if (
+        operationType === OperationType.ADD &&
+        !inputExistsInTagSearch &&
+        isValidTagName(inputValue) &&
+        type === EntityType.Tag &&
+        urns.length === 0
+    ) {
         tagSearchOptions?.push(
             <Select.Option value={CREATE_TAG_VALUE} key={CREATE_TAG_VALUE}>
                 <Typography.Link> Create {inputValue}</Typography.Link>
@@ -175,8 +190,7 @@ export default function AddTagsTermsModal({
                 onClose={onCloseModal}
                 onBack={() => setShowCreateModal(false)}
                 tagName={inputValue}
-                entityUrn={entityUrn}
-                entitySubresource={entitySubresource}
+                resources={resources}
             />
         );
     }
@@ -222,61 +236,13 @@ export default function AddTagsTermsModal({
         setSelectedTags(selectedTags.filter((term) => term.urn !== urn));
     };
 
-    // Function to handle the modal action's
-    const onOk = () => {
-        let mutation: ((input: any) => Promise<any>) | null = null;
-        if (type === EntityType.Tag) {
-            mutation = addTagsMutation;
-        }
-        if (type === EntityType.GlossaryTerm) {
-            mutation = addTermsMutation;
-        }
-
-        if (!entityUrn || !mutation) {
-            onCloseModal();
-            return;
-        }
-        setDisableAdd(true);
-
-        let input = {};
-        let actionType = EntityActionType.UpdateSchemaTags;
-        if (type === EntityType.Tag) {
-            input = {
-                tagUrns: urns,
-                resourceUrn: entityUrn,
-                subResource: entitySubresource,
-                subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
-            };
-            if (entitySubresource) {
-                actionType = EntityActionType.UpdateSchemaTags;
-            } else {
-                actionType = EntityActionType.UpdateTags;
-            }
-        }
-        if (type === EntityType.GlossaryTerm) {
-            input = {
-                termUrns: urns,
-                resourceUrn: entityUrn,
-                subResource: entitySubresource,
-                subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
-            };
-            if (entitySubresource) {
-                actionType = EntityActionType.UpdateSchemaTerms;
-            } else {
-                actionType = EntityActionType.UpdateTerms;
-            }
-        }
-
-        analytics.event({
-            type: EventType.EntityActionEvent,
-            entityType,
-            entityUrn,
-            actionType,
-        });
-
-        mutation({
+    const batchAddTags = () => {
+        batchAddTagsMutation({
             variables: {
-                input,
+                input: {
+                    tagUrns: urns,
+                    resources,
+                },
             },
         })
             .then(({ errors }) => {
@@ -292,10 +258,104 @@ export default function AddTagsTermsModal({
                 message.error({ content: `Failed to add: \n ${e.message || ''}`, duration: 3 });
             })
             .finally(() => {
-                setDisableAdd(false);
+                setDisableAction(false);
                 onCloseModal();
                 setUrns([]);
             });
+    };
+
+    const batchAddTerms = () => {
+        addTermsMutation({
+            variables: {
+                input: {
+                    termUrns: urns,
+                    resourceUrn: resources[0].resourceUrn,
+                    subResource: resources[0].subResource,
+                    subResourceType: resources[0].subResource ? SubResourceType.DatasetField : null,
+                },
+            },
+        })
+            .then(({ errors }) => {
+                if (!errors) {
+                    message.success({
+                        content: `Added ${type === EntityType.GlossaryTerm ? 'Terms' : 'Tags'}!`,
+                        duration: 2,
+                    });
+                }
+            })
+            .catch((e) => {
+                message.destroy();
+                message.error({ content: `Failed to add: \n ${e.message || ''}`, duration: 3 });
+            })
+            .finally(() => {
+                setDisableAction(false);
+                onCloseModal();
+                setUrns([]);
+            });
+    };
+
+    const batchRemoveTags = () => {
+        batchRemoveTagsMutation({
+            variables: {
+                input: {
+                    tagUrns: urns,
+                    resources,
+                },
+            },
+        })
+            .then(({ errors }) => {
+                if (!errors) {
+                    message.success({
+                        content: `Removed ${type === EntityType.GlossaryTerm ? 'Terms' : 'Tags'}!`,
+                        duration: 2,
+                    });
+                }
+            })
+            .catch((e) => {
+                message.destroy();
+                message.error({ content: `Failed to remove: \n ${e.message || ''}`, duration: 3 });
+            })
+            .finally(() => {
+                setDisableAction(false);
+                onCloseModal();
+                setUrns([]);
+            });
+    };
+
+    const batchRemoveTerms = () => {
+        // Not yet supported
+    };
+
+    const editTags = () => {
+        if (operationType === OperationType.ADD) {
+            batchAddTags();
+        } else {
+            batchRemoveTags();
+        }
+    };
+
+    const editTerms = () => {
+        if (operationType === OperationType.ADD) {
+            batchAddTerms();
+        } else {
+            batchRemoveTerms();
+        }
+    };
+
+    // Function to handle the modal action's
+    const onOk = () => {
+        console.log(entityType); // TODO: Add analytics
+        if (!resources) {
+            onCloseModal();
+            return;
+        }
+        setDisableAction(true);
+
+        if (type === EntityType.Tag) {
+            editTags();
+        } else {
+            editTerms();
+        }
     };
 
     function selectTermFromBrowser(urn: string, displayName: string) {
@@ -318,11 +378,9 @@ export default function AddTagsTermsModal({
 
     return (
         <Modal
-            title={`Add ${entityRegistry.getEntityName(type)}s`}
+            title={`${operationType === OperationType.ADD ? 'Add' : 'Remove'} ${entityRegistry.getEntityName(type)}s`}
             visible={visible}
             onCancel={onCloseModal}
-            okButtonProps={{ disabled: urns.length === 0 }}
-            okText="Add"
             footer={
                 <>
                     <Button onClick={onCloseModal} type="text">
@@ -332,9 +390,9 @@ export default function AddTagsTermsModal({
                         id="addTagButton"
                         data-testid="add-tag-term-from-modal-btn"
                         onClick={onOk}
-                        disabled={urns.length === 0 || disableAdd}
+                        disabled={urns.length === 0 || disableAction}
                     >
-                        Add
+                        Done
                     </Button>
                 </>
             }

--- a/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { message, Button, Input, Modal, Space } from 'antd';
 import styled from 'styled-components';
-import { useAddTagMutation } from '../../../graphql/mutations.generated';
+import { useBatchAddTagsMutation } from '../../../graphql/mutations.generated';
 import { useCreateTagMutation } from '../../../graphql/tag.generated';
-import { SubResourceType } from '../../../types.generated';
+import { ResourceRefInput } from '../../../types.generated';
 import { useEnterKeyListener } from '../useEnterKeyListener';
 
 type CreateTagModalProps = {
@@ -11,24 +11,16 @@ type CreateTagModalProps = {
     onClose: () => void;
     onBack: () => void;
     tagName: string;
-    entityUrn: string;
-    entitySubresource?: string;
+    resources: ResourceRefInput[];
 };
 
 const FullWidthSpace = styled(Space)`
     width: 100%;
 `;
 
-export default function CreateTagModal({
-    onClose,
-    onBack,
-    visible,
-    tagName,
-    entityUrn,
-    entitySubresource,
-}: CreateTagModalProps) {
+export default function CreateTagModal({ onClose, onBack, visible, tagName, resources }: CreateTagModalProps) {
     const [stagedDescription, setStagedDescription] = useState('');
-    const [addTagMutation] = useAddTagMutation();
+    const [batchAddTagsMutation] = useBatchAddTagsMutation();
 
     const [createTagMutation] = useCreateTagMutation();
     const [disableCreate, setDisableCreate] = useState(false);
@@ -48,13 +40,11 @@ export default function CreateTagModal({
         })
             .then(() => {
                 // then apply the tag to the dataset
-                addTagMutation({
+                batchAddTagsMutation({
                     variables: {
                         input: {
-                            tagUrn,
-                            resourceUrn: entityUrn,
-                            subResource: entitySubresource,
-                            subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
+                            tagUrns: [tagUrn],
+                            resources,
                         },
                     },
                 })

--- a/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
@@ -19,7 +19,7 @@ import { EMPTY_MESSAGES, ANTD_GRAY } from '../../entity/shared/constants';
 import { useRemoveTagMutation, useRemoveTermMutation } from '../../../graphql/mutations.generated';
 import { DomainLink } from './DomainLink';
 import { TagProfileDrawer } from './TagProfileDrawer';
-import AddTagsTermsModal from './AddTagsTermsModal';
+import EditTagTermsModal from './AddTagsTermsModal';
 
 type Props = {
     uneditableTags?: GlobalTags | null;
@@ -311,7 +311,7 @@ export default function TagTermGroup({
                     </NoElementButton>
                 )}
             {showAddModal && !!entityUrn && !!entityType && (
-                <AddTagsTermsModal
+                <EditTagTermsModal
                     type={addModalType}
                     visible
                     onCloseModal={() => {
@@ -319,9 +319,13 @@ export default function TagTermGroup({
                         setShowAddModal(false);
                         refetch?.();
                     }}
-                    entityUrn={entityUrn}
+                    resources={[
+                        {
+                            resourceUrn: entityUrn,
+                            subResource: entitySubresource,
+                        },
+                    ]}
                     entityType={entityType}
-                    entitySubresource={entitySubresource}
                 />
             )}
         </>

--- a/datahub-web-react/src/graphql/mutations.graphql
+++ b/datahub-web-react/src/graphql/mutations.graphql
@@ -2,8 +2,16 @@ mutation removeTag($input: TagAssociationInput!) {
     removeTag(input: $input)
 }
 
+mutation batchRemoveTags($input: BatchRemoveTagsInput!) {
+    batchRemoveTags(input: $input)
+}
+
 mutation addTag($input: TagAssociationInput!) {
     addTag(input: $input)
+}
+
+mutation batchAddTags($input: BatchAddTagsInput!) {
+    batchAddTags(input: $input)
 }
 
 mutation removeTerm($input: TermAssociationInput!) {


### PR DESCRIPTION
**Summary**

In this PR, we open up support for batch adding and removing tags to an entity search list!

**Changes**

- Refactor LabelUtils to support batch applying tags. Remove single apply logic.
- Adding new resolvers for mutations batchAddTags and batchRemoveTags
- Minor UI refactoring to only expose add / remove tags functionality in search select

**Status**
Ready for review

**Screenshots**



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)