### PR TITLE
(fix) Makes containers description searchable

### DIFF
--- a/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entity/container/ContainerEntity.tsx
@@ -134,7 +134,7 @@ export class ContainerEntity implements Entity<Container> {
                 platformName={data.platform.properties?.displayName || data.platform.name}
                 platformLogo={data.platform.properties?.logoUrl}
                 platformInstanceId={data.dataPlatformInstance?.instanceId}
-                description={data.properties?.description}
+                description={data.editableProperties?.description || data.properties?.description}
                 owners={data.ownership?.owners}
                 subTypes={data.subTypes}
                 container={data.container}

--- a/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
@@ -33,5 +33,9 @@ record ContainerProperties includes CustomProperties, ExternalReference {
   /**
    * Description of the Asset Container as it exists inside a source system
    */
+  @Searchable = {
+    "fieldType": "TEXT",
+    "hasValuesFieldName": "hasDescription"
+  }
   description: optional string
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/container/EditableContainerProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/container/EditableContainerProperties.pdl
@@ -10,5 +10,9 @@ record EditableContainerProperties {
   /**
    * Description of the Asset Container as its received on the DataHub Platform
    */
+  @Searchable = {
+    "fieldType": "TEXT",
+    "fieldName": "editedDescription",
+  }
   description: optional string
 }


### PR DESCRIPTION
Currently, the descriptions for containers are not searchable, which is not ideal for me as we put useful, generalized information for users about the datasets in the container. Not sure if this is accidental or deliberate, but i have made the editableDescription and Description searchable, and updated the UI for the editable container description to show up.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)