### PR TITLE
feat(search): Add support for Elasticsearch object field type

### DIFF
--- a/docs/modeling/extending-the-metadata-model.md
+++ b/docs/modeling/extending-the-metadata-model.md
@@ -323,7 +323,7 @@ It takes the following parameters:
   annotations. To customize the set of analyzers used to index a certain field, you must add a new field type and define
   the set of mappings to be applied in the MappingsBuilder.
 
-  Thus far, we have implemented 9 fieldTypes:
+  Thus far, we have implemented 10 fieldTypes:
 
     1. *KEYWORD* - Short text fields that only support exact matches, often used only for filtering
 
@@ -344,6 +344,10 @@ It takes the following parameters:
     8. *COUNT* - Count fields used for filtering.
   
     9. *DATETIME* - Datetime fields used to represent timestamps.
+
+    10. *OBJECT* - Each property in an object will become an extra column in Elasticsearch and can be referenced as 
+    `field.property` in queries. You should be careful to not use it on objects with many properties as it can cause a
+    mapping explosion in Elasticsearch.
 
 - **fieldName**: string (optional) - The name of the field in search index document. Defaults to the field name where
   the annotation resides.
@@ -388,7 +392,14 @@ Now, when Datahub ingests Dashboards, it will index the Dashboard’s title in E
 Dashboards, that query will be used to search on the title index and matching Dashboards will be returned.
 
 Note, when @Searchable annotation is applied to a map, it will convert it into a list with "key.toString()
