### PR TITLE
feat(ingestion-ui) Add ability to set debug_mode on UI ingestion sources

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/IngestionResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/IngestionResolverUtils.java
@@ -142,6 +142,7 @@ public class IngestionResolverUtils {
     result.setRecipe(config.getRecipe());
     result.setVersion(config.getVersion());
     result.setExecutorId(config.getExecutorId());
+    result.setDebugMode(config.isDebugMode());
     return result;
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
@@ -44,6 +44,7 @@ public class CreateIngestionExecutionRequestResolver implements DataFetcher<Comp
   private static final String MANUAL_EXECUTION_SOURCE_NAME = "MANUAL_INGESTION_SOURCE";
   private static final String RECIPE_ARG_NAME = "recipe";
   private static final String VERSION_ARG_NAME = "version";
+  private static final String DEBUG_MODE_ARG_NAME = "debug_mode";
 
   private final EntityClient _entityClient;
   private final IngestionConfiguration _ingestionConfiguration;
@@ -112,6 +113,11 @@ public class CreateIngestionExecutionRequestResolver implements DataFetcher<Comp
           if (ingestionSourceInfo.getConfig().hasVersion()) {
             arguments.put(VERSION_ARG_NAME, ingestionSourceInfo.getConfig().getVersion());
           }
+          String debugMode = "false";
+          if (ingestionSourceInfo.getConfig().hasDebugMode()) {
+            debugMode = ingestionSourceInfo.getConfig().isDebugMode() ? "true" : "false";
+          }
+          arguments.put(DEBUG_MODE_ARG_NAME, debugMode);
           execInput.setArgs(new StringMap(arguments));
 
           proposal.setEntityType(Constants.EXECUTION_REQUEST_ENTITY_NAME);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/UpsertIngestionSourceResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/UpsertIngestionSourceResolver.java
@@ -122,6 +122,7 @@ public class UpsertIngestionSourceResolver implements DataFetcher<CompletableFut
     if (input.getExecutorId() != null) {
       result.setExecutorId(input.getExecutorId());
     }
+    result.setDebugMode(input.getDebugMode());
     return result;
   }
 

