### PR TITLE
fix(ci): process older issues first

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          ascending: true
           days-before-issue-stale: 30
           days-before-issue-close: 30
           stale-issue-label: "stale"

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/stale@v5
         with:
           ascending: true
+          operations-per-run: 100
           days-before-issue-stale: 30
           days-before-issue-close: 30
           stale-issue-label: "stale"


### PR DESCRIPTION
We are not processing older issues because of some limits https://github.com/actions/stale#operations-per-run. It makes more sense to process in ascending order so older things are processed first.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)