### PR TITLE
fix(ingest): okta - make async loop init more robust

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -46,13 +46,11 @@ logger = logging.getLogger(__name__)
 class OktaConfig(ConfigModel):
     # Required: Domain of the Okta deployment. Example: dev-33231928.okta.com
     okta_domain: str = Field(
-        default="dev-33231928.okta.com",
-        description="The location of your Okta Domain, without a protocol. Can be found in Okta Developer console.",
+        description="The location of your Okta Domain, without a protocol. Can be found in Okta Developer console. e.g. dev-33231928.okta.com",
     )
     # Required: An API token generated from Okta.
     okta_api_token: str = Field(
-        default="00be4R_M2MzDqXawbWgfKGpKee0kuEOfX1RCQSRx00",
-        description="An API token generated for the DataHub application inside your Okta Developer Console.",
+        description="An API token generated for the DataHub application inside your Okta Developer Console. e.g. 00be4R_M2MzDqXawbWgfKGpKee0kuEOfX1RCQSRx00",
     )
 
     # Optional: Whether to ingest users, groups, or both.
@@ -266,8 +264,9 @@ class OktaSource(Source):
         # Step 0: get or create the event loop
         # This method can be called on the main thread or an async thread, so we must create a new loop if one doesn't exist
         # See https://docs.python.org/3/library/asyncio-eventloop.html for more info.
+
         try:
-            event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+            event_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
         except RuntimeError:
             event_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(event_loop)

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -263,8 +263,12 @@ class OktaSource(Source):
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
 
-        # Step 0: create the event loop
-        event_loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+        # Step 0: get or create the event loop
+        try:
+            event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        except RuntimeError:
+            event_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(event_loop)
 
         # Step 1: Produce MetadataWorkUnits for CorpGroups.
         if self.config.ingest_groups:

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -264,6 +264,8 @@ class OktaSource(Source):
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
 
         # Step 0: get or create the event loop
+        # This method can be called on the main thread or an async thread, so we must create a new loop if one doesn't exist
+        # See https://docs.python.org/3/library/asyncio-eventloop.html for more info.
         try:
             event_loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
         except RuntimeError:


### PR DESCRIPTION
Since the introduction of async decorators on ingest runs, the okta source fails due to an implicit dependency on running on the main thread (usage of asyncio.get_event_loop() method).
Adding a fail-safe to always initialize a loop.  

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)