### PR TITLE
feat(ingestion) Add Save & Run button to managed ingestion builder

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/IngestionSourceBuilderModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/IngestionSourceBuilderModal.tsx
@@ -59,7 +59,7 @@ export enum IngestionSourceBuilderStep {
 type Props = {
     initialState?: SourceBuilderState;
     visible: boolean;
-    onSubmit?: (input: SourceBuilderState, resetState: () => void) => void;
+    onSubmit?: (input: SourceBuilderState, resetState: () => void, shouldRun?: boolean) => void;
     onCancel?: () => void;
 };
 
@@ -98,11 +98,15 @@ export const IngestionSourceBuilderModal = ({ initialState, visible, onSubmit, o
         onCancel?.();
     };
 
-    const submit = () => {
-        onSubmit?.(ingestionBuilderState, () => {
-            setStepStack([initialStep]);
-            setIngestionBuilderState({});
-        });
+    const submit = (shouldRun?: boolean) => {
+        onSubmit?.(
+            ingestionBuilderState,
+            () => {
+                setStepStack([initialStep]);
+                setIngestionBuilderState({});
+            },
+            shouldRun,
+        );
     };
 
     const currentStep = stepStack[stepStack.length - 1];

--- a/datahub-web-react/src/app/ingest/source/builder/NameSourceStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/NameSourceStep.tsx
@@ -9,7 +9,7 @@ const ControlsContainer = styled.div`
     margin-top: 8px;
 `;
 
-const SaveRunButton = styled(Button)`
+const SaveButton = styled(Button)`
     margin-right: 15px;
 `;
 
@@ -98,17 +98,18 @@ export const NameSourceStep = ({ state, updateState, prev, submit }: StepProps) 
             <ControlsContainer>
                 <Button onClick={prev}>Previous</Button>
                 <div>
-                    <SaveRunButton
-                        disabled={!(state.name !== undefined && state.name.length > 0)}
-                        onClick={() => onClickCreate(true)}
-                    >
-                        Save & Run
-                    </SaveRunButton>
-                    <Button
+                    <SaveButton
                         disabled={!(state.name !== undefined && state.name.length > 0)}
                         onClick={() => onClickCreate(false)}
                     >
                         Save
+                    </SaveButton>
+                    <Button
+                        disabled={!(state.name !== undefined && state.name.length > 0)}
+                        onClick={() => onClickCreate(true)}
+                        type="primary"
+                    >
+                        Save & Run
                     </Button>
                 </div>
             </ControlsContainer>

--- a/datahub-web-react/src/app/ingest/source/builder/NameSourceStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/NameSourceStep.tsx
@@ -9,6 +9,10 @@ const ControlsContainer = styled.div`
     margin-top: 8px;
 `;
 
+const SaveRunButton = styled(Button)`
+    margin-right: 15px;
+`;
+
 export const NameSourceStep = ({ state, updateState, prev, submit }: StepProps) => {
     const setName = (stagedName: string) => {
         const newState: SourceBuilderState = {
@@ -40,9 +44,9 @@ export const NameSourceStep = ({ state, updateState, prev, submit }: StepProps) 
         updateState(newState);
     };
 
-    const onClickCreate = () => {
+    const onClickCreate = (shouldRun?: boolean) => {
         if (state.name !== undefined && state.name.length > 0) {
-            submit();
+            submit(shouldRun);
         }
     };
 
@@ -93,9 +97,20 @@ export const NameSourceStep = ({ state, updateState, prev, submit }: StepProps) 
             </Form>
             <ControlsContainer>
                 <Button onClick={prev}>Previous</Button>
-                <Button disabled={!(state.name !== undefined && state.name.length > 0)} onClick={onClickCreate}>
-                    Done
-                </Button>
+                <div>
+                    <SaveRunButton
+                        disabled={!(state.name !== undefined && state.name.length > 0)}
+                        onClick={() => onClickCreate(true)}
+                    >
+                        Save & Run
+                    </SaveRunButton>
+                    <Button
+                        disabled={!(state.name !== undefined && state.name.length > 0)}
+                        onClick={() => onClickCreate(false)}
+                    >
+                        Save
+                    </Button>
+                </div>
             </ControlsContainer>
         </>
     );

--- a/datahub-web-react/src/app/ingest/source/builder/types.ts
+++ b/datahub-web-react/src/app/ingest/source/builder/types.ts
@@ -21,7 +21,7 @@ export type StepProps = {
     updateState: (newState: SourceBuilderState) => void;
     goTo: (step: IngestionSourceBuilderStep) => void;
     prev?: () => void;
-    submit: () => void;
+    submit: (shouldRun?: boolean) => void;
     cancel: () => void;
 };
 


### PR DESCRIPTION
Creates a new button in the managed ingestion builder that allows you to save your newly created source, or update an existing source, and then also run ingestion at the same time. I also update the loading state to show "Loading..." while we have the timeout to refetch all sources.

Here's what it looks like:
<img width="1468" alt="image" src="https://user-images.githubusercontent.com/28656603/183193220-99858ca6-1c08-4a5f-9518-94adbf368063.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)