### PR TITLE
feat(inputs): improving clarity on inputs for dashboards

### DIFF
--- a/datahub-web-react/src/app/entity/chart/ChartSnippet.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartSnippet.tsx
@@ -9,12 +9,13 @@ import { getMatchPrioritizingPrimary } from '../shared/utils';
 type Props = {
     matchedFields: MatchedField[];
     inputFields: Maybe<InputFields> | undefined;
+    isMatchingDashboard?: boolean;
 };
 
 const LABEL_INDEX_NAME = 'fieldLabels';
 const TYPE_PROPERTY_KEY_NAME = 'type';
 
-export const ChartSnippet = ({ matchedFields, inputFields }: Props) => {
+export const ChartSnippet = ({ matchedFields, inputFields, isMatchingDashboard = false }: Props) => {
     const matchedField = getMatchPrioritizingPrimary(matchedFields, 'fieldLabels');
 
     if (matchedField?.name === LABEL_INDEX_NAME) {
@@ -36,7 +37,8 @@ export const ChartSnippet = ({ matchedFields, inputFields }: Props) => {
 
             return (
                 <Typography.Text>
-                    Matches {termType} <TagTermGroup uneditableGlossaryTerms={{ terms: [matchedGlossaryTerm] }} />
+                    Matches {termType} <TagTermGroup uneditableGlossaryTerms={{ terms: [matchedGlossaryTerm] }} />{' '}
+                    {isMatchingDashboard && 'on a contained Chart'}
                 </Typography.Text>
             );
         }
@@ -44,7 +46,8 @@ export const ChartSnippet = ({ matchedFields, inputFields }: Props) => {
 
     return matchedField ? (
         <Typography.Text>
-            Matches {FIELDS_TO_HIGHLIGHT.get(matchedField.name)} <b>{matchedField.value}</b>
+            Matches {FIELDS_TO_HIGHLIGHT.get(matchedField.name)} <b>{matchedField.value}</b>{' '}
+            {isMatchingDashboard && 'on a contained Chart'}
         </Typography.Text>
     ) : null;
 };

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -23,7 +23,6 @@ import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domai
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
 import { DashboardStatsSummarySubHeader } from './profile/DashboardStatsSummarySubHeader';
-import { InputFieldsTab } from '../shared/tabs/Entity/InputFieldsTab';
 import { ChartSnippet } from '../chart/ChartSnippet';
 
 /**
@@ -86,16 +85,6 @@ export class DashboardEntity implements Entity<Dashboard> {
                 {
                     name: 'Documentation',
                     component: DocumentationTab,
-                },
-                {
-                    name: 'Fields',
-                    component: InputFieldsTab,
-                    display: {
-                        visible: (_, dashboard: GetDashboardQuery) =>
-                            (dashboard?.dashboard?.inputFields?.fields?.length || 0) > 0,
-                        enabled: (_, dashboard: GetDashboardQuery) =>
-                            (dashboard?.dashboard?.inputFields?.fields?.length || 0) > 0,
-                    },
                 },
                 {
                     name: 'Properties',
@@ -215,7 +204,13 @@ export class DashboardEntity implements Entity<Dashboard> {
                 statsSummary={data.statsSummary}
                 lastUpdatedMs={data.properties?.lastModified?.time}
                 createdMs={data.properties?.created?.time}
-                snippet={<ChartSnippet matchedFields={result.matchedFields} inputFields={data.inputFields} />}
+                snippet={
+                    <ChartSnippet
+                        isMatchingDashboard
+                        matchedFields={result.matchedFields}
+                        inputFields={data.inputFields}
+                    />
+                }
             />
         );
     };


### PR DESCRIPTION
We've received feedback that this inputs tabs can be confusing for dashboards given they are actually the aggregation of all inputs of all charts inside the dashboard. Adding clarity here by updating snippets and hiding the tab on dashboards.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)