### PR TITLE
feat(docs): Adds docs on K8s scheduled ingestion

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -150,6 +150,7 @@ module.exports = {
               "metadata-ingestion/schedule_docs/intro",
               "metadata-ingestion/schedule_docs/cron",
               "metadata-ingestion/schedule_docs/airflow",
+              "metadata-ingestion/schedule_docs/kubernetes",
             ],
           },
           // {

--- a/metadata-ingestion/schedule_docs/kubernetes.md
+++ b/metadata-ingestion/schedule_docs/kubernetes.md
@@ -1,0 +1,47 @@
+# Using Kubernetes
+
+If you have deployed DataHub using our official [helm charts](https://github.com/acryldata/datahub-helm) you can use the 
+datahub ingestion cron subchart to schedule ingestions. 
+
+Here is an example of what that configuration would look like in your **values.yaml**:
+
+```yaml
+datahub-ingestion-cron:
+  enabled: true
+  crons:
+    mysql:
+      schedule: "0 * * * *" # Every hour
+      recipe:
+        configmapName: recipe-config
+        fileName: mysql_recipe.yml
+```
+
+This assumes the pre-existence of a Kubernetes ConfigMap which holds all recipes being scheduled in the same namespace as
+where the cron jobs will be running.
+
+An example could be:
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: recipe-config
+data:
+  mysql_recipe.yml: |-
+    source:
+      type: mysql
+      config:
+        # Coordinates
+        host_port: <MYSQL HOST>:3306
+        database: dbname
+    
+        # Credentials
+        username: root
+        password: example
+    
+    sink:
+      type: datahub-rest
+      config:
+        server: http://<GMS_HOST>:8080
+```
+
+For more information, please see the [documentation](https://github.com/acryldata/datahub-helm/tree/master/charts/datahub/subcharts/datahub-ingestion-cron) of this sub-chart.


### PR DESCRIPTION
Adds documentation on how to use DataHub's ingestion cron sub chart to schedule ingestion runs in Kubernetes.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)