### PR TITLE
feat(spark-lineage): support s3 urn formatting as per s3 python source

### DIFF
--- a/metadata-integration/java/spark-lineage/README.md
+++ b/metadata-integration/java/spark-lineage/README.md
@@ -77,6 +77,35 @@ spark = SparkSession.builder()
 | spark.datahub.metadata.dataset.env              |          | PROD    | [Supported values](https://datahubproject.io/docs/graphql/enums#fabrictype). In all other cases, will fallback to PROD           |
 | spark.datahub.coalesce_jobs              |          |  false     |  Only one datajob(taask) will be emitted containing all input and output datasets for the spark application          |
 | spark.datahub.parent.datajob_urn              |          |       | Specified dataset will be set as upstream dataset for datajob created. Effective only when spark.datahub.coalesce_jobs is set to true     |
+| spark.datahub.platform.s3.path_spec_list          |          |       | Comma separated list of path_specs which will be used to generate urn of datasets. If not specified complete s3 path will be used. Please check below for examples.    |
+| spark.datahub.platform.s3.path_alias_list          |          |       | Comma separated list of path alias specifying the order in which the are matched. Use this, if you have pathSpecs with different env and platformInstance settings.    |
+| spark.datahub.platform.s3.$path_alias.path_spec_list          |          |       | Comma separated list of path_specs which will be used to generate urn of datasets. If not specified or matched common `path_spec_list` will be used.      |
+| spark.datahub.platform.s3.$path_alias.env          |          |       | Fabric Type for given alias. If not specified will fall back to `dataset.env` |
+| spark.datahub.platform.s3.$path_alias.platformInstance          |          |       | Platform instance for matched alias. If not specified will fall back to `dataset.platformInstance`      |
+
+## path_spec_list Examples
+
+| Absolute path                     | path_spec                        | Urn                                                                        |
+|-----------------------------------|----------------------------------|----------------------------------------------------------------------------|
+| s3://my-bucket/foo/tests/bar.avro | Not provided                     | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)  |
+| s3://my-bucket/foo/tests/bar.avro | s3://my-bucket/foo/{table}/*     | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)           |
+| s3://my-bucket/foo/tests/bar.avro | s3://my-bucket/foo/tests/{table} | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)  |
+| s3://my-bucket/foo/tests/bar.avro | s3://my-bucket/{table}/*/*       | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo,PROD)                 |
+| s3://my-bucket/foo/tests/bar.avro | s3://my-bucket/{table}           | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo,PROD)                 |
+| s3://my-bucket/foo/tests/bar.avro | s3://my-bucket/*/*/{table}       | urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)  |
+
+## path_alias_list Example:
+
+Example below explains the configuration of case, where files from 2 buckets being processed in single spark application and files from my-bucket are supposed have "instance1" as platformInstance and "PROD" as env and files from bucket2 should have env "DEV" in their dataset URNs.
+
+```yml
+spark.datahub.platform.s3.path_alias_list :  path1,path2
+spark.datahub.platform.s3.path1.env : PROD
+spark.datahub.platform.s3.path1.path_spec_list: s3://my-bucket/*/*/{table}
+spark.datahub.platform.s3.path1.platform_instance : instance-1 
+spark.datahub.platform.s3.path2.env: DEV
+spark.datahub.platform.s3.path2.path_spec_list: s3://bucket2/*/{table}
+``` 
 
 ## What to Expect: The Metadata Model
 

--- a/metadata-integration/java/spark-lineage/build.gradle
+++ b/metadata-integration/java/spark-lineage/build.gradle
@@ -98,6 +98,7 @@ dependencies {
   // Tests need a concrete log4j available. Providing it here
   testImplementation 'org.apache.logging.log4j:log4j-api:2.17.1'
   testImplementation 'org.apache.logging.log4j:log4j-core:2.17.1'
+  
 
 
   testImplementation(externalDependency.postgresql){
@@ -105,7 +106,7 @@ dependencies {
   }
 
   testImplementation externalDependency.mockito
-
+  testImplementation 'org.mockito:mockito-inline:4.2.0' 
   testImplementation(externalDependency.mockServer){
     exclude group: "com.fasterxml.jackson.core"
   } // older version to allow older guava

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
@@ -277,7 +277,7 @@ public class DatahubSparkListener extends SparkListener {
     String appId = ctx.applicationId();
     Config datahubConfig = appConfig.get(appId);
     if (datahubConfig == null) {
-      Config datahubConf = LineageUtils.parseSparkConfig();
+      Config datahubConf = SparkConfigUtil.parseSparkConfig();
       appConfig.put(appId, datahubConf);
       Config pipelineConfig = datahubConf.hasPath(PIPELINE_KEY) ? datahubConf.getConfig(PIPELINE_KEY)
           : com.typesafe.config.ConfigFactory.empty();
@@ -296,7 +296,7 @@ public class DatahubSparkListener extends SparkListener {
   }
 
   private String getPipelineName(SparkContext cx) {
-    Config datahubConfig = appConfig.computeIfAbsent(cx.applicationId(), s -> LineageUtils.parseSparkConfig());
+    Config datahubConfig = appConfig.computeIfAbsent(cx.applicationId(), s -> SparkConfigUtil.parseSparkConfig());
     String name = "";
     if (datahubConfig.hasPath(DATABRICKS_CLUSTER_KEY)) {
       name = datahubConfig.getString(DATABRICKS_CLUSTER_KEY) + "_" + cx.applicationId();

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/SparkConfigUtil.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/SparkConfigUtil.java
@@ -1,0 +1,109 @@
+package datahub.spark;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
+
+import com.linkedin.common.FabricType;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SparkConfigUtil {
+
+  private static final String DATASET_KEY = "metadata.dataset";
+  private static final String DATASET_PLATFORM_INSTANCE_KEY = "metadata.dataset.platformInstance";
+
+  private static final String PLATFORM_KEY = "platform";
+
+  private static final String S3_CONFIG_KEY = PLATFORM_KEY + ".s3";
+  private static final String PATH_SPEC_LIST_KEY = "path_spec_list";
+  private static final String PLATFORM_INSTANCE_KEY = "platformInstance";
+  private static final String FABRIC_TYPE_KEY = "env";
+  private static final String S3_PATH_SPEC_LIST_KEY = S3_CONFIG_KEY + "." + PATH_SPEC_LIST_KEY;
+  private static final String S3_CONFIG_ALIAS_KEY = S3_CONFIG_KEY + ".path_alias_list";
+
+  private SparkConfigUtil() {
+
+  }
+
+  public static Config parseSparkConfig() {
+    SparkConf conf = SparkEnv.get().conf();
+    String propertiesString = Arrays.stream(conf.getAllWithPrefix("spark.datahub."))
+        .map(tup -> tup._1 + "= \"" + tup._2 + "\"").collect(Collectors.joining("\n"));
+    return ConfigFactory.parseString(propertiesString);
+  }
+
+  public static String getCommonPlatformInstance() {
+    Config datahubConfig = parseSparkConfig();
+    return datahubConfig.hasPath(DATASET_PLATFORM_INSTANCE_KEY) ? datahubConfig.getString(DATASET_PLATFORM_INSTANCE_KEY)
+        : null;
+  }
+
+  public static Config getDatasetConfig() {
+    Config datahubConfig = parseSparkConfig();
+    return datahubConfig.hasPath(DATASET_KEY) ? datahubConfig.getConfig(DATASET_KEY) : null;
+  }
+
+  public static FabricType getCommonFabricType() {
+
+    return getFabricType(getDatasetConfig());
+  }
+
+  public static List<String> getS3PathSpecList() {
+    Config datahubConfig = parseSparkConfig();
+    if (datahubConfig.hasPath(S3_PATH_SPEC_LIST_KEY)) {
+      log.debug(S3_PATH_SPEC_LIST_KEY + ":" + datahubConfig.getString(S3_PATH_SPEC_LIST_KEY));
+      return Arrays.asList(datahubConfig.getString(S3_PATH_SPEC_LIST_KEY).split(","));
+    }
+
+    return null;
+  }
+
+  public static List<String> getS3PathAliasList() {
+    Config datahubConfig = parseSparkConfig();
+    return datahubConfig.hasPath(S3_CONFIG_ALIAS_KEY) ? Arrays.asList(datahubConfig.getString(S3_CONFIG_ALIAS_KEY)
+        .split(","))
+        : null;
+  }
+
+  public static Config getS3PathAliasDetails(String pathAlias) {
+    String pathAliasKey = S3_CONFIG_KEY + "." + pathAlias;
+    Config datahubConfig = parseSparkConfig();
+    return datahubConfig.hasPath(pathAliasKey) ? datahubConfig.getConfig(pathAliasKey) : null;
+  }
+
+  public static List<String> getPathSpecList(Config pathSpecConfig) {
+    return pathSpecConfig.hasPath(PATH_SPEC_LIST_KEY) ? Arrays.asList(pathSpecConfig.getString(PATH_SPEC_LIST_KEY)
+        .split(",")) : null;
+  }
+
+  public static String getPlatformInstance(Config pathSpecConfig) {
+    return pathSpecConfig.hasPath(PATH_SPEC_LIST_KEY) ? pathSpecConfig.getString(PLATFORM_INSTANCE_KEY)
+        : null;
+  }
+
+  public static FabricType getFabricType(Config pathSpecConfig) {
+    // setting default fabric type as 'PROD'
+    FabricType fabricType = FabricType.PROD;
+    if (pathSpecConfig != null) {
+      String fabricTypeString = pathSpecConfig.hasPath(FABRIC_TYPE_KEY)
+          ? pathSpecConfig.getString(FABRIC_TYPE_KEY).toUpperCase()
+          : "PROD";
+      try {
+        fabricType = FabricType.valueOf(fabricTypeString);
+      } catch (IllegalArgumentException e) {
+        log.warn("Invalid env ({}). Setting env to default PROD", fabricTypeString);
+
+      }
+    }
+
+    return fabricType;
+  }
+
+}

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/LineageUtils.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/LineageUtils.java
@@ -1,39 +1,29 @@
 package datahub.spark.model;
 
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.spark.SparkContext;
+import org.apache.spark.SparkContext$;
+import org.apache.spark.sql.SparkSession;
+
 import com.linkedin.common.FabricType;
 import com.linkedin.common.urn.DataFlowUrn;
 import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.TupleKey;
 import com.linkedin.common.urn.Urn;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.spark.SparkConf;
-import org.apache.spark.SparkContext;
-import org.apache.spark.SparkContext$;
-import org.apache.spark.SparkEnv;
-import org.apache.spark.sql.SparkSession;
 import scala.Option;
 import scala.runtime.AbstractFunction0;
 import scala.runtime.AbstractFunction1;
 
-@Slf4j
 public class LineageUtils {
 
   private static Map<String, LineageConsumer> consumers = new ConcurrentHashMap<>();
 
-  // hook for replacing paths during testing. Not the cleanest way, TODO improve.
-  /* This is for generating urn from a hash of the plan */
-  // private static Function<String, String> PATH_REPLACER = (x -> x);
 
   private LineageUtils() {
 
@@ -77,13 +67,6 @@ public class LineageUtils {
     return consumers.get(consumerType);
   }
 
-  public static Config parseSparkConfig() {
-    SparkConf conf = SparkEnv.get().conf();
-    String propertiesString = Arrays.stream(conf.getAllWithPrefix("spark.datahub."))
-        .map(tup -> tup._1 + "= \"" + tup._2 + "\"").collect(Collectors.joining("\n"));
-    return ConfigFactory.parseString(propertiesString);
-  }
-
   // TODO: URN creation with platform instance needs to be inside DatasetUrn class
   public static DatasetUrn createDatasetUrn(String platform, String platformInstance, String name,
       FabricType fabricType) {
@@ -91,24 +74,4 @@ public class LineageUtils {
     return new DatasetUrn(new DataPlatformUrn(platform), datasteName, fabricType);
   }
 
-  /* This is for generating urn from a hash of the plan */
-
-  /*
-   * public static String scrubPlan(String plan) { String s =
-   * plan.replaceAll("#[0-9]*", ""); s =
-   * s.replaceAll("JdbcRelationProvider@[0-9a-zA-Z]*,", "JdbcRelationProvider,");
-   * s = s.replaceAll("InMemoryFileIndex@[0-9a-zA-Z]*,", "InMemoryFileIndex,"); s
-   * = s.replaceAll("Created Time:[^\n]+\n", ""); s =
-   * s.replaceAll("Last Access:[^\n]+\n", ""); s = s.replaceAll("Owner:[^\n]+\n",
-   * ""); s = s.replaceAll("Statistics:[^\n]+\n", ""); s =
-   * s.replaceAll("Table Properties:[^\n]+\n", ""); //
-   * System.out.println("CLEAN: " + s); return s; }
-   * 
-   * public static void setPathReplacer(Function<String, String> replacer) {
-   * PATH_REPLACER = replacer; }
-   * 
-   * public static String hash(String s) { s = PATH_REPLACER.apply(s);
-   * log.debug("PATH REPLACED " + s); return Hashing.md5().hashString(s,
-   * Charset.forName("US-ASCII")).toString(); }
-   */
 }

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/CatalogTableDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/CatalogTableDataset.java
@@ -17,4 +17,12 @@ public class CatalogTableDataset extends SparkDataset {
     super("hive", platformInstance, dsName, fabricType);
   }
 
+  public CatalogTableDataset(String dsName) {
+    super("hive", dsName);
+  }
+
+  public CatalogTableDataset(CatalogTable table) {
+    this(table.qualifiedName());
+  }
+
 }

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsDatasetFactory.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsDatasetFactory.java
@@ -1,0 +1,24 @@
+package datahub.spark.model.dataset;
+
+import org.apache.hadoop.fs.Path;
+
+public class HdfsDatasetFactory {
+
+  private HdfsDatasetFactory() {
+
+  }
+
+  public static SparkDataset createDataset(Path path) throws InstantiationException {
+    String pathUri = path.toUri().toString();
+    if (S3Dataset.isMatch(pathUri)) {
+      return S3Dataset.create(pathUri);
+    } else {
+      return createHdfsDataset(pathUri);
+    }
+  }
+
+  private static SparkDataset createHdfsDataset(String pathUri) {
+    return new HdfsPathDataset(pathUri);
+  }
+
+}

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 
 @ToString
 public class HdfsPathDataset extends SparkDataset {
-  
+
   public HdfsPathDataset(Path path, String platformInstance, FabricType fabricType) {
     // TODO check static partitions?
     this(path.toUri().toString(), platformInstance, fabricType);
@@ -17,6 +17,11 @@ public class HdfsPathDataset extends SparkDataset {
   public HdfsPathDataset(String pathUri, String platformInstance, FabricType fabricType) {
     // TODO check static partitions?
     super("hdfs", platformInstance, pathUri, fabricType);
+  }
+
+  public HdfsPathDataset(String pathUri) {
+    // TODO check static partitions?
+    super("hdfs", pathUri);
   }
 
 }

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/JdbcDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/JdbcDataset.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 
 @ToString
 public class JdbcDataset extends SparkDataset {
-  //TODO: Should map to the central location on datahub for platform names
+  // TODO: Should map to the central location on datahub for platform names
   private static final Map<String, String> PLATFORM_NAME_MAPPING = new HashMap<>();
   static {
     PLATFORM_NAME_MAPPING.put("postgresql", "postgres");
@@ -18,6 +18,10 @@ public class JdbcDataset extends SparkDataset {
 
   public JdbcDataset(String url, String tbl, String platformInstance, FabricType fabricType) {
     super(platformName(url), platformInstance, dsName(url, tbl), fabricType);
+  }
+
+  public JdbcDataset(String url, String tbl) {
+    super(platformName(url), dsName(url, tbl));
   }
 
   private static String platformName(String url) {

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/PathUriNormalizationUtil.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/PathUriNormalizationUtil.java
@@ -1,0 +1,48 @@
+package datahub.spark.model.dataset;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PathUriNormalizationUtil {
+
+  private PathUriNormalizationUtil() {
+
+  }
+
+  private static final String TABLE = "{table}";
+  private static final String TABLE_MARKER = "/{table}";
+  private static final String TABLE_MARKER_REGEX = "/\\{table\\}";
+
+/* This utility method normalizes the pathUri as per pathSpec.
+ * pathSpec must contain {table} modifier
+ * If pathUri cannot be normalized then null value is returned.
+ */
+  
+  static String getMatchedUri(String pathUri, String pathSpec) {
+    if (pathSpec.contains(TABLE_MARKER)) {
+      String miniSpec = pathSpec.split(TABLE_MARKER_REGEX)[0] + TABLE_MARKER;
+      String[] specFolderList = miniSpec.split("/");
+      String[] pathFolderList = pathUri.split("/");
+      StringBuffer uri = new StringBuffer();
+      if (pathFolderList.length >= specFolderList.length) {
+        for (int i = 0; i < specFolderList.length; i++) {
+          if (specFolderList[i].equals(pathFolderList[i]) || specFolderList[i].equals("*")) {
+            uri.append(pathFolderList[i] + "/");
+          } else if (specFolderList[i].equals(TABLE)) {
+            uri.append(pathFolderList[i]);
+            log.debug("Actual path [" + pathUri + "] matched with path_spec [" + pathSpec
+                + "]");
+            return uri.toString();
+          } else {
+            break;
+          }
+        }
+      }
+      log.debug("No path spec matched with actual path [" + pathUri + "]");
+    } else {
+      log.warn("Invalid path spec [" + pathSpec + "]. Path spec should contain {table}");
+    }
+    return null;
+  }
+
+}

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/S3Dataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/S3Dataset.java
@@ -1,0 +1,91 @@
+package datahub.spark.model.dataset;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import com.linkedin.common.FabricType;
+import com.typesafe.config.Config;
+
+import datahub.spark.SparkConfigUtil;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class S3Dataset extends SparkDataset {
+
+
+
+  public S3Dataset(String pathUri, String platformInstance, FabricType fabricType) {
+    super("s3", platformInstance, pathUri, fabricType);
+  }
+
+  public S3Dataset(String pathUri) {
+    super("s3", pathUri);
+  }
+
+  public static boolean isMatch(String pathUri) {
+    return isS3Uri(pathUri);
+  }
+
+  public static S3Dataset create(String pathUri) throws InstantiationException {
+    if (!isMatch(pathUri)) {
+      throw new InstantiationException("S3Dataset instance cannot be created for non S3 pathUri: " + pathUri);
+    }
+    List<String> pathAliasList = SparkConfigUtil.getS3PathAliasList();
+    log.debug("path_alias_list: " + String.join(",", pathAliasList));
+    if (pathAliasList != null && pathAliasList.size() > 0) {
+      for (String pathAlias : SparkConfigUtil.getS3PathAliasList()) {
+        log.debug("Checking match for path_alias: " + pathAlias);
+        Config pathSpecConfig = SparkConfigUtil.getS3PathAliasDetails(pathAlias);
+        if (pathSpecConfig != null) {
+          String s3Uri = getS3Uri(pathUri, SparkConfigUtil.getPathSpecList(pathSpecConfig));
+          if (s3Uri != null) {
+            String platformInstance = SparkConfigUtil.getPlatformInstance(pathSpecConfig);
+            FabricType fabricType = SparkConfigUtil.getFabricType(pathSpecConfig);
+            return new S3Dataset(getDatasetName(s3Uri), platformInstance, fabricType);
+          }
+        }
+
+      }
+      log.debug("nothing matched from path_alias_list. Falling back using config 'path_spec_list'");
+    }
+    String s3Uri = getS3Uri(pathUri, SparkConfigUtil.getS3PathSpecList());
+    if (s3Uri == null) {
+      s3Uri = pathUri;
+    }
+    return new S3Dataset(getDatasetName(s3Uri));
+  }
+
+  private static String getDatasetName(String s3Uri) {
+    return stripS3Prefix(s3Uri);
+  }
+
+  private static String getS3Uri(String pathUri, List<String> pathSpecs) {
+
+    if (pathSpecs == null || pathSpecs.size() == 0) {
+      log.debug("No path_spec_list configuration found. Falling back to creating dataset name with complete s3 uri");
+    } else {
+      for (String pathSpec : pathSpecs) {
+        String uri = PathUriNormalizationUtil.getMatchedUri(pathUri, pathSpec);
+        if (uri != null) {
+          return uri;
+        }
+      }
+    }
+    return null;
+  }
+
+ 
+
+  private static boolean isS3Uri(String uri) {
+    return getS3PrefixStream().anyMatch(s -> uri.startsWith(s));
+  }
+
+  private static String stripS3Prefix(String uri) {
+    return getS3PrefixStream().filter(p -> uri.startsWith(p)).map(q -> uri.replaceFirst("^" + q, ""))
+        .findFirst().orElse(uri);
+  }
+
+  private static Stream<String> getS3PrefixStream() {
+    return Stream.of("s3://", "s3n://", "s3a://");
+  }
+}

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/SparkDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/SparkDataset.java
@@ -3,17 +3,24 @@ package datahub.spark.model.dataset;
 import com.linkedin.common.FabricType;
 import com.linkedin.common.urn.DatasetUrn;
 
+import datahub.spark.SparkConfigUtil;
 import datahub.spark.model.LineageUtils;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode
 public abstract class SparkDataset {
-  
+
   private DatasetUrn urn;
-  
+
   public SparkDataset(String platform, String platformInstance, String name, FabricType fabricType) {
     super();
     this.urn = LineageUtils.createDatasetUrn(platform, platformInstance, name, fabricType);
+  }
+
+  public SparkDataset(String platform, String name) {
+    super();
+    this.urn = LineageUtils.createDatasetUrn(platform, SparkConfigUtil.getCommonPlatformInstance(), name,
+        SparkConfigUtil.getCommonFabricType());
   }
 
   public DatasetUrn urn() {

--- a/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/model/dataset/HdfsDatasetFactoryTest.java
+++ b/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/model/dataset/HdfsDatasetFactoryTest.java
@@ -1,0 +1,85 @@
+package datahub.spark.model.dataset;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.fs.Path;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.linkedin.common.FabricType;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import datahub.spark.SparkConfigUtil;
+
+public class HdfsDatasetFactoryTest {
+
+  @Test
+  public void testNoPathSpecList() throws InstantiationException, IllegalArgumentException {
+    try (MockedStatic<SparkConfigUtil> utilities = Mockito.mockStatic(SparkConfigUtil.class)) {
+      utilities.when(SparkConfigUtil::getCommonFabricType).thenReturn(FabricType.PROD);
+      SparkDataset dataset = HdfsDatasetFactory.createDataset(new Path("s3://my-bucket/foo/tests/bar.avro"));
+      Assert.assertEquals("urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)", dataset.urn()
+          .toString());
+    }
+  }
+
+  @Test
+  public void testPathSpecList() throws InstantiationException, IllegalArgumentException {
+    try (MockedStatic<SparkConfigUtil> utilities = Mockito.mockStatic(SparkConfigUtil.class)) {
+      utilities.when(SparkConfigUtil::getCommonFabricType).thenReturn(FabricType.PROD);
+      utilities.when(SparkConfigUtil::getS3PathSpecList).thenReturn(Arrays.asList("s3a://wrong-my-bucket/foo/{table}",
+          "s3a://my-bucket/foo/{table}"));
+      SparkDataset dataset = HdfsDatasetFactory.createDataset(new Path("s3a://my-bucket/foo/tests/bar.avro"));
+      Assert.assertEquals("urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests,PROD)", dataset.urn()
+          .toString());
+    }
+  }
+
+  @Test
+  public void testNoMatchPathSpecList() throws InstantiationException, IllegalArgumentException {
+    try (MockedStatic<SparkConfigUtil> utilities = Mockito.mockStatic(SparkConfigUtil.class)) {
+      utilities.when(SparkConfigUtil::getCommonFabricType).thenReturn(FabricType.PROD);
+      utilities.when(SparkConfigUtil::getS3PathSpecList).thenReturn(Arrays.asList("s3a://wrong-my-bucket/foo/{table}"));
+      SparkDataset dataset = HdfsDatasetFactory.createDataset(new Path("s3a://my-bucket/foo/tests/bar.avro"));
+      Assert.assertEquals("urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo/tests/bar.avro,PROD)", dataset.urn()
+          .toString());
+    }
+  }
+
+  @Test
+  public void testPathSpecListPlatformInstance() throws InstantiationException, IllegalArgumentException {
+    try (MockedStatic<SparkConfigUtil> utilities = Mockito.mockStatic(SparkConfigUtil.class)) {
+      utilities.when(SparkConfigUtil::getCommonFabricType).thenReturn(FabricType.PROD);
+      utilities.when(SparkConfigUtil::getCommonPlatformInstance).thenReturn("instance");
+      utilities.when(SparkConfigUtil::getS3PathSpecList).thenReturn(Arrays.asList("s3a://wrong-my-bucket/foo/{table}",
+          "s3a://my-bucket/foo/{table}"));
+      SparkDataset dataset = HdfsDatasetFactory.createDataset(new Path("s3a://my-bucket/foo/tests/bar.avro"));
+      Assert.assertEquals("urn:li:dataset:(urn:li:dataPlatform:s3,instance.my-bucket/foo/tests,PROD)", dataset.urn()
+          .toString());
+    }
+  }
+
+  @Test
+  public void testPathAliasList() throws InstantiationException, IllegalArgumentException {
+    Map<String, String> configMap = new HashMap<String, String>();
+    configMap.put("path_spec_list", "s3a://my-bucket/{table}");
+    Config config = ConfigFactory.parseMap(configMap);
+    try (MockedStatic<SparkConfigUtil> utilities = Mockito.mockStatic(SparkConfigUtil.class)) {
+      utilities.when(SparkConfigUtil::getCommonFabricType).thenReturn(FabricType.PROD);
+      utilities.when(SparkConfigUtil::getS3PathAliasList).thenReturn(Arrays.asList("path1", "path2"));
+      utilities.when(() -> SparkConfigUtil.getS3PathAliasDetails("path1")).thenReturn(ConfigFactory.empty());
+      utilities.when(() -> SparkConfigUtil.getS3PathAliasDetails("path2")).thenReturn(config);
+      utilities.when(() -> SparkConfigUtil.getPathSpecList(config)).thenCallRealMethod();
+      utilities.when(() -> SparkConfigUtil.getFabricType(config)).thenCallRealMethod();
+      
+      SparkDataset dataset = HdfsDatasetFactory.createDataset(new Path("s3a://my-bucket/foo/tests/bar.avro"));
+      Assert.assertEquals("urn:li:dataset:(urn:li:dataPlatform:s3,my-bucket/foo,PROD)", dataset.urn()
+          .toString());
+    }
+  }
+}

--- a/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/model/dataset/TestS3UriMatching.java
+++ b/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/model/dataset/TestS3UriMatching.java
@@ -38,6 +38,6 @@ public class TestS3UriMatching {
 
   @Test
   public void testS3UriMatching() {
-    Assert.assertEquals(matchedUri, S3Dataset.getMatchedUri(PATH, pathSpec));
+    Assert.assertEquals(matchedUri, PathUriNormalizationUtil.getMatchedUri(PATH, pathSpec));
   }
 }

--- a/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/model/dataset/TestS3UriMatching.java
+++ b/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/model/dataset/TestS3UriMatching.java
@@ -1,0 +1,43 @@
+package datahub.spark.model.dataset;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.testng.Assert;
+
+@RunWith(Parameterized.class)
+public class TestS3UriMatching {
+
+  private String pathSpec;
+  private String matchedUri;
+  private static final String PATH = "s3://my-bucket/foo/tests/bar.avro";
+
+  public TestS3UriMatching(String pathSpec, String matchedUri) {
+    super();
+    this.pathSpec = pathSpec;
+    this.matchedUri = matchedUri;
+  }
+
+  @Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+        
+        { "s3://my-bucket/foo/tests/{table}", "s3://my-bucket/foo/tests/bar.avro" },
+        { "s3://my-bucket/{table}/*/*", "s3://my-bucket/foo" },
+        { "s3://my-bucket/{table}", "s3://my-bucket/foo" },
+        { "s3://my-bucket/*/*/{table}", "s3://my-bucket/foo/tests/bar.avro" },
+        { "s3://my-bucket/*/foo/", null },
+        { "s3://my-bucket/foo/*/*/*/{table}", null },
+        { "s3://my-bucket/foo/{table}/*", "s3://my-bucket/foo/tests" }
+    });
+  }
+
+  @Test
+  public void testS3UriMatching() {
+    Assert.assertEquals(matchedUri, S3Dataset.getMatchedUri(PATH, pathSpec));
+  }
+}


### PR DESCRIPTION
This PR enables datahub-spark-lineage to format the dataset urns generated for the 's3' platform dataset to match with those generated by the "S3 Data lake" source. 
This will enable end-to-end lineage creation.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)