### PR TITLE
feat(ingestion): add github_info config for dbt

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, root_validator, validator
 from pydantic.fields import Field
 
 from datahub.configuration.common import AllowDenyPattern, ConfigurationError
+from datahub.configuration.github import GitHubInfo
 from datahub.emitter import mce_builder
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
@@ -311,6 +312,10 @@ class DBTConfig(StatefulIngestionConfigBase):
     backcompat_skip_source_on_lineage_edge: bool = Field(
         False,
         description="Prior to version 0.8.41, lineage edges to sources were directed to the target platform node rather than the dbt source node. This contradicted the established pattern for other lineage edges to point to upstream dbt nodes. To revert lineage logic to this legacy approach, set this flag to true.",
+    )
+    github_info: Optional[GitHubInfo] = Field(
+        None,
+        description="Reference to your github location to enable easy navigation from DataHub to your dbt files.",
     )
 
     @property
@@ -1778,6 +1783,12 @@ class DBTSource(StatefulIngestionSourceBase):
             tags=node.tags,
             name=node.name,
         )
+        if self.config.github_info is not None:
+            github_file_url = self.config.github_info.get_url_for_file_path(
+                node.dbt_file_path
+            )
+            dbt_properties.externalUrl = github_file_url
+
         return dbt_properties
 
     def _create_view_properties_aspect(self, node: DBTNode) -> ViewPropertiesClass:


### PR DESCRIPTION
This PR adds the option to configure a GitHub repository for dbt, similar to what exists for Looker: https://datahubproject.io/docs/generated/ingestion/sources/looker. Most dbt models should be version controlled and this makes DataHub even more useful.

Tested locally with `DATAHUB_VERSION="v0.8.43"`, `acryl-datahub==0.8.43.1`.

Screenshot:
![image](https://user-images.githubusercontent.com/26257211/184743158-420e771e-7072-42c7-aaaf-384023ae4255.png)

I just noticed the "View in Dbt ->" should be "View in GitHub" in the UI, there is the same issue with Looker where it shows "View in Looker" while linking to GitHub.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)