### PR TITLE
fix(ingest): snowflake-beta fix missing initialization of variable

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
@@ -99,6 +99,7 @@ class SnowflakeProfiler(SnowflakeCommonMixin):
                     dataset_name = self.get_dataset_identifier(
                         table.name, schema.name, db.name
                     )
+                    skip_profiling = False
                     # no need to filter by size_in_bytes and row_count limits,
                     # if table level profilin, since its not expensive
                     if not self.is_dataset_eligible_for_profiling(


### PR DESCRIPTION
Fixing issue -  UnboundLocalError: local variable 'skip_profiling' referenced before assignment
This issue happens if `profiling.profile_table_level_only` is enabled in snowflake-beta.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)