### PR TITLE
fix(ui) Refresh executions on Ingestion page when they are visible

### DIFF
--- a/datahub-web-react/src/app/ingest/source/IngestionSourceExecutionList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceExecutionList.tsx
@@ -35,11 +35,12 @@ const StatusButton = styled(Button)`
 
 type Props = {
     urn: string;
+    isExpanded: boolean;
     lastRefresh: number;
     onRefresh: () => void;
 };
 
-export const IngestionSourceExecutionList = ({ urn, lastRefresh, onRefresh }: Props) => {
+export const IngestionSourceExecutionList = ({ urn, isExpanded, lastRefresh, onRefresh }: Props) => {
     const [focusExecutionUrn, setFocusExecutionUrn] = useState<undefined | string>(undefined);
 
     const start = 0;
@@ -56,8 +57,10 @@ export const IngestionSourceExecutionList = ({ urn, lastRefresh, onRefresh }: Pr
     const [cancelExecutionRequestMutation] = useCancelIngestionExecutionRequestMutation();
 
     useEffect(() => {
-        refetch();
-    }, [lastRefresh, refetch]);
+        if (isExpanded) {
+            refetch();
+        }
+    }, [lastRefresh, isExpanded, refetch]);
 
     const handleViewDetails = (focusUrn: string) => {
         setFocusExecutionUrn(focusUrn);

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -120,7 +120,7 @@ export const IngestionSourceList = () => {
     const onRefresh = useCallback(() => {
         refetch();
         // Used to force a re-render of the child execution request list.
-        setLastRefresh(new Date().getMilliseconds());
+        setLastRefresh(new Date().getTime());
     }, [refetch]);
 
     useEffect(() => {

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTable.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTable.tsx
@@ -129,10 +129,11 @@ function IngestionSourceTable({
                 emptyText: <Empty description="No Ingestion Sources!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
             }}
             expandable={{
-                expandedRowRender: (record) => {
+                expandedRowRender: (record, _index, _indent, expanded) => {
                     return (
                         <IngestionSourceExecutionList
                             urn={record.urn}
+                            isExpanded={expanded}
                             lastRefresh={lastRefresh}
                             onRefresh={onRefresh}
                         />


### PR DESCRIPTION
Fixes a bug that only occurs sometimes when we're unlucky where we don't fetch the executions list because the `lastRefresh` time did not change. This was happening because `new Date().getMilliseconds()` will return how many milliseconds into the second we are, not the total number of milliseconds since the epoch. That means that since we refresh exactly every 3 seconds, there's a real chance that occasionally this number is the same as the previous `lastRefresh` and we don't refresh the executions list. Fix this by setting `lastRefresh` as the number of milliseconds since the epoch so it's always new.

I also noticed that we were refreshing every executions list from every source that was opened at any point, even if it is now closed. So I added a check to only refresh if the executions list is open.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)