### PR TITLE
feat(ingest): implement compression for CheckpointState

### DIFF
--- a/metadata-ingestion/tests/unit/stateful_ingestion/state/test_checkpoint.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/state/test_checkpoint.py
@@ -128,3 +128,20 @@ def test_serde_idempotence(state_obj):
         config_class=MySQLConfig,
     )
     assert orig_checkpoint_obj == serde_checkpoint_obj
+
+
+def test_supported_encodings():
+    """
+    Tests utf-8 and base85 encodings
+    """
+    test_state = BaseUsageCheckpointState(
+        version="1.0", begin_timestamp_millis=1, end_timestamp_millis=100
+    )
+
+    # 1. Test UTF-8 encoding
+    test_state.serde = "utf-8"
+    test_serde_idempotence(test_state)
+
+    # 2. Test Base85 encoding
+    test_state.serde = "base85"
+    test_serde_idempotence(test_state)


### PR DESCRIPTION
Stateful ingestion - add and enable by default bz2 compression and base85 encoding for CheckpointState

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)