### PR TITLE
fix(docs-site): style custom announcement bar

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -11,9 +11,7 @@ module.exports = {
   favicon: "img/favicon.ico",
   organizationName: "datahub-project", // Usually your GitHub org/user name.
   projectName: "datahub", // Usually your repo name.
-  stylesheets: [
-    "https://fonts.googleapis.com/css2?family=Manrope:wght@400;600&display=swap",
-  ],
+  stylesheets: ["https://fonts.googleapis.com/css2?family=Manrope:wght@400;600&display=swap"],
   noIndex: isSaas,
   customFields: {
     isSaas: isSaas,
@@ -22,27 +20,8 @@ module.exports = {
     ...(!isSaas && {
       announcementBar: {
         id: "announcement",
-        content: `
-          <div style="
-            display: flex;
-            gap: 2em;
-            justify-content: center;
-            align-items: center;
-        ">
-          <div style="
-            display: flex;
-            align-items: center;
-            gap: 1em;
-          ">
-          <img src="/img/acryl-logo-white-mark.svg" style="
-            max-height: 35px;
-          ">
-          <p style="
-            margin-bottom: 0;
-          "><strong>Managed DataHub</strong><span> &nbsp;Acryl Data delivers an easy to consume DataHub platform for the enterprise</span></p></div>
-          <a href="https://www.acryldata.io/datahub-beta" target="_blank" class="button button--primary">Sign up for Managed DataHub →</a>
-          </div>
-        `,
+        content:
+          '<div><img src="/img/acryl-logo-white-mark.svg" /><p><strong>Managed DataHub</strong><span> &nbsp;Acryl Data delivers an easy to consume DataHub platform for the enterprise</span></p></div> <a href="https://www.acryldata.io/datahub-sign-up" target="_blank" class="button button--primary">Sign up for Managed DataHub&nbsp;→</a>',
         backgroundColor: "#070707",
         textColor: "#ffffff",
         isCloseable: false,
@@ -52,12 +31,8 @@ module.exports = {
       title: null,
       logo: {
         alt: "DataHub Logo",
-        src: `img/${
-          isSaas ? "acryl" : "datahub"
-        }-logo-color-light-horizontal.svg`,
-        srcDark: `img/${
-          isSaas ? "acryl" : "datahub"
-        }-logo-color-dark-horizontal.svg`,
+        src: `img/${isSaas ? "acryl" : "datahub"}-logo-color-light-horizontal.svg`,
+        srcDark: `img/${isSaas ? "acryl" : "datahub"}-logo-color-dark-horizontal.svg`,
       },
       items: [
         {
@@ -212,9 +187,7 @@ module.exports = {
         blog: false,
         theme: {
           customCss: [
-            isSaas
-              ? require.resolve("./src/styles/acryl.scss")
-              : require.resolve("./src/styles/datahub.scss"),
+            isSaas ? require.resolve("./src/styles/acryl.scss") : require.resolve("./src/styles/datahub.scss"),
             require.resolve("./src/styles/global.scss"),
           ],
         },
@@ -222,10 +195,7 @@ module.exports = {
     ],
   ],
   plugins: [
-    [
-      "@docusaurus/plugin-ideal-image",
-      { quality: 100, sizes: [320, 640, 1280, 1440, 1600] },
-    ],
+    ["@docusaurus/plugin-ideal-image", { quality: 100, sizes: [320, 640, 1280, 1440, 1600] }],
     "docusaurus-plugin-sass",
     [
       "docusaurus-graphql-plugin",

--- a/docs-website/src/styles/global.scss
+++ b/docs-website/src/styles/global.scss
@@ -66,7 +66,7 @@ html[data-theme="dark"] .invert-on-dark {
   padding: 5vh 0;
 }
 
-div[class^="announcementBarContent"] {
+div[class^="announcementBar"] div {
   display: flex;
   align-items: center;
   padding: 0 1rem;

--- a/docs-website/src/styles/global.scss
+++ b/docs-website/src/styles/global.scss
@@ -66,39 +66,42 @@ html[data-theme="dark"] .invert-on-dark {
   padding: 5vh 0;
 }
 
-div[class^="announcementBar"] div {
-  display: flex;
-  align-items: center;
-  padding: 0 1rem;
-  justify-content: space-between;
-  font-size: 1rem;
-  > div {
+div[class^="announcementBar"] {
+  z-index: calc(var(--ifm-z-index-fixed) - 1);
+  div {
     display: flex;
     align-items: center;
+    padding: 0 1rem;
+    justify-content: space-between;
+    font-size: 1rem;
+    > div {
+      display: flex;
+      align-items: center;
 
-    > p {
-      text-align: left;
-      line-height: 1.1rem;
-      margin: 0;
-      > span {
-        @media (max-width: 780px) {
+      > p {
+        text-align: left;
+        line-height: 1.1rem;
+        margin: 0;
+        > span {
+          @media (max-width: 780px) {
+            display: none;
+          }
+        }
+        @media (max-width: 480px) {
           display: none;
         }
       }
-      @media (max-width: 480px) {
-        display: none;
-      }
     }
-  }
 
-  img {
-    width: 24px;
-    height: auto;
-    margin-right: 1rem;
-  }
-  a {
-    color: var(--ifm-button-color);
-    text-decoration: none;
+    img {
+      width: 24px;
+      height: auto;
+      margin-right: 1rem;
+    }
+    a {
+      color: var(--ifm-button-color);
+      text-decoration: none;
+    }
   }
 }
 


### PR DESCRIPTION
The docusaurus version update changed the class names on the announcement bar which broke the custom styles for it. Adjusting the selector brought back the styles. Also updated the link url while I was in there.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)