### PR TITLE
fix(tags) Add creator of tag as the owner of it

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -704,7 +704,7 @@ public class GmsGraphQLEngine {
         builder.type("Mutation", typeWiring -> typeWiring
             .dataFetcher("updateDataset", new MutableTypeResolver<>(datasetType))
             .dataFetcher("updateDatasets", new MutableTypeBatchResolver<>(datasetType))
-            .dataFetcher("createTag", new CreateTagResolver(this.entityClient))
+            .dataFetcher("createTag", new CreateTagResolver(this.entityClient, this.entityService))
             .dataFetcher("updateTag", new MutableTypeResolver<>(tagType))
             .dataFetcher("setTagColor", new SetTagColorResolver(entityClient, entityService))
             .dataFetcher("deleteTag", new DeleteTagResolver(entityClient))

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/CreateTagResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/CreateTagResolverTest.java
@@ -4,6 +4,7 @@ import com.datahub.authentication.Authentication;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.CreateTagInput;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.tag.TagProperties;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.Constants;
@@ -12,6 +13,7 @@ import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletionException;
+
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -30,10 +32,11 @@ public class CreateTagResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     // Create resolver
+    EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockClient.ingestProposal(Mockito.any(MetadataChangeProposal.class), Mockito.any(Authentication.class)))
         .thenReturn(String.format("urn:li:tag:%s", TEST_INPUT.getId()));
-    CreateTagResolver resolver = new CreateTagResolver(mockClient);
+    CreateTagResolver resolver = new CreateTagResolver(mockClient, mockService);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
@@ -65,8 +68,9 @@ public class CreateTagResolverTest {
   @Test
   public void testGetUnauthorized() throws Exception {
     // Create resolver
+    EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    CreateTagResolver resolver = new CreateTagResolver(mockClient);
+    CreateTagResolver resolver = new CreateTagResolver(mockClient, mockService);
 
     // Execute resolver
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
@@ -83,11 +87,12 @@ public class CreateTagResolverTest {
   @Test
   public void testGetEntityClientException() throws Exception {
     // Create resolver
+    EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.doThrow(RuntimeException.class).when(mockClient).ingestProposal(
         Mockito.any(),
         Mockito.any(Authentication.class));
-    CreateTagResolver resolver = new CreateTagResolver(mockClient);
+    CreateTagResolver resolver = new CreateTagResolver(mockClient, mockService);
 
     // Execute resolver
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);


### PR DESCRIPTION
When a user creates a tag, now assign that user as an owner of said tag.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)