### PR TITLE
fix(ui): Split based on Data Platform delimiter in Lineage viz

### DIFF
--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -194,7 +194,7 @@ export class ChartEntity implements Entity<Chart> {
             name: entity.properties?.name || '',
             type: EntityType.Chart,
             icon: entity?.platform?.properties?.logoUrl || '',
-            platform: entity?.platform.properties?.displayName || entity?.platform.name,
+            platform: entity?.platform,
         };
     };
 

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -211,7 +211,7 @@ export class DashboardEntity implements Entity<Dashboard> {
             name: entity.properties?.name || '',
             type: EntityType.Dashboard,
             icon: entity?.platform?.properties?.logoUrl || '',
-            platform: entity?.platform.properties?.displayName || entity?.platform.name,
+            platform: entity?.platform,
         };
     };
 

--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -180,7 +180,7 @@ export class DataJobEntity implements Entity<DataJob> {
             name: entity?.properties?.name || '',
             type: EntityType.DataJob,
             icon: entity?.dataFlow?.platform?.properties?.logoUrl || '',
-            platform: getDataJobPlatformName(entity),
+            platform: entity?.dataFlow?.platform,
         };
     };
 

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -303,7 +303,7 @@ export class DatasetEntity implements Entity<Dataset> {
             type: EntityType.Dataset,
             subtype: entity?.subTypes?.typeNames?.[0] || undefined,
             icon: entity?.platform?.properties?.logoUrl || undefined,
-            platform: entity?.platform?.name,
+            platform: entity?.platform,
         };
     };
 

--- a/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -144,7 +144,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
             name: entity.name,
             type: EntityType.MlfeatureTable,
             icon: entity.platform.properties?.logoUrl || undefined,
-            platform: entity.platform.name,
+            platform: entity.platform,
         };
     };
 

--- a/datahub-web-react/src/app/entity/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlModel/MLModelEntity.tsx
@@ -130,7 +130,7 @@ export class MLModelEntity implements Entity<MlModel> {
             name: entity.name,
             type: EntityType.Mlmodel,
             icon: entity.platform?.properties?.logoUrl || undefined,
-            platform: entity.platform?.name,
+            platform: entity.platform,
         };
     };
 

--- a/datahub-web-react/src/app/entity/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entity/mlModelGroup/MLModelGroupEntity.tsx
@@ -115,7 +115,7 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
             name: entity.name,
             type: EntityType.MlmodelGroup,
             icon: entity.platform?.properties?.logoUrl || undefined,
-            platform: entity.platform?.name,
+            platform: entity.platform,
         };
     };
 

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -24,10 +24,10 @@ function truncate(input, length) {
     return input;
 }
 
