### PR TITLE
fix(ci): use different image for smoke base image

### DIFF
--- a/.github/workflows/docker-ingestion-smoke.yml
+++ b/.github/workflows/docker-ingestion-smoke.yml
@@ -8,36 +8,65 @@ on:
     paths:
       - "docker/datahub-ingestion/**"
       - "smoke-test/**"
+      - ".github/workflows/docker-ingestion-smoke.yml"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-jobs:
+env:
+  IMAGE: acryldata/datahub-ingestion-smoke
 
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      unique_tag: ${{ steps.tag.outputs.unique_tag }}
+      publish: ${{ steps.publish.outputs.publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
+        run: |
+          echo "GITHUB_REF: $GITHUB_REF"
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,head\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          UNIQUE_TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          echo "tag=$TAG"
+          echo "unique_tag=$UNIQUE_TAG"
+          echo "::set-output name=tag::$TAG"
+          echo "::set-output name=unique_tag::$UNIQUE_TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+          ENABLE_PUBLISH: ${{ secrets.ACRYL_DOCKER_PASSWORD }}
+        run: |
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   build-smoke:
     name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
+    needs: setup
+    outputs:
+      image_tag: ${{ steps.docker_meta.outputs.tags }}
+      image_name: ${{ env.IMAGE }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Build and push
+        uses: ./.github/actions/docker-custom-build-and-push
         with:
+          images: |
+            ${{ env.IMAGE }}
+          tags: ${{ needs.setup.outputs.tag }}
           username: ${{ secrets.ACRYL_DOCKER_USERNAME }}
           password: ${{ secrets.ACRYL_DOCKER_PASSWORD }}
-      - name: Build and Push image
-        uses: docker/build-push-action@v2
-        with:
+          publish: ${{ needs.setup.outputs.publish }}
           context: .
           file: ./docker/datahub-ingestion/smoke.Dockerfile
           platforms: linux/amd64,linux/arm64
-          tags: acryldata/datahub-ingestion-base:smoke
-          push: true


### PR DESCRIPTION
Going to use https://hub.docker.com/r/acryldata/datahub-ingestion-smoke so we have separate tags for each build

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)