### PR TITLE
feat(ingest): make sink use type annotations

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/sink/console.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/console.py
@@ -1,26 +1,13 @@
-import dataclasses
 import logging
 
+from datahub.configuration.common import ConfigModel
 from datahub.ingestion.api.common import RecordEnvelope
 from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
 
 logger = logging.getLogger(__name__)
 
 
-@dataclasses.dataclass
-class ConsoleSink(Sink):
-    report: SinkReport = dataclasses.field(default_factory=SinkReport)
-
-    @classmethod
-    def create(cls, config_dict, ctx):
-        return cls(ctx)
-
-    def handle_work_unit_start(self, wu):
-        pass
-
-    def handle_work_unit_end(self, wu):
-        pass
-
+class ConsoleSink(Sink[ConfigModel, SinkReport]):
     def write_record_async(
         self, record_envelope: RecordEnvelope, write_callback: WriteCallback
     ) -> None:
@@ -28,9 +15,3 @@ class ConsoleSink(Sink):
         if write_callback:
             self.report.report_record_written(record_envelope)
             write_callback.on_success(record_envelope, {})
-
-    def get_report(self):
-        return self.report
-
-    def close(self):
-        pass

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -15,7 +15,7 @@ from datahub.cli.cli_utils import set_env_variables_override_config
 from datahub.configuration.common import ConfigurationError, OperationalError
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter
-from datahub.ingestion.api.common import PipelineContext, RecordEnvelope, WorkUnit
+from datahub.ingestion.api.common import RecordEnvelope, WorkUnit
 from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.graph.client import DatahubClientConfig
@@ -87,17 +87,11 @@ class BoundedExecutor:
         self.executor.shutdown(wait)
 
 
-@dataclass
-class DatahubRestSink(Sink):
-    config: DatahubRestSinkConfig
+class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
     emitter: DatahubRestEmitter
-    report: DataHubRestSinkReport
     treat_errors_as_warnings: bool = False
 
-    def __init__(self, ctx: PipelineContext, config: DatahubRestSinkConfig):
-        super().__init__(ctx)
-        self.config = config
-        self.report = DataHubRestSinkReport()
+    def __post_init__(self) -> None:
         self.emitter = DatahubRestEmitter(
             self.config.server,
             self.config.token,
@@ -130,11 +124,6 @@ class DatahubRestSink(Sink):
             max_workers=self.config.max_threads,
             bound=self.config.max_pending_requests,
         )
-
-    @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "DatahubRestSink":
-        config = DatahubRestSinkConfig.parse_obj(config_dict)
-        return cls(ctx, config)
 
     def handle_work_unit_start(self, workunit: WorkUnit) -> None:
         if isinstance(workunit, MetadataWorkUnit):
@@ -222,9 +211,6 @@ class DatahubRestSink(Sink):
             except Exception as e:
                 write_callback.on_failure(record_envelope, e, failure_metadata={})
 
-    def get_report(self) -> SinkReport:
-        return self.report
-
     def close(self):
         self.executor.shutdown(wait=True)
 
@@ -232,4 +218,4 @@ class DatahubRestSink(Sink):
         return self.emitter.__repr__()
 
     def configured(self) -> str:
-        return self.__repr__()
+        return repr(self)

--- a/metadata-ingestion/src/datahub/ingestion/sink/file.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/file.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from datahub.configuration.common import ConfigModel
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
+from datahub.ingestion.api.common import RecordEnvelope
 from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
     MetadataChangeEvent,
@@ -20,30 +20,12 @@ class FileSinkConfig(ConfigModel):
     filename: str
 
 
-class FileSink(Sink):
-    config: FileSinkConfig
-    report: SinkReport
-
-    def __init__(self, ctx: PipelineContext, config: FileSinkConfig):
-        super().__init__(ctx)
-        self.config = config
-        self.report = SinkReport()
-
+class FileSink(Sink[FileSinkConfig, SinkReport]):
+    def __post_init__(self) -> None:
         fpath = pathlib.Path(self.config.filename)
         self.file = fpath.open("w")
         self.file.write("[\n")
         self.wrote_something = False
