### PR TITLE
feat(GraphQL API): Add "browsePaths" field to browsable entity types 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -82,6 +82,7 @@ import com.linkedin.datahub.graphql.resolvers.auth.ListAccessTokensResolver;
 import com.linkedin.datahub.graphql.resolvers.auth.RevokeAccessTokenResolver;
 import com.linkedin.datahub.graphql.resolvers.browse.BrowsePathsResolver;
 import com.linkedin.datahub.graphql.resolvers.browse.BrowseResolver;
+import com.linkedin.datahub.graphql.resolvers.browse.EntityBrowsePathsResolver;
 import com.linkedin.datahub.graphql.resolvers.chart.ChartStatsSummaryResolver;
 import com.linkedin.datahub.graphql.resolvers.config.AppConfigResolver;
 import com.linkedin.datahub.graphql.resolvers.container.ContainerEntitiesResolver;
@@ -839,6 +840,7 @@ public class GmsGraphQLEngine {
         builder
             .type("Dataset", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.datasetType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                             (env) -> ((Dataset) env.getSource()).getPlatform().getUrn())
@@ -1016,6 +1018,7 @@ public class GmsGraphQLEngine {
   private void configureNotebookResolvers(final RuntimeWiring.Builder builder) {
     builder.type("Notebook", typeWiring -> typeWiring
         .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+        .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.notebookType))
         .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
             (env) -> ((Notebook) env.getSource()).getPlatform().getUrn()))
         .dataFetcher("dataPlatformInstance",
@@ -1034,6 +1037,7 @@ public class GmsGraphQLEngine {
     private void configureDashboardResolvers(final RuntimeWiring.Builder builder) {
         builder.type("Dashboard", typeWiring -> typeWiring
             .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+            .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dashboardType))
             .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
             .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                     (env) -> ((Dashboard) env.getSource()).getPlatform().getUrn()))
@@ -1084,6 +1088,7 @@ public class GmsGraphQLEngine {
     private void configureChartResolvers(final RuntimeWiring.Builder builder) {
         builder.type("Chart", typeWiring -> typeWiring
             .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+            .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.chartType))
             .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
             .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                 (env) -> ((Chart) env.getSource()).getPlatform().getUrn()))
@@ -1129,6 +1134,11 @@ public class GmsGraphQLEngine {
                         .map(graphType -> (EntityType<?, ?>) graphType)
                         .collect(Collectors.toList())
                 )))
