### PR TITLE
fix(ui) Remove constraint for searching with less than 3 characters

### DIFF
--- a/datahub-web-react/src/app/entity/group/AddGroupMembersModal.tsx
+++ b/datahub-web-react/src/app/entity/group/AddGroupMembersModal.tsx
@@ -40,18 +40,16 @@ export const AddGroupMembersModal = ({ urn, visible, onCloseModal, onSubmit }: P
     const inputEl = useRef(null);
 
     const handleUserSearch = (text: string) => {
-        if (text.length > 2) {
-            userSearch({
-                variables: {
-                    input: {
-                        type: EntityType.CorpUser,
-                        query: text,
-                        start: 0,
-                        count: 5,
-                    },
+        userSearch({
+            variables: {
+                input: {
+                    type: EntityType.CorpUser,
+                    query: text,
+                    start: 0,
+                    count: 5,
                 },
-            });
-        }
+            },
+        });
     };
 
     // Renders a search result in the select dropdown.

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SetDomainModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SetDomainModal.tsx
@@ -48,18 +48,16 @@ export const SetDomainModal = ({ urns, onCloseModal, refetch }: Props) => {
     };
 
     const handleSearch = (text: string) => {
-        if (text.length > 2) {
-            domainSearch({
-                variables: {
-                    input: {
-                        type: EntityType.Domain,
-                        query: text,
-                        start: 0,
-                        count: 5,
-                    },
+        domainSearch({
+            variables: {
+                input: {
+                    type: EntityType.Domain,
+                    query: text,
+                    start: 0,
+                    count: 5,
                 },
-            });
-        }
+            },
+        });
     };
 
     // Renders a search result in the select dropdown.

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/EditOwnersModal.tsx
@@ -83,18 +83,16 @@ export const EditOwnersModal = ({
 
     // Invokes the search API as the owner types
     const handleSearch = (type: EntityType, text: string, searchQuery: any) => {
-        if (text.length > 2) {
-            searchQuery({
-                variables: {
-                    input: {
-                        type,
-                        query: text,
-                        start: 0,
-                        count: 5,
-                    },
+        searchQuery({
+            variables: {
+                input: {
+                    type,
+                    query: text,
+                    start: 0,
+                    count: 5,
                 },
-            });
-        }
+            },
+        });
     };
 
     // Invokes the user search API for both users and groups.

--- a/datahub-web-react/src/app/policy/PolicyActorForm.tsx
+++ b/datahub-web-react/src/app/policy/PolicyActorForm.tsx
@@ -121,18 +121,16 @@ export default function PolicyActorForm({ policyType, actors, setActors }: Props
 
     // Invokes the search API as the user types
     const handleSearch = (type: EntityType, text: string, searchQuery: any) => {
-        if (text.length > 2) {
-            searchQuery({
-                variables: {
-                    input: {
-                        type,
-                        query: text,
-                        start: 0,
-                        count: 10,
-                    },
+        searchQuery({
+            variables: {
+                input: {
+                    type,
+                    query: text,
+                    start: 0,
+                    count: 10,
                 },
-            });
-        }
+            },
+        });
     };
 
     // Invokes the user search API as the user types

--- a/datahub-web-react/src/app/policy/PolicyPrivilegeForm.tsx
+++ b/datahub-web-react/src/app/policy/PolicyPrivilegeForm.tsx
@@ -224,34 +224,30 @@ export default function PolicyPrivilegeForm({
         const entityTypes = resourceTypeSelectValue
             .map((resourceType) => mapResourceTypeToEntityType(resourceType, resourcePrivileges))
             .filter((entityType): entityType is EntityType => !!entityType);
-        if (text.length > 2) {
-            searchResources({
-                variables: {
-                    input: {
-                        types: entityTypes,
-                        query: text,
-                        start: 0,
-                        count: 10,
-                    },
+        searchResources({
+            variables: {
+                input: {
+                    types: entityTypes,
+                    query: text,
+                    start: 0,
+                    count: 10,
                 },
-            });
-        }
+            },
+        });
     };
 
     // Handle domain search, if the domain type has an associated EntityType mapping.
     const handleDomainSearch = (text: string) => {
-        if (text.length > 2) {
-            searchDomains({
-                variables: {
-                    input: {
-                        type: EntityType.Domain,
-                        query: text,
-                        start: 0,
-                        count: 10,
-                    },
+        searchDomains({
+            variables: {
+                input: {
+                    type: EntityType.Domain,
+                    query: text,
+                    start: 0,
+                    count: 10,
                 },
-            });
-        }
+            },
+        });
     };
 
     const renderSearchResult = (result) => {


### PR DESCRIPTION
We've received reports that our search UI in some places is weird when search results don't get updated if there are less than 3 characters. It's specifically weird when you type in 3 characters and backspace, still seeing the same results. This simply removes that constraint from submitting search requests with less than 3. If there's less than 3 we'll still show no data, but at least now it updates when you backspace from 3 to 2.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)