-
-    @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "FileSink":
-        config = FileSinkConfig.parse_obj(config_dict)
-        return cls(ctx, config)
-
-    def handle_work_unit_start(self, wu):
-        self.id = wu.id
-
-    def handle_work_unit_end(self, wu):
-        pass
 
     def write_record_async(
         self,
@@ -68,9 +50,6 @@ class FileSink(Sink):
 
         self.report.report_record_written(record_envelope)
         write_callback.on_success(record_envelope, {})
-
-    def get_report(self):
-        return self.report
 
     def close(self):
         self.file.write("\n]")

--- a/metadata-ingestion/src/datahub/ingestion/sink/sink_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/sink_registry.py
@@ -1,7 +1,15 @@
+from typing import Type
+
 from datahub.ingestion.api.registry import PluginRegistry
 from datahub.ingestion.api.sink import Sink
 
-sink_registry = PluginRegistry[Sink]()
+
+def _check_sink_classes(cls: Type[Sink]) -> None:
+    assert cls.get_config_class()
+    assert cls.get_report_class()
+
+
+sink_registry = PluginRegistry[Sink](extra_cls_check=_check_sink_classes)
 sink_registry.register_from_entrypoint("datahub.ingestion.sink.plugins")
 
 # These sinks are always enabled

--- a/metadata-ingestion/src/datahub/ingestion/sink/sink_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/sink_registry.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Type
 
 from datahub.ingestion.api.registry import PluginRegistry
@@ -5,6 +6,7 @@ from datahub.ingestion.api.sink import Sink
 
 
 def _check_sink_classes(cls: Type[Sink]) -> None:
+    assert not dataclasses.is_dataclass(cls), f"Sink {cls} is a dataclass"
     assert cls.get_config_class()
     assert cls.get_report_class()
 

--- a/metadata-ingestion/tests/test_helpers/sink_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/sink_helpers.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from datahub.ingestion.api.common import RecordEnvelope, WorkUnit
+from datahub.configuration.common import ConfigModel
+from datahub.ingestion.api.common import RecordEnvelope
 from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
-from datahub.ingestion.run.pipeline import PipelineContext
 
 
 class RecordingSinkReport(SinkReport):
@@ -13,28 +13,9 @@ class RecordingSinkReport(SinkReport):
         self.received_records.append(record_envelope)
 
 
-class RecordingSink(Sink):
-    def __init__(self):
-        self.sink_report = RecordingSinkReport()
-
-    @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "Sink":
-        return cls()
-
-    def handle_work_unit_start(self, workunit: WorkUnit) -> None:
-        pass
-
-    def handle_work_unit_end(self, workunit: WorkUnit) -> None:
-        pass
-
+class RecordingSink(Sink[ConfigModel, RecordingSinkReport]):
     def write_record_async(
         self, record_envelope: RecordEnvelope, callback: WriteCallback
     ) -> None:
-        self.sink_report.report_record_written(record_envelope)
+        self.report.report_record_written(record_envelope)
         callback.on_success(record_envelope, {})
-
-    def get_report(self) -> SinkReport:
-        return self.sink_report
-
-    def close(self) -> None:
-        pass

--- a/metadata-ingestion/tests/unit/test_kafka_sink.py
+++ b/metadata-ingestion/tests/unit/test_kafka_sink.py
@@ -16,7 +16,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
 
 
 class KafkaSinkTest(unittest.TestCase):
-    @patch("datahub.ingestion.sink.datahub_kafka.PipelineContext", autospec=True)
+    @patch("datahub.ingestion.api.sink.PipelineContext", autospec=True)
     @patch("datahub.emitter.kafka_emitter.SerializingProducer", autospec=True)
     def test_kafka_sink_config(self, mock_producer, mock_context):
         kafka_sink = DatahubKafkaSink.create(
@@ -59,7 +59,7 @@ class KafkaSinkTest(unittest.TestCase):
         kafka_sink.close()
         assert mock_producer.call_count == 2  # constructor should be called
 
-    @patch("datahub.ingestion.sink.datahub_kafka.PipelineContext", autospec=True)
+    @patch("datahub.ingestion.api.sink.PipelineContext", autospec=True)
     @patch("datahub.emitter.kafka_emitter.SerializingProducer", autospec=True)
     @patch("datahub.ingestion.sink.datahub_kafka._KafkaCallback", autospec=True)
     def test_kafka_sink_write(self, mock_k_callback, mock_producer, mock_context):
@@ -102,7 +102,7 @@ class KafkaSinkTest(unittest.TestCase):
 
     # TODO: Test that kafka producer is configured correctly
 
-    @patch("datahub.ingestion.sink.datahub_kafka.PipelineContext", autospec=True)
+    @patch("datahub.ingestion.api.sink.PipelineContext", autospec=True)
     @patch("datahub.emitter.kafka_emitter.SerializingProducer", autospec=True)
     def test_kafka_sink_close(self, mock_producer, mock_context):
         mock_producer_instance = mock_producer.return_value


### PR DESCRIPTION
Overall this should reduce the amount of code required to define a sink type.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)