### PR TITLE
feat(ingestion) Fetch live logs on an ingestion run from UI

### DIFF
--- a/datahub-web-react/src/app/ingest/source/ExecutionRequestDetailsModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/ExecutionRequestDetailsModal.tsx
@@ -11,6 +11,8 @@ import {
     getExecutionRequestStatusDisplayColor,
     getExecutionRequestStatusDisplayText,
     getExecutionRequestStatusIcon,
+    getExecutionRequestSummaryText,
+    RUNNING,
     SUCCESS,
 } from './utils';
 
@@ -89,7 +91,7 @@ type Props = {
 
 export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
     const [showExpandedLogs, setShowExpandedLogs] = useState(true);
-    const { data, loading, error } = useGetIngestionExecutionRequestQuery({ variables: { urn } });
+    const { data, loading, error, refetch } = useGetIngestionExecutionRequestQuery({ variables: { urn } });
     const output = data?.executionRequest?.result?.report || 'No output found.';
 
     useEffect(() => {
@@ -105,6 +107,14 @@ export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
     const logs = (showExpandedLogs && output) || output.slice(0, 100);
     const result = data?.executionRequest?.result?.status;
 
+    useEffect(() => {
+        const interval = setInterval(() => {
+            if (result === RUNNING) refetch();
+        }, 2000);
+
+        return () => clearInterval(interval);
+    });
+
     const ResultIcon = result && getExecutionRequestStatusIcon(result);
     const resultColor = result && getExecutionRequestStatusDisplayColor(result);
     const resultText = result && (
@@ -114,12 +124,9 @@ export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
         </Typography.Text>
     );
     const resultSummaryText =
-        (result && (
-            <Typography.Text type="secondary">
-                Ingestion {result === SUCCESS ? 'successfully completed' : 'completed with errors'}.
-            </Typography.Text>
-        )) ||
+        (result && <Typography.Text type="secondary">{getExecutionRequestSummaryText(result)}</Typography.Text>) ||
         undefined;
+    const isOutputExpandable = output.length > 100;
 
     return (
         <Modal
@@ -160,11 +167,20 @@ export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
                         </Button>
                     </SectionSubHeader>
                     <Typography.Paragraph ellipsis>
-                        <pre>{`${logs}${!showExpandedLogs && '...'}`}</pre>
-                        {!showExpandedLogs && (
-                            <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(true)}>
-                                Show More
-                            </ShowMoreButton>
+                        <pre>{`${logs}${!showExpandedLogs ? '...' : ''}`}</pre>
+                        {isOutputExpandable && (
+                            <>
+                                {!showExpandedLogs && (
+                                    <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(true)}>
+                                        Show More
+                                    </ShowMoreButton>
+                                )}
+                                {showExpandedLogs && (
+                                    <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(false)}>
+                                        Hide
+                                    </ShowMoreButton>
+                                )}
+                            </>
                         )}
                     </Typography.Paragraph>
                 </LogsSection>

--- a/datahub-web-react/src/app/ingest/source/ExecutionRequestDetailsModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/ExecutionRequestDetailsModal.tsx
@@ -169,18 +169,9 @@ export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
                     <Typography.Paragraph ellipsis>
                         <pre>{`${logs}${!showExpandedLogs ? '...' : ''}`}</pre>
                         {isOutputExpandable && (
-                            <>
-                                {!showExpandedLogs && (
-                                    <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(true)}>
-                                        Show More
-                                    </ShowMoreButton>
-                                )}
-                                {showExpandedLogs && (
-                                    <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(false)}>
-                                        Hide
-                                    </ShowMoreButton>
-                                )}
-                            </>
+                            <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(!showExpandedLogs)}>
+                                {showExpandedLogs ? 'Hide' : 'Show More'}
+                            </ShowMoreButton>
                         )}
                     </Typography.Paragraph>
                 </LogsSection>

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -95,6 +95,7 @@ export const IngestionSourceList = () => {
     const [lastRefresh, setLastRefresh] = useState(0);
     // Set of removed urns used to account for eventual consistency
     const [removedUrns, setRemovedUrns] = useState<string[]>([]);
+    const [refreshInterval, setRefreshInterval] = useState<NodeJS.Timeout | null>(null);
 
     // Ingestion Source Queries
     const { loading, error, data, refetch } = useListIngestionSourcesQuery({
@@ -124,8 +125,6 @@ export const IngestionSourceList = () => {
         // Used to force a re-render of the child execution request list.
         setLastRefresh(new Date().getMilliseconds());
     }, [refetch]);
-
-    const [refreshInterval, setRefreshInterval] = useState<NodeJS.Timeout | null>(null);
 
     useEffect(() => {
         const runningSource = filteredSources.find((source) =>

--- a/datahub-web-react/src/app/ingest/source/utils.ts
+++ b/datahub-web-react/src/app/ingest/source/utils.ts
@@ -55,6 +55,21 @@ export const getExecutionRequestStatusDisplayText = (status: string) => {
     );
 };
 
+export const getExecutionRequestSummaryText = (status: string) => {
+    switch (status) {
+        case RUNNING:
+            return 'Ingestion is running';
+        case SUCCESS:
+            return 'Ingestion successfully completed';
+        case FAILURE:
+            return 'Ingestion completed with errors';
+        case CANCELLED:
+            return 'Ingestion was cancelled';
+        default:
+            return 'Ingestion status not recognized';
+    }
+};
+
 export const getExecutionRequestStatusDisplayColor = (status: string) => {
     return (
         (status === RUNNING && REDESIGN_COLORS.BLUE) ||


### PR DESCRIPTION
When viewing ingestion run details in the modal, continuously refetch to get updated logs every 2 seconds if the status of the ingestion run is `RUNNING`. Related to this, this PR also adds ingestion summary text for all ingestion run statuses and swaps the disabled "Execute" button for the actively running ingestion source to be a "Details" button that opens the summary modal.

This also cleans a few other things up.
- Add the ability to hide expanded logs if you expand them
- Hide "Show more" if you can't expand in the first place
- Prevent indefinite polling to get all ingestion sources after executing a run once we no longer have any sources that are RUNNING. Happens when we execute and even after the run is complete we poll until you refresh the page.
- Related ^ start polling for all ingestion sources if we have one that is RUNNING. This would be an issue if the user comes to the ingestion page and there is a source running, but we aren't polling so it will never update.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)