-function getLastTokenOfTitle(title?: string): string {
+function getLastTokenOfTitle(title?: string, delimiter?: string): string {
     if (!title) return '';
 
-    const lastToken = title?.split('.').slice(-1)[0];
+    const lastToken = title?.split(delimiter || '.').slice(-1)[0];
 
     // if the last token does not contain any content, the string should not be tokenized on `.`
     if (lastToken.replace(/\s/g, '').length === 0) {
@@ -118,7 +118,9 @@ export default function LineageEntityNode({
         [],
     );
 
-    let platformDisplayText = capitalizeFirstLetter(node.data.platform);
+    let platformDisplayText = capitalizeFirstLetter(
+        node.data.platform?.properties?.displayName || node.data.platform?.name,
+    );
     if (node.data.siblingPlatforms && !isHideSiblingMode) {
         platformDisplayText = node.data.siblingPlatforms
             .map((platform) => platform.properties?.displayName || platform.name)
@@ -324,7 +326,13 @@ export default function LineageEntityNode({
                             textAnchor="start"
                             fill={isCenterNode ? '#1890FF' : 'black'}
                         >
-                            {truncate(getLastTokenOfTitle(node.data.name), 16)}
+                            {truncate(
+                                getLastTokenOfTitle(
+                                    node.data.name,
+                                    node.data.platform?.properties?.datasetNameDelimiter,
+                                ),
+                                16,
+                            )}
                         </UnselectableText>
                     )}
                 </Group>

--- a/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
+++ b/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
@@ -7,14 +7,18 @@ import {
     dataset5,
     dataset5WithLineage,
     dataset6WithLineage,
+    dataFlow1,
 } from '../../../Mocks';
-import { EntityType, RelationshipDirection } from '../../../types.generated';
+import { DataPlatform, EntityType, RelationshipDirection } from '../../../types.generated';
 import { getTestEntityRegistry } from '../../../utils/test-utils/TestPageContainer';
 import { Direction, FetchedEntities } from '../types';
 import constructTree from '../utils/constructTree';
 import extendAsyncEntities from '../utils/extendAsyncEntities';
 
 const testEntityRegistry = getTestEntityRegistry();
+const kafkaPlatform: DataPlatform = dataset3.platform;
+
+const airflowPlatform: DataPlatform = dataFlow1.platform;
 
 describe('constructTree', () => {
     it('handles nodes without any lineage', () => {
@@ -34,7 +38,7 @@ describe('constructTree', () => {
             unexploredChildren: 0,
             children: [],
             icon: undefined,
-            platform: 'Kafka',
+            platform: kafkaPlatform,
         });
     });
 
@@ -68,7 +72,7 @@ describe('constructTree', () => {
             type: EntityType.Dataset,
             unexploredChildren: 0,
             icon: undefined,
-            platform: 'Kafka',
+            platform: kafkaPlatform,
             children: [
                 {
                     name: 'Fourth Test Dataset',
@@ -79,7 +83,7 @@ describe('constructTree', () => {
                     countercurrentChildrenUrns: [],
                     children: [],
                     icon: undefined,
-                    platform: 'Kafka',
+                    platform: kafkaPlatform,
                     status: null,
                 },
             ],
@@ -116,7 +120,7 @@ describe('constructTree', () => {
             type: EntityType.Dataset,
             unexploredChildren: 0,
             icon: undefined,
-            platform: 'Kafka',
+            platform: kafkaPlatform,
             children: [
                 {
                     countercurrentChildrenUrns: [],
@@ -127,7 +131,7 @@ describe('constructTree', () => {
                     urn: 'urn:li:dataset:5',
                     children: [],
                     icon: undefined,
-                    platform: 'Kafka',
+                    platform: kafkaPlatform,
                     status: null,
                 },
             ],
@@ -165,7 +169,7 @@ describe('constructTree', () => {
             type: EntityType.Dataset,
             unexploredChildren: 0,
             icon: undefined,
-            platform: 'Kafka',
+            platform: kafkaPlatform,
             children: [
                 {
                     name: 'Fourth Test Dataset',
@@ -175,7 +179,7 @@ describe('constructTree', () => {
                     urn: 'urn:li:dataset:4',
                     countercurrentChildrenUrns: ['urn:li:dataset:3'],
                     icon: undefined,
-                    platform: 'Kafka',
+                    platform: kafkaPlatform,
                     status: null,
                     children: [
                         {
@@ -186,7 +190,7 @@ describe('constructTree', () => {
                             urn: 'urn:li:dataset:6',
                             countercurrentChildrenUrns: ['urn:li:dataset:4'],
                             icon: undefined,
-                            platform: 'Kafka',
+                            platform: kafkaPlatform,
                             status: null,
                             children: [
                                 {
@@ -202,7 +206,7 @@ describe('constructTree', () => {
                                         'urn:li:dataset:4',
                                     ],
                                     icon: undefined,
-                                    platform: 'Kafka',
+                                    platform: kafkaPlatform,
                                     status: null,
                                 },
                             ],
@@ -216,7 +220,7 @@ describe('constructTree', () => {
                             children: [],
                             countercurrentChildrenUrns: ['urn:li:dataset:7', 'urn:li:dataset:6', 'urn:li:dataset:4'],
                             icon: undefined,
-                            platform: 'Kafka',
+                            platform: kafkaPlatform,
                             status: null,
                         },
                     ],
@@ -283,7 +287,7 @@ describe('constructTree', () => {
             type: EntityType.Dataset,
             unexploredChildren: 0,
             icon: undefined,
-            platform: 'Kafka',
+            platform: kafkaPlatform,
             children: [
                 {
                     name: 'Fourth Test Dataset',
@@ -294,7 +298,7 @@ describe('constructTree', () => {
                     children: [],
                     countercurrentChildrenUrns: ['urn:li:dataset:3'],
                     icon: undefined,
-                    platform: 'Kafka',
+                    platform: kafkaPlatform,
                     status: null,
                 },
             ],
@@ -366,7 +370,7 @@ describe('constructTree', () => {
             type: EntityType.Dataset,
             unexploredChildren: 0,
             icon: undefined,
-            platform: 'Kafka',
+            platform: kafkaPlatform,
             subtype: undefined,
             children: [
                 {
@@ -379,7 +383,7 @@ describe('constructTree', () => {
                     countercurrentChildrenUrns: [],
                     icon: '',
                     status: null,
-                    platform: 'Airflow',
+                    platform: airflowPlatform,
                     subtype: undefined,
                 },
             ],

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -40,7 +40,7 @@ export type FetchedEntity = {
     downstreamChildren?: Array<EntityAndType>;
     numDownstreamChildren?: number;
     fullyFetched?: boolean;
-    platform?: string;
+    platform?: DataPlatform;
     status?: Maybe<Status>;
     siblingPlatforms?: Maybe<DataPlatform[]>;
 };
@@ -58,7 +58,7 @@ export type NodeData = {
     // Hidden children are unexplored but in the opposite direction of the flow of the graph.
     // Currently our visualization does not support expanding in two directions
     countercurrentChildrenUrns?: string[];
-    platform?: string;
+    platform?: DataPlatform;
     status?: Maybe<Status>;
     siblingPlatforms?: Maybe<DataPlatform[]>;
 };


### PR DESCRIPTION
**Summary**

Previously we split asset names in Lineage view by a period. This does not work in cases where the delimiter for a platform should NOT be a period (e.g. S3). This PR fixes that by using the configured Data Platform delimiter to split names in the lineage viz. 

Verified with S3 datasets ending in file extensions. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)