+            .type("BrowsableEntity", typeWiring -> typeWiring
+                .typeResolver(new EntityInterfaceTypeResolver(browsableTypes.stream()
+                    .map(graphType -> (EntityType<?, ?>) graphType)
+                    .collect(Collectors.toList())
+                )))
             .type("OwnerType", typeWiring -> typeWiring
                 .typeResolver(new EntityInterfaceTypeResolver(ownerTypes.stream()
                     .filter(graphType -> graphType instanceof EntityType)
@@ -1162,6 +1172,7 @@ public class GmsGraphQLEngine {
         builder
             .type("DataJob", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataJobType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("dataFlow", new LoadableTypeResolver<>(dataFlowType,
                     (env) -> ((DataJob) env.getSource()).getDataFlow().getUrn()))
@@ -1197,6 +1208,7 @@ public class GmsGraphQLEngine {
         builder
             .type("DataFlow", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataFlowType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                     (env) -> ((DataFlow) env.getSource()).getPlatform().getUrn()))
@@ -1217,6 +1229,7 @@ public class GmsGraphQLEngine {
         builder
             .type("MLFeatureTable", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlFeatureTableType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("platform",
                         new LoadableTypeResolver<>(dataPlatformType,
@@ -1271,6 +1284,7 @@ public class GmsGraphQLEngine {
             )
             .type("MLModel", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlModelType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                     (env) -> ((MLModel) env.getSource()).getPlatform().getUrn()))
@@ -1297,6 +1311,7 @@ public class GmsGraphQLEngine {
             )
             .type("MLModelGroup", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
+                .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlModelGroupType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                                 (env) -> ((MLModelGroup) env.getSource()).getPlatform().getUrn())

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/EntityBrowsePathsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/EntityBrowsePathsResolver.java
@@ -1,0 +1,35 @@
+package com.linkedin.datahub.graphql.resolvers.browse;
+
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.types.BrowsableEntityType;
+import com.linkedin.datahub.graphql.generated.BrowsePath;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class EntityBrowsePathsResolver implements DataFetcher<CompletableFuture<List<BrowsePath>>> {
+
+  private final BrowsableEntityType<?, ?> _browsableType;
+
+  public EntityBrowsePathsResolver(@Nonnull final BrowsableEntityType<?, ?> browsableType) {
+    _browsableType = browsableType;
+  }
+
+  @Override
+  public CompletableFuture<List<BrowsePath>> get(DataFetchingEnvironment environment) {
+
+    final QueryContext context = environment.getContext();
+    final String urn = ((Entity) environment.getSource()).getUrn();
+
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        return _browsableType.browsePaths(urn, context);
+      } catch (Exception e) {
+        throw new RuntimeException(String.format("Failed to retrieve browse paths for entity with urn %s", urn), e);
+      }
+    });
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/BrowsableEntityType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/BrowsableEntityType.java
@@ -27,6 +27,7 @@ public interface BrowsableEntityType<T extends Entity, K> extends EntityType<T, 
      * @param count the number of results to retrieve
      * @param context the {@link QueryContext} corresponding to the request.
      */
+    @Nonnull
     BrowseResults browse(@Nonnull List<String> path,
                          @Nullable List<FacetFilterInput> filters,
                          int start,
@@ -39,6 +40,7 @@ public interface BrowsableEntityType<T extends Entity, K> extends EntityType<T, 
      * @param urn the entity urn to fetch browse paths for
      * @param context the {@link QueryContext} corresponding to the request.
      */
+    @Nonnull
     List<BrowsePath> browsePaths(@Nonnull String urn, @Nonnull final QueryContext context) throws Exception;
 
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -516,6 +516,16 @@ interface Entity {
 }
 
 """
+A Metadata Entity which is browsable, or has browse paths.
+"""
+interface BrowsableEntity {
+  """
+  The browse paths corresponding to an entity. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
+}
+
+"""
 A top level Metadata Entity Type
 """
 enum EntityType {
@@ -881,7 +891,7 @@ interface EntityWithRelationships implements Entity {
 """
 A Dataset entity, which encompasses Relational Tables, Document store collections, streaming topics, and other sets of data having an independent lifecycle
 """
-type Dataset implements EntityWithRelationships & Entity {
+type Dataset implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the Dataset
     """
@@ -1014,6 +1024,11 @@ type Dataset implements EntityWithRelationships & Entity {
     Edges extending from this entity grouped by direction in the lineage graph
     """
     lineage(input: LineageInput!): EntityLineageResult
+
+    """
+    The browse paths corresponding to the dataset. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 
     """
     Experimental! The resolved health statuses of the Dataset
@@ -3881,7 +3896,7 @@ input InstitutionalMemoryMetadataUpdate {
 """
 A Notebook Metadata Entity
 """
-type Notebook implements Entity {
+type Notebook implements Entity & BrowsableEntity {
     """
     The primary key of the Notebook
     """
@@ -3966,6 +3981,11 @@ type Notebook implements Entity {
     Standardized platform.
     """
     platform: DataPlatform!
+
+    """
+    The browse paths corresponding to the Notebook. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 }
 
 """
@@ -4122,7 +4142,7 @@ type ChangeAuditStamps {
 """
 A Dashboard Metadata Entity
 """
-type Dashboard implements EntityWithRelationships & Entity {
+type Dashboard implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the Dashboard
     """
@@ -4218,6 +4238,11 @@ type Dashboard implements EntityWithRelationships & Entity {
     Edges extending from this entity grouped by direction in the lineage graph
     """
     lineage(input: LineageInput!): EntityLineageResult
+
+    """
+    The browse paths corresponding to the dashboard. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 
     """
     Experimental (Subject to breaking change) -- Statistics about how this Dashboard is used
@@ -4395,7 +4420,7 @@ type DashboardProperties {
 """
 A Chart Metadata Entity
 """
-type Chart implements EntityWithRelationships & Entity {
+type Chart implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the Chart
     """
@@ -4503,6 +4528,11 @@ type Chart implements EntityWithRelationships & Entity {
     Edges extending from this entity grouped by direction in the lineage graph
     """
     lineage(input: LineageInput!): EntityLineageResult
+
+    """
+    The browse paths corresponding to the chart. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 
     """
     Deprecated, use properties field instead
@@ -4755,7 +4785,7 @@ enum ChartQueryType {
 A Data Flow Metadata Entity, representing an set of pipelined Data Job or Tasks required
 to produce an output Dataset Also known as a Data Pipeline
 """
-type DataFlow implements EntityWithRelationships & Entity {
+type DataFlow implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of a Data Flow
     """
@@ -4847,6 +4877,11 @@ type DataFlow implements EntityWithRelationships & Entity {
     lineage(input: LineageInput!): EntityLineageResult
 
     """
+    The browse paths corresponding to the data flow. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
+
+    """
     Deprecated, use properties field instead
     Additional read only information about a Data flow
     """
@@ -4935,7 +4970,7 @@ type DataFlowProperties {
 A Data Job Metadata Entity, representing an individual unit of computation or Task
 to produce an output Dataset Always part of a parent Data Flow aka Pipeline
 """
-type DataJob implements EntityWithRelationships & Entity {
+type DataJob implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the Data Job
     """
@@ -5021,6 +5056,11 @@ type DataJob implements EntityWithRelationships & Entity {
     Edges extending from this entity grouped by direction in the lineage graph
     """
     lineage(input: LineageInput!): EntityLineageResult
+
+    """
+    The browse paths corresponding to the data job. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 
     """
     Deprecated, use properties field instead
@@ -7649,7 +7689,7 @@ input CreateGroupInput {
 """
 An ML Model Metadata Entity Note that this entity is incubating
 """
-type MLModel implements EntityWithRelationships & Entity {
+type MLModel implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the ML model
     """
@@ -7787,6 +7827,11 @@ type MLModel implements EntityWithRelationships & Entity {
     lineage(input: LineageInput!): EntityLineageResult
 
     """
+    The browse paths corresponding to the ML Model. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
+
+    """
     The structured glossary terms associated with the entity
     """
     glossaryTerms: GlossaryTerms
@@ -7806,7 +7851,7 @@ type MLModel implements EntityWithRelationships & Entity {
 An ML Model Group Metadata Entity
 Note that this entity is incubating
 """
-type MLModelGroup implements EntityWithRelationships & Entity {
+type MLModelGroup implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the ML Model Group
     """
@@ -7876,6 +7921,11 @@ type MLModelGroup implements EntityWithRelationships & Entity {
     Edges extending from this entity grouped by direction in the lineage graph
     """
     lineage(input: LineageInput!): EntityLineageResult
+
+    """
+    The browse paths corresponding to the ML Model Group. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 
     """
     Tags applied to entity
@@ -8188,7 +8238,7 @@ description: String
 """
 An ML Feature Table Entity Note that this entity is incubating
 """
-type MLFeatureTable implements EntityWithRelationships & Entity {
+type MLFeatureTable implements EntityWithRelationships & Entity & BrowsableEntity {
     """
     The primary key of the ML Feature Table
     """
@@ -8264,6 +8314,11 @@ type MLFeatureTable implements EntityWithRelationships & Entity {
     Edges extending from this entity grouped by direction in the lineage graph
     """
     lineage(input: LineageInput!): EntityLineageResult
+
+    """
+    The browse paths corresponding to the ML Feature Table. If no Browse Paths have been generated before, this will be null.
+    """
+    browsePaths: [BrowsePath!]
 
     """
     Tags applied to entity

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/browse/EntityBrowsePathsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/browse/EntityBrowsePathsResolverTest.java
@@ -1,0 +1,78 @@
+package com.linkedin.datahub.graphql.resolvers.browse;
+
+import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.BrowsePath;
+import com.linkedin.datahub.graphql.generated.Dataset;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.types.BrowsableEntityType;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class EntityBrowsePathsResolverTest {
+
+  private static final String TEST_ENTITY_URN = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
+
+  @Test
+  public void testGetSuccess() throws Exception {
+    // Create resolver
+    BrowsableEntityType mockType = Mockito.mock(BrowsableEntityType.class);
+
+    List<String> path = ImmutableList.of("prod", "mysql");
+    Mockito.when(mockType.browsePaths(Mockito.eq(TEST_ENTITY_URN), Mockito.any()))
+      .thenReturn(ImmutableList.of(
+          new BrowsePath(path))
+      );
+
+    // Execute resolver
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Urn datasetUrn = Urn.createFromString(TEST_ENTITY_URN);
+    Dataset datasetEntity = new Dataset();
+    datasetEntity.setUrn(datasetUrn.toString());
+    datasetEntity.setType(EntityType.DATASET);
+    Mockito.when(mockEnv.getSource()).thenReturn(datasetEntity);
+
+    EntityBrowsePathsResolver resolver = new EntityBrowsePathsResolver(mockType);
+    List<BrowsePath> result = resolver.get(mockEnv).get();
+
+    Assert.assertEquals(result.get(0).getPath(), path);
+  }
+
+  @Test
+  public void testGetBrowsePathsException() throws Exception {
+    BrowsableEntityType mockType = Mockito.mock(BrowsableEntityType.class);
+    Mockito.doThrow(RemoteInvocationException.class).when(mockType).browsePaths(
+        Mockito.any(),
+        Mockito.any());
+
+    EntityBrowsePathsResolver resolver = new EntityBrowsePathsResolver(mockType);
+
+    // Execute resolver
+    QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Urn datasetUrn = Urn.createFromString(TEST_ENTITY_URN);
+    Dataset datasetEntity = new Dataset();
+    datasetEntity.setUrn(datasetUrn.toString());
+    datasetEntity.setType(EntityType.DATASET);
+    Mockito.when(mockEnv.getSource()).thenReturn(datasetEntity);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}


### PR DESCRIPTION
**Summary**

We've heard community requests for fetching browse paths with an entity query all in one go. This PR adds a new 'browsePaths' field to the set of entities which are browsable to achieve this.

**Status**

Ready for review

**Validation**

Did some local sanity checks:

GraphQL query: 

```
query dataset {
  dataset(urn: "urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleHdfsDataset,PROD)") {
    browsePaths {
      path
    }
  }
}
```

and result:

```
{
  "data": {
    "dataset": {
      "browsePaths": [
        {
          "path": [
            "prod",
            "hdfs"
          ]
        }
      ]
    }
  },
  "extensions": {}
}
```


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)