### PR TITLE
feat(test): add read-only smoke tests

### DIFF
--- a/smoke-test/requirements.txt
+++ b/smoke-test/requirements.txt
@@ -3,3 +3,5 @@ pytest-dependency>=0.5.1
 psutil
 tenacity
 -e ../metadata-ingestion[datahub-rest,datahub-kafka,mysql]
+slack-sdk==3.18.1
+aiohttp

--- a/smoke-test/tests/__init__.py
+++ b/smoke-test/tests/__init__.py
@@ -1,4 +1,4 @@
 import os
 
 # Disable telemetry
-os.putenv("DATAHUB_TELEMETRY_ENABLED", "false")
+os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"

--- a/smoke-test/tests/conftest.py
+++ b/smoke-test/tests/conftest.py
@@ -4,9 +4,10 @@ import pytest
 import requests
 
 from tests.utils import get_frontend_url, wait_for_healthcheck_util
+from tests.test_result_msg import send_message
 
 # Disable telemetry
-os.putenv("DATAHUB_TELEMETRY_ENABLED", "false")
+os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 
 
 @pytest.fixture(scope="session")
@@ -34,3 +35,8 @@ def frontend_session(wait_for_healthchecks):
 def test_healthchecks(wait_for_healthchecks):
     # Call to wait_for_healthchecks fixture will do the actual functionality.
     pass
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """ whole test run finishes. """
+    send_message(exitstatus)

--- a/smoke-test/tests/delete/delete_test.py
+++ b/smoke-test/tests/delete/delete_test.py
@@ -8,7 +8,7 @@ from datahub.cli.delete_cli import delete_references
 from tests.utils import ingest_file_via_rest, wait_for_healthcheck_util
 
 # Disable telemetry
-os.putenv("DATAHUB_TELEMETRY_ENABLED", "false")
+os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 
 
 @pytest.fixture(scope="session")

--- a/smoke-test/tests/pytest.ini
+++ b/smoke-test/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    read_only: marks tests as read only (deselect with '-m "not read_only"')

--- a/smoke-test/tests/read_only/test_analytics.py
+++ b/smoke-test/tests/read_only/test_analytics.py
@@ -1,0 +1,55 @@
+import pytest
+
+from tests.utils import get_frontend_url
+
+
+@pytest.mark.read_only
+def test_highlights_is_accessible(frontend_session):
+    json = {
+        "query": """
+            query getHighlights {
+                getHighlights {
+                    value
+                    title
+                    body
+                }
+            }
+        """,
+    }
+    response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    res_json = response.json()
+    assert res_json, f"Received JSON was {res_json}"
+
+
+@pytest.mark.read_only
+def test_analytics_chart_is_accessible(frontend_session):
+    json = {
+        "query": """
+            query getAnalyticsCharts {
+                getAnalyticsCharts {
+                    groupId
+                    title
+                }
+            }
+        """,
+    }
+    response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    res_json = response.json()
+    assert res_json, f"Received JSON was {res_json}"
+
+
+@pytest.mark.read_only
+def test_metadata_analytics_chart_is_accessible(frontend_session):
+    json = {
+        "query": """
+            query getMetadataAnalyticsCharts($input: MetadataAnalyticsInput!) {
+                getMetadataAnalyticsCharts(input: $input) {
+                    groupId
+                    title
+                }
+            }
+        """,
+    }
+    response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    res_json = response.json()
+    assert res_json, f"Received JSON was {res_json}"

--- a/smoke-test/tests/read_only/test_ingestion_list.py
+++ b/smoke-test/tests/read_only/test_ingestion_list.py
@@ -1,0 +1,45 @@
+import pytest
+
+from tests.test_result_msg import add_datahub_stats
+from tests.utils import get_frontend_url
+
+
+@pytest.mark.read_only
+def test_policies_are_accessible(frontend_session):
+    json = {
+        "query": """
+            query listIngestionSources($input: ListIngestionSourcesInput!) {
+                listIngestionSources(input: $input) {
+                    total
+                    ingestionSources {
+                        urn
+                        name
+                        type
+                        config {
+                            version
+                        }
+                    }
+                }
+            }
+        """,
+        "variables": {"input": {"query": "*"}},
+    }
+
+    response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    res_json = response.json()
+    assert res_json, f"Received JSON was {res_json}"
+
+    res_data = res_json.get("data", {}).get("listIngestionSources", {})
+    assert res_data, f"Received listIngestionSources were {res_data}"
+    add_datahub_stats("num-ingestion-sources", res_data["total"])
+
+    if res_data["total"] > 0:
+        for ingestion_source in res_data.get("ingestionSources"):
+            name = ingestion_source.get("name")
+            source_type = ingestion_source.get("type")
+            urn = ingestion_source.get("urn")
+            version = ingestion_source.get("config", {}).get("version")
+            add_datahub_stats(
+                f"ingestion-source-{urn}",
+                {"name": name, "version": version, "source_type": source_type},
+            )

