### PR TITLE
fix(docs-site): make banner a bit smaller

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -22,8 +22,27 @@ module.exports = {
     ...(!isSaas && {
       announcementBar: {
         id: "announcement",
-        content:
-          '<div><img src="/img/acryl-logo-white-mark.svg" /><p><strong>Managed DataHub</strong><span> &nbsp;Acryl Data delivers an easy to consume DataHub platform for the enterprise</span></p></div> <a href="https://www.acryldata.io/datahub-beta" target="_blank" class="button button--primary">Sign up for Managed DataHub →</a>',
+        content: `
+          <div style="
+            display: flex;
+            gap: 2em;
+            justify-content: center;
+            align-items: center;
+        ">
+          <div style="
+            display: flex;
+            align-items: center;
+            gap: 1em;
+          ">
+          <img src="/img/acryl-logo-white-mark.svg" style="
+            max-height: 35px;
+          ">
+          <p style="
+            margin-bottom: 0;
+          "><strong>Managed DataHub</strong><span> &nbsp;Acryl Data delivers an easy to consume DataHub platform for the enterprise</span></p></div>
+          <a href="https://www.acryldata.io/datahub-beta" target="_blank" class="button button--primary">Sign up for Managed DataHub →</a>
+          </div>
+        `,
         backgroundColor: "#070707",
         textColor: "#ffffff",
         isCloseable: false,


### PR DESCRIPTION
This is not a full fix - desktop looks better but mobile is still pretty bad.

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/12566801/191624213-8bfb60ff-da64-416d-ad49-3e2d2c0ce91d.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)