### PR TITLE
fix(ingestion): Fix SQL Lineage Parser to handle special tokens with a hyphen in table and column names.

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/sql_lineage_parser_impl.py
+++ b/metadata-ingestion/src/datahub/utilities/sql_lineage_parser_impl.py
@@ -42,8 +42,13 @@ class SqlLineageSQLParserImpl:
             self._ADMIN_SWAP_TOKEN: "admin",
         }
         for replacement, original in self.token_to_original.items():
+            # Replace original tokens with replacement. Since table and column name can contain a hyphen('-'),
+            # also prevent original tokens appearing as part of these names with a hyphen from getting substituted.
             sql_query = re.sub(
-                rf"(\b{original}\b)", rf"{replacement}", sql_query, flags=re.IGNORECASE
+                rf"((?<!-)\b{original}\b)(?!-)",
+                rf"{replacement}",
+                sql_query,
+                flags=re.IGNORECASE,
             )
 
         # SqlLineageParser lowercarese tablenames and we need to replace Looker specific token which should be uppercased

--- a/metadata-ingestion/tests/unit/test_utilities.py
+++ b/metadata-ingestion/tests/unit/test_utilities.py
@@ -320,3 +320,32 @@ year(order_date)"""
     table_list = SqlLineageSQLParser(sql_query).get_tables()
     table_list.sort()
     assert table_list == ["order_items", "orders", "staffs"]
+
+
+def test_sqllineage_sql_parser_tables_with_special_names():
+
+    # The hyphen appears after the special token in tables names, and before the special token in the column names.
+    sql_query = """
+SELECT `column-date`, `column-hour`, `column-timestamp`, `column-data`, `column-admin`
+FROM `date-table` d
+JOIN `hour-table` h on d.`column-date`= h.`column-hour`
+JOIN `timestamp-table` t on d.`column-date` = t.`column-timestamp`
+JOIN `data-table` da on d.`column-date` = da.`column-data`
+JOIN `admin-table` a on d.`column-date` = a.`column-admin`
+"""
+    expected_tables = [
+        "admin-table",
+        "data-table",
+        "date-table",
+        "hour-table",
+        "timestamp-table",
+    ]
+    expected_columns = [
+        "column-admin",
+        "column-data",
+        "column-date",
+        "column-hour",
+        "column-timestamp",
+    ]
+    assert sorted(SqlLineageSQLParser(sql_query).get_tables()) == expected_tables
+    assert sorted(SqlLineageSQLParser(sql_query).get_columns()) == expected_columns


### PR DESCRIPTION
Prevents table and column names connected with a hyphen with the special tokens from getting replaced with alternate internal tokens.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)