### PR TITLE
refactor(frontend): Misc frontend improvements

### DIFF
--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -120,7 +120,7 @@ public class Application extends Controller {
             .entrySet()
             .stream()
             // Remove X-DataHub-Actor to prevent malicious delegation.
-            .filter(entry -> !AuthenticationConstants.LEGACY_X_DATAHUB_ACTOR_HEADER.equals(entry.getKey()))
+            .filter(entry -> !AuthenticationConstants.LEGACY_X_DATAHUB_ACTOR_HEADER.equalsIgnoreCase(entry.getKey()))
             .filter(entry -> !Http.HeaderNames.CONTENT_LENGTH.equals(entry.getKey()))
             .filter(entry -> !Http.HeaderNames.CONTENT_TYPE.equals(entry.getKey()))
             .filter(entry -> !Http.HeaderNames.AUTHORIZATION.equals(entry.getKey()))
@@ -305,7 +305,11 @@ public class Application extends Controller {
     // Case 2: Map requests to /gms to / (Rest.li API)
     final String gmsApiPath = "/api/gms";
     if (path.startsWith(gmsApiPath)) {
-      return String.format("%s", path.substring(gmsApiPath.length()));
+      String newPath = path.substring(gmsApiPath.length());
+      if (!newPath.startsWith("/")) {
+        newPath = "/" + newPath;
+      }
+      return newPath;
     }
 
     // Otherwise, return original path

--- a/datahub-frontend/app/controllers/AuthenticationController.java
+++ b/datahub-frontend/app/controllers/AuthenticationController.java
@@ -305,10 +305,10 @@ public class AuthenticationController extends Controller {
             try {
                 _logger.debug("Attempting jaas authentication");
                 AuthenticationManager.authenticateJaasUser(username, password);
+                _logger.debug("Jaas authentication successful. Login succeeded");
                 loginSucceeded = true;
-                _logger.debug("Jaas authentication successful");
             } catch (Exception e) {
-                _logger.debug("Jaas authentication error", e);
+                _logger.debug("Jaas authentication error. Login failed", e);
             }
         }
 

--- a/datahub-frontend/app/controllers/CentralLogoutController.java
+++ b/datahub-frontend/app/controllers/CentralLogoutController.java
@@ -41,7 +41,7 @@ public class CentralLogoutController extends LogoutController {
   public Result executeLogout() throws ExecutionException, InterruptedException {
     if (_isOidcEnabled) {
       try {
-        return logout().toCompletableFuture().get();
+        return logout().toCompletableFuture().get().withNewSession();
       } catch (Exception e) {
         log.error("Caught exception while attempting to perform SSO logout! It's likely that SSO integration is mis-configured.", e);
         return redirect(
@@ -50,6 +50,6 @@ public class CentralLogoutController extends LogoutController {
                     + "or refer to server logs for more information.")));
       }
     }
-    return redirect("/");
+    return redirect("/").withNewSession();
   }
 }

--- a/datahub-frontend/app/security/AuthenticationManager.java
+++ b/datahub-frontend/app/security/AuthenticationManager.java
@@ -4,7 +4,6 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import javax.annotation.Nonnull;
 import javax.naming.AuthenticationException;
-import javax.naming.NamingException;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -23,21 +22,18 @@ public class AuthenticationManager {
 
   }
 
-  public static void authenticateJaasUser(@Nonnull String userName, @Nonnull String password) throws NamingException {
+  public static void authenticateJaasUser(@Nonnull String userName, @Nonnull String password) throws Exception {
     Preconditions.checkArgument(!StringUtils.isAnyEmpty(userName), "Username cannot be empty");
+    JAASLoginService jaasLoginService = new JAASLoginService("WHZ-Authentication");
+    PropertyUserStoreManager propertyUserStoreManager = new PropertyUserStoreManager();
+    propertyUserStoreManager.start();
+    jaasLoginService.setBeans(Collections.singletonList(propertyUserStoreManager));
+    JAASLoginService.INSTANCE.set(jaasLoginService);
     try {
-      JAASLoginService jaasLoginService = new JAASLoginService("WHZ-Authentication");
-      PropertyUserStoreManager propertyUserStoreManager = new PropertyUserStoreManager();
-      propertyUserStoreManager.start();
-      jaasLoginService.setBeans(Collections.singletonList(propertyUserStoreManager));
-      JAASLoginService.INSTANCE.set(jaasLoginService);
       LoginContext lc = new LoginContext("WHZ-Authentication", new WHZCallbackHandler(userName, password));
       lc.login();
     } catch (LoginException le) {
       throw new AuthenticationException(le.toString());
-    } catch (Exception e) {
-      // Bad abstract class design, empty doStart that has throws Exception in the signature and subclass that also
-      // does not throw any checked exceptions. This should never happen, all it does is create an empty HashMap...
     }
   }
 


### PR DESCRIPTION
**Summary**

In this PR, we address a few improvements to datahub-frontend container, including:

1. Case insensitive compare when removing X-DataHub-Actor header
2. Verifying that the relative path provided in URL starts with a slash
3. Explicitly deleting Play session on logout 
4. Catching all errors during JaaS login, failing closed


**Status**
READY FOR REVIEW

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)