-=value.toString()" as elements. This allows us to index map fields, while not increasing the number of columns indexed.
+=value.toString()" as elements. This allows us to index map fields, while not increasing the number of columns indexed. 
+This way, the keys can be queried by `aMapField:key1=value1`.
+
+You can change this behavior by specifying the fieldType as OBJECT in the @Searchable annotation. It will put each key 
+into a column in Elasticsearch instead of an array of serialized kay-value pairs. This way the query would look more 
+like `aMapField.key1:value1`. As this method will increase the number of columns with each unique key - large maps can
+cause a mapping explosion in Elasticsearch. You should *not* use the object fieldType if you expect your maps to get 
+large.
 
 #### @Relationship
 

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/annotation/SearchableAnnotation.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/annotation/SearchableAnnotation.java
@@ -53,7 +53,8 @@ public class SearchableAnnotation {
     URN_PARTIAL,
     BOOLEAN,
     COUNT,
-    DATETIME
+    DATETIME,
+    OBJECT
   }
 
   @Nonnull

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/EntitySpecBuilderTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/EntitySpecBuilderTest.java
@@ -138,7 +138,7 @@ public class EntitySpecBuilderTest {
     assertEquals(new TestEntityInfo().schema().getFullName(), testEntityInfo.getPegasusSchema().getFullName());
 
     // Assert on Searchable Fields
-    assertEquals(8, testEntityInfo.getSearchableFieldSpecs().size());
+    assertEquals(9, testEntityInfo.getSearchableFieldSpecs().size());
     assertEquals("customProperties", testEntityInfo.getSearchableFieldSpecMap().get(
         new PathSpec("customProperties").toString()).getSearchableAnnotation().getFieldName());
     assertEquals(SearchableAnnotation.FieldType.KEYWORD, testEntityInfo.getSearchableFieldSpecMap().get(
@@ -170,6 +170,11 @@ public class EntitySpecBuilderTest {
         .getSearchableAnnotation().getFieldName());
     assertEquals(SearchableAnnotation.FieldType.TEXT, testEntityInfo.getSearchableFieldSpecMap().get(
         new PathSpec("nestedRecordArrayField", "*", "nestedArrayArrayField", "*").toString())
+        .getSearchableAnnotation().getFieldType());
+    assertEquals("esObjectField", testEntityInfo.getSearchableFieldSpecMap().get(
+        new PathSpec("esObjectField").toString()).getSearchableAnnotation().getFieldName());
+    assertEquals(SearchableAnnotation.FieldType.OBJECT, testEntityInfo.getSearchableFieldSpecMap().get(
+            new PathSpec("esObjectField").toString())
         .getSearchableAnnotation().getFieldType());
 
     // Assert on Relationship Fields

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilder.java
@@ -82,6 +82,8 @@ public class MappingsBuilder {
       mappingForField.put("type", "long");
     } else if (fieldType == FieldType.DATETIME) {
       mappingForField.put("type", "date");
+    } else if (fieldType == FieldType.OBJECT) {
+      mappingForField.put("type", "object");
     } else {
       log.info("FieldType {} has no mappings implemented", fieldType);
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/TestEntityUtil.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/TestEntityUtil.java
@@ -41,6 +41,7 @@ public class TestEntityUtil {
             new SimpleNestedRecord2().setNestedArrayStringField("nestedArray2")
                 .setNestedArrayArrayField(new StringArray(ImmutableList.of("testNestedArray1", "testNestedArray2"))))));
     testEntityInfo.setCustomProperties(new StringMap(ImmutableMap.of("key1", "value1", "key2", "value2")));
+    testEntityInfo.setEsObjectField(new StringMap(ImmutableMap.of("key1", "value1", "key2", "value2")));
     return testEntityInfo;
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/extractor/FieldExtractorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/extractor/FieldExtractorTest.java
@@ -45,5 +45,6 @@ public class FieldExtractorTest {
     assertEquals(result.get(nameToSpec.get("nestedArrayStringField")), ImmutableList.of("nestedArray1", "nestedArray2"));
     assertEquals(result.get(nameToSpec.get("nestedArrayArrayField")), ImmutableList.of("testNestedArray1", "testNestedArray2"));
     assertEquals(result.get(nameToSpec.get("customProperties")), ImmutableList.of("key1=value1", "key2=value2"));
+    assertEquals(result.get(nameToSpec.get("esObjectField")), ImmutableList.of("key1=value1", "key2=value2"));
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilderTest.java
@@ -16,7 +16,7 @@ public class MappingsBuilderTest {
     Map<String, Object> result = MappingsBuilder.getMappings(TestEntitySpecBuilder.getSpec());
     assertEquals(result.size(), 1);
     Map<String, Object> properties = (Map<String, Object>) result.get("properties");
-    assertEquals(properties.size(), 15);
+    assertEquals(properties.size(), 16);
     assertEquals(properties.get("urn"), ImmutableMap.of("type", "keyword"));
     assertEquals(properties.get("runId"), ImmutableMap.of("type", "keyword"));
     assertTrue(properties.containsKey("browsePaths"));
@@ -84,6 +84,10 @@ public class MappingsBuilderTest {
     assertEquals(nestedForeignKeySubfields.size(), 2);
     assertTrue(nestedForeignKeySubfields.containsKey("keyword"));
     assertTrue(nestedForeignKeySubfields.containsKey("ngram"));
+
+    // OBJECT
+    Map<String, Object> esObjectField = (Map<String, Object>) properties.get("esObjectField");
+    assertEquals(esObjectField.get("type"), "object");
 
     // Scores
     Map<String, Object> feature1 = (Map<String, Object>) properties.get("feature1");

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilderTest.java
@@ -88,6 +88,7 @@ public class MappingsBuilderTest {
     // OBJECT
     Map<String, Object> esObjectField = (Map<String, Object>) properties.get("esObjectField");
     assertEquals(esObjectField.get("type"), "object");
+    assertEquals(customPropertiesField.get("normalizer"), "keyword_normalizer");
 
     // Scores
     Map<String, Object> feature1 = (Map<String, Object>) properties.get("feature1");

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchQueryBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchQueryBuilderTest.java
@@ -25,11 +25,12 @@ public class SearchQueryBuilderTest {
     assertEquals(keywordQuery.queryString(), "testQuery");
     assertEquals(keywordQuery.analyzer(), "custom_keyword");
     Map<String, Float> keywordFields = keywordQuery.fields();
-    assertEquals(keywordFields.size(), 8);
+    assertEquals(keywordFields.size(), 9);
     assertEquals(keywordFields.get("keyPart1").floatValue(), 10.0f);
     assertFalse(keywordFields.containsKey("keyPart3"));
     assertEquals(keywordFields.get("textFieldOverride").floatValue(), 1.0f);
     assertEquals(keywordFields.get("customProperties").floatValue(), 1.0f);
+    assertEquals(keywordFields.get("esObjectField").floatValue(), 1.0f);
     QueryStringQueryBuilder textQuery = (QueryStringQueryBuilder) shouldQueries.get(1);
     assertEquals(textQuery.queryString(), "testQuery");
     assertEquals(textQuery.analyzer(), "word_delimited");

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandlerTest.java
@@ -42,10 +42,10 @@ public class SearchRequestHandlerTest {
     HighlightBuilder highlightBuilder = sourceBuilder.highlighter();
     List<String> fields =
         highlightBuilder.fields().stream().map(HighlightBuilder.Field::name).collect(Collectors.toList());
-    assertEquals(fields.size(), 16);
+    assertEquals(fields.size(), 18);
     List<String> highlightableFields =
         ImmutableList.of("keyPart1", "textArrayField", "textFieldOverride", "foreignKey", "nestedForeignKey",
-            "nestedArrayStringField", "nestedArrayArrayField", "customProperties");
+            "nestedArrayStringField", "nestedArrayArrayField", "customProperties", "esObjectField");
     highlightableFields.forEach(field -> {
       assertTrue(fields.contains(field));
       assertTrue(fields.contains(field + ".*"));
@@ -91,7 +91,7 @@ public class SearchRequestHandlerTest {
             .filter(match -> match.fieldName().equals("removed"))
             .findAny();
 
-    assertTrue(mustNotHaveRemovedCondition.isPresent(), "Expected must not have removed condition to exist" 
+    assertTrue(mustNotHaveRemovedCondition.isPresent(), "Expected must not have removed condition to exist"
             + " if filter does not have it");
 
     final Filter filterWithRemovedCondition = new Filter().setOr(
@@ -118,7 +118,7 @@ public class SearchRequestHandlerTest {
             .filter(match -> match.fieldName().equals("removed"))
             .findAny();
 
-    assertFalse(mustNotHaveRemovedCondition.isPresent(), "Expect `must not have removed` condition to not" 
+    assertFalse(mustNotHaveRemovedCondition.isPresent(), "Expect `must not have removed` condition to not"
             + " exist because filter already has it a condition for the removed property");
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
@@ -22,7 +22,7 @@ public class SearchDocumentTransformerTest {
 
   @Test
   public void testTransform() throws IOException {
-    SearchDocumentTransformer searchDocumentTransformer = new SearchDocumentTransformer(1000);
+    SearchDocumentTransformer searchDocumentTransformer = new SearchDocumentTransformer(1000, 1000);
     TestEntitySnapshot snapshot = TestEntityUtil.getSnapshot();
     EntitySpec testEntitySpec = TestEntitySpecBuilder.getSpec();
     Optional<String> result = searchDocumentTransformer.transformSnapshot(snapshot, testEntitySpec, false);
@@ -54,7 +54,7 @@ public class SearchDocumentTransformerTest {
 
   @Test
   public void testTransformForDelete() throws IOException {
-    SearchDocumentTransformer searchDocumentTransformer = new SearchDocumentTransformer(1000);
+    SearchDocumentTransformer searchDocumentTransformer = new SearchDocumentTransformer(1000, 1000);
     TestEntitySnapshot snapshot = TestEntityUtil.getSnapshot();
     EntitySpec testEntitySpec = TestEntitySpecBuilder.getSpec();
     Optional<String> result = searchDocumentTransformer.transformSnapshot(snapshot, testEntitySpec, true);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchDocumentTransformerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchDocumentTransformerFactory.java
@@ -14,8 +14,11 @@ public class SearchDocumentTransformerFactory {
   @Value("${elasticsearch.index.maxArrayLength}")
   private int maxArrayLength;
 
+  @Value("${elasticsearch.index.maxObjectKeys}")
+  private int maxObjectKeys;
+
   @Bean("searchDocumentTransformer")
   protected SearchDocumentTransformer getInstance() {
-    return new SearchDocumentTransformer(maxArrayLength);
+    return new SearchDocumentTransformer(maxArrayLength, maxObjectKeys);
   }
 }

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -150,6 +150,7 @@ elasticsearch:
     numReplicas: ${ELASTICSEARCH_NUM_REPLICAS_PER_INDEX:1}
     numRetries: ${ELASTICSEARCH_INDEX_BUILDER_NUM_RETRIES:3}
     maxArrayLength: ${SEARCH_DOCUMENT_MAX_ARRAY_LENGTH:1000}
+    maxObjectKeys: ${SEARCH_DOCUMENT_MAX_OBJECT_KEYS:1000}
     mainTokenizer: ${ELASTICSEARCH_MAIN_TOKENIZER:#{null}}
 
 # TODO: Kafka topic convention

--- a/test-models/src/main/pegasus/com/datahub/test/TestEntityInfo.pdl
+++ b/test-models/src/main/pegasus/com/datahub/test/TestEntityInfo.pdl
@@ -75,4 +75,13 @@ record TestEntityInfo includes CustomProperties {
     }
     nestedArrayArrayField: optional array[string]
   }]
+
+  @Searchable = {
+    "/*": {
+      "name": "esObjectField",
+      "fieldType": "OBJECT",
+      "addToFilters": true
+    }
+  }
+  esObjectField: optional map[string, string]
 }

--- a/test-models/src/main/pegasus/com/datahub/test/TestEntityInfo.pdl
+++ b/test-models/src/main/pegasus/com/datahub/test/TestEntityInfo.pdl
@@ -80,7 +80,7 @@ record TestEntityInfo includes CustomProperties {
     "/*": {
       "name": "esObjectField",
       "fieldType": "OBJECT",
-      "addToFilters": true
+      "queryByDefault": true
     }
   }
   esObjectField: optional map[string, string]


### PR DESCRIPTION
This change will add support for object field type through `@Searchable` annotations. 

As large number of keys on an object field type would create equally large number of columns in the index - I've also added a setting `elasticsearch.index.maxObjectKeys` to limit how many keys can be indexed.