### PR TITLE
fix(ingest): remove dbt `delete_tests_as_datasets` option

### DIFF
--- a/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
@@ -1,9 +1,7 @@
 [
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -12,14 +10,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
@@ -37,11 +31,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "stg_customers",
-                        "qualifiedName": null,
                         "description": "",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -57,17 +48,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -77,11 +63,7 @@
                         "fields": [
                             {
                                 "fieldPath": "customer_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -89,19 +71,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "first_name",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -109,19 +83,11 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "last_name",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -129,16 +95,9 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 },
                 {
@@ -147,14 +106,12 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 },
                 {
@@ -167,20 +124,14 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -189,14 +140,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
@@ -214,11 +161,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "stg_payments",
-                        "qualifiedName": null,
                         "description": "",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -234,17 +178,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -254,11 +193,7 @@
                         "fields": [
                             {
                                 "fieldPath": "payment_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -266,19 +201,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "order_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -286,19 +213,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "payment_method",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -306,19 +225,11 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "amount",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -326,16 +237,9 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 },
                 {
@@ -344,14 +248,12 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 },
                 {
@@ -364,20 +266,14 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -386,14 +282,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
@@ -411,11 +303,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "stg_orders",
-                        "qualifiedName": null,
                         "description": "",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -431,17 +320,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -451,11 +335,7 @@
                         "fields": [
                             {
                                 "fieldPath": "order_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -463,19 +343,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "customer_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -483,19 +355,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "order_date",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.DateType": {}
@@ -503,19 +367,11 @@
                                 },
                                 "nativeDataType": "DATE",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "status",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -523,16 +379,9 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 },
                 {
@@ -541,14 +390,12 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 },
                 {
@@ -561,20 +408,14 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -583,14 +424,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
@@ -608,11 +445,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "raw_customers",
-                        "qualifiedName": null,
                         "description": "",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -628,17 +462,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -648,11 +477,7 @@
                         "fields": [
                             {
                                 "fieldPath": "id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -660,19 +485,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "first_name",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -680,19 +497,11 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "last_name",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -700,35 +509,22 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -737,14 +533,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
@@ -762,11 +554,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "raw_orders",
-                        "qualifiedName": null,
                         "description": "",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -782,17 +571,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -802,11 +586,7 @@
                         "fields": [
                             {
                                 "fieldPath": "id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -814,19 +594,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "user_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -834,19 +606,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "order_date",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.DateType": {}
@@ -854,19 +618,11 @@
                                 },
                                 "nativeDataType": "DATE",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "status",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -874,35 +630,22 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -911,14 +654,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
@@ -936,11 +675,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "raw_payments",
-                        "qualifiedName": null,
                         "description": "",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -956,17 +692,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -976,11 +707,7 @@
                         "fields": [
                             {
                                 "fieldPath": "id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -988,19 +715,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "order_id",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1008,19 +727,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "payment_method",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -1028,19 +739,11 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "amount",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1048,35 +751,22 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -1085,14 +775,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
@@ -1110,11 +796,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "customers",
-                        "qualifiedName": null,
                         "description": "This table has basic information about a customer, as well as some derived facts based on a customer's orders",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -1130,17 +813,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -1150,11 +828,8 @@
                         "fields": [
                             {
                                 "fieldPath": "customer_id",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "This is a unique identifier for a customer",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1162,19 +837,12 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "first_name",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Customer's first name. PII.",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -1182,19 +850,12 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "last_name",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Customer's last name. PII.",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -1202,19 +863,12 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "first_order",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Date (UTC) of a customer's first order",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.DateType": {}
@@ -1222,19 +876,12 @@
                                 },
                                 "nativeDataType": "DATE",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "most_recent_order",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Date (UTC) of a customer's most recent order",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.DateType": {}
@@ -1242,19 +889,12 @@
                                 },
                                 "nativeDataType": "DATE",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "number_of_orders",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Count of the number of orders a customer has placed",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1262,19 +902,11 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "customer_lifetime_value",
-                                "jsonPath": null,
                                 "nullable": false,
-                                "description": null,
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1282,16 +914,9 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 },
                 {
@@ -1300,8 +925,7 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
                                 "type": "TRANSFORMED"
@@ -1309,8 +933,7 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
                                 "type": "TRANSFORMED"
@@ -1318,14 +941,12 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 },
                 {
@@ -1338,20 +959,14 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -1360,14 +975,10 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
@@ -1385,11 +996,8 @@
                             "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
                             "catalog_version": "1.1.0"
                         },
-                        "externalUrl": null,
                         "name": "orders",
-                        "qualifiedName": null,
                         "description": "This table has basic information about orders, as well as some derived facts based on payments",
-                        "uri": null,
                         "tags": []
                     }
                 },
@@ -1405,17 +1013,12 @@
                         "version": 0,
                         "created": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         },
-                        "deleted": null,
-                        "dataset": null,
-                        "cluster": null,
                         "hash": "",
                         "platformSchema": {
                             "com.linkedin.pegasus2avro.schema.MySqlDDL": {
@@ -1425,11 +1028,8 @@
                         "fields": [
                             {
                                 "fieldPath": "order_id",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "This is a unique identifier for an order",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1437,19 +1037,12 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "customer_id",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Foreign key to the customers table",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1457,19 +1050,12 @@
                                 },
                                 "nativeDataType": "INT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "order_date",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Date (UTC) that the order was placed",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.DateType": {}
@@ -1477,19 +1063,12 @@
                                 },
                                 "nativeDataType": "DATE",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "status",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Orders can be one of the following statuses:\n\n| status         | description                                                                                                            |\n|----------------|------------------------------------------------------------------------------------------------------------------------|\n| placed         | The order has been placed but has not yet left the warehouse                                                           |\n| shipped        | The order has ben shipped to the customer and is currently in transit                                                  |\n| completed      | The order has been received by the customer                                                                            |\n| return_pending | The customer has indicated that they would like to return the order, but it has not yet been received at the warehouse |\n| returned       | The order has been returned by the customer and received at the warehouse                                              |",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}
@@ -1497,19 +1076,12 @@
                                 },
                                 "nativeDataType": "STRING",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "credit_card_amount",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Amount of the order (AUD) paid for by credit card",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1517,19 +1089,12 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "coupon_amount",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Amount of the order (AUD) paid for by coupon",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1537,19 +1102,12 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "bank_transfer_amount",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Amount of the order (AUD) paid for by bank transfer",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1557,19 +1115,12 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "gift_card_amount",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Amount of the order (AUD) paid for by gift card",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1577,19 +1128,12 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             },
                             {
                                 "fieldPath": "amount",
-                                "jsonPath": null,
                                 "nullable": false,
                                 "description": "Total amount (AUD) of the order",
-                                "created": null,
-                                "lastModified": null,
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -1597,16 +1141,9 @@
                                 },
                                 "nativeDataType": "FLOAT64",
                                 "recursive": false,
-                                "globalTags": null,
-                                "glossaryTerms": null,
-                                "isPartOfKey": false,
-                                "isPartitioningKey": null,
-                                "jsonProps": null
+                                "isPartOfKey": false
                             }
-                        ],
-                        "primaryKeys": null,
-                        "foreignKeysSpecs": null,
-                        "foreignKeys": null
+                        ]
                     }
                 },
                 {
@@ -1615,8 +1152,7 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
                                 "type": "TRANSFORMED"
@@ -1624,14 +1160,12 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 },
                 {
@@ -1644,17 +1178,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
@@ -1665,30 +1194,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_customers,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
@@ -1699,30 +1221,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_payments,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
@@ -1733,30 +1248,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.stg_orders,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
@@ -1767,30 +1275,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_customers,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
@@ -1801,30 +1302,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_orders,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
@@ -1835,30 +1329,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.raw_payments,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD)",
@@ -1869,30 +1356,23 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.customers,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.orders,PROD)",
@@ -1903,33 +1383,25 @@
                             {
                                 "auditStamp": {
                                     "time": 0,
-                                    "actor": "urn:li:corpuser:unknown",
-                                    "impersonator": null
+                                    "actor": "urn:li:corpuser:unknown"
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop.orders,PROD)",
                                 "type": "TRANSFORMED"
                             }
-                        ],
-                        "fineGrainedLineages": null
+                        ]
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1938,17 +1410,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -1957,36 +1424,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.assert_total_payment_amount_is_positive,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1995,17 +1438,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2014,36 +1452,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.unique_stg_customers_customer_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2052,17 +1466,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2071,36 +1480,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_stg_customers_customer_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2109,17 +1494,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2128,36 +1508,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.unique_stg_orders_order_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2166,17 +1522,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2185,36 +1536,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_stg_orders_order_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2223,17 +1550,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2242,36 +1564,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.accepted_values_stg_orders_4f514bf94b77b7ea437830eec4421c58,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2280,17 +1578,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2299,36 +1592,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.unique_stg_payments_payment_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2337,17 +1606,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2356,36 +1620,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_stg_payments_payment_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2394,17 +1634,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2413,36 +1648,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.accepted_values_stg_payments_c7909fb19b1f0177c2bf99c7912f06ef,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2451,17 +1662,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2470,36 +1676,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.unique_customers_customer_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2508,17 +1690,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2527,36 +1704,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_customers_customer_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2565,17 +1718,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2584,36 +1732,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.dbt_expectations_expect_column_24b3791150378f1941309a295b2320de,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2622,17 +1746,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2641,36 +1760,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.dbt_expectations_expect_column_e42202dc29e1149de0f5c3966219796d,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2679,17 +1774,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2698,36 +1788,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.unique_orders_order_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2736,17 +1802,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2755,36 +1816,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_order_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2793,17 +1830,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2812,36 +1844,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_customer_id,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2850,17 +1858,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2869,17 +1872,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2888,36 +1886,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.relationships_orders_customer_id__customer_id__ref_customers_,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2926,17 +1900,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -2945,36 +1914,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.accepted_values_orders_1ce6ab157c285f7cd2ac656013faf758,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -2983,17 +1928,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -3002,36 +1942,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_amount,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -3040,17 +1956,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -3059,36 +1970,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_credit_card_amount,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -3097,17 +1984,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -3116,36 +1998,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.dbt_expectations_expect_column_fdf581b1071168614662824120d65b90,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -3154,17 +2012,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -3173,36 +2026,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_coupon_amount,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -3211,17 +2040,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -3230,36 +2054,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_bank_transfer_amount,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -3268,17 +2068,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
@@ -3287,36 +2082,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,calm-pagoda-323403.jaffle_shop_dbt_test__audit.not_null_orders_gift_card_amount,PROD)",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "value": "{\"removed\": true}",
-        "contentType": "application/json"
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
-    }
-},
-{
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3325,17 +2096,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3344,17 +2110,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3363,17 +2124,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3382,17 +2138,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3401,17 +2152,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3420,17 +2166,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3439,17 +2180,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3458,17 +2194,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3477,17 +2208,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3496,17 +2222,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3515,17 +2236,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3534,17 +2250,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3553,17 +2264,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3572,17 +2278,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3591,17 +2292,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3610,17 +2306,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3629,17 +2320,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3648,17 +2334,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3667,17 +2348,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3686,17 +2362,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3705,17 +2376,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3724,17 +2390,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3743,17 +2404,12 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 },
 {
-    "auditHeader": null,
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3762,10 +2418,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "dbt-2022_02_03-07_00_00"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -557,7 +557,6 @@ def test_dbt_tests(pytestconfig, tmp_path, mock_time, **kwargs):
                         (test_resources_dir / "jaffle_shop_catalog.json").resolve()
                     ),
                     target_platform="postgres",
-                    delete_tests_as_datasets=True,
                     test_results_path=str(
                         (test_resources_dir / "jaffle_shop_test_results.json").resolve()
                     ),
@@ -698,7 +697,6 @@ def test_dbt_tests_only_assertions(pytestconfig, tmp_path, mock_time, **kwargs):
                         (test_resources_dir / "jaffle_shop_catalog.json").resolve()
                     ),
                     target_platform="postgres",
-                    delete_tests_as_datasets=True,
                     test_results_path=str(
                         (test_resources_dir / "jaffle_shop_test_results.json").resolve()
                     ),


### PR DESCRIPTION
This option was added for backwards compat and can be dropped now.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)