### PR TITLE
fix(siblings): set sleep after checking if the restore step should run

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreDbtSiblingsIndices.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreDbtSiblingsIndices.java
@@ -61,9 +61,6 @@ public class RestoreDbtSiblingsIndices implements BootstrapStep {
     log.info("Attempting to run RestoreDbtSiblingsIndices upgrade..");
     log.info(String.format("Waiting %s seconds..", SLEEP_SECONDS));
 
-    // Sleep to ensure deployment process finishes.
-    Thread.sleep(SLEEP_SECONDS * 1000);
-
     EntityResponse response = _entityService.getEntityV2(
         Constants.DATA_HUB_UPGRADE_ENTITY_NAME, SIBLING_UPGRADE_URN,
         Collections.singleton(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME)
@@ -76,6 +73,9 @@ public class RestoreDbtSiblingsIndices implements BootstrapStep {
         return;
       }
     }
+
+    // Sleep to ensure deployment process finishes.
+    Thread.sleep(SLEEP_SECONDS * 1000);
 
     log.info("Bootstrapping sibling aspects");
 


### PR DESCRIPTION
This lines dbt step up with the restore glossary step.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)