### PR TITLE
fix(ui) Make LookML deploy key a textarea and format key

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/FormField.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/FormField.tsx
@@ -100,7 +100,9 @@ function FormField(props: Props) {
     if (field.type === FieldType.DICT) return <DictField field={field} />;
 
     const isBoolean = field.type === FieldType.BOOLEAN;
-    const input = isBoolean ? <Checkbox /> : <Input placeholder={field.placeholder} />;
+    let input = <Input placeholder={field.placeholder} />;
+    if (isBoolean) input = <Checkbox />;
+    if (field.type === FieldType.TEXTAREA) input = <Input.TextArea placeholder={field.placeholder} />;
     const valuePropName = isBoolean ? 'checked' : 'value';
     const getValueFromEvent = isBoolean ? undefined : (e) => (e.target.value === '' ? null : e.target.value);
 

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
@@ -8,6 +8,7 @@ export enum FieldType {
     SELECT,
     SECRET,
     DICT,
+    TEXTAREA,
 }
 
 interface Option {

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/lookml.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/lookml.tsx
@@ -24,14 +24,19 @@ export const LOOKML_GITHUB_INFO_REPO: RecipeField = {
     rules: [{ required: true, message: 'Github Repo is required' }],
 };
 
+const deployKeyFieldPath = 'source.config.github_info.deploy_key';
 export const DEPLOY_KEY: RecipeField = {
     name: 'github_info.deploy_key',
     label: 'GitHub Deploy Key',
     tooltip: 'The SSH private key that has been provisioned for read access on the GitHub repository.',
-    type: FieldType.SECRET,
+    type: FieldType.TEXTAREA,
     fieldPath: 'source.config.github_info.deploy_key',
-    placeholder: 'DEPLOY_KEY',
+    placeholder: '-----BEGIN OPENSSH PRIVATE KEY-----\n...',
     rules: [{ required: true, message: 'Github Deploy Key is required' }],
+    setValueOnRecipeOverride: (recipe: any, value: string) => {
+        const valueWithNewLine = `${value}\n`;
+        return setFieldValueOnRecipe(recipe, valueWithNewLine, deployKeyFieldPath);
+    },
 };
 
 function validateApiSection(getFieldValue, fieldName) {


### PR DESCRIPTION
Secrets do not work with ssh keys right now. Instead, let's allow them to paste the key in this text area to set on the recipe. I auto add a new line for them to format properly.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)