### PR TITLE
fix(superset): do not crash when display_uri is not set

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -84,7 +84,7 @@ class SupersetConfig(ConfigModel):
     def default_display_uri_to_connect_uri(cls, values):
         base = values.get("display_uri")
         if base is None:
-            values.set("display_uri", values.get("connect_uri"))
+            values["display_uri"] = values.get("connect_uri")
         return values
 
 

--- a/metadata-ingestion/tests/unit/test_superset_source.py
+++ b/metadata-ingestion/tests/unit/test_superset_source.py
@@ -1,0 +1,22 @@
+from datahub.ingestion.source.superset import SupersetConfig
+
+
+def test_default_values():
+
+    config = SupersetConfig.parse_obj({})
+
+    assert config.connect_uri == "localhost:8088"
+    assert config.display_uri == "localhost:8088"
+    assert config.provider == "db"
+    assert config.env == "PROD"
+    assert config.username is None
+    assert config.password is None
+
+
+def test_set_display_uri():
+    display_uri = "some_host:1234"
+
+    config = SupersetConfig.parse_obj({"display_uri": display_uri})
+
+    assert config.connect_uri == "localhost:8088"
+    assert config.display_uri == display_uri


### PR DESCRIPTION
Fix for #5709 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
