### PR TITLE
fix(ui): Fixing minor search redirect filtering issue introduced by sticky filters

### DIFF
--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -13,6 +13,7 @@ import { navigateToSearchUrl } from './utils/navigateToSearchUrl';
 import { useGetAuthenticatedUser } from '../useGetAuthenticatedUser';
 import analytics, { EventType } from '../analytics';
 import useFilters from './utils/useFilters';
+import { PageRoutes } from '../../conf/Global';
 
 const styles = {
     children: {
@@ -34,14 +35,21 @@ const defaultProps = {
     onAutoComplete: undefined,
 };
 
+const isSearchResultPage = (path: string) => {
+    return path.startsWith(PageRoutes.SEARCH);
+};
+
 /**
  * A page that includes a sticky search header (nav bar)
  */
 export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) => {
     const location = useLocation();
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
-    const filters: Array<FacetFilterInput> = useFilters(params);
-    const currentQuery: string = decodeURIComponent(params.query ? (params.query as string) : '');
+    const paramFilters: Array<FacetFilterInput> = useFilters(params);
+    const filters = isSearchResultPage(location.pathname) ? paramFilters : [];
+    const currentQuery: string = isSearchResultPage(location.pathname)
+        ? decodeURIComponent(params.query ? (params.query as string) : '')
+        : '';
 
     const history = useHistory();
     const entityRegistry = useEntityRegistry();


### PR DESCRIPTION
**Summary**

We recently rolled out an improvement to search UX where filters are now sticky, and not clear automatically between searches. In doing so we introduced a minor bug wherein if you've applied filters on a non-search results page (e.g. search embedded in entity profile), then we'll keep those filters even if you type in a new query to the search bar.

This PR ensures that we only reuse the filters for global search results if we are on the search page itself. This ensures that if we are transitioning from any other page that the filters are not persisted. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)