### PR TITLE
chore(ingest): remove orderedset dependency

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -314,7 +314,7 @@ plugins: Dict[str, Set[str]] = {
     "trino": sql_common | trino,
     "starburst-trino-usage": sql_common | usage_common | trino,
     "nifi": {"requests", "packaging"},
-    "powerbi": {"orderedset"} | microsoft_common,
+    "powerbi": microsoft_common,
     "vertica": sql_common | {"sqlalchemy-vertica[vertica-python]==0.0.5"},
 }
 

--- a/metadata-ingestion/src/datahub/utilities/dedup_list.py
+++ b/metadata-ingestion/src/datahub/utilities/dedup_list.py
@@ -1,0 +1,18 @@
+from typing import Iterable, List, Set, TypeVar
+
+_T = TypeVar("_T")
+
+
+def deduplicate_list(iterable: Iterable[_T]) -> List[_T]:
+    """
+    Remove duplicates from an iterable, preserving order.
+    This serves as a replacement for OrderedSet, which is broken in Python 3.10.
+    """
+
+    seen: Set[_T] = set()
+    result: List[_T] = []
+    for item in iterable:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result


### PR DESCRIPTION
See https://github.com/simonpercivall/orderedset/issues/36 - the orderedset package is dead.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)