### PR TITLE
fix(ci): cleanup sleeps to instead use retries

### DIFF
--- a/smoke-test/test_rapid.py
+++ b/smoke-test/test_rapid.py
@@ -1,9 +1,15 @@
-import time
-
 import pytest
 import requests
+import tenacity
 
-from tests.utils import get_frontend_url, ingest_file_via_rest, wait_for_healthcheck_util
+from tests.utils import (
+    get_frontend_url,
+    ingest_file_via_rest,
+    wait_for_healthcheck_util,
+    get_sleep_info,
+)
+
+sleep_sec, sleep_times = get_sleep_info()
 
 bootstrap_small = "test_resources/bootstrap_single.json"
 bootstrap_small_2 = "test_resources/bootstrap_single2.json"
@@ -29,9 +35,10 @@ def frontend_session(wait_for_healthchecks):
     yield session
 
 
-def test_ingestion_via_rest_rapid(frontend_session, wait_for_healthchecks):
-    ingest_file_via_rest(bootstrap_small)
-    ingest_file_via_rest(bootstrap_small_2)
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(sleep_times), wait=tenacity.wait_fixed(sleep_sec)
+)
+def _ensure_dataset_present_correctly(frontend_session):
     urn = "urn:li:dataset:(urn:li:dataPlatform:testPlatform,testDataset,PROD)"
     json = {
         "query": """query getDataset($urn: String!) {\n
@@ -66,8 +73,6 @@ def test_ingestion_via_rest_rapid(frontend_session, wait_for_healthchecks):
             }""",
         "variables": {"urn": urn},
     }
-    #
-    time.sleep(2)
     response = frontend_session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
     response.raise_for_status()
     res_data = response.json()
@@ -76,5 +81,9 @@ def test_ingestion_via_rest_rapid(frontend_session, wait_for_healthchecks):
     assert res_data["data"]
     assert res_data["data"]["dataset"]
     assert res_data["data"]["dataset"]["urn"] == urn
-    # commenting this out temporarily while we work on fixing this race condition for elasticsearch
-    # assert len(res_data["data"]["dataset"]["outgoing"]["relationships"]) == 1
+
+
+def test_ingestion_via_rest_rapid(frontend_session, wait_for_healthchecks):
+    ingest_file_via_rest(bootstrap_small)
+    ingest_file_via_rest(bootstrap_small_2)
+    _ensure_dataset_present_correctly(frontend_session)

--- a/smoke-test/tests/assertions/assertions_test.py
+++ b/smoke-test/tests/assertions/assertions_test.py
@@ -1,9 +1,9 @@
 import json
-import time
 import urllib
 
 import pytest
 import requests
+import tenacity
 from datahub.emitter.mce_builder import make_dataset_urn, make_schema_field_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
@@ -23,11 +23,12 @@ from datahub.metadata.schema_classes import (
     PartitionSpecClass,
     PartitionTypeClass,
 )
-from tests.utils import delete_urns_from_file, get_gms_url, ingest_file_via_rest, wait_for_healthcheck_util
+from tests.utils import delete_urns_from_file, get_gms_url, ingest_file_via_rest, wait_for_healthcheck_util, get_sleep_info
 
 restli_default_headers = {
     "X-RestLi-Protocol-Version": "2.0.0",
 }
+sleep_sec, sleep_times = get_sleep_info()
 
 
 def create_test_data(test_file):
@@ -246,12 +247,11 @@ def test_run_ingestion(generate_test_data):
     ingest_file_via_rest(generate_test_data)
 
 
-@pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
-def test_gms_get_latest_assertions_results_by_partition():
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(sleep_times), wait=tenacity.wait_fixed(sleep_sec)
+)
+def _gms_get_latest_assertions_results_by_partition():
     urn = make_dataset_urn("postgres", "foo")
-
-    # sleep for elasticsearch indices to be updated
-    time.sleep(5)
 
     # Query
     # Given the dataset
@@ -311,6 +311,11 @@ def test_gms_get_latest_assertions_results_by_partition():
         ]
         == urn
     )
+
+
+@pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
+def test_gms_get_latest_assertions_results_by_partition():
+    _gms_get_latest_assertions_results_by_partition()
 
 
 @pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])

--- a/smoke-test/tests/domains/domains_test.py
+++ b/smoke-test/tests/domains/domains_test.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 import tenacity
 from tests.utils import (
@@ -32,7 +30,6 @@ def test_healthchecks(wait_for_healthchecks):
     stop=tenacity.stop_after_attempt(sleep_times), wait=tenacity.wait_fixed(sleep_sec)
 )
 def _ensure_more_domains(frontend_session, list_domains_json, before_count):
-    time.sleep(2)
 
     # Get new count of Domains
     response = frontend_session.post(


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)