### PR TITLE
fix(bootstrap): Remove malformed test in bootstrap.json

### DIFF
--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -3243,44 +3243,5 @@
       "contentType":"application/json"
     },
     "systemMetadata":null
-  },
-  {
-    "auditHeader": null,
-    "entityType": "test",
-    "entityUrn": "urn:li:test:953001aa-fb7b-4a43-916f-3efd95ab9047",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "testInfo",
-    "aspect": {
-      "value": "{\"name\": \"Sample Test 1\", \"category\": \"Examples\", \"description\": \"An example of Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{}\"} }",
-      "contentType": "application/json"
-    },
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "entityType": "test",
-    "entityUrn": "urn:li:test:76ca947d-d988-4f0d-8c2f-055de2c6f4b5",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "testInfo",
-    "aspect": {
-      "value": "{\"name\": \"Sample Test 2\", \"category\": \"Examples\", \"description\": \"An example of another Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{}\"} }",
-      "contentType": "application/json"
-    },
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "testResults",
-    "aspect": {
-      "value": "{\"failing\": [ { \"test\": \"urn:li:test:953001aa-fb7b-4a43-916f-3efd95ab9047\", \"type\": \"FAILURE\" } ], \"passing\": [ { \"test\": \"urn:li:test:76ca947d-d988-4f0d-8c2f-055de2c6f4b5\", \"type\": \"SUCCESS\" }]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": null
   }
 ]

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -191,7 +191,7 @@ springdoc:
     disabled: true
 
 metadataTests:
-  enabled: ${METADATA_TESTS_ENABLED:true}
+  enabled: ${METADATA_TESTS_ENABLED:false}
 
 siblings:
   enabled: ${ENABLE_SIBLING_HOOK:true} # enable to turn on automatic sibling associations for dbt


### PR DESCRIPTION
**Summary**
In this PR we remove malformed tests in bootstrap.json file. We also disable the test engine by default. 

This causes unwanted error logs in the TestEngine component. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)