### PR TITLE
fix(docs) Fix link from Business Glossary ingestion page

### DIFF
--- a/metadata-ingestion/archived/source_docs/business_glossary.md
+++ b/metadata-ingestion/archived/source_docs/business_glossary.md
@@ -8,7 +8,7 @@ Works with `acryl-datahub` out of the box.
 
 ## Capabilities
 
-This plugin pulls business glossary metadata from a yaml-formatted file. An example of one such file is located in the examples directory [here](../examples/bootstrap_data/business_glossary.yml).
+This plugin pulls business glossary metadata from a yaml-formatted file. An example of one such file is located in the examples directory [here](https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/examples/bootstrap_data/business_glossary.yml).
 
 ## Quickstart recipe
 

--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
@@ -257,7 +257,7 @@ def get_mces_from_term(
 @dataclass
 class BusinessGlossaryFileSource(Source):
     """
-    This plugin pulls business glossary metadata from a yaml-formatted file. An example of one such file is located in the examples directory [here](../examples/bootstrap_data/business_glossary.yml).
+    This plugin pulls business glossary metadata from a yaml-formatted file. An example of one such file is located in the examples directory [here](https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/examples/bootstrap_data/business_glossary.yml).
     """
 
     config: BusinessGlossarySourceConfig


### PR DESCRIPTION
A link on our business glossary docs page was broken (check the page [here](https://datahubproject.io/docs/generated/ingestion/sources/business-glossary/) and click the link that goes "An example of one such file is located in the examples directory [here](https://github.com/datahub-project/datahub/blob/master/docs/generated/ingestion/examples/bootstrap_data/business_glossary.yml)." and that "here" has a broken link.

This links directly to the github example file.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)