### PR TITLE
fix(transformer): fix invalid lastModified.actor entry in transformers

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -103,7 +103,7 @@ class AddDatasetOwnership(DatasetOwnershipTransformer):
             owners=[],
             lastModified=in_ownership_aspect.lastModified
             if in_ownership_aspect is not None
-            else AuditStampClass.construct_with_defaults(),
+            else None,
         )
 
         # Check if user want to keep existing ownerships

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -15,7 +15,6 @@ from datahub.ingestion.transformer.dataset_transformer import (
     DatasetOwnershipTransformer,
 )
 from datahub.metadata.schema_classes import (
-    AuditStampClass,
     OwnerClass,
     OwnershipClass,
     OwnershipTypeClass,

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_terms.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_schema_terms.py
@@ -80,7 +80,9 @@ class AddDatasetSchemaTerms(DatasetSchemaMetadataTransformer):
             terms=[],
             auditStamp=schema_field.glossaryTerms.auditStamp
             if schema_field.glossaryTerms is not None
-            else AuditStampClass.construct_with_defaults(),
+            else AuditStampClass(
+                time=builder.get_sys_time(), actor="urn:li:corpUser:restEmitter"
+            ),
         )
         new_glossary_term.terms.extend(terms_to_add)
         new_glossary_term.terms.extend(server_terms)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_terms.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_terms.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Callable, List, Optional, Union, cast
 
+import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import (
     KeyValuePattern,
     TransformerSemantics,
@@ -91,7 +92,9 @@ class AddDatasetTerms(DatasetTermsTransformer):
             terms=[],
             auditStamp=in_glossary_terms.auditStamp
             if in_glossary_terms is not None
-            else AuditStampClass.construct_with_defaults(),
+            else AuditStampClass(
+                time=builder.get_sys_time(), actor="urn:li:corpUser:restEmitter"
+            ),
         )
         # Check if user want to keep existing terms
         if in_glossary_terms is not None and self.config.replace_existing is False:


### PR DESCRIPTION
Usage of `AuditStampClass.construct_with_defaults()` introduced in this [commit](https://github.com/datahub-project/datahub/commit/2f65e2f226123ab115c8960922213f631d9c001e) create AuditStamp with empty string actor urn, leading to invalid record. Reverting to auditStamp entry, that was used earlier.
Issue was reported on [Slack](https://datahubspace.slack.com/archives/C029A3M079U/p1662968709729969)


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)