### PR TITLE
perf(operations): performance improvement to operations tab via reduced fetching

### DIFF
--- a/datahub-web-react/src/graphql/dataProcess.graphql
+++ b/datahub-web-react/src/graphql/dataProcess.graphql
@@ -20,14 +20,77 @@ fragment runResults on DataProcessInstanceResult {
             timestampMillis
         }
         inputs: relationships(input: { types: ["Consumes"], direction: OUTGOING, start: 0, count: 20 }) {
-            ...fullRelationshipResults
+            ...runRelationshipResults
         }
         outputs: relationships(input: { types: ["Produces"], direction: OUTGOING, start: 0, count: 20 }) {
-            ...fullRelationshipResults
+            ...runRelationshipResults
         }
         parentTemplate: relationships(input: { types: ["InstanceOf"], direction: OUTGOING, start: 0, count: 1 }) {
-            ...fullRelationshipResults
+            ...runRelationshipResults
         }
         externalUrl
+    }
+}
+
+fragment runRelationshipResults on EntityRelationshipsResult {
+    start
+    count
+    total
+    relationships {
+        type
+        direction
+        entity {
+            urn
+            type
+            ... on Dataset {
+                name
+                properties {
+                    name
+                    description
+                    qualifiedName
+                }
+                editableProperties {
+                    description
+                }
+                platform {
+                    ...platformFields
+                }
+                subTypes {
+                    typeNames
+                }
+                status {
+                    removed
+                }
+            }
+            ... on DataJob {
+                urn
+                type
+                dataFlow {
+                    ...nonRecursiveDataFlowFields
+                }
+                jobId
+                properties {
+                    name
+                    description
+                    externalUrl
+                    customProperties {
+                        key
+                        value
+                    }
+                }
+                deprecation {
+                    ...deprecationFields
+                }
+                dataPlatformInstance {
+                    ...dataPlatformInstanceFields
+                }
+                editableProperties {
+                    description
+                }
+                status {
+                    removed
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
We were fetching way too much for this tab, most especially relationships of the individual datasets.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)