### PR TITLE
refactor(gms): Improving JWT parsing logic

### DIFF
--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/token/StatelessTokenServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/token/StatelessTokenServiceTest.java
@@ -3,7 +3,16 @@ package com.datahub.authentication.token;
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.ActorType;
 import com.datahub.authentication.authenticator.DataHubTokenAuthenticator;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+import javax.crypto.spec.SecretKeySpec;
 import org.testng.annotations.Test;
 
 import static com.datahub.authentication.token.TokenClaims.*;
@@ -116,5 +125,43 @@ public class StatelessTokenServiceTest {
 
     // Validation should fail.
     assertThrows(TokenException.class, () -> statelessTokenService.validateAccessToken(changedToken));
+  }
+
+  @Test
+  public void testValidateAccessTokenFailsDueToNoneAlgorithm() {
+    // Token with none algorithm type.
+    String badToken =
+        "eyJhbGciOiJub25lIn0.eyJhY3RvclR5cGUiOiJVU0VSIiwiYWN0b3JJZCI6Il9fZGF0YWh1Yl9zeXN0ZW0iL"
+            + "CJ0eXBlIjoiU0VTU0lPTiIsInZlcnNpb24iOiIxIiwianRpIjoiN2VmOTkzYjQtMjBiOC00Y2Y5LTljNm"
+            + "YtMTE2NjNjZWVmOTQzIiwic3ViIjoiZGF0YWh1YiIsImlzcyI6ImRhdGFodWItbWV0YWRhdGEtc2VydmljZSJ9.";
+    StatelessTokenService statelessTokenService = new StatelessTokenService(TEST_SIGNING_KEY, "HS256");
+    // Validation should fail.
+    assertThrows(TokenException.class, () -> statelessTokenService.validateAccessToken(badToken));
+  }
+
+  @Test
+  public void testValidateAccessTokenFailsDueToUnsupportedSigningAlgorithm() throws Exception {
+    StatelessTokenService statelessTokenService = new StatelessTokenService(TEST_SIGNING_KEY, "HS256");
+
+    Map<String, Object> claims = new HashMap<>();
+    claims.put(TOKEN_VERSION_CLAIM_NAME, String.valueOf(TokenVersion.ONE.numericValue)); // Hardcode version 1 for now.
+    claims.put(TOKEN_TYPE_CLAIM_NAME, "SESSION");
+    claims.put(ACTOR_TYPE_CLAIM_NAME, "USER");
+    claims.put(ACTOR_ID_CLAIM_NAME, "__datahub_system");
+
+    final JwtBuilder builder = Jwts.builder()
+        .addClaims(claims)
+        .setId(UUID.randomUUID().toString())
+        .setIssuer("datahub-metadata-service")
+        .setSubject("datahub");
+     builder.setExpiration(new Date(System.currentTimeMillis() + 60));
+
+    final String testSigningKey = "TLHLdPSivAwIjXP4MT4TtlitsEGkOKjQGNnqsprisfghpU8g";
+    byte [] apiKeySecretBytes = testSigningKey.getBytes(StandardCharsets.UTF_8);
+    final Key signingKey = new SecretKeySpec(apiKeySecretBytes, SignatureAlgorithm.HS384.getJcaName());
+    final String badToken = builder.signWith(signingKey, SignatureAlgorithm.HS384).compact();
+
+    // Validation should fail.
+    assertThrows(TokenException.class, () -> statelessTokenService.validateAccessToken(badToken));
   }
 }


### PR DESCRIPTION
**Summary**

In this PR, we improve how JWTs are parsed by the StatelessTokenService. We ensure that the token is signed by a specific signature and also treat as a JWS. 

**Status**

Ready for review



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)