### PR TITLE
fix(ingest): use default telemetry ID when config is unwritable

### DIFF
--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -101,8 +101,12 @@ class Telemetry:
         if not CONFIG_FILE.exists() or not self.load_config():
             # set up defaults
             self.client_id = str(uuid.uuid4())
-            self.enabled = self.enabled & ENV_ENABLED
-            self.update_config()
+            self.enabled = self.enabled and ENV_ENABLED
+            if not self.update_config():
+                # If we're not able to persist the client ID, we should default
+                # to a standardized value. This prevents us from minting a new
+                # client ID every time we start the CLI.
+                self.client_id = "00000000-0000-0000-0000-000000000001"
 
         # send updated user-level properties
         self.mp = None


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)