### PR TITLE
feat(domains): highlighting domain recommendation cards on homepage

### DIFF
--- a/datahub-web-react/src/app/home/HomePageRecommendations.tsx
+++ b/datahub-web-react/src/app/home/HomePageRecommendations.tsx
@@ -62,6 +62,13 @@ const NoMetadataContainer = styled.div`
     align-items: center;
 `;
 
+const DomainsRecomendationContainer = styled.div`
+    margin-top: -48px;
+    margin-bottom: 32px;
+    max-width: 1000px;
+    min-width: 750px;
+`;
+
 type Props = {
     userUrn: string;
 };
@@ -122,7 +129,7 @@ export const HomePageRecommendations = ({ userUrn }: Props) => {
                 <RecommendationContainer>
                     {domainRecommendationModule && (
                         <>
-                            <RecommendationContainer>
+                            <DomainsRecomendationContainer>
                                 <RecommendationTitle level={4}>{domainRecommendationModule.title}</RecommendationTitle>
                                 <ThinDivider />
                                 <RecommendationModule
@@ -130,7 +137,7 @@ export const HomePageRecommendations = ({ userUrn }: Props) => {
                                     scenarioType={scenario}
                                     showTitle={false}
                                 />
-                            </RecommendationContainer>
+                            </DomainsRecomendationContainer>
                         </>
                     )}
                     <RecommendationTitle level={4}>Explore your Metadata</RecommendationTitle>

--- a/datahub-web-react/src/app/home/HomePageRecommendations.tsx
+++ b/datahub-web-react/src/app/home/HomePageRecommendations.tsx
@@ -2,7 +2,12 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Button, Divider, Empty, Typography } from 'antd';
 import { RocketOutlined } from '@ant-design/icons';
-import { EntityType, RecommendationModule as RecommendationModuleType, ScenarioType } from '../../types.generated';
+import {
+    EntityType,
+    RecommendationModule as RecommendationModuleType,
+    RecommendationRenderType,
+    ScenarioType,
+} from '../../types.generated';
 import { useListRecommendationsQuery } from '../../graphql/recommendations.generated';
 import { RecommendationModule } from '../recommendations/RecommendationModule';
 import { BrowseEntityCard } from '../search/BrowseEntityCard';
@@ -106,10 +111,28 @@ export const HomePageRecommendations = ({ userUrn }: Props) => {
         }
     }, [hasLoadedEntityCounts, hasIngestedMetadata]);
 
+    // we want to render the domain module first if it exists
+    const domainRecommendationModule = recommendationModules?.find(
+        (module) => module.renderType === RecommendationRenderType.DomainSearchList,
+    );
+
     return (
         <RecommendationsContainer>
             {orderedEntityCounts && orderedEntityCounts.length > 0 && (
                 <RecommendationContainer>
+                    {domainRecommendationModule && (
+                        <>
+                            <RecommendationContainer>
+                                <RecommendationTitle level={4}>{domainRecommendationModule.title}</RecommendationTitle>
+                                <ThinDivider />
+                                <RecommendationModule
+                                    module={domainRecommendationModule as RecommendationModuleType}
+                                    scenarioType={scenario}
+                                    showTitle={false}
+                                />
+                            </RecommendationContainer>
+                        </>
+                    )}
                     <RecommendationTitle level={4}>Explore your Metadata</RecommendationTitle>
                     <ThinDivider />
                     {hasIngestedMetadata ? (
@@ -140,18 +163,20 @@ export const HomePageRecommendations = ({ userUrn }: Props) => {
                 </RecommendationContainer>
             )}
             {recommendationModules &&
-                recommendationModules.map((module) => (
-                    <RecommendationContainer>
-                        <RecommendationTitle level={4}>{module.title}</RecommendationTitle>
-                        <ThinDivider />
-                        <RecommendationModule
-                            key={module.moduleId}
-                            module={module as RecommendationModuleType}
-                            scenarioType={scenario}
-                            showTitle={false}
-                        />
-                    </RecommendationContainer>
-                ))}
+                recommendationModules
+                    .filter((module) => module.renderType !== RecommendationRenderType.DomainSearchList)
+                    .map((module) => (
+                        <RecommendationContainer>
+                            <RecommendationTitle level={4}>{module.title}</RecommendationTitle>
+                            <ThinDivider />
+                            <RecommendationModule
+                                key={module.moduleId}
+                                module={module as RecommendationModuleType}
+                                scenarioType={scenario}
+                                showTitle={false}
+                            />
+                        </RecommendationContainer>
+                    ))}
             <GettingStartedModal onClose={() => setShowGettingStartedModal(false)} visible={showGettingStartedModal} />
         </RecommendationsContainer>
     );

--- a/datahub-web-react/src/app/recommendations/renderer/component/DomainSearchList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/DomainSearchList.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import { PageRoutes } from '../../../../conf/Global';
 import { Domain, EntityType, RecommendationContent } from '../../../../types.generated';
 import { IconStyleType } from '../../../entity/Entity';
-import { urlEncodeUrn } from '../../../entity/shared/utils';
 import { LogoCountCard } from '../../../shared/LogoCountCard';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 
@@ -34,10 +32,7 @@ export const DomainSearchList = ({ content, onClick }: Props) => {
         <DomainListContainer>
             {domainsWithCounts.map((domain, index) => (
                 <Link
-                    to={{
-                        pathname: `${PageRoutes.SEARCH}`,
-                        search: `?filter_domains=${urlEncodeUrn(domain.domain.urn)}`,
-                    }}
+                    to={entityRegistry.getEntityUrl(EntityType.Domain, domain.domain.urn)}
                     key={domain.domain.urn}
                     onClick={() => onClick?.(index)}
                 >


### PR DESCRIPTION
Also switches up their link to go to domain entity page rather than search.

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/2455694/184995786-d602de25-6239-4108-8f13-842d3fde1838.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)