### PR TITLE
fix(audit logs) Set actor urn on audit stamp through Java Entity Client

### DIFF
--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -440,7 +440,7 @@ public class JavaEntityClient implements EntityClient {
     public String ingestProposal(@Nonnull MetadataChangeProposal metadataChangeProposal,
         @Nonnull final Authentication authentication) throws RemoteInvocationException {
         final AuditStamp auditStamp =
-            new AuditStamp().setTime(_clock.millis()).setActor(Urn.createFromString(Constants.UNKNOWN_ACTOR));
+            new AuditStamp().setTime(_clock.millis()).setActor(Urn.createFromString(authentication.getActor().toUrnStr()));
         final List<MetadataChangeProposal> additionalChanges =
             AspectUtils.getAdditionalChanges(metadataChangeProposal, _entityService);
 

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -439,8 +439,9 @@ public class JavaEntityClient implements EntityClient {
     @Override
     public String ingestProposal(@Nonnull MetadataChangeProposal metadataChangeProposal,
         @Nonnull final Authentication authentication) throws RemoteInvocationException {
+        String actorUrnStr = authentication.getActor() != null ? authentication.getActor().toUrnStr() : Constants.UNKNOWN_ACTOR;
         final AuditStamp auditStamp =
-            new AuditStamp().setTime(_clock.millis()).setActor(Urn.createFromString(authentication.getActor().toUrnStr()));
+            new AuditStamp().setTime(_clock.millis()).setActor(Urn.createFromString(actorUrnStr));
         final List<MetadataChangeProposal> additionalChanges =
             AspectUtils.getAdditionalChanges(metadataChangeProposal, _entityService);
 


### PR DESCRIPTION
Previously we were simply setting the actor urn to UNKNOWN when making changes to metadata through the Java Entity Client. This now sets the actor urn so we can have correct audit logs in the mysql createdby column.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)