### PR TITLE
refactor(looker): Migrating to new browse path format 

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -109,7 +109,7 @@ class LookerExploreNamingConfig(ConfigModel):
     )
     explore_browse_pattern: NamingPattern = NamingPattern(
         allowed_vars=naming_pattern_variables,
-        pattern="/{env}/{platform}/{project}/explores/{model}.{name}",
+        pattern="/{env}/{platform}/{project}/explores",
     )
 
     @validator("explore_naming_pattern", "explore_browse_pattern", pre=True)
@@ -136,7 +136,7 @@ class LookerViewNamingConfig(ConfigModel):
     view_browse_pattern: NamingPattern = Field(
         NamingPattern(
             allowed_vars=naming_pattern_variables,
-            pattern="/{env}/{platform}/{project}/views/{name}",
+            pattern="/{env}/{platform}/{project}/views",
         ),
         description="Pattern for providing browse paths to views. Allowed variables are `{project}`, `{model}`, `{name}`, `{platform}` and `{env}`",
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -726,7 +726,7 @@ class LookerDashboardSource(TestableSource):
         dashboard_snapshot.aspects.append(dashboard_info)
         if looker_dashboard.folder_path is not None:
             browse_path = BrowsePathsClass(
-                paths=[f"/looker/{looker_dashboard.folder_path}/{looker_dashboard.id}"]
+                paths=[f"/looker/{looker_dashboard.folder_path}"]
             )
             dashboard_snapshot.aspects.append(browse_path)
 

--- a/metadata-ingestion/tests/integration/looker/golden_test_allow_ingest.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_allow_ingest.json
@@ -59,7 +59,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/explores/data.my_view"
+                            "/prod/looker/lkml_samples/explores"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest.json
@@ -59,7 +59,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/explores/data.my_view"
+                            "/prod/looker/lkml_samples/explores"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest_joins.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest_joins.json
@@ -59,7 +59,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/explores/data.my_view"
+                            "/prod/looker/lkml_samples/explores"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/looker/golden_test_ingest_unaliased_joins.json
+++ b/metadata-ingestion/tests/integration/looker/golden_test_ingest_unaliased_joins.json
@@ -59,7 +59,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/explores/data.my_view"
+                            "/prod/looker/lkml_samples/explores"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/looker/looker_mces_usage_history.json
+++ b/metadata-ingestion/tests/integration/looker/looker_mces_usage_history.json
@@ -45,7 +45,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/explores/data.my_view"
+                            "/prod/looker/lkml_samples/explores"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/lookml/expected_output.json
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -530,7 +530,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -628,7 +628,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -726,7 +726,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -885,7 +885,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -983,7 +983,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1081,7 +1081,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1281,7 +1281,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/lookml/expected_output.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -530,7 +530,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -628,7 +628,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -726,7 +726,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -885,7 +885,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -983,7 +983,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1081,7 +1081,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1281,7 +1281,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_bigquery.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_api_hive2.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -530,7 +530,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -628,7 +628,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -726,7 +726,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -885,7 +885,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -983,7 +983,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1081,7 +1081,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1281,7 +1281,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_badsql_parser.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -266,7 +266,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -496,7 +496,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -594,7 +594,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -692,7 +692,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -851,7 +851,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -949,7 +949,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1047,7 +1047,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1128,7 +1128,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -530,7 +530,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -628,7 +628,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -726,7 +726,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -885,7 +885,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -983,7 +983,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1081,7 +1081,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1281,7 +1281,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_deny_pattern.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_deny_pattern.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -106,7 +106,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -204,7 +204,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -363,7 +363,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -461,7 +461,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_platform_instance.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_offline_platform_instance.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -530,7 +530,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -628,7 +628,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -726,7 +726,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -885,7 +885,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -983,7 +983,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1081,7 +1081,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1281,7 +1281,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_mces_with_external_urls.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -530,7 +530,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/include_able_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -628,7 +628,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -726,7 +726,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/extending_looker_events"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -885,7 +885,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/autodetect_sql_name_based_on_view_name"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -983,7 +983,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/test_include_external_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1081,7 +1081,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/fragment_derived_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -1281,7 +1281,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/customer_facts"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },

--- a/metadata-ingestion/tests/integration/lookml/lookml_reachable_views.json
+++ b/metadata-ingestion/tests/integration/lookml/lookml_reachable_views.json
@@ -8,7 +8,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },
@@ -283,7 +283,7 @@
                 {
                     "com.linkedin.pegasus2avro.common.BrowsePaths": {
                         "paths": [
-                            "/prod/looker/lkml_samples/views/my_view2"
+                            "/prod/looker/lkml_samples/views"
                         ]
                     }
                 },


### PR DESCRIPTION
**Summary**

In this PR, we migrate the browse paths produced by looker sources to the new format, which does NOT mandate that the path ends with the asset's name or id. Learn more about the migration here: https://github.com/datahub-project/datahub/blob/648d10c16e2591e43b96f930997fa5490e27aa06/docs/advanced/browse-paths-upgrade.md


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)