### PR TITLE
feat(search): Sticky search filters + misc bug fixes & improvements

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolver.java
@@ -5,6 +5,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.DomainEntitiesInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.resolvers.EntityTypeMapper;
 import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.filter.Condition;
@@ -17,9 +18,11 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 
 
 /**
@@ -71,7 +74,7 @@ public class DomainEntitiesResolver implements DataFetcher<CompletableFuture<Sea
             .setValue(urn);
 
         return UrnSearchResultsMapper.map(_entityClient.searchAcrossEntities(
-            Collections.emptyList(),
+            SEARCHABLE_ENTITY_TYPES.stream().map(EntityTypeMapper::getName).collect(Collectors.toList()),
             query,
             new Filter().setOr(new ConjunctiveCriterionArray(
                 new ConjunctiveCriterion().setAnd(new CriterionArray(ImmutableList.of(filterCriterion)))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolver.java
@@ -16,7 +16,6 @@ import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/DomainEntitiesResolverTest.java
@@ -7,6 +7,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.DomainEntitiesInput;
+import com.linkedin.datahub.graphql.resolvers.EntityTypeMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
@@ -21,9 +22,11 @@ import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.*;
 import static org.testng.Assert.*;
 
 
@@ -50,7 +53,7 @@ public class DomainEntitiesResolverTest {
         .setValue(domainUrn);
 
     Mockito.when(mockClient.searchAcrossEntities(
-        Mockito.eq(Collections.emptyList()),
+        Mockito.eq(SEARCHABLE_ENTITY_TYPES.stream().map(EntityTypeMapper::getName).collect(Collectors.toList())),
         Mockito.eq("*"),
         Mockito.eq(
             new Filter().setOr(new ConjunctiveCriterionArray(

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -52,6 +52,7 @@ export const EmbeddedListSearchSection = ({
             baseParams,
             query: q,
             page: 1,
+            filters,
             history,
         });
     };

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchSelect.tsx
@@ -65,6 +65,9 @@ export const SearchSelect = ({ fixedEntityTypes, placeholderText, selectedEntiti
     const [numResultsPerPage, setNumResultsPerPage] = useState(SearchCfg.RESULTS_PER_PAGE);
 
     // Compute search filters
+    const filtersWithoutEntities: Array<FacetFilterInput> = filters.filter(
+        (filter) => filter.field !== ENTITY_FILTER_NAME,
+    );
     const entityFilters: Array<EntityType> = filters
         .filter((filter) => filter.field === ENTITY_FILTER_NAME)
         .map((filter) => filter.value.toUpperCase() as EntityType);
@@ -78,7 +81,7 @@ export const SearchSelect = ({ fixedEntityTypes, placeholderText, selectedEntiti
                 query,
                 start: (page - 1) * numResultsPerPage,
                 count: numResultsPerPage,
-                filters,
+                filters: filtersWithoutEntities,
             },
         },
     });
@@ -96,6 +99,7 @@ export const SearchSelect = ({ fixedEntityTypes, placeholderText, selectedEntiti
     };
 
     const onChangeFilters = (newFilters: Array<FacetFilterInput>) => {
+        setPage(1);
         setFilters(newFilters);
     };
 

--- a/datahub-web-react/src/app/ingest/source/IngestedAssets.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestedAssets.tsx
@@ -6,6 +6,7 @@ import { EmbeddedListSearchModal } from '../../entity/shared/components/styled/s
 import { ANTD_GRAY } from '../../entity/shared/constants';
 import { formatNumber } from '../../shared/formatNumber';
 import { Message } from '../../shared/Message';
+import { useEntityRegistry } from '../../useEntityRegistry';
 import { extractEntityTypeCountsFromFacets } from './utils';
 
 const HeaderContainer = styled.div`
@@ -31,6 +32,8 @@ const EntityCountsContainer = styled.div`
     display: flex;
     justify-content: left;
     align-items: center;
+    max-width: 100%;
+    flex-wrap: wrap;
 `;
 
 const EntityCount = styled.div`
@@ -49,7 +52,12 @@ type Props = {
     id: string;
 };
 
+const ENTITY_FACET_NAME = 'entity';
+const TYPE_NAMES_FACET_NAME = 'typeNames';
+
 export default function IngestedAssets({ id }: Props) {
+    const entityRegistry = useEntityRegistry();
+
     // First thing to do is to search for all assets with the id as the run id!
     const [showAssetSearch, setShowAssetSearch] = useState(false);
 
@@ -74,13 +82,14 @@ export default function IngestedAssets({ id }: Props) {
     const facets = data?.searchAcrossEntities?.facets;
 
     // Extract facets to construct the per-entity type breakdown stats
-    const hasEntityTypeFacet = (facets?.findIndex((facet) => facet.field === 'entity') || -1) >= 0;
+    const hasEntityTypeFacet = (facets || []).findIndex((facet) => facet.field === ENTITY_FACET_NAME) >= 0;
     const entityTypeFacets =
-        (hasEntityTypeFacet && facets?.filter((facet) => facet.field === 'entity')[0]) || undefined;
-    const hasSubTypeFacet = (facets?.findIndex((facet) => facet.field === 'typeNames') || -1) >= 0;
-    const subTypeFacets = (hasSubTypeFacet && facets?.filter((facet) => facet.field === 'typeNames')[0]) || undefined;
+        (hasEntityTypeFacet && facets?.filter((facet) => facet.field === ENTITY_FACET_NAME)[0]) || undefined;
+    const hasSubTypeFacet = (facets || []).findIndex((facet) => facet.field === TYPE_NAMES_FACET_NAME) >= 0;
+    const subTypeFacets =
+        (hasSubTypeFacet && facets?.filter((facet) => facet.field === TYPE_NAMES_FACET_NAME)[0]) || undefined;
     const countsByEntityType =
-        (entityTypeFacets && extractEntityTypeCountsFromFacets(entityTypeFacets, subTypeFacets)) || [];
+        (entityTypeFacets && extractEntityTypeCountsFromFacets(entityRegistry, entityTypeFacets, subTypeFacets)) || [];
 
     // The total number of assets ingested
     const total = data?.searchAcrossEntities?.total || 0;

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -203,6 +203,7 @@ export const SearchBar = ({
     const [searchQuery, setSearchQuery] = useState<string>();
     const [selected, setSelected] = useState<string>();
     useEffect(() => setSelected(initialQuery), [initialQuery]);
+
     const searchEntityTypes = entityRegistry.getSearchEntityTypes();
     const userUrn = useGetAuthenticatedUserUrn();
     const { data } = useListRecommendationsQuery({
@@ -309,6 +310,7 @@ export const SearchBar = ({
                     } else {
                         // Navigate directly to the entity profile.
                         history.push(getEntityPath(option.type, value, entityRegistry, false, false));
+                        setSelected('');
                     }
                 }}
                 onSearch={(value: string) => onQueryChange(value)}
@@ -333,6 +335,7 @@ export const SearchBar = ({
                     data-testid="search-input"
                     onFocus={handleFocus}
                     onBlur={handleBlur}
+                    allowClear
                     prefix={<SearchOutlined onClick={() => onSearch(filterSearchQuery(searchQuery || ''))} />}
                 />
             </StyledAutoComplete>

--- a/datahub-web-react/src/app/search/SearchFilter.tsx
+++ b/datahub-web-react/src/app/search/SearchFilter.tsx
@@ -54,7 +54,17 @@ const StyledDownOutlined = styled(DownOutlined)`
 export const SearchFilter = ({ facet, selectedFilters, onFilterSelect, defaultDisplayFilters }: Props) => {
     const [areFiltersVisible, setAreFiltersVisible] = useState(defaultDisplayFilters);
     const [expanded, setExpanded] = useState(false);
-    const shouldTruncate = facet.aggregations.length > TRUNCATED_FILTER_LENGTH;
+
+    const isFacetSelected = (field, value) => {
+        return selectedFilters.find((f) => f.field === field && f.value === value) !== undefined;
+    };
+
+    // Aggregations filtered for count > 0 or selected = true
+    const filteredAggregations = facet.aggregations.filter(
+        (agg) => agg.count > 0 || isFacetSelected(facet.field, agg.value),
+    );
+
+    const shouldTruncate = filteredAggregations.length > TRUNCATED_FILTER_LENGTH;
 
     return (
         <SearchFilterWrapper key={facet.field}>
@@ -68,29 +78,27 @@ export const SearchFilter = ({ facet, selectedFilters, onFilterSelect, defaultDi
             </Title>
             {areFiltersVisible && (
                 <>
-                    {facet.aggregations.map((aggregation, i) => {
-                        if (i >= TRUNCATED_FILTER_LENGTH && !expanded) {
-                            return null;
-                        }
-                        return (
-                            <span key={`${facet.field}-${aggregation.value}`}>
-                                <CheckBox
-                                    data-testid={`facet-${facet.field}-${aggregation.value}`}
-                                    checked={
-                                        selectedFilters.find(
-                                            (f) => f.field === facet.field && f.value === aggregation.value,
-                                        ) !== undefined
-                                    }
-                                    onChange={(e: CheckboxChangeEvent) =>
-                                        onFilterSelect(e.target.checked, facet.field, aggregation.value)
-                                    }
-                                >
-                                    <SearchFilterLabel field={facet.field} aggregation={aggregation} />
-                                </CheckBox>
-                                <br />
-                            </span>
-                        );
-                    })}
+                    {facet.aggregations
+                        .filter((agg) => agg.count > 0 || isFacetSelected(facet.field, agg.value))
+                        .map((aggregation, i) => {
+                            if (i >= TRUNCATED_FILTER_LENGTH && !expanded) {
+                                return null;
+                            }
+                            return (
+                                <span key={`${facet.field}-${aggregation.value}`}>
+                                    <CheckBox
+                                        data-testid={`facet-${facet.field}-${aggregation.value}`}
+                                        checked={isFacetSelected(facet.field, aggregation.value)}
+                                        onChange={(e: CheckboxChangeEvent) =>
+                                            onFilterSelect(e.target.checked, facet.field, aggregation.value)
+                                        }
+                                    >
+                                        <SearchFilterLabel field={facet.field} aggregation={aggregation} />
+                                    </CheckBox>
+                                    <br />
+                                </span>
+                            );
+                        })}
                     {shouldTruncate && (
                         <ExpandButton type="text" onClick={() => setExpanded(!expanded)}>
                             {expanded ? '- Less' : '+ More'}

--- a/datahub-web-react/src/app/search/SearchFilter.tsx
+++ b/datahub-web-react/src/app/search/SearchFilter.tsx
@@ -9,6 +9,12 @@ import { FacetMetadata } from '../../types.generated';
 import { SearchFilterLabel } from './SearchFilterLabel';
 import { TRUNCATED_FILTER_LENGTH } from './utils/constants';
 
+const GRAPH_DEGREE_FILTER_FIELD = 'degree';
+
+const isGraphDegreeFilter = (field: string) => {
+    return GRAPH_DEGREE_FILTER_FIELD === field;
+};
+
 type Props = {
     facet: FacetMetadata;
     selectedFilters: Array<{
@@ -61,7 +67,7 @@ export const SearchFilter = ({ facet, selectedFilters, onFilterSelect, defaultDi
 
     // Aggregations filtered for count > 0 or selected = true
     const filteredAggregations = facet.aggregations.filter(
-        (agg) => agg.count > 0 || isFacetSelected(facet.field, agg.value),
+        (agg) => agg.count > 0 || isFacetSelected(facet.field, agg.value) || isGraphDegreeFilter(facet.field),
     );
 
     const shouldTruncate = filteredAggregations.length > TRUNCATED_FILTER_LENGTH;
@@ -79,7 +85,12 @@ export const SearchFilter = ({ facet, selectedFilters, onFilterSelect, defaultDi
             {areFiltersVisible && (
                 <>
                     {facet.aggregations
-                        .filter((agg) => agg.count > 0 || isFacetSelected(facet.field, agg.value))
+                        .filter(
+                            (agg) =>
+                                agg.count > 0 ||
+                                isFacetSelected(facet.field, agg.value) ||
+                                isGraphDegreeFilter(facet.field),
+                        )
                         .map((aggregation, i) => {
                             if (i >= TRUNCATED_FILTER_LENGTH && !expanded) {
                                 return null;

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -4,7 +4,7 @@ import * as QueryString from 'query-string';
 import { useTheme } from 'styled-components';
 import { SearchHeader } from './SearchHeader';
 import { useEntityRegistry } from '../useEntityRegistry';
-import { EntityType } from '../../types.generated';
+import { EntityType, FacetFilterInput } from '../../types.generated';
 import {
     GetAutoCompleteMultipleResultsQuery,
     useGetAutoCompleteMultipleResultsLazyQuery,
@@ -12,6 +12,7 @@ import {
 import { navigateToSearchUrl } from './utils/navigateToSearchUrl';
 import { useGetAuthenticatedUser } from '../useGetAuthenticatedUser';
 import analytics, { EventType } from '../analytics';
+import useFilters from './utils/useFilters';
 
 const styles = {
     children: {
@@ -39,6 +40,7 @@ const defaultProps = {
 export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) => {
     const location = useLocation();
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
+    const filters: Array<FacetFilterInput> = useFilters(params);
     const currentQuery: string = decodeURIComponent(params.query ? (params.query as string) : '');
 
     const history = useHistory();
@@ -69,6 +71,7 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
         navigateToSearchUrl({
             type,
             query,
+            filters,
             history,
         });
     };

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/aggregator/AllEntitiesSearchAggregator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/aggregator/AllEntitiesSearchAggregator.java
@@ -158,7 +158,6 @@ public class AllEntitiesSearchAggregator {
       searchResults = ConcurrencyUtils.transformAndCollectAsync(entities, entity -> new Pair<>(entity,
           _cachingEntitySearchService.search(entity, input, postFilters, sortCriterion, queryFrom, querySize, searchFlags)))
           .stream()
-          .filter(pair -> pair.getValue().getNumEntities() > 0)
           .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
     }
     return searchResults;

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.search.elasticsearch.query.request;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.DoubleMap;
@@ -7,6 +8,10 @@ import com.linkedin.data.template.LongMap;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.search.AggregationMetadata;
@@ -55,6 +60,8 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+
+import static com.linkedin.metadata.utils.SearchUtil.*;
 
 
 @Slf4j
@@ -243,10 +250,10 @@ public class SearchRequestHandler {
   }
 
   @WithSpan
-  public SearchResult extractResult(@Nonnull SearchResponse searchResponse, int from, int size) {
+  public SearchResult extractResult(@Nonnull SearchResponse searchResponse, Filter filter, int from, int size) {
     int totalCount = (int) searchResponse.getHits().getTotalHits().value;
     List<SearchEntity> resultList = getResults(searchResponse);
-    SearchResultMetadata searchResultMetadata = extractSearchResultMetadata(searchResponse);
+    SearchResultMetadata searchResultMetadata = extractSearchResultMetadata(searchResponse, filter);
 
     return new SearchResult().setEntities(new SearchEntityArray(resultList))
         .setMetadata(searchResultMetadata)
@@ -319,26 +326,26 @@ public class SearchRequestHandler {
    * Extracts SearchResultMetadata section.
    *
    * @param searchResponse the raw {@link SearchResponse} as obtained from the search engine
+   * @param filter the provided Filter to use with Elasticsearch
+   *
    * @return {@link SearchResultMetadata} with aggregation and list of urns obtained from {@link SearchResponse}
    */
   @Nonnull
