### PR TITLE
fix(delta-table): allow env, credential file based s3 auth

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/config.py
@@ -85,9 +85,6 @@ class DeltaLakeSourceConfig(PlatformSourceConfigBase, EnvBasedSourceConfigBase):
     @pydantic.root_validator()
     def validate_config(cls, values: Dict) -> Dict[str, Any]:
         values["_is_s3"] = is_s3_uri(values.get("base_path", ""))
-        if values["_is_s3"]:
-            if values.get("s3") is None:
-                raise ValueError("s3 config must be set for s3 path")
         values["_complete_path"] = values.get("base_path")
         if values.get("relative_path") is not None:
             values[

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/delta_lake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/delta_lake_utils.py
@@ -12,14 +12,15 @@ def read_delta_table(
     try:
         opts = {}
         if delta_lake_config.is_s3():
-            if delta_lake_config.s3 is None:
-                raise ValueError("aws_config not set. Cannot browse s3")
-            if delta_lake_config.s3.aws_config is None:
-                raise ValueError("aws_config not set. Cannot browse s3")
-            opts = {
-                "AWS_ACCESS_KEY_ID": delta_lake_config.s3.aws_config.aws_access_key_id,
-                "AWS_SECRET_ACCESS_KEY": delta_lake_config.s3.aws_config.aws_secret_access_key,
-            }
+            if (
+                delta_lake_config.s3 is not None
+                and delta_lake_config.s3.aws_config is not None
+            ):
+                creds = delta_lake_config.s3.aws_config.get_credentials()
+                opts = {
+                    "AWS_ACCESS_KEY_ID": creds.get("aws_access_key_id", ""),
+                    "AWS_SECRET_ACCESS_KEY": creds.get("aws_secret_access_key", ""),
+                }
         delta_table = DeltaTable(path, storage_options=opts)
 
     except PyDeltaTableError as e:


### PR DESCRIPTION
This PR removes the restriction of providing s3 auth through aws-config

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)