### PR TITLE
Add UP_FOR_RETRY DPI run result

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -5212,6 +5212,11 @@ enum DataProcessInstanceRunResultType {
     The run was skipped
     """
     SKIPPED
+
+    """
+    The run failed and is up for retry
+    """
+    UP_FOR_RETRY
 }
 
 

--- a/datahub-web-react/src/app/ingest/source/utils.ts
+++ b/datahub-web-react/src/app/ingest/source/utils.ts
@@ -1,5 +1,5 @@
 import YAML from 'yamljs';
-import { CheckCircleOutlined, CloseCircleOutlined, LoadingOutlined } from '@ant-design/icons';
+import { CheckCircleOutlined, ClockCircleOutlined, CloseCircleOutlined, LoadingOutlined } from '@ant-design/icons';
 import { ANTD_GRAY, REDESIGN_COLORS } from '../../entity/shared/constants';
 import { SOURCE_TEMPLATE_CONFIGS } from './conf/sources';
 import { EntityType, FacetMetadata } from '../../../types.generated';
@@ -34,6 +34,7 @@ export const RUNNING = 'RUNNING';
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
 export const CANCELLED = 'CANCELLED';
+export const UP_FOR_RETRY = 'UP_FOR_RETRY';
 
 export const CLI_EXECUTOR_ID = '__datahub_cli_';
 export const MANUAL_INGESTION_SOURCE = 'MANUAL_INGESTION_SOURCE';
@@ -46,6 +47,7 @@ export const getExecutionRequestStatusIcon = (status: string) => {
         (status === SUCCESS && CheckCircleOutlined) ||
         (status === FAILURE && CloseCircleOutlined) ||
         (status === CANCELLED && CloseCircleOutlined) ||
+        (status === UP_FOR_RETRY && ClockCircleOutlined) ||
         undefined
     );
 };
@@ -56,6 +58,7 @@ export const getExecutionRequestStatusDisplayText = (status: string) => {
         (status === SUCCESS && 'Succeeded') ||
         (status === FAILURE && 'Failed') ||
         (status === CANCELLED && 'Cancelled') ||
+        (status === UP_FOR_RETRY && 'Up for Retry') ||
         status
     );
 };
@@ -80,6 +83,7 @@ export const getExecutionRequestStatusDisplayColor = (status: string) => {
         (status === RUNNING && REDESIGN_COLORS.BLUE) ||
         (status === SUCCESS && 'green') ||
         (status === FAILURE && 'red') ||
+        (status === UP_FOR_RETRY && 'orange') ||
         (status === CANCELLED && ANTD_GRAY[9]) ||
         ANTD_GRAY[7]
     );

--- a/metadata-ingestion/src/datahub/api/entities/dataprocess/dataprocess_instance.py
+++ b/metadata-ingestion/src/datahub/api/entities/dataprocess/dataprocess_instance.py
@@ -42,6 +42,7 @@ class InstanceRunResult(str, Enum):
     SUCCESS = RunResultType.SUCCESS
     SKIPPED = RunResultType.SKIPPED
     FAILURE = RunResultType.FAILURE
+    UP_FOR_RETRY = RunResultType.UP_FOR_RETRY
 
 
 @dataclass

--- a/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInstanceRunResult.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataprocess/DataProcessInstanceRunResult.pdl
@@ -3,7 +3,7 @@ record DataProcessInstanceRunResult
 {
 
     /**
-    *  The final result, e.g. SUCCESS, FAILURE or SKIPPED.
+    *  The final result, e.g. SUCCESS, FAILURE, SKIPPED, or UP_FOR_RETRY.
     */
     type: enum RunResultType {
     /**
@@ -17,7 +17,11 @@ record DataProcessInstanceRunResult
     /**
     *  The Run Skipped
     */
-    SKIPPED
+    SKIPPED,
+    /**
+    *  The Run Failed and will Retry
+    */
+    UP_FOR_RETRY
     },
 
     /**


### PR DESCRIPTION
This PR adds the "UP_FOR_RETRY" Data Process Instance RunResult type. Airflow tasks can go into the "up for retry" state, and we want to be able to reflect that in DataHub.

Tested in our own fork: 
<img width="1763" alt="Screen Shot 2022-08-17 at 1 46 56 PM" src="https://user-images.githubusercontent.com/111152273/185239933-716f0f08-7ac9-4fe5-8567-f2753ed3bae2.png">

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)