### PR TITLE
 build(docs-website): only show release notes for recent releases

### DIFF
--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -422,7 +422,9 @@ custom_edit_url: https://github.com/datahub-project/datahub/blob/master/docs-web
   });
 
   // We only embed release notes for releases in the last 3 months.
-  const release_notes_date_cutoff = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 * 3);
+  const release_notes_date_cutoff = new Date(
+    Date.now() - 1000 * 60 * 60 * 24 * 30 * 3
+  );
 
   // Construct a summary table.
   const releaseNoteVersions = new Set();

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -395,7 +395,7 @@ function markdown_sanitize_and_linkify(content: string): string {
 
 function pretty_format_date(datetime: string): string {
   const d = new Date(Date.parse(datetime));
-  return d.toDateString();
+  return d.toISOString().split("T")[0];
 }
 
 function make_link_anchor(text: string): string {
@@ -417,26 +417,32 @@ custom_edit_url: https://github.com/datahub-project/datahub/blob/master/docs-web
 ## Summary\n\n`);
 
   const releases_list = await octokit.rest.repos.listReleases({
-    owner: "linkedin",
+    owner: "datahub-project",
     repo: "datahub",
   });
 
+  // We only embed release notes for releases in the last 3 months.
+  const release_notes_date_cutoff = new Date(Date.now() - 1000 * 60 * 60 * 24 * 30 * 3);
+
   // Construct a summary table.
-  let pastVersionCutoff = false;
   const releaseNoteVersions = new Set();
   contents.content += "| Version | Release Date | Links |\n";
   contents.content += "| ------- | ------------ | ----- |\n";
   for (const release of releases_list.data) {
+    if (release.prerelease || release.draft) {
+      continue;
+    }
+    const release_date = new Date(Date.parse(release.created_at));
+
     let row = `| **${release.tag_name}** | ${pretty_format_date(
       release.created_at
     )} |`;
-    if (release.tag_name == "v0.6.1") {
-      pastVersionCutoff = true;
-    } else if (!pastVersionCutoff) {
+    if (release_date > release_notes_date_cutoff) {
       row += `[Release Notes](#${make_link_anchor(release.tag_name)}), `;
       releaseNoteVersions.add(release.tag_name);
     }
     row += `[View on GitHub](${release.html_url}) |\n`;
+
     contents.content += row;
   }
   contents.content += "\n\n";


### PR DESCRIPTION
Bonus: also hides the release candidates from the docs website and tweaks our date formatting to look better.