### PR TITLE
docs: datahub_conn_id => conn_id in Airflow Integration

### DIFF
--- a/docs/lineage/airflow.md
+++ b/docs/lineage/airflow.md
@@ -44,7 +44,7 @@ We recommend you use the lineage plugin if you are on Airflow version >= 2.0.2 o
 
     |Name   | Default value   | Description   |
     |---|---|---|
-    | datahub.datahub_conn_id | datahub_rest_default  | The name of the datahub connection you set in step 1.  |
+    | datahub.conn_id | datahub_rest_default  | The name of the datahub connection you set in step 1.  |
     | datahub.cluster |  prod | name of the airflow cluster  |
     | datahub.capture_ownership_info | true  |  If true, the owners field of the DAG will be capture as a DataHub corpuser.   |
     | datahub.capture_tags_info  | true   | If true, the tags field of the DAG will be captured as DataHub tags.  |


### PR DESCRIPTION
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

I read airflow integration(https://datahubproject.io/docs/lineage/airflow/#using-datahubs-airflow-lineage-plugin-new), and found that `datahub_conn_id` should be changed to `conn_id`.
I add some conversation with @treff7es in Slack (https://datahubspace.slack.com/archives/C029A3M079U/p1663069150243549?thread_ts=1662611232.747409&cid=C029A3M079U)

This is my first contribution..!
If something is wrong, plz let me know!
Thank you.