--- a/smoke-test/tests/read_only/test_policies.py
+++ b/smoke-test/tests/read_only/test_policies.py
@@ -1,0 +1,32 @@
+import pytest
+
+from tests.test_result_msg import add_datahub_stats
+from tests.utils import get_frontend_url
+
+
+@pytest.mark.read_only
+def test_policies_are_accessible(frontend_session):
+    json = {
+        "query": """
+            query listPolicies($input: ListPoliciesInput!) {
+                listPolicies(input: $input) {
+                    total
+                    policies {
+                        urn
+                        name
+                        state
+                    }
+                }
+            }
+        """,
+        "variables": {"input": {"query": "*"}},
+    }
+
+    response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    res_json = response.json()
+    assert res_json, f"Received JSON was {res_json}"
+
+    res_data = res_json.get("data", {}).get("listPolicies", {})
+    assert res_data, f"Received listPolicies were {res_data}"
+    assert res_data["total"] > 0, f"Total was {res_data['total']}"
+    add_datahub_stats("num-policies", res_data["total"])

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -1,0 +1,88 @@
+import pytest
+import requests
+
+from tests.test_result_msg import add_datahub_stats
+from tests.utils import get_frontend_url, get_gms_url
+
+restli_default_headers = {
+    "X-RestLi-Protocol-Version": "2.0.0",
+}
+
+
+def _get_search_result(entity: str):
+    json = {"input": "*", "entity": entity, "start": 0, "count": 1}
+    response = requests.post(
+        f"{get_gms_url()}/entities?action=search",
+        headers=restli_default_headers,
+        json=json,
+    )
+    res_data = response.json()
+    assert res_data, f"response data was {res_data}"
+    assert res_data["value"], f"response data was {res_data}"
+    return res_data["value"]
+
+
+@pytest.mark.read_only
+@pytest.mark.parametrize(
+    "entity_type,api_name",
+    [
+        ("chart", "chart"),
+        ("dataset", "dataset"),
+        ("dashboard", "dashboard"),
+        (
+            # Task
+            "dataJob",
+            "dataJob",
+        ),
+        (
+            # Pipeline
+            "dataFlow",
+            "dataFlow",
+        ),
+        ("container", "container"),
+        ("tag", "tag"),
+        ("corpUser", "corpUser"),
+        ("mlFeature", "mlFeature"),
+        ("glossaryTerm", "glossaryTerm"),
+        ("domain", "domain"),
+        ("mlPrimaryKey", "mlPrimaryKey"),
+        ("corpGroup", "corpGroup"),
+        ("mlFeatureTable", "mlFeatureTable"),
+        (
+            # Term group
+            "glossaryNode",
+            "glossaryNode",
+        ),
+        ("mlModel", "mlModel"),
+    ],
+)
+def test_search_works(frontend_session, entity_type, api_name):
+    search_result = _get_search_result(entity_type)
+    num_entities = search_result["numEntities"]
+    add_datahub_stats(f"num-{entity_type}", num_entities)
+    if num_entities == 0:
+        print(f"[WARN] No results for {entity_type}")
+        return
+    entities = search_result["entities"]
+
+    first_urn = entities[0]["entity"]
+
+    json = {
+        "query": """
+            query """
+        + api_name
+        + """($input: String!) {
+                """
+        + api_name
+        + """(urn: $input) {
+                    urn
+                }
+            }
+        """,
+        "variables": {"input": first_urn},
+    }
+    response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    response.raise_for_status()
+    res_data = response.json()
+    assert res_data["data"], f"res_data was {res_data}"
+    assert res_data["data"][api_name]["urn"] == first_urn, f"res_data was {res_data}"

--- a/smoke-test/tests/read_only/test_services_up.py
+++ b/smoke-test/tests/read_only/test_services_up.py
@@ -5,7 +5,8 @@ import requests
 
 from tests.utils import get_gms_url, wait_for_healthcheck_util
 
-DATAHUB_VERSION = os.getenv("DATAHUB_VERSION")
+# Kept separate so that it does not cause failures in PRs
+DATAHUB_VERSION = os.getenv("TEST_DATAHUB_VERSION")
 
 
 @pytest.mark.read_only
