### PR TITLE
feat(ingestion) Update managed ingestion scheduler to be easier to use

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -75,6 +75,7 @@
         "react-color": "^2.19.3",
         "react-dom": "^17.0.0",
         "react-icons": "4.3.1",
+        "react-js-cron": "^2.1.0",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.1.6",
         "react-scripts": "4.0.3",

--- a/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
@@ -56,7 +56,7 @@ const ItemDescriptionText = styled(Typography.Paragraph)``;
 const DAILY_MIDNIGHT_CRON_INTERVAL = '0 0 * * *';
 
 export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps) => {
-    const interval = state.schedule?.interval || DAILY_MIDNIGHT_CRON_INTERVAL;
+    const interval = state.schedule?.interval?.replaceAll(', ', ' ') || DAILY_MIDNIGHT_CRON_INTERVAL;
     const timezone = state.schedule?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     const setTimezone = (tz: string) => {

--- a/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
@@ -1,5 +1,7 @@
-import { Button, Form, Input, Typography } from 'antd';
+import { Button, Form, Typography } from 'antd';
 import React, { useMemo } from 'react';
+import { Cron } from 'react-js-cron';
+import 'react-js-cron/dist/styles.css';
 import styled from 'styled-components';
 import cronstrue from 'cronstrue';
 import { CheckCircleOutlined } from '@ant-design/icons';
@@ -24,7 +26,6 @@ const SelectTemplateHeader = styled(Typography.Title)`
 
 const CronText = styled(Typography.Paragraph)`
     &&& {
-        margin-top: 8px;
         margin-bottom: 0px;
     }
     color: ${ANTD_GRAY[7]};
@@ -41,10 +42,21 @@ const ControlsContainer = styled.div`
     margin-top: 8px;
 `;
 
+const StyledFormItem = styled(Form.Item)`
+    .cron-builder {
+        color: ${ANTD_GRAY[7]};
+    }
+    .cron-builder-select {
+        min-width: 100px;
+    }
+`;
+
 const ItemDescriptionText = styled(Typography.Paragraph)``;
 
+const DAILY_MIDNIGHT_CRON_INTERVAL = '0 0 * * *';
+
 export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps) => {
-    const interval = state.schedule?.interval || '';
+    const interval = state.schedule?.interval || DAILY_MIDNIGHT_CRON_INTERVAL;
     const timezone = state.schedule?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     const setTimezone = (tz: string) => {
@@ -110,9 +122,14 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                 <Typography.Text>Configure your ingestion source to run on a schedule.</Typography.Text>
             </Section>
             <Form layout="vertical">
-                <Form.Item required label={<Typography.Text strong>Schedule</Typography.Text>}>
-                    <ItemDescriptionText>Provide a custom cron schedule.</ItemDescriptionText>
-                    <Input value={interval} onChange={(e) => setCronInterval(e.target.value)} placeholder="* * * * *" />
+                <StyledFormItem required label={<Typography.Text strong>Schedule</Typography.Text>}>
+                    <Cron
+                        value={interval}
+                        setValue={setCronInterval}
+                        clearButton={false}
+                        className="cron-builder"
+                        leadingZero
+                    />
                     <CronText>
                         {cronAsText.error && <>Invalid cron schedule. Cron must be of UNIX form:</>}
                         {!cronAsText.text && (
@@ -127,7 +144,7 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                             </>
                         )}
                     </CronText>
-                </Form.Item>
+                </StyledFormItem>
                 <Form.Item required label={<Typography.Text strong>Timezone</Typography.Text>}>
                     <ItemDescriptionText>Select the timezone to run the cron schedule in.</ItemDescriptionText>
                     <TimezoneSelect value={timezone} onChange={setTimezone} />

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -13978,6 +13978,11 @@ react-is@^17.0.0, react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-js-cron@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-js-cron/-/react-js-cron-2.1.0.tgz#ce88a3260617222d8e1dc51534bb6606088304fc"
+  integrity sha512-mxpSS8WJAY6gRZ+XR8z22u4mRKfHmB4ej2BO3DKrNRZhTGdIdF19F45LZT6GKjQqVyWOYMK1mFafTvgqqoAXlQ==
+
 react-markdown@6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-6.0.2.tgz#d89be45c278b1e5f0196f851fffb11e30c69f027"


### PR DESCRIPTION
Uses a library `react-js-cron` to create a human readable cron job scheduler for managed ingestion. Instead of having to type out the actual cron schedule (confusing for everyone let's be honest), the user can choose exactly what they want from dropdowns that are dynamic depending on what they select.

For example, here's the default view (runs daily at midnight):
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/28656603/182711733-652f32b9-db02-47d5-a26c-296be6d1708b.png">

Then if you want to get fancier and do certain days of the week:
<img width="1406" alt="image" src="https://user-images.githubusercontent.com/28656603/182711870-fabb8718-4588-4058-aef4-c7f83379386b.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)