### PR TITLE
fix(spark-lineage): Create application setup on sqlevent start

### DIFF
--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatahubSparkListener.java
@@ -320,6 +320,7 @@ public class DatahubSparkListener extends SparkListener {
     LogicalPlan plan = queryExec.optimizedPlan();
     SparkSession sess = queryExec.sparkSession();
     SparkContext ctx = sess.sparkContext();
+    checkOrCreateApplicationSetup(ctx);
     (new SqlStartTask(sqlStart, plan, ctx)).run();
   }
 


### PR DESCRIPTION
This PR creates datahub setup for spark application on sqlstart event if not done on the spark application start event. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)