--- a/datahub-graphql-core/src/main/resources/ingestion.graphql
+++ b/datahub-graphql-core/src/main/resources/ingestion.graphql
@@ -317,6 +317,11 @@ type IngestionConfig {
   Advanced: The version of the ingestion framework to use
   """
   version: String
+
+  """
+  Advanced: Whether or not to run ingestion in debug mode
+  """
+  debugMode: Boolean
 }
 
 """
@@ -453,6 +458,11 @@ input UpdateIngestionSourceConfigInput {
   The id of the executor to use for executing the recipe
   """
   executorId: String!
+
+  """
+  Whether or not to run ingestion in debug mode
+  """
+  debugMode: Boolean!
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/UpsertIngestionSourceResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/UpsertIngestionSourceResolverTest.java
@@ -28,7 +28,7 @@ public class UpsertIngestionSourceResolverTest {
       "Test source",
       "mysql", "Test source description",
       new UpdateIngestionSourceScheduleInput("* * * * *", "UTC"),
-      new UpdateIngestionSourceConfigInput("my test recipe", "0.8.18", "executor id")
+      new UpdateIngestionSourceConfigInput("my test recipe", "0.8.18", "executor id", false)
   );
 
   @Test

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceList.tsx
@@ -261,6 +261,7 @@ export const IngestionSourceList = () => {
                         (recipeBuilderState.config?.executorId?.length &&
                             (recipeBuilderState.config?.executorId as string)) ||
                         DEFAULT_EXECUTOR_ID,
+                    debugMode: recipeBuilderState.config?.debugMode || false,
                 },
                 schedule: recipeBuilderState.schedule && {
                     interval: recipeBuilderState.schedule?.interval as string,

--- a/datahub-web-react/src/app/ingest/source/builder/IngestionSourceBuilderModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/IngestionSourceBuilderModal.tsx
@@ -74,8 +74,6 @@ export const IngestionSourceBuilderModal = ({ initialState, visible, onSubmit, o
     const [modalExpanded, setModalExpanded] = useState(false);
     const [ingestionBuilderState, setIngestionBuilderState] = useState<SourceBuilderState>({});
 
-    console.log('initialState', initialState);
-
     // Reset the ingestion builder modal state when the modal is re-opened.
     const prevInitialState = useRef(initialState);
     useEffect(() => {

--- a/datahub-web-react/src/app/ingest/source/builder/IngestionSourceBuilderModal.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/IngestionSourceBuilderModal.tsx
@@ -74,6 +74,8 @@ export const IngestionSourceBuilderModal = ({ initialState, visible, onSubmit, o
     const [modalExpanded, setModalExpanded] = useState(false);
     const [ingestionBuilderState, setIngestionBuilderState] = useState<SourceBuilderState>({});
 
+    console.log('initialState', initialState);
+
     // Reset the ingestion builder modal state when the modal is re-opened.
     const prevInitialState = useRef(initialState);
     useEffect(() => {

--- a/datahub-web-react/src/app/ingest/source/builder/NameSourceStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/NameSourceStep.tsx
@@ -1,4 +1,4 @@
-import { Button, Collapse, Form, Input, Typography } from 'antd';
+import { Button, Checkbox, Collapse, Form, Input, Typography } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 import { SourceBuilderState, StepProps } from './types';
@@ -39,6 +39,17 @@ export const NameSourceStep = ({ state, updateState, prev, submit }: StepProps) 
             config: {
                 ...state.config,
                 version,
+            },
+        };
+        updateState(newState);
+    };
+
+    const setDebugMode = (debugMode: boolean) => {
+        const newState: SourceBuilderState = {
+            ...state,
+            config: {
+                ...state.config,
+                debugMode,
             },
         };
         updateState(newState);
@@ -90,6 +101,15 @@ export const NameSourceStep = ({ state, updateState, prev, submit }: StepProps) 
                                 placeholder="0.8.42"
                                 value={state.config?.version || ''}
                                 onChange={(event) => setVersion(event.target.value)}
+                            />
+                        </Form.Item>
+                        <Form.Item label={<Typography.Text strong>Debug Mode</Typography.Text>}>
+                            <Typography.Paragraph>
+                                Advanced: Turn on debug mode in order to get more verbose logs.
+                            </Typography.Paragraph>
+                            <Checkbox
+                                checked={state.config?.debugMode || false}
+                                onChange={(event) => setDebugMode(event.target.checked)}
                             />
                         </Form.Item>
                     </Collapse.Panel>

--- a/datahub-web-react/src/app/ingest/source/builder/types.ts
+++ b/datahub-web-react/src/app/ingest/source/builder/types.ts
@@ -77,5 +77,10 @@ export interface SourceBuilderState {
          * Advanced: The version of the DataHub Ingestion Framework to use to perform ingestion
          */
         version?: string | null;
+
+        /**
+         * Advanced: Whether or not to run this ingestion source in debug mode
+         */
+        debugMode?: boolean | null;
     };
 }

--- a/datahub-web-react/src/graphql/ingestion.graphql
+++ b/datahub-web-react/src/graphql/ingestion.graphql
@@ -11,6 +11,7 @@ query listIngestionSources($input: ListIngestionSourcesInput!) {
                 recipe
                 version
                 executorId
+                debugMode
             }
             schedule {
                 interval
@@ -46,6 +47,7 @@ query getIngestionSource($urn: String!, $runStart: Int, $runCount: Int) {
             recipe
             version
             executorId
+            debugMode
         }
         schedule {
             interval

--- a/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
+++ b/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
@@ -283,6 +283,7 @@ public class IngestionScheduler {
     private static final String EXECUTION_REQUEST_SOURCE_NAME = "SCHEDULED_INGESTION_SOURCE";
     private static final String RECIPE_ARGUMENT_NAME = "recipe";
     private static final String VERSION_ARGUMENT_NAME = "version";
+    private static final String DEBUG_MODE_ARG_NAME = "debug_mode";
 
     private final Authentication _systemAuthentication;
     private final EntityClient _entityClient;
@@ -350,6 +351,11 @@ public class IngestionScheduler {
         arguments.put(VERSION_ARGUMENT_NAME, _ingestionSourceInfo.getConfig().hasVersion()
             ? _ingestionSourceInfo.getConfig().getVersion()
             : _ingestionConfiguration.getDefaultCliVersion());
+        String debugMode = "false";
+        if (_ingestionSourceInfo.getConfig().hasDebugMode()) {
+          debugMode = _ingestionSourceInfo.getConfig().isDebugMode() ? "true" : "false";
+        }
+        arguments.put(DEBUG_MODE_ARG_NAME, debugMode);
         input.setArgs(new StringMap(arguments));
 
         proposal.setEntityType(Constants.EXECUTION_REQUEST_ENTITY_NAME);

--- a/metadata-models/src/main/pegasus/com/linkedin/ingestion/DataHubIngestionSourceInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/ingestion/DataHubIngestionSourceInfo.pdl
@@ -51,5 +51,10 @@ record DataHubIngestionSourceInfo {
       * The id of the executor to use to execute the ingestion run
       */
       executorId: optional string
+
+     /**
+      * Whether or not to run this ingestion source in debug mode
+      */
+      debugMode: optional boolean
   }
 }


### PR DESCRIPTION
Adds a checkbox under advanced when creating a UI based ingestion source that allows you to set whether or not you want the source to be in debug_mode and get more fine-grained logging.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)