### PR TITLE
feat(cli): extend put command to support platform creation

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -270,16 +270,8 @@ datahub get --urn "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PR
 
 The `put` group of commands allows you to write metadata into DataHub. This is a flexible way for you to issue edits to metadata from the command line.
 
-#### put platform
-The **put platform** command instructs `datahub` to create or update metadata about a data platform. This is very useful if you are using a custom data platform, to set up its logo and display name for a native UI experience.
-
-```shell
-datahub put platform --name longtail_schemas --display_name "Long Tail Schemas" --logo "https://flink.apache.org/img/logo/png/50/color_50.png"
-✅ Successfully wrote data platform metadata for urn:li:dataPlatform:longtail_schemas to DataHub (DataHubRestEmitter: configured to talk to https://longtailcompanions.acryl.io/api/gms with token: eyJh**********Cics)
-```
-
 #### put aspect
-The following command instructs `datahub` to set the `ownership` aspect of the dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)` to the value in the file `ownership.json`.
+The **put aspect** (also the default `put`) command instructs `datahub` to set the `ownership` aspect of the dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)` to the value in the file `ownership.json`.
 The JSON in the `ownership.json` file needs to conform to the [`Ownership`](https://github.com/datahub-project/datahub/blob/master/metadata-models/src/main/pegasus/com/linkedin/common/Ownership.pdl) Aspect model as shown below.
 
 ```json
@@ -304,6 +296,15 @@ datahub --debug put --urn "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDa
 curl -X POST -H 'User-Agent: python-requests/2.26.0' -H 'Accept-Encoding: gzip, deflate' -H 'Accept: */*' -H 'Connection: keep-alive' -H 'X-RestLi-Protocol-Version: 2.0.0' -H 'Content-Type: application/json' --data '{"proposal": {"entityType": "dataset", "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)", "aspectName": "ownership", "changeType": "UPSERT", "aspect": {"contentType": "application/json", "value": "{\"owners\": [{\"owner\": \"urn:li:corpuser:jdoe\", \"type\": \"DEVELOPER\"}, {\"owner\": \"urn:li:corpuser:jdub\", \"type\": \"DATAOWNER\"}]}"}}}' 'http://localhost:8080/aspects/?action=ingestProposal'
 Update succeeded with status 200
 ```
+
+#### put platform
+The **put platform** command (available in version>0.8.44.4) instructs `datahub` to create or update metadata about a data platform. This is very useful if you are using a custom data platform, to set up its logo and display name for a native UI experience.
+
+```shell
+datahub put platform --name longtail_schemas --display_name "Long Tail Schemas" --logo "https://flink.apache.org/img/logo/png/50/color_50.png"
+✅ Successfully wrote data platform metadata for urn:li:dataPlatform:longtail_schemas to DataHub (DataHubRestEmitter: configured to talk to https://longtailcompanions.acryl.io/api/gms with token: eyJh**********Cics)
+```
+
 
 ### migrate
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -268,8 +268,18 @@ datahub get --urn "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PR
 
 ### put
 
-The `put` command allows you to write metadata into DataHub. This is a flexible way for you to issue edits to metadata from the command line.
-For example, the following command instructs `datahub` to set the `ownership` aspect of the dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)` to the value in the file `ownership.json`.
+The `put` group of commands allows you to write metadata into DataHub. This is a flexible way for you to issue edits to metadata from the command line.
+
+#### put platform
+The **put platform** command instructs `datahub` to create or update metadata about a data platform. This is very useful if you are using a custom data platform, to set up its logo and display name for a native UI experience.
+
+```shell
+datahub put platform --name longtail_schemas --display_name "Long Tail Schemas" --logo "https://flink.apache.org/img/logo/png/50/color_50.png"
+✅ Successfully wrote data platform metadata for urn:li:dataPlatform:longtail_schemas to DataHub (DataHubRestEmitter: configured to talk to https://longtailcompanions.acryl.io/api/gms with token: eyJh**********Cics)
+```
+
+#### put aspect
+The following command instructs `datahub` to set the `ownership` aspect of the dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)` to the value in the file `ownership.json`.
 The JSON in the `ownership.json` file needs to conform to the [`Ownership`](https://github.com/datahub-project/datahub/blob/master/metadata-models/src/main/pegasus/com/linkedin/common/Ownership.pdl) Aspect model as shown below.
 
 ```json

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -271,7 +271,8 @@ datahub get --urn "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PR
 The `put` group of commands allows you to write metadata into DataHub. This is a flexible way for you to issue edits to metadata from the command line.
 
 #### put aspect
-The **put aspect** (also the default `put`) command instructs `datahub` to set the `ownership` aspect of the dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)` to the value in the file `ownership.json`.
+The **put aspect** (also the default `put`) command instructs `datahub` to set a specific aspect for an entity to a specified value.
+For example, the command shown below sets the `ownership` aspect of the dataset `urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)` to the value in the file `ownership.json`.
 The JSON in the `ownership.json` file needs to conform to the [`Ownership`](https://github.com/datahub-project/datahub/blob/master/metadata-models/src/main/pegasus/com/linkedin/common/Ownership.pdl) Aspect model as shown below.
 
 ```json

--- a/metadata-ingestion/src/datahub/cli/put_cli.py
+++ b/metadata-ingestion/src/datahub/cli/put_cli.py
@@ -105,5 +105,5 @@ def platform(
         )
     )
     click.echo(
-        f"✅ Successfully wrote data platform metadata for {platform_urn} to DataHub"
+        f"✅ Successfully wrote data platform metadata for {platform_urn} to DataHub ({datahub_graph})"
     )

--- a/metadata-ingestion/src/datahub/cli/put_cli.py
+++ b/metadata-ingestion/src/datahub/cli/put_cli.py
@@ -1,19 +1,33 @@
 import json
 import logging
-from typing import Any
+from typing import Any, Optional
 
 import click
+from click_default_group import DefaultGroup
 
-from datahub.cli.cli_utils import post_entity
+from datahub.cli.cli_utils import get_url_and_token, post_entity
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+from datahub.metadata.schema_classes import (
+    DataPlatformInfoClass as DataPlatformInfo,
+    PlatformTypeClass,
+)
 from datahub.telemetry import telemetry
 from datahub.upgrade import upgrade
+from datahub.utilities.urns.data_platform_urn import DataPlatformUrn
 from datahub.utilities.urns.urn import guess_entity_type
 
 logger = logging.getLogger(__name__)
 
 
-@click.command(
-    name="put",
+@click.group(cls=DefaultGroup, default="aspect")
+def put() -> None:
+    """A group of commands to put metadata in DataHub."""
+    pass
+
+
+@put.command(
+    name="aspect",
     context_settings=dict(
         ignore_unknown_options=True,
         allow_extra_args=True,
@@ -25,7 +39,7 @@ logger = logging.getLogger(__name__)
 @click.pass_context
 @upgrade.check_upgrade
 @telemetry.with_telemetry
-def put(ctx: Any, urn: str, aspect: str, aspect_data: str) -> None:
+def aspect(ctx: Any, urn: str, aspect: str, aspect_data: str) -> None:
     """Update a single aspect of an entity"""
 
     entity_type = guess_entity_type(urn)
@@ -38,3 +52,58 @@ def put(ctx: Any, urn: str, aspect: str, aspect_data: str) -> None:
             aspect_value=aspect_obj,
         )
         click.secho(f"Update succeeded with status {status}", fg="green")
+
+
+@put.command()
+@click.pass_context
+@upgrade.check_upgrade
+@telemetry.with_telemetry
+@click.option(
+    "--name",
+    type=str,
+    help="Platform name",
+    required=True,
+)
+@click.option(
+    "--display_name",
+    type=str,
+    help="Platform Display Name (human friendly)",
+    required=False,
+)
+@click.option(
+    "--logo",
+    type=str,
+    help="Logo URL that must be reachable from the DataHub UI.",
+    required=True,
+)
+def platform(
+    ctx: click.Context, name: str, display_name: Optional[str], logo: str
+) -> None:
+    """
+    Create or update a dataplatform entity in DataHub
+    """
+
+    if name.startswith(f"urn:li:{DataPlatformUrn.ENTITY_TYPE}"):
+        platform_urn = DataPlatformUrn.create_from_string(name)
+        platform_name = platform_urn.get_entity_id_as_string()
+    else:
+        platform_name = name.lower()
+        platform_urn = DataPlatformUrn.create_from_id(platform_name)
+
+    data_platform_info = DataPlatformInfo(
+        name=name,
+        type=PlatformTypeClass.OTHERS,
+        datasetNameDelimiter=".",
+        displayName=display_name or platform_name,
+        logoUrl=logo,
+    )
+    (url, token) = get_url_and_token()
+    datahub_graph = DataHubGraph(DataHubGraphConfig(server=url, token=token))
+    datahub_graph.emit(
+        MetadataChangeProposalWrapper(
+            entityUrn=str(platform_urn), aspect=data_platform_info
+        )
+    )
+    click.echo(
+        f"✅ Successfully wrote data platform metadata for {platform_urn} to DataHub"
+    )

--- a/metadata-integration/java/datahub-protobuf/README.md
+++ b/metadata-integration/java/datahub-protobuf/README.md
@@ -645,7 +645,7 @@ You can also route results to a file by using the `--transport file --filename e
 ##### Important Flags
 Here are a few important flags to use with this command
 - --env : Defaults to DEV, you should use PROD once you have ironed out all the issues with running this command.
-- --platform: Defaults to Kafka (as most people use protobuf schema repos with Kafka), but you can provide a custom platform name for this e.g. (`schema_repo` or `<company_name>_schemas`). If you use a custom platform, make sure to provision the custom platform on your DataHub instance with a logo etc, to get a native experience.
+- --platform: Defaults to Kafka (as most people use protobuf schema repos with Kafka), but you can provide a custom platform name for this e.g. (`schema_repo` or `<company_name>_schemas`). If you use a custom platform, make sure to provision the custom platform on your DataHub instance with a logo etc, to get a native experience. See how to use the [put platform command](../../../docs/cli.md#put-platform) to accomplish this.
 - --subtype : This gives your entities a more descriptive category than Dataset in the UI. Defaults to schema, but you might find topic, event or message more descriptive.
 
 


### PR DESCRIPTION
Adds support to create a dataplatform entity using the cli. 

e.g.
```
datahub put platform --name custom_platform --logo https://custom_platform_logo.png --display_name "Custom Platform"
```

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)