### PR TITLE
fix(ui): Long overdue - Fix red error screens during OIDC login, logout exception scenarios

### DIFF
--- a/datahub-frontend/app/controllers/AuthenticationController.java
+++ b/datahub-frontend/app/controllers/AuthenticationController.java
@@ -275,8 +275,17 @@ public class AuthenticationController extends Controller {
             _logger.debug("Found previous login attempt. Removing it manually to prevent unexpected errors.");
             _playSessionStore.set(playWebContext, client.getName() + ATTEMPTED_AUTHENTICATION_SUFFIX, "");
         }
-        final HttpAction action = client.redirect(playWebContext);
-        return new PlayHttpActionAdapter().adapt(action.getCode(), playWebContext);
+
+        try {
+            final HttpAction action = client.redirect(playWebContext);
+            return new PlayHttpActionAdapter().adapt(action.getCode(), playWebContext);
+        } catch (Exception e) {
+            _logger.error("Caught exception while attempting to redirect to SSO identity provider! It's likely that SSO integration is mis-configured", e);
+            return redirect(
+                String.format("/login?error_msg=%s",
+                URLEncoder.encode("Failed to redirect to Single Sign-On provider. Please contact your DataHub Administrator, "
+                    + "or refer to server logs for more information.")));
+        }
     }
 
     private String encodeRedirectUri(final String redirectUri) {

--- a/datahub-frontend/app/controllers/CentralLogoutController.java
+++ b/datahub-frontend/app/controllers/CentralLogoutController.java
@@ -1,6 +1,8 @@
 package controllers;
 
 import com.typesafe.config.Config;
+import java.net.URLEncoder;
+import lombok.extern.slf4j.Slf4j;
 import org.pac4j.play.LogoutController;
 import play.mvc.Result;
 
@@ -10,6 +12,7 @@ import java.util.concurrent.ExecutionException;
 /**
  * Responsible for handling logout logic with oidc providers
  */
+@Slf4j
 public class CentralLogoutController extends LogoutController {
 
   private static final String AUTH_BASE_URL_CONFIG_PATH = "auth.baseUrl";
@@ -37,7 +40,15 @@ public class CentralLogoutController extends LogoutController {
    */
   public Result executeLogout() throws ExecutionException, InterruptedException {
     if (_isOidcEnabled) {
-      return logout().toCompletableFuture().get();
+      try {
+        return logout().toCompletableFuture().get();
+      } catch (Exception e) {
+        log.error("Caught exception while attempting to perform SSO logout! It's likely that SSO integration is mis-configured.", e);
+        return redirect(
+            String.format("/login?error_msg=%s",
+                URLEncoder.encode("Failed to sign out using Single Sign-On provider. Please contact your DataHub Administrator, "
+                    + "or refer to server logs for more information.")));
+      }
     }
     return redirect("/");
   }

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -51,9 +51,3 @@ DATAHUB_AKKA_MAX_HEADER_COUNT=64
 
 # Change to override max header value length defaults
 DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH=8k
-
-AUTH_OIDC_ENABLED=true
-AUTH_OIDC_CLIENT_ID=0oa6957b1o9dVm3JM5d7
-AUTH_OIDC_CLIENT_SECRET=wObio8oYQUtaLIGw5DMG6gB1dc3uXIpJTNMkXZhe
-AUTH_OIDC_DISCOVERY_URI=https://dev-76500509.okta.com/.well-known/openid-configuration
-AUTH_OIDC_BASE_URL=http://localhost:9002

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -51,3 +51,9 @@ DATAHUB_AKKA_MAX_HEADER_COUNT=64
 
 # Change to override max header value length defaults
 DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH=8k
+
+AUTH_OIDC_ENABLED=true
+AUTH_OIDC_CLIENT_ID=0oa6957b1o9dVm3JM5d7
+AUTH_OIDC_CLIENT_SECRET=wObio8oYQUtaLIGw5DMG6gB1dc3uXIpJTNMkXZhe
+AUTH_OIDC_DISCOVERY_URI=https://dev-76500509.okta.com/.well-known/openid-configuration
+AUTH_OIDC_BASE_URL=http://localhost:9002

--- a/datahub-web-react/src/app/auth/LogIn.tsx
+++ b/datahub-web-react/src/app/auth/LogIn.tsx
@@ -43,6 +43,8 @@ export type LogInProps = Record<string, never>;
 export const LogIn: React.VFC<LogInProps> = () => {
     const isLoggedIn = useReactiveVar(isLoggedInVar);
     const location = useLocation();
+    const params = QueryString.parse(location.search);
+    const maybeRedirectError = params.error_msg;
 
     const themeConfig = useTheme();
     const [loading, setLoading] = useState(false);
@@ -78,13 +80,13 @@ export const LogIn: React.VFC<LogInProps> = () => {
     );
 
     if (isLoggedIn) {
-        const params = QueryString.parse(location.search);
         const maybeRedirectUri = params.redirect_uri;
         return <Redirect to={(maybeRedirectUri && decodeURIComponent(maybeRedirectUri as string)) || '/'} />;
     }
 
     return (
         <div className={styles.login_page}>
+            {(maybeRedirectError || '').length > 0 && <Message type="error" content={maybeRedirectError} />}
             <div className={styles.login_box}>
                 <div className={styles.login_logo_box}>
                     <Image wrapperClassName={styles.logo_image} src={themeConfig.assets?.logoUrl} preview={false} />

--- a/datahub-web-react/src/app/auth/LogIn.tsx
+++ b/datahub-web-react/src/app/auth/LogIn.tsx
@@ -86,7 +86,9 @@ export const LogIn: React.VFC<LogInProps> = () => {
 
     return (
         <div className={styles.login_page}>
-            {(maybeRedirectError || '').length > 0 && <Message type="error" content={maybeRedirectError} />}
+            {maybeRedirectError && maybeRedirectError.length > 0 && (
+                <Message type="error" content={maybeRedirectError} />
+            )}
             <div className={styles.login_box}>
                 <div className={styles.login_logo_box}>
                     <Image wrapperClassName={styles.logo_image} src={themeConfig.assets?.logoUrl} preview={false} />


### PR DESCRIPTION
**Summary**

Previously, when we failed to login or logout using SSO (oidc), we hit a red screen of death. In this PR we've added logic to 

1. Clearly log the error to the admin / operator
2. Redirect the poor user back to the /login page with a persistent error warning pinned to the top. 

**Screenshots**
Below is the new error scenario, redirect to login with an error!

![Screen Shot 2022-08-22 at 8 12 17 PM](https://user-images.githubusercontent.com/17549204/186061838-5d87d0f5-c97a-42f2-aea0-dedbcae73e80.png)
![Screen Shot 2022-08-22 at 7 47 35 PM](https://user-images.githubusercontent.com/17549204/186061835-e971b146-2387-4e9b-87dc-9552df971b08.png)



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)