### PR TITLE
feat(docker): Adds JAVA_OPTS to upgrade docker image

### DIFF
--- a/docker/datahub-upgrade/Dockerfile
+++ b/docker/datahub-upgrade/Dockerfile
@@ -44,4 +44,4 @@ FROM ${APP_ENV}-install as final
 RUN addgroup -S datahub && adduser -S datahub -G datahub
 USER datahub
 
-ENTRYPOINT ["java", "-jar", "/datahub/datahub-upgrade/bin/datahub-upgrade.jar"]
+ENTRYPOINT java $JAVA_OPTS -jar /datahub/datahub-upgrade/bin/datahub-upgrade.jar

--- a/docker/datahub-upgrade/README.md
+++ b/docker/datahub-upgrade/README.md
@@ -43,6 +43,8 @@ EBEAN_DATASOURCE_HOST=<your-ebean-host>:3306
 EBEAN_DATASOURCE_URL=jdbc:mysql://<your-ebean-host>:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8
 EBEAN_DATASOURCE_DRIVER=com.mysql.jdbc.Driver
 
+JAVA_OPTS=-Xms100M -Xmx300m
+
 KAFKA_BOOTSTRAP_SERVER=<your-kafka-host>:29092
 KAFKA_SCHEMAREGISTRY_URL=http://<your-kafka-host>:8081
 

--- a/docker/datahub-upgrade/env/docker.env
+++ b/docker/datahub-upgrade/env/docker.env
@@ -4,6 +4,8 @@ EBEAN_DATASOURCE_HOST=mysql:3306
 EBEAN_DATASOURCE_URL=jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8
 EBEAN_DATASOURCE_DRIVER=com.mysql.jdbc.Driver
 
+JAVA_OPTS=-Xms100M -Xmx300m
+
 KAFKA_BOOTSTRAP_SERVER=broker:29092
 KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
 


### PR DESCRIPTION
Adds support for defining the JAVA_OPTS as an environment variable for the `datahub-upgrade` docker image.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)