### PR TITLE
feat(hooks): Add toggle for enabling/disabling platform event hook

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -81,6 +81,9 @@ public class MetadataChangeLogProcessor {
 
     // Here - plug in additional "custom processor hooks"
     for (MetadataChangeLogHook hook : this.hooks) {
+      if (!hook.isEnabled()) {
+        continue;
+      }
       try (Timer.Context ignored = MetricUtils.timer(this.getClass(), hook.getClass().getSimpleName() + "_latency")
           .time()) {
         hook.invoke(event);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/MetadataChangeLogHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/MetadataChangeLogHook.java
@@ -19,6 +19,13 @@ public interface MetadataChangeLogHook {
   default void init() { }
 
   /**
+   * Return whether the hook is enabled or not. If not enabled, the below invoke method is not triggered
+   */
+  default boolean isEnabled() {
+    return true;
+  }
+
+  /**
    * Invoke the hook when a MetadataChangeLog is received
    */
   void invoke(@Nonnull MetadataChangeLog log) throws Exception;

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHook.java
@@ -35,6 +35,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
@@ -91,17 +92,25 @@ public class EntityChangeEventGeneratorHook implements MetadataChangeLogHook {
   private final EntityClient _entityClient;
   private final Authentication _systemAuthentication;
   private final EntityRegistry _entityRegistry;
+  private final Boolean _isEnabled;
 
   @Autowired
   public EntityChangeEventGeneratorHook(
       @Nonnull final AspectDifferRegistry aspectDifferRegistry,
       @Nonnull final RestliEntityClient entityClient,
       @Nonnull final Authentication systemAuthentication,
-      @Nonnull final EntityRegistry entityRegistry) {
+      @Nonnull final EntityRegistry entityRegistry,
+      @Nonnull @Value("${entityChangeEvents.enabled:true}") Boolean isEnabled) {
     _aspectDifferRegistry = Objects.requireNonNull(aspectDifferRegistry);
     _entityClient = Objects.requireNonNull(entityClient);
     _systemAuthentication = Objects.requireNonNull(systemAuthentication);
     _entityRegistry = Objects.requireNonNull(entityRegistry);
+    _isEnabled = isEnabled;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return _isEnabled;
   }
 
   @Override

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -79,7 +79,8 @@ public class EntityChangeEventGeneratorHookTest {
         differRegistry,
         _mockClient,
         mockAuthentication,
-        createMockEntityRegistry());
+        createMockEntityRegistry(),
+        true);
   }
 
   @Test

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -199,3 +199,6 @@ siblings:
 
 featureFlags:
   showSimplifiedHomepageByDefault: ${SHOW_SIMPLIFIED_HOMEPAGE_BY_DEFAULT:false} # shows a simplified homepage with just datasets, charts and dashboards by default to users. this can be configured in user settings
+
+entityChangeEvents:
+  enabled: ${ENABLE_ENTITY_CHANGE_EVENTS_HOOK:true}


### PR DESCRIPTION
Adds the possibility to skip MCL processor hooks. 
Starts with adding toggle for Entity Change Events.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)