-  private SearchResultMetadata extractSearchResultMetadata(@Nonnull SearchResponse searchResponse) {
+  private SearchResultMetadata extractSearchResultMetadata(@Nonnull SearchResponse searchResponse, @Nullable Filter filter) {
     final SearchResultMetadata searchResultMetadata =
         new SearchResultMetadata().setAggregations(new AggregationMetadataArray());
 
-    final List<AggregationMetadata> aggregationMetadataList = extractAggregationMetadata(searchResponse);
-    if (!aggregationMetadataList.isEmpty()) {
-      searchResultMetadata.setAggregations(new AggregationMetadataArray(aggregationMetadataList));
-    }
+    final List<AggregationMetadata> aggregationMetadataList = extractAggregationMetadata(searchResponse, filter);
+    searchResultMetadata.setAggregations(new AggregationMetadataArray(aggregationMetadataList));
 
     return searchResultMetadata;
   }
 
-  private List<AggregationMetadata> extractAggregationMetadata(@Nonnull SearchResponse searchResponse) {
+  private List<AggregationMetadata> extractAggregationMetadata(@Nonnull SearchResponse searchResponse, @Nullable Filter filter) {
     final List<AggregationMetadata> aggregationMetadataList = new ArrayList<>();
 
     if (searchResponse.getAggregations() == null) {
-      return aggregationMetadataList;
+      return addFiltersToAggregationMetadata(aggregationMetadataList, filter);
     }
 
     for (Map.Entry<String, Aggregation> entry : searchResponse.getAggregations().getAsMap().entrySet()) {
@@ -353,7 +360,7 @@ public class SearchRequestHandler {
       aggregationMetadataList.add(aggregationMetadata);
     }
 
-    return aggregationMetadataList;
+    return addFiltersToAggregationMetadata(aggregationMetadataList, filter);
   }
 
   @WithSpan
@@ -392,5 +399,102 @@ public class SearchRequestHandler {
     }
 
     return aggResult;
+  }
+
+  /**
+   * Injects the missing conjunctive filters into the aggregations list.
+   */
+  private List<AggregationMetadata> addFiltersToAggregationMetadata(@Nonnull final List<AggregationMetadata> originalMetadata, @Nullable final Filter filter) {
+    if (filter == null) {
+      return originalMetadata;
+    }
+    if (filter.hasOr()) {
+      addOrFiltersToAggregationMetadata(filter.getOr(), originalMetadata);
+    } else if (filter.hasCriteria()) {
+      addCriteriaFiltersToAggregationMetadata(filter.getCriteria(), originalMetadata);
+    }
+    return originalMetadata;
+  }
+
+  private void addOrFiltersToAggregationMetadata(@Nonnull final ConjunctiveCriterionArray or, @Nonnull final List<AggregationMetadata> originalMetadata) {
+    for (ConjunctiveCriterion conjunction : or) {
+      // For each item in the conjunction, inject an empty aggregation if necessary
+      addCriteriaFiltersToAggregationMetadata(conjunction.getAnd(), originalMetadata);
+    }
+  }
+
+  private void addCriteriaFiltersToAggregationMetadata(@Nonnull final CriterionArray criteria, @Nonnull final List<AggregationMetadata> originalMetadata) {
+    // For each criterion check whether its already appearing in aggregations
+    Map<String, AggregationMetadata> aggMetadataMap = originalMetadata.stream().collect(Collectors.toMap(
+        AggregationMetadata::getName, agg -> agg));
+
+    for (Criterion criterion : criteria) {
+      addCriterionFiltersToAggregationMetadata(criterion, originalMetadata, aggMetadataMap);
+    }
+  }
+
+  private void addCriterionFiltersToAggregationMetadata(
+      @Nonnull final Criterion criterion,
+      @Nonnull final List<AggregationMetadata> originalMetadata,
+      @Nonnull Map<String, AggregationMetadata> aggregationMetadataMap) {
+    // Map a filter criterion to a facet field (e.g. domains.keyword -> domains)
+    final String finalFacetField = toFacetField(criterion.getField());
+
+    if (finalFacetField == null) {
+      log.warn(String.format("Found invalid filter field for entity search. Invalid or unrecognized facet %s", criterion.getField()));
+      return;
+    }
+
+    if (aggregationMetadataMap.containsKey(finalFacetField)) {
+      /*
+       * If we already have aggregations for the facet field, simply inject any missing values counts into the set.
+       * If there are no results for a particular facet value, it will NOT be in the original aggregation set returned by
+       * Elasticsearch.
+       */
+      AggregationMetadata originalAggMetadata = aggregationMetadataMap.get(finalFacetField);
+      addMissingAggregationValueToAggregationMetadata(criterion.getValue(), originalAggMetadata);
+    } else {
+      /*
+       * If we do not have ANY aggregation for the facet field, then inject a new aggregation metadata object for the
+       * facet field.
+       * If there are no results for a particular facet, it will NOT be in the original aggregation set returned by
+       * Elasticsearch.
+       */
+      originalMetadata.add(buildAggregationMetadata(
+          finalFacetField,
+          _filtersToDisplayName.getOrDefault(finalFacetField, finalFacetField),
+          new LongMap(ImmutableMap.of(criterion.getValue(), 0L)),
+          new FilterValueArray(ImmutableList.of(createFilterValue(criterion.getValue(), 0L))))
+      );
+    }
+  }
+
+  private void addMissingAggregationValueToAggregationMetadata(@Nonnull final String value, @Nonnull final AggregationMetadata originalMetadata) {
+    if (originalMetadata.getAggregations().entrySet().stream().noneMatch(entry -> value.equals(entry.getKey()))) {
+      // No aggregation found for filtered value -- inject one!
+      originalMetadata.getAggregations().put(value, 0L);
+      originalMetadata.getFilterValues().add(createFilterValue(value, 0L));
+    }
+  }
+
+  private AggregationMetadata buildAggregationMetadata(
+      @Nonnull final String facetField,
+      @Nonnull final String displayName,
+      @Nonnull final LongMap aggValues,
+      @Nonnull final FilterValueArray filterValues) {
+    return new AggregationMetadata()
+        .setName(facetField)
+        .setDisplayName(displayName)
+        .setAggregations(aggValues)
+        .setFilterValues(filterValues);
+  }
+
+  @Nullable
+  private String toFacetField(@Nonnull final String filterField) {
+    String trimmedField = filterField.replace(ESUtils.KEYWORD_SUFFIX, "");
+    if (_facetFields.contains(trimmedField)) {
+      return trimmedField;
+    }
+    return null;
   }
 }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/SearchUtil.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/SearchUtil.java
@@ -19,15 +19,19 @@ public class SearchUtil {
 
   public static List<FilterValue> convertToFilters(Map<String, Long> aggregations) {
     return aggregations.entrySet().stream().map(entry -> {
-      FilterValue value = new FilterValue().setValue(entry.getKey()).setFacetCount(entry.getValue());
-      if (entry.getKey().startsWith(URN_PREFIX)) {
-        try {
-          value.setEntity(Urn.createFromString(entry.getKey()));
-        } catch (URISyntaxException e) {
-          log.error("Failed to create urn for filter value: {}", entry.getKey());
-        }
-      }
-      return value;
+      return createFilterValue(entry.getKey(), entry.getValue());
     }).sorted(Comparator.comparingLong(value -> -value.getFacetCount())).collect(Collectors.toList());
+  }
+
+  public static FilterValue createFilterValue(String value, Long facetCount) {
+    FilterValue result = new FilterValue().setValue(value).setFacetCount(facetCount);
+    if (value.startsWith(URN_PREFIX)) {
+      try {
+        result.setEntity(Urn.createFromString(value));
+      } catch (URISyntaxException e) {
+        log.error("Failed to create urn for filter value: {}", value);
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
**Summary**

In this PR we introduce "sticky" search filters, which are those that do NOT clear when your search query is changed. This is supported across all surface areas. 

In addition to this, we fix a few minor search bugs (URN appearing in autocomplete once selected), ingested assets entities not appearing. 

**Changes**

1. [GMS] Change the ElasticSearch backend to support injecting aggregation results based on a Search Filter (to ensure that fields which are filtered for have result of 0 in aggregation set) 
2. [GMS] Change the ElasicSearch backend to avoid filtering out empty search results for a specific entity type. 
3. [UI] Fix a minor bug in IngestedAssets that prevented the entity breakdown from showing
4. [UI] Fix a styling bug in IngestedAssets for wrapping entity type counts 
5. [UI] Fix a minor bug where an URN was placed in the search box when autocomplete result was clicked 
6. [GMS] Fix a minor bug where Domain Entities resolver was querying all entity indexes 
7. [UI] Keep filters persistent on subsequent searches 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)