### PR TITLE
feat(ingestion) Followups to live ingestion logs in UI

### DIFF
--- a/datahub-web-react/src/app/ingest/source/ExecutionRequestDetailsModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/ExecutionRequestDetailsModal.tsx
@@ -90,15 +90,9 @@ type Props = {
 };
 
 export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
-    const [showExpandedLogs, setShowExpandedLogs] = useState(true);
+    const [showExpandedLogs, setShowExpandedLogs] = useState(false);
     const { data, loading, error, refetch } = useGetIngestionExecutionRequestQuery({ variables: { urn } });
     const output = data?.executionRequest?.result?.report || 'No output found.';
-
-    useEffect(() => {
-        if (output.length > 100) {
-            setShowExpandedLogs(false);
-        }
-    }, [output, setShowExpandedLogs]);
 
     const downloadLogs = () => {
         downloadFile(output, `exec-${urn}.log`);
@@ -167,7 +161,7 @@ export const ExecutionDetailsModal = ({ urn, visible, onClose }: Props) => {
                         </Button>
                     </SectionSubHeader>
                     <Typography.Paragraph ellipsis>
-                        <pre>{`${logs}${!showExpandedLogs ? '...' : ''}`}</pre>
+                        <pre>{`${logs}${!showExpandedLogs && isOutputExpandable ? '...' : ''}`}</pre>
                         {isOutputExpandable && (
                             <ShowMoreButton type="link" onClick={() => setShowExpandedLogs(!showExpandedLogs)}>
                                 {showExpandedLogs ? 'Hide' : 'Show More'}

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -137,6 +137,7 @@ export const IngestionSourceList = () => {
             }
         } else if (refreshInterval) {
             clearInterval(refreshInterval);
+            setRefreshInterval(null);
         }
     }, [filteredSources, refreshInterval, onRefresh]);
 


### PR DESCRIPTION
Fixes two things after testing live logs out further:
1. Prevents the logs from auto-collapsing every time we refetch to get updated logs (we had a useEffect checking the length of logs and setting the piece of state for expanding to false every time) - now just default to collapsed but only change if they toggle the button
2. Clear the interval piece of state which resets state properly so we can execute multiple sources and poll properly.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)