### PR TITLE
docs(schema history): Correct typo in schema history documentation

### DIFF
--- a/docs/schema-history.md
+++ b/docs/schema-history.md
@@ -17,7 +17,7 @@ the dataset schema are, and when those were reported. Here's an example from our
 
 ![](./imgs/schema-blame-latest-version.png)
 
-If you click on an older version in the selector, you'll travel back in time and see what the schena looked like back then. Notice
+If you click on an older version in the selector, you'll travel back in time and see what the schema looked like back then. Notice
 the changes here to the glossary terms for the `status` field, and to the descriptions for the `created_at` and `updated_at`
 fields.
 


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Super small PR - changing "schena" to "schema" because might as well fix typos when you see them 😄 