### PR TITLE
feat(model): Add optional message field to auditstamp

### DIFF
--- a/li-utils/src/main/pegasus/com/linkedin/common/AuditStamp.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/AuditStamp.pdl
@@ -21,7 +21,7 @@ record AuditStamp {
   impersonator: optional Urn
 
   /**
-   * Additional message to keep track of in the event
+   * Additional context around how the particular change happened. For example: was the change created by an automated process, or manually.
    */
   message: optional string
 }

--- a/li-utils/src/main/pegasus/com/linkedin/common/AuditStamp.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/AuditStamp.pdl
@@ -21,7 +21,7 @@ record AuditStamp {
   impersonator: optional Urn
 
   /**
-   * Additional context around how the particular change happened. For example: was the change created by an automated process, or manually.
+   * Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.
    */
   message: optional string
 }

--- a/li-utils/src/main/pegasus/com/linkedin/common/AuditStamp.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/AuditStamp.pdl
@@ -19,4 +19,9 @@ record AuditStamp {
    * The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.
    */
   impersonator: optional Urn
+
+  /**
+   * Additional message to keep track of in the event
+   */
+  message: optional string
 }

--- a/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-avro2pegasus-mae.json
+++ b/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-avro2pegasus-mae.json
@@ -18,7 +18,8 @@
             "lastModified": {
               "time": 0,
               "actor": "urn:li:corpuser:foobar",
-              "impersonator": null
+              "impersonator": null,
+              "message": null
             }
           }
         }

--- a/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-avro2pegasus-mce.json
+++ b/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-avro2pegasus-mce.json
@@ -16,7 +16,8 @@
             "lastModified": {
               "time": 0,
               "actor": "urn:li:corpuser:foobar",
-              "impersonator": null
+              "impersonator": null,
+              "message": null
             }
           }
         }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -377,6 +377,11 @@
               "type" : "Urn",
               "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
               "optional" : true
+            }, {
+              "name" : "message",
+              "type" : "string",
+              "doc" : "Additional message to keep track of in the event",
+              "optional" : true
             } ]
           },
           "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -136,6 +136,11 @@
               "type" : "Urn",
               "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
               "optional" : true
+            }, {
+              "name" : "message",
+              "type" : "string",
+              "doc" : "Additional message to keep track of in the event",
+              "optional" : true
             } ]
           },
           "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesV2.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesV2.snapshot.json
@@ -29,6 +29,11 @@
       "type" : "Urn",
       "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
       "optional" : true
+    }, {
+      "name" : "message",
+      "type" : "string",
+      "doc" : "Additional message to keep track of in the event",
+      "optional" : true
     } ]
   }, "com.linkedin.common.Time", "com.linkedin.common.Urn", {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesVersionedV2.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesVersionedV2.snapshot.json
@@ -29,6 +29,11 @@
       "type" : "Urn",
       "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
       "optional" : true
+    }, {
+      "name" : "message",
+      "type" : "string",
+      "doc" : "Additional message to keep track of in the event",
+      "optional" : true
     } ]
   }, "com.linkedin.common.Time", "com.linkedin.common.Urn", {
     "type" : "typeref",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -136,6 +136,11 @@
               "type" : "Urn",
               "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
               "optional" : true
+            }, {
+              "name" : "message",
+              "type" : "string",
+              "doc" : "Additional message to keep track of in the event",
+              "optional" : true
             } ]
           },
           "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
@@ -29,6 +29,11 @@
       "type" : "Urn",
       "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
       "optional" : true
+    }, {
+      "name" : "message",
+      "type" : "string",
+      "doc" : "Additional message to keep track of in the event",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -136,6 +136,11 @@
               "type" : "Urn",
               "doc" : "The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor.",
               "optional" : true
+            }, {
+              "name" : "message",
+              "type" : "string",
+              "doc" : "Additional message to keep track of in the event",
+              "optional" : true
             } ]
           },
           "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",


### PR DESCRIPTION
This allows us to track context around audit stamps.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)