### PR TITLE
fix(domains): adding 10,000+ text when domain list caps out elastic count capacity

### DIFF
--- a/datahub-web-react/src/app/domain/DomainListItem.tsx
+++ b/datahub-web-react/src/app/domain/DomainListItem.tsx
@@ -8,6 +8,7 @@ import { useEntityRegistry } from '../useEntityRegistry';
 import AvatarsGroup from '../shared/avatar/AvatarsGroup';
 import EntityDropdown from '../entity/shared/EntityDropdown';
 import { EntityMenuItems } from '../entity/shared/EntityDropdown/EntityDropdown';
+import { ELASTIC_MAX_COUNT, getElasticCappedTotalValueText } from '../entity/shared/constants';
 
 const DomainItemContainer = styled(Row)`
     display: flex;
@@ -49,17 +50,12 @@ type Props = {
     onDelete?: () => void;
 };
 
-const ELASTIC_MAX_COUNT = 10000;
-
 export default function DomainListItem({ domain, onDelete }: Props) {
     const entityRegistry = useEntityRegistry();
     const displayName = entityRegistry.getDisplayName(EntityType.Domain, domain);
     const logoIcon = entityRegistry.getIcon(EntityType.Domain, 12, IconStyleType.ACCENT);
     const owners = domain.ownership?.owners;
-    let totalEntitiesText = `${domain.entities?.total || 0}`;
-    if (totalEntitiesText === `${ELASTIC_MAX_COUNT}`) {
-        totalEntitiesText = `${ELASTIC_MAX_COUNT}+`;
-    }
+    let totalEntitiesText = getElasticCappedTotalValueText(domain.entities?.total || 0);
 
     return (
         <List.Item>

--- a/datahub-web-react/src/app/domain/DomainListItem.tsx
+++ b/datahub-web-react/src/app/domain/DomainListItem.tsx
@@ -56,9 +56,9 @@ export default function DomainListItem({ domain, onDelete }: Props) {
     const displayName = entityRegistry.getDisplayName(EntityType.Domain, domain);
     const logoIcon = entityRegistry.getIcon(EntityType.Domain, 12, IconStyleType.ACCENT);
     const owners = domain.ownership?.owners;
-    const totalEntitiesText = `${domain.entities?.total || 0}`;
+    let totalEntitiesText = `${domain.entities?.total || 0}`;
     if (totalEntitiesText === `${ELASTIC_MAX_COUNT}`) {
-        totalEntitiesText === `${ELASTIC_MAX_COUNT}+`;
+        totalEntitiesText = `${ELASTIC_MAX_COUNT}+`;
     }
 
     return (

--- a/datahub-web-react/src/app/domain/DomainListItem.tsx
+++ b/datahub-web-react/src/app/domain/DomainListItem.tsx
@@ -49,12 +49,17 @@ type Props = {
     onDelete?: () => void;
 };
 
+const ELASTIC_MAX_COUNT = 10000;
+
 export default function DomainListItem({ domain, onDelete }: Props) {
     const entityRegistry = useEntityRegistry();
     const displayName = entityRegistry.getDisplayName(EntityType.Domain, domain);
     const logoIcon = entityRegistry.getIcon(EntityType.Domain, 12, IconStyleType.ACCENT);
     const owners = domain.ownership?.owners;
-    const totalEntities = domain.entities?.total;
+    const totalEntitiesText = `${domain.entities?.total || 0}`;
+    if (totalEntitiesText === `${ELASTIC_MAX_COUNT}`) {
+        totalEntitiesText === `${ELASTIC_MAX_COUNT}+`;
+    }
 
     return (
         <List.Item>
@@ -66,8 +71,8 @@ export default function DomainListItem({ domain, onDelete }: Props) {
                             <DomainNameContainer>
                                 <Typography.Text>{displayName}</Typography.Text>
                             </DomainNameContainer>
-                            <Tooltip title={`There are ${totalEntities} entities in this domain.`}>
-                                <Tag>{totalEntities || 0} entities</Tag>
+                            <Tooltip title={`There are ${totalEntitiesText} entities in this domain.`}>
+                                <Tag>{totalEntitiesText} entities</Tag>
                             </Tooltip>
                         </DomainHeaderContainer>
                     </Link>

--- a/datahub-web-react/src/app/domain/DomainListItem.tsx
+++ b/datahub-web-react/src/app/domain/DomainListItem.tsx
@@ -8,7 +8,7 @@ import { useEntityRegistry } from '../useEntityRegistry';
 import AvatarsGroup from '../shared/avatar/AvatarsGroup';
 import EntityDropdown from '../entity/shared/EntityDropdown';
 import { EntityMenuItems } from '../entity/shared/EntityDropdown/EntityDropdown';
-import { ELASTIC_MAX_COUNT, getElasticCappedTotalValueText } from '../entity/shared/constants';
+import { getElasticCappedTotalValueText } from '../entity/shared/constants';
 
 const DomainItemContainer = styled(Row)`
     display: flex;
@@ -55,7 +55,7 @@ export default function DomainListItem({ domain, onDelete }: Props) {
     const displayName = entityRegistry.getDisplayName(EntityType.Domain, domain);
     const logoIcon = entityRegistry.getIcon(EntityType.Domain, 12, IconStyleType.ACCENT);
     const owners = domain.ownership?.owners;
-    let totalEntitiesText = getElasticCappedTotalValueText(domain.entities?.total || 0);
+    const totalEntitiesText = getElasticCappedTotalValueText(domain.entities?.total || 0);
 
     return (
         <List.Item>

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -59,10 +59,10 @@ export const EMPTY_MESSAGES = {
 
 export const ELASTIC_MAX_COUNT = 10000;
 
-export const getElasticCappedTotalValueText(count: number) {
+export const getElasticCappedTotalValueText = (count: number) => {
     if (count === ELASTIC_MAX_COUNT) {
         return `${ELASTIC_MAX_COUNT}+`;
     }
 
     return `${count}`;
-}
+};

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -56,3 +56,13 @@ export const EMPTY_MESSAGES = {
         description: 'Terms can inherit from other terms to represent an "Is A" style relationship.',
     },
 };
+
+export const ELASTIC_MAX_COUNT = 10000;
+
+export const getElasticCappedTotalValueText(count: number) {
+    if (count === ELASTIC_MAX_COUNT) {
+        return `${ELASTIC_MAX_COUNT}+`;
+    }
+
+    return `${count}`;
+}

--- a/datahub-web-react/src/app/identity/group/GroupListItem.tsx
+++ b/datahub-web-react/src/app/identity/group/GroupListItem.tsx
@@ -8,6 +8,7 @@ import CustomAvatar from '../../shared/avatar/CustomAvatar';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import EntityDropdown from '../../entity/shared/EntityDropdown';
 import { EntityMenuItems } from '../../entity/shared/EntityDropdown/EntityDropdown';
+import { getElasticCappedTotalValueText } from '../../entity/shared/constants';
 
 type Props = {
     group: CorpGroup;
@@ -54,7 +55,7 @@ export default function GroupListItem({ group, onDelete }: Props) {
                                 <Typography.Text type="secondary">{group.properties?.description}</Typography.Text>
                             </div>
                         </div>
-                        <Tag>{(group as any).memberCount?.total || 0} members</Tag>
+                        <Tag>{getElasticCappedTotalValueText((group as any).memberCount?.total || 0)} members</Tag>
                     </GroupHeaderContainer>
                 </Link>
                 <GroupItemButtonGroup>


### PR DESCRIPTION
Adds clarity to domain list page for domains that have more than 10,000 elements

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)