### PR TITLE
feat(ui): Adding slack handle to corp group info

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupPropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupPropertiesMapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.types.corpgroup.mappers;
 
+import com.linkedin.data.template.GetMode;
 import com.linkedin.datahub.graphql.generated.CorpGroupProperties;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 
@@ -24,6 +25,7 @@ public class CorpGroupPropertiesMapper implements ModelMapper<com.linkedin.ident
     result.setEmail(info.getEmail());
     result.setDescription(info.getDescription());
     result.setDisplayName(info.getDisplayName());
+    result.setSlack(info.getSlack(GetMode.DEFAULT));
     return result;
   }
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -3224,6 +3224,11 @@ type CorpGroupProperties {
     email of this group
     """
     email: String
+
+    """
+    Slack handle for the group
+    """
+    slack: String
 }
 
 """

--- a/datahub-web-react/src/app/entity/group/GroupProfile.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupProfile.tsx
@@ -103,7 +103,7 @@ export default function GroupProfile() {
             data?.corpGroup?.info?.displayName ||
             undefined,
         email: data?.corpGroup?.editableProperties?.email || data?.corpGroup?.properties?.email || undefined,
-        slack: data?.corpGroup?.editableProperties?.slack || undefined,
+        slack: data?.corpGroup?.editableProperties?.slack || data?.corpGroup?.properties?.slack || undefined,
         aboutText:
             data?.corpGroup?.editableProperties?.description || data?.corpGroup?.properties?.description || undefined,
         groupMemberRelationships: groupMemberRelationships as EntityRelationshipsResult,

--- a/datahub-web-react/src/graphql/group.graphql
+++ b/datahub-web-react/src/graphql/group.graphql
@@ -21,6 +21,7 @@ query getGroup($urn: String!, $membersCount: Int!) {
             displayName
             description
             email
+            slack
         }
         ownership {
             ...ownershipFields

--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -83,7 +83,8 @@
               "email": "jdoe@linkedin.com",
               "admins": ["urn:li:corpuser:jdoe", "urn:li:corpuser:datahub"],
               "members": ["urn:li:corpuser:jdoe", "urn:li:corpuser:datahub"],
-              "groups": []
+              "groups": [],
+              "slack":  "bfoo-squad"
             }
           }
         ]

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpGroupInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpGroupInfo.pdl
@@ -73,4 +73,8 @@ record CorpGroupInfo {
   }
   description: optional string
 
+  /**
+   * Slack channel for the group
+   */
+  slack: optional string
 }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -380,7 +380,7 @@
             }, {
               "name" : "message",
               "type" : "string",
-              "doc" : "Additional message to keep track of in the event",
+              "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
               "optional" : true
             } ]
           },
@@ -1891,6 +1891,11 @@
       "Searchable" : {
         "fieldType" : "TEXT_PARTIAL"
       }
+    }, {
+      "name" : "slack",
+      "type" : "string",
+      "doc" : "Slack channel for the group",
+      "optional" : true
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpGroupUrn" ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -139,7 +139,7 @@
             }, {
               "name" : "message",
               "type" : "string",
-              "doc" : "Additional message to keep track of in the event",
+              "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
               "optional" : true
             } ]
           },
@@ -2139,6 +2139,11 @@
                     "Searchable" : {
                       "fieldType" : "TEXT_PARTIAL"
                     }
+                  }, {
+                    "name" : "slack",
+                    "type" : "string",
+                    "doc" : "Slack channel for the group",
+                    "optional" : true
                   } ],
                   "Aspect" : {
                     "EntityUrns" : [ "com.linkedin.common.CorpGroupUrn" ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesV2.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesV2.snapshot.json
@@ -32,7 +32,7 @@
     }, {
       "name" : "message",
       "type" : "string",
-      "doc" : "Additional message to keep track of in the event",
+      "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
       "optional" : true
     } ]
   }, "com.linkedin.common.Time", "com.linkedin.common.Urn", {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesVersionedV2.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entitiesVersionedV2.snapshot.json
@@ -32,7 +32,7 @@
     }, {
       "name" : "message",
       "type" : "string",
-      "doc" : "Additional message to keep track of in the event",
+      "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
       "optional" : true
     } ]
   }, "com.linkedin.common.Time", "com.linkedin.common.Urn", {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -139,7 +139,7 @@
             }, {
               "name" : "message",
               "type" : "string",
-              "doc" : "Additional message to keep track of in the event",
+              "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
               "optional" : true
             } ]
           },
@@ -1642,6 +1642,11 @@
       "Searchable" : {
         "fieldType" : "TEXT_PARTIAL"
       }
+    }, {
+      "name" : "slack",
+      "type" : "string",
+      "doc" : "Slack channel for the group",
+      "optional" : true
     } ],
     "Aspect" : {
       "EntityUrns" : [ "com.linkedin.common.CorpGroupUrn" ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
@@ -32,7 +32,7 @@
     }, {
       "name" : "message",
       "type" : "string",
-      "doc" : "Additional message to keep track of in the event",
+      "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
       "optional" : true
     } ]
   }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -139,7 +139,7 @@
             }, {
               "name" : "message",
               "type" : "string",
-              "doc" : "Additional message to keep track of in the event",
+              "doc" : "Additional context around how DataHub was informed of the particular change. For example: was the change created by an automated process, or manually.",
               "optional" : true
             } ]
           },
@@ -2133,6 +2133,11 @@
                     "Searchable" : {
                       "fieldType" : "TEXT_PARTIAL"
                     }
+                  }, {
+                    "name" : "slack",
+                    "type" : "string",
+                    "doc" : "Slack channel for the group",
+                    "optional" : true
                   } ],
                   "Aspect" : {
                     "EntityUrns" : [ "com.linkedin.common.CorpGroupUrn" ],


### PR DESCRIPTION
**Summary**

In this PR, we add support for a slack handle specific in the CorpGroupInfo aspect, by community request.

**Status**

Ready for review!


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)