### PR TITLE
feat(ingestion-ui) Use CLI version defined in recipe for test connection

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
@@ -74,6 +74,9 @@ public class CreateTestConnectionRequestResolver implements DataFetcher<Completa
 
         Map<String, String> arguments = new HashMap<>();
         arguments.put(RECIPE_ARG_NAME, input.getRecipe());
+        if (input.getVersion() != null) {
+          arguments.put(VERSION_ARG_NAME, input.getVersion());
+        }
         execInput.setArgs(new StringMap(arguments));
 
         proposal.setEntityType(Constants.EXECUTION_REQUEST_ENTITY_NAME);

--- a/datahub-graphql-core/src/main/resources/ingestion.graphql
+++ b/datahub-graphql-core/src/main/resources/ingestion.graphql
@@ -207,6 +207,11 @@ input CreateTestConnectionRequestInput {
   A JSON-encoded recipe
   """
   recipe: String!
+
+  """
+  Advanced: The version of the ingestion framework to use
+  """
+  version: String
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolverTest.java
@@ -17,7 +17,8 @@ import static org.testng.Assert.*;
 public class CreateTestConnectionRequestResolverTest {
 
   private static final CreateTestConnectionRequestInput TEST_INPUT = new CreateTestConnectionRequestInput(
-      "test recipe"
+      "test recipe",
+      "0.8.44"
   );
 
   @Test

--- a/datahub-web-react/src/app/ingest/source/builder/DefineRecipeStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/DefineRecipeStep.tsx
@@ -88,7 +88,7 @@ export const DefineRecipeStep = ({ state, updateState, goTo, prev, ingestionSour
     if (type && CONNECTORS_WITH_FORM.has(type)) {
         return (
             <RecipeBuilder
-                type={type}
+                state={state}
                 isEditing={isEditing}
                 displayRecipe={displayRecipe}
                 sourceConfigs={sourceConfigs}

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeBuilder.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeBuilder.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components/macro';
 import { ANTD_GRAY } from '../../../entity/shared/constants';
 import { YamlEditor } from './YamlEditor';
 import RecipeForm from './RecipeForm/RecipeForm';
-import { SourceConfig } from './types';
+import { SourceBuilderState, SourceConfig } from './types';
 
 export const ControlsContainer = styled.div`
     display: flex;
@@ -39,7 +39,7 @@ const ButtonsWrapper = styled.div`
 `;
 
 interface Props {
-    type: string;
+    state: SourceBuilderState;
     isEditing: boolean;
     displayRecipe: string;
     sourceConfigs?: SourceConfig;
@@ -49,7 +49,7 @@ interface Props {
 }
 
 function RecipeBuilder(props: Props) {
-    const { type, isEditing, displayRecipe, sourceConfigs, setStagedRecipe, onClickNext, goToPrevious } = props;
+    const { state, isEditing, displayRecipe, sourceConfigs, setStagedRecipe, onClickNext, goToPrevious } = props;
 
     const [isViewingForm, setIsViewingForm] = useState(true);
 
@@ -77,7 +77,7 @@ function RecipeBuilder(props: Props) {
             </ButtonsWrapper>
             {isViewingForm && (
                 <RecipeForm
-                    type={type}
+                    state={state}
                     isEditing={isEditing}
                     displayRecipe={displayRecipe}
                     sourceConfigs={sourceConfigs}

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/RecipeForm.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/RecipeForm.tsx
@@ -10,7 +10,7 @@ import FormField from './FormField';
 import TestConnectionButton from './TestConnection/TestConnectionButton';
 import { useListSecretsQuery } from '../../../../../graphql/ingestion.generated';
 import { RecipeField, setFieldValueOnRecipe } from './common';
-import { SourceConfig } from '../types';
+import { SourceBuilderState, SourceConfig } from '../types';
 
 export const ControlsContainer = styled.div`
     display: flex;
@@ -89,7 +89,7 @@ function shouldRenderFilterSectionHeader(field: RecipeField, index: number, filt
 }
 
 interface Props {
-    type: string;
+    state: SourceBuilderState;
     isEditing: boolean;
     displayRecipe: string;
     sourceConfigs?: SourceConfig;
@@ -99,9 +99,11 @@ interface Props {
 }
 
 function RecipeForm(props: Props) {
-    const { type, isEditing, displayRecipe, sourceConfigs, setStagedRecipe, onClickNext, goToPrevious } = props;
+    const { state, isEditing, displayRecipe, sourceConfigs, setStagedRecipe, onClickNext, goToPrevious } = props;
+    const { type } = state;
+    const version = state.config?.version;
     const { fields, advancedFields, filterFields, filterSectionTooltip, advancedSectionTooltip, defaultOpenSections } =
-        RECIPE_FIELDS[type];
+        RECIPE_FIELDS[type as string];
     const allFields = [...fields, ...advancedFields, ...filterFields];
     const { data, refetch: refetchSecrets } = useListSecretsQuery({
         variables: {
@@ -147,9 +149,13 @@ function RecipeForm(props: Props) {
                             removeMargin={i === fields.length - 1}
                         />
                     ))}
-                    {CONNECTORS_WITH_TEST_CONNECTION.has(type) && (
+                    {CONNECTORS_WITH_TEST_CONNECTION.has(type as string) && (
                         <TestConnectionWrapper>
-                            <TestConnectionButton recipe={displayRecipe} sourceConfigs={sourceConfigs} />
+                            <TestConnectionButton
+                                recipe={displayRecipe}
+                                sourceConfigs={sourceConfigs}
+                                version={version}
+                            />
                         </TestConnectionWrapper>
                     )}
                 </Collapse.Panel>

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/TestConnection/TestConnectionButton.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/TestConnection/TestConnectionButton.tsx
@@ -29,10 +29,11 @@ export function getRecipeJson(recipeYaml: string) {
 interface Props {
     recipe: string;
     sourceConfigs?: SourceConfig;
+    version?: string | null;
 }
 
 function TestConnectionButton(props: Props) {
-    const { recipe, sourceConfigs } = props;
+    const { recipe, sourceConfigs, version } = props;
     const [isLoading, setIsLoading] = useState(false);
     const [isModalVisible, setIsModalVisible] = useState(false);
     const [pollingInterval, setPollingInterval] = useState<null | NodeJS.Timeout>(null);
@@ -84,7 +85,7 @@ function TestConnectionButton(props: Props) {
     function testConnection() {
         const recipeJson = getRecipeJson(recipe);
         if (recipeJson) {
-            createTestConnectionRequest({ variables: { input: { recipe: recipeJson } } })
+            createTestConnectionRequest({ variables: { input: { recipe: recipeJson, version } } })
                 .then((res) =>
                     getIngestionExecutionRequest({
                         variables: { urn: res.data?.createTestConnectionRequest as string },


### PR DESCRIPTION
If there's a CLI version of ingestion set on this source, use that when running test connections. Otherwise continue to use the default as normal.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)