### PR TITLE
feat(ingestion-ui) Display CLI-based ingestion sources in UI

### DIFF
--- a/datahub-web-react/src/app/ingest/source/IngestionSourceExecutionList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceExecutionList.tsx
@@ -13,6 +13,9 @@ import {
     getExecutionRequestStatusDisplayColor,
     getExecutionRequestStatusIcon,
     getExecutionRequestStatusDisplayText,
+    CLI_INGESTION_SOURCE,
+    SCHEDULED_INGESTION_SOURCE,
+    MANUAL_INGESTION_SOURCE,
 } from './utils';
 
 const ListContainer = styled.div`
@@ -160,8 +163,9 @@ export const IngestionSourceExecutionList = ({ urn, lastRefresh, onRefresh }: Pr
             key: 'source',
             render: (source: string) => {
                 return (
-                    (source === 'MANUAL_INGESTION_SOURCE' && 'Manual Execution') ||
-                    (source === 'SCHEDULED_INGESTION_SOURCE' && 'Scheduled Execution') ||
+                    (source === MANUAL_INGESTION_SOURCE && 'Manual Execution') ||
+                    (source === SCHEDULED_INGESTION_SOURCE && 'Scheduled Execution') ||
+                    (source === CLI_INGESTION_SOURCE && 'CLI Execution') ||
                     'N/A'
                 );
             },

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -39,7 +39,7 @@ const FilterWrapper = styled.div`
     display: flex;
 `;
 
-enum IngestionSourceType {
+export enum IngestionSourceType {
     ALL,
     UI,
     CLI,

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTable.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTable.tsx
@@ -1,0 +1,152 @@
+import { Empty, Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { StyledTable } from '../../entity/shared/components/styled/StyledTable';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { CLI_EXECUTOR_ID } from './utils';
+import {
+    LastStatusColumn,
+    TypeColumn,
+    ActionsColumn,
+    ScheduleColumn,
+    LastExecutionColumn,
+} from './IngestionSourceTableColumns';
+import { IngestionSource } from '../../../types.generated';
+import { IngestionSourceExecutionList } from './IngestionSourceExecutionList';
+
+const StyledSourceTable = styled(StyledTable)`
+    .cliIngestion {
+        td {
+            background-color: ${ANTD_GRAY[2]} !important;
+        }
+    }
+` as typeof StyledTable;
+
+interface Props {
+    lastRefresh: number;
+    sources: IngestionSource[];
+    setFocusExecutionUrn: (urn: string) => void;
+    onExecute: (urn: string) => void;
+    onEdit: (urn: string) => void;
+    onView: (urn: string) => void;
+    onDelete: (urn: string) => void;
+    onRefresh: () => void;
+}
+
+function IngestionSourceTable({
+    lastRefresh,
+    sources,
+    setFocusExecutionUrn,
+    onExecute,
+    onEdit,
+    onView,
+    onDelete,
+    onRefresh,
+}: Props) {
+    const tableColumns = [
+        {
+            title: 'Type',
+            dataIndex: 'type',
+            key: 'type',
+            render: TypeColumn,
+        },
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+            render: (name: string) => name || '',
+        },
+        {
+            title: 'Schedule',
+            dataIndex: 'schedule',
+            key: 'schedule',
+            render: ScheduleColumn,
+        },
+        {
+            title: 'Execution Count',
+            dataIndex: 'execCount',
+            key: 'execCount',
+            render: (execCount: any) => <Typography.Text>{execCount || '0'}</Typography.Text>,
+        },
+        {
+            title: 'Last Execution',
+            dataIndex: 'lastExecTime',
+            key: 'lastExecTime',
+            render: LastExecutionColumn,
+        },
+        {
+            title: 'Last Status',
+            dataIndex: 'lastExecStatus',
+            key: 'lastExecStatus',
+            render: (status: any, record) => (
+                <LastStatusColumn status={status} record={record} setFocusExecutionUrn={setFocusExecutionUrn} />
+            ),
+        },
+        {
+            title: '',
+            dataIndex: '',
+            key: 'x',
+            render: (_, record: any) => (
+                <ActionsColumn
+                    record={record}
+                    setFocusExecutionUrn={setFocusExecutionUrn}
+                    onExecute={onExecute}
+                    onDelete={onDelete}
+                    onView={onView}
+                    onEdit={onEdit}
+                />
+            ),
+        },
+    ];
+
+    const tableData = sources.map((source) => ({
+        urn: source.urn,
+        type: source.type,
+        name: source.name,
+        schedule: source.schedule?.interval,
+        timezone: source.schedule?.timezone,
+        execCount: source.executions?.total || 0,
+        lastExecUrn:
+            source.executions?.total && source.executions?.total > 0 && source.executions?.executionRequests[0].urn,
+        lastExecTime:
+            source.executions?.total &&
+            source.executions?.total > 0 &&
+            source.executions?.executionRequests[0].result?.startTimeMs,
+        lastExecStatus:
+            source.executions?.total &&
+            source.executions?.total > 0 &&
+            source.executions?.executionRequests[0].result?.status,
+        cliIngestion: source.config.executorId === CLI_EXECUTOR_ID,
+    }));
+
+    return (
+        <StyledSourceTable
+            columns={tableColumns}
+            dataSource={tableData}
+            rowKey="urn"
+            rowClassName={(record, _) => (record.cliIngestion ? 'cliIngestion' : '')}
+            locale={{
+                emptyText: <Empty description="No Ingestion Sources!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
+            }}
+            expandable={{
+                expandedRowRender: (record) => {
+                    return (
+                        <IngestionSourceExecutionList
+                            urn={record.urn}
+                            lastRefresh={lastRefresh}
+                            onRefresh={onRefresh}
+                        />
+                    );
+                },
+                rowExpandable: (record) => {
+                    return record.execCount > 0;
+                },
+                defaultExpandAllRows: false,
+                indentSize: 0,
+            }}
+            pagination={false}
+        />
+    );
+}
+
+export default IngestionSourceTable;

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
@@ -1,0 +1,186 @@
+import { blue } from '@ant-design/colors';
+import { CodeOutlined, CopyOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Button, Image, Tooltip, Typography } from 'antd';
+import cronstrue from 'cronstrue';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { capitalizeFirstLetter } from '../../shared/textUtil';
+import {
+    getExecutionRequestStatusDisplayColor,
+    getExecutionRequestStatusDisplayText,
+    getExecutionRequestStatusIcon,
+    RUNNING,
+    sourceTypeToIconUrl,
+} from './utils';
+
+const PreviewImage = styled(Image)`
+    max-height: 28px;
+    width: auto;
+    object-fit: contain;
+    margin: 0px;
+    background-color: transparent;
+`;
+
+const StatusContainer = styled.div`
+    display: flex;
+    justify-content: left;
+    align-items: center;
+`;
+
+const StatusButton = styled(Button)`
+    padding: 0px;
+    margin: 0px;
+`;
+
+const ActionButtonContainer = styled.div`
+    display: flex;
+    justify-content: right;
+`;
+
+const TypeWrapper = styled.div`
+    align-items: center;
+    display: flex;
+`;
+
+const CliBadge = styled.span`
+    margin-left: 20px;
+    border-radius: 15px;
+    border: 1px solid ${ANTD_GRAY[8]};
+    padding: 1px 4px;
+    font-size: 10px;
+
+    font-size: 8px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    border: 1px solid ${blue[6]};
+    color: ${blue[6]};
+
+    svg {
+        display: none;
+        margin-right: 5px;
+    }
+`;
+
+export function TypeColumn(type: string, record: any) {
+    const iconUrl = sourceTypeToIconUrl(type);
+    const typeDisplayName = capitalizeFirstLetter(type);
+
+    return (
+        <TypeWrapper>
+            {iconUrl ? (
+                <Tooltip overlay={typeDisplayName}>
+                    <PreviewImage preview={false} src={iconUrl} alt={type || ''} />
+                </Tooltip>
+            ) : (
+                <Typography.Text strong>{typeDisplayName}</Typography.Text>
+            )}
+            {record.cliIngestion && (
+                <Tooltip title="This source is ingested from the command-line interface (CLI)">
+                    <CliBadge>
+                        <CodeOutlined />
+                        CLI
+                    </CliBadge>
+                </Tooltip>
+            )}
+        </TypeWrapper>
+    );
+}
+
+export function LastExecutionColumn(time: any) {
+    const executionDate = time && new Date(time);
+    const localTime = executionDate && `${executionDate.toLocaleDateString()} at ${executionDate.toLocaleTimeString()}`;
+    return <Typography.Text>{localTime || 'N/A'}</Typography.Text>;
+}
+
+export function ScheduleColumn(schedule: any, record: any) {
+    const tooltip = schedule && `Runs ${cronstrue.toString(schedule).toLowerCase()} (${record.timezone})`;
+    return (
+        <Tooltip title={tooltip || 'Not scheduled'}>
+            <Typography.Text code>{schedule || 'None'}</Typography.Text>
+        </Tooltip>
+    );
+}
+
+interface LastStatusProps {
+    status: any;
+    record: any;
+    setFocusExecutionUrn: (urn: string) => void;
+}
+
+export function LastStatusColumn({ status, record, setFocusExecutionUrn }: LastStatusProps) {
+    const Icon = getExecutionRequestStatusIcon(status);
+    const text = getExecutionRequestStatusDisplayText(status);
+    const color = getExecutionRequestStatusDisplayColor(status);
+    return (
+        <StatusContainer>
+            {Icon && <Icon style={{ color }} />}
+            <StatusButton type="link" onClick={() => setFocusExecutionUrn(record.lastExecUrn)}>
+                <Typography.Text strong style={{ color, marginLeft: 8 }}>
+                    {text || 'N/A'}
+                </Typography.Text>
+            </StatusButton>
+        </StatusContainer>
+    );
+}
+
+interface ActionsColumnProps {
+    record: any;
+    setFocusExecutionUrn: (urn: string) => void;
+    onExecute: (urn: string) => void;
+    onEdit: (urn: string) => void;
+    onView: (urn: string) => void;
+    onDelete: (urn: string) => void;
+}
+
+export function ActionsColumn({
+    record,
+    onEdit,
+    setFocusExecutionUrn,
+    onView,
+    onExecute,
+    onDelete,
+}: ActionsColumnProps) {
+    return (
+        <ActionButtonContainer>
+            {navigator.clipboard && (
+                <Tooltip title="Copy Ingestion Source URN">
+                    <Button
+                        style={{ marginRight: 16 }}
+                        icon={<CopyOutlined />}
+                        onClick={() => {
+                            navigator.clipboard.writeText(record.urn);
+                        }}
+                    />
+                </Tooltip>
+            )}
+            {!record.cliIngestion && (
+                <Button style={{ marginRight: 16 }} onClick={() => onEdit(record.urn)}>
+                    EDIT
+                </Button>
+            )}
+            {record.cliIngestion && (
+                <Button style={{ marginRight: 16 }} onClick={() => onView(record.urn)}>
+                    VIEW
+                </Button>
+            )}
+            {record.lastExecStatus !== RUNNING && (
+                <Button
+                    disabled={record.cliIngestion}
+                    style={{ marginRight: 16 }}
+                    onClick={() => onExecute(record.urn)}
+                >
+                    EXECUTE
+                </Button>
+            )}
+            {record.lastExecStatus === RUNNING && (
+                <Button style={{ marginRight: 16 }} onClick={() => setFocusExecutionUrn(record.lastExecUrn)}>
+                    DETAILS
+                </Button>
+            )}
+            <Button onClick={() => onDelete(record.urn)} type="text" shape="circle" danger>
+                <DeleteOutlined />
+            </Button>
+        </ActionButtonContainer>
+    );
+}

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
@@ -170,7 +170,7 @@ export function ActionsColumn({
                     style={{ marginRight: 16 }}
                     onClick={() => onExecute(record.urn)}
                 >
-                    EXECUTE
+                    RUN
                 </Button>
             )}
             {record.lastExecStatus === RUNNING && (

--- a/datahub-web-react/src/app/ingest/source/RecipeViewerModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/RecipeViewerModal.tsx
@@ -1,0 +1,46 @@
+import Editor from '@monaco-editor/react';
+import { Button, Modal } from 'antd';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { jsonToYaml } from './utils';
+
+const YamlWrapper = styled.div`
+    padding: 24px;
+`;
+
+interface Props {
+    recipe?: string;
+    onCancel: () => void;
+}
+
+function RecipeViewerModal({ recipe, onCancel }: Props) {
+    const formattedRecipe = recipe ? jsonToYaml(recipe) : '';
+
+    return (
+        <Modal
+            visible
+            onCancel={onCancel}
+            width={800}
+            title="View Ingestion Recipe"
+            footer={<Button onClick={onCancel}>Done</Button>}
+        >
+            <YamlWrapper>
+                <Editor
+                    options={{
+                        readOnly: true,
+                        minimap: { enabled: false },
+                        scrollbar: {
+                            vertical: 'hidden',
+                            horizontal: 'hidden',
+                        },
+                    }}
+                    height="55vh"
+                    defaultLanguage="yaml"
+                    value={formattedRecipe}
+                />
+            </YamlWrapper>
+        </Modal>
+    );
+}
+
+export default RecipeViewerModal;

--- a/datahub-web-react/src/app/ingest/source/__tests__/IngestionSourceList.test.tsx
+++ b/datahub-web-react/src/app/ingest/source/__tests__/IngestionSourceList.test.tsx
@@ -1,0 +1,38 @@
+import { IngestionSourceType, shouldIncludeSource } from '../IngestionSourceList';
+import { CLI_EXECUTOR_ID } from '../utils';
+
+describe('shouldIncludeSource', () => {
+    it('should return true if the source filter is for CLI and the source is a CLI source', () => {
+        const source = { config: { executorId: CLI_EXECUTOR_ID } };
+        const isSourceIncluded = shouldIncludeSource(source, IngestionSourceType.CLI);
+        expect(isSourceIncluded).toBe(true);
+    });
+
+    it('should return false if the source filter is for CLI and the source is not a CLI source', () => {
+        const source = { config: { executorId: 'default' } };
+        const isSourceIncluded = shouldIncludeSource(source, IngestionSourceType.CLI);
+        expect(isSourceIncluded).toBe(false);
+    });
+
+    it('should return true if the source filter is for UI and the source is a UI source', () => {
+        const source = { config: { executorId: 'default' } };
+        const isSourceIncluded = shouldIncludeSource(source, IngestionSourceType.UI);
+        expect(isSourceIncluded).toBe(true);
+    });
+
+    it('should return false if the source filter is for UI and the source is not a UI source', () => {
+        const source = { config: { executorId: CLI_EXECUTOR_ID } };
+        const isSourceIncluded = shouldIncludeSource(source, IngestionSourceType.UI);
+        expect(isSourceIncluded).toBe(false);
+    });
+
+    it('should return true no matter what if the source type is all', () => {
+        const source1 = { config: { executorId: CLI_EXECUTOR_ID } };
+        const isSourceIncluded1 = shouldIncludeSource(source1, IngestionSourceType.ALL);
+        expect(isSourceIncluded1).toBe(true);
+
+        const source2 = { config: { executorId: 'default' } };
+        const isSourceIncluded2 = shouldIncludeSource(source2, IngestionSourceType.ALL);
+        expect(isSourceIncluded2).toBe(true);
+    });
+});

--- a/datahub-web-react/src/app/ingest/source/utils.ts
+++ b/datahub-web-react/src/app/ingest/source/utils.ts
@@ -35,6 +35,11 @@ export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
 export const CANCELLED = 'CANCELLED';
 
+export const CLI_EXECUTOR_ID = '__datahub_cli_';
+export const MANUAL_INGESTION_SOURCE = 'MANUAL_INGESTION_SOURCE';
+export const SCHEDULED_INGESTION_SOURCE = 'SCHEDULED_INGESTION_SOURCE';
+export const CLI_INGESTION_SOURCE = 'CLI_INGESTION_SOURCE';
+
 export const getExecutionRequestStatusIcon = (status: string) => {
     return (
         (status === RUNNING && LoadingOutlined) ||


### PR DESCRIPTION
Adds necessary checks and styles for displaying CLI based ingestion sources in the managed ingestion list in the UI. If it's from CLI, disable the execute button, only allow them to view their recipe (not edit), and have a few small styling changes.

The VAST majority of the diff here is from refactoring. If you view the changes by commit, this will be much easier to review.

Some screenshots:
**one snowflake CLI ingestion source**
<img width="1428" alt="image" src="https://user-images.githubusercontent.com/28656603/185483961-07b64f0d-be82-4630-89c3-aebc9f156f81.png">

**when you expand its executions**
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/28656603/185484016-9d0fd8ae-31c5-46a5-bdc1-87ecb8dfc82e.png">

**When you click the "View" button for CLI sources - read-only viewer of the recipe**
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/28656603/185484129-6542680a-1f0a-477b-8b08-7b3ee08e78c1.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)