@@ -21,4 +22,4 @@ def test_gms_config_accessible():
     if DATAHUB_VERSION is not None:
         assert gms_config["versions"]["linkedin/datahub"]["version"] == DATAHUB_VERSION
     else:
-        print("[WARN] DATAHUB_VERSION is not set")
+        print("[WARN] TEST_DATAHUB_VERSION is not set")

--- a/smoke-test/tests/read_only/test_services_up.py
+++ b/smoke-test/tests/read_only/test_services_up.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+import requests
+
+from tests.utils import get_gms_url, wait_for_healthcheck_util
+
+DATAHUB_VERSION = os.getenv("DATAHUB_VERSION")
+
+
+@pytest.mark.read_only
+def test_services_up():
+    wait_for_healthcheck_util()
+
+
+@pytest.mark.read_only
+def test_gms_config_accessible():
+    gms_config = requests.get(f"{get_gms_url()}/config").json()
+    assert gms_config is not None
+
+    if DATAHUB_VERSION is not None:
+        assert gms_config["versions"]["linkedin/datahub"]["version"] == DATAHUB_VERSION
+    else:
+        print("[WARN] DATAHUB_VERSION is not set")

--- a/smoke-test/tests/test_result_msg.py
+++ b/smoke-test/tests/test_result_msg.py
@@ -1,0 +1,37 @@
+from slack_sdk import WebClient
+import os
+import asyncio
+from datahub.upgrade.upgrade import retrieve_version_stats
+
+
+datahub_stats = {}
+
+
+def add_datahub_stats(stat_name, stat_val):
+    datahub_stats[stat_name] = stat_val
+
+
+def send_to_slack(passed: str):
+    slack_api_token = os.getenv('SLACK_API_TOKEN')
+    slack_channel = os.getenv('SLACK_CHANNEL')
+    test_identifier = os.getenv('TEST_IDENTIFIER', 'LOCAL_TEST')
+    if slack_api_token is None or slack_channel is None:
+        return
+    client = WebClient(token=slack_api_token)
+
+    key: str
+    message = ""
+    for key, val in datahub_stats.items():
+        if key.startswith("num-"):
+            entity_type = key.replace("num-", "")
+            message += f"Num {entity_type} is {val}\n"
+
+    client.chat_postMessage(channel=slack_channel, text=f'{test_identifier} Status - {passed}\n{message}')
+
+
+def send_message(exitstatus):
+    try:
+        send_to_slack('PASSED' if exitstatus == 0 else 'FAILED')
+    except Exception as e:
+        # We don't want to fail pytest at all
+        print(f"Exception happened for sending msg to slack {e}")

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -4,12 +4,13 @@ import requests
 from time import sleep
 
 from tests.utils import get_frontend_url, wait_for_healthcheck_util, get_admin_credentials
-from datahub.cli.ingest_cli import get_session_and_host
+
 
 # Disable telemetry
-os.putenv("DATAHUB_TELEMETRY_ENABLED", "false")
+os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 
 (admin_user, admin_pass) = get_admin_credentials()
+
 
 @pytest.fixture(scope="session")
 def wait_for_healthchecks():

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -7,8 +7,10 @@ from datahub.cli import cli_utils
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.cli.docker import check_local_docker_containers
 
+
 def get_admin_credentials():
-  return ("datahub", "datahub")
+    return ("datahub", "datahub")
+
 
 def get_gms_url():
     return os.getenv("DATAHUB_GMS_URL") or "http://localhost:8080"
@@ -52,14 +54,14 @@ def is_k8s_enabled():
 def wait_for_healthcheck_util():
     if is_k8s_enabled():
         # Simply assert that kubernetes endpoints are healthy, but don't wait.
-        assert not check_k8s_endpoint(f"{get_frontend_url()}/admin")
-        assert not check_k8s_endpoint(f"{get_gms_url()}/health")
+        assert not check_endpoint(f"{get_frontend_url()}/admin")
+        assert not check_endpoint(f"{get_gms_url()}/health")
     else:
         # Simply assert that docker is healthy, but don't wait.
         assert not check_local_docker_containers()
 
 
-def check_k8s_endpoint(url):
+def check_endpoint(url):
     try:
         get = requests.get(url)
         if get.status_code == 200:

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -7,10 +7,8 @@ from datahub.cli import cli_utils
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.cli.docker import check_local_docker_containers
 
-
 def get_admin_credentials():
-    return ("datahub", "datahub")
-
+  return ("datahub", "datahub")
 
 def get_gms_url():
     return os.getenv("DATAHUB_GMS_URL") or "http://localhost:8080"


### PR DESCRIPTION
Also fixed `os.putenv` to `os.environ` as the former is for subprocesses created not the current process.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)