### PR TITLE
feat(ingestion): Add fail-safe stale entity removal via configurable 'fail_safe_threshold' param.

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/state/dbt_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/dbt_state.py
@@ -84,6 +84,28 @@ class DbtCheckpointState(StaleEntityCheckpointStateBase["DbtCheckpointState"]):
         elif type == "assertion":
             yield from self._get_assertion_urns_not_in(other_checkpoint_state)
 
+    def get_percent_entities_changed(
+        self, old_checkpoint_state: "DbtCheckpointState"
+    ) -> float:
+        old_count_all = 0
+        overlap_count_all = 0
+        for new_entities, old_entities in [
+            (self.encoded_node_urns, old_checkpoint_state.encoded_node_urns),
+            (self.encoded_assertion_urns, old_checkpoint_state.encoded_assertion_urns),
+        ]:
+            (
+                overlap_count,
+                old_count,
+                _,
+            ) = StaleEntityCheckpointStateBase.get_entity_overlap_and_cardinalities(
+                new_entities=new_entities, old_entities=old_entities
+            )
+            overlap_count_all += overlap_count
+            old_count_all += old_count
+        if old_count_all:
+            return overlap_count * 100.0 / old_count_all
+        return 0.0
+
     def prepare_for_commit(self) -> None:
         self.encoded_node_urns = list(set(self.encoded_node_urns))
         self.encoded_assertion_urns = list(set(self.encoded_assertion_urns))

--- a/metadata-ingestion/src/datahub/ingestion/source/state/dbt_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/dbt_state.py
@@ -87,24 +87,15 @@ class DbtCheckpointState(StaleEntityCheckpointStateBase["DbtCheckpointState"]):
     def get_percent_entities_changed(
         self, old_checkpoint_state: "DbtCheckpointState"
     ) -> float:
-        old_count_all = 0
-        overlap_count_all = 0
-        for new_entities, old_entities in [
-            (self.encoded_node_urns, old_checkpoint_state.encoded_node_urns),
-            (self.encoded_assertion_urns, old_checkpoint_state.encoded_assertion_urns),
-        ]:
-            (
-                overlap_count,
-                old_count,
-                _,
-            ) = StaleEntityCheckpointStateBase.get_entity_overlap_and_cardinalities(
-                new_entities=new_entities, old_entities=old_entities
-            )
-            overlap_count_all += overlap_count
-            old_count_all += old_count
-        if old_count_all:
-            return overlap_count * 100.0 / old_count_all
-        return 0.0
+        return StaleEntityCheckpointStateBase.compute_percent_entities_changed(
+            [
+                (self.encoded_node_urns, old_checkpoint_state.encoded_node_urns),
+                (
+                    self.encoded_assertion_urns,
+                    old_checkpoint_state.encoded_assertion_urns,
+                ),
+            ]
+        )
 
     def prepare_for_commit(self) -> None:
         self.encoded_node_urns = list(set(self.encoded_node_urns))

--- a/metadata-ingestion/src/datahub/ingestion/source/state/kafka_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/kafka_state.py
@@ -61,14 +61,6 @@ class KafkaCheckpointState(StaleEntityCheckpointStateBase["KafkaCheckpointState"
     def get_percent_entities_changed(
         self, old_checkpoint_state: "KafkaCheckpointState"
     ) -> float:
-        (
-            overlap_count,
-            old_count,
-            _,
-        ) = StaleEntityCheckpointStateBase.get_entity_overlap_and_cardinalities(
-            new_entities=self.encoded_topic_urns,
-            old_entities=old_checkpoint_state.encoded_topic_urns,
+        return StaleEntityCheckpointStateBase.compute_percent_entities_changed(
+            [(self.encoded_topic_urns, old_checkpoint_state.encoded_topic_urns)]
         )
-        if old_count:
-            return overlap_count * 100.0 / old_count
-        return 0.0

--- a/metadata-ingestion/src/datahub/ingestion/source/state/kafka_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/kafka_state.py
@@ -57,3 +57,18 @@ class KafkaCheckpointState(StaleEntityCheckpointStateBase["KafkaCheckpointState"
             yield from self._get_urns_not_in(
                 self.encoded_topic_urns, other_checkpoint_state.encoded_topic_urns
             )
+
+    def get_percent_entities_changed(
+        self, old_checkpoint_state: "KafkaCheckpointState"
+    ) -> float:
+        (
+            overlap_count,
+            old_count,
+            _,
+        ) = StaleEntityCheckpointStateBase.get_entity_overlap_and_cardinalities(
+            new_entities=self.encoded_topic_urns,
+            old_entities=old_checkpoint_state.encoded_topic_urns,
+        )
+        if old_count:
+            return overlap_count * 100.0 / old_count
+        return 0.0

--- a/metadata-ingestion/src/datahub/ingestion/source/state/sql_common_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/sql_common_state.py
@@ -126,23 +126,17 @@ class BaseSQLAlchemyCheckpointState(
     def get_percent_entities_changed(
         self, old_checkpoint_state: "BaseSQLAlchemyCheckpointState"
     ) -> float:
-        old_count_all = 0
-        overlap_count_all = 0
-        for new_entities, old_entities in [
-            (self.encoded_assertion_urns, old_checkpoint_state.encoded_assertion_urns),
-            (self.encoded_container_urns, old_checkpoint_state.encoded_container_urns),
-            (self.encoded_table_urns, old_checkpoint_state.encoded_table_urns),
-            (self.encoded_view_urns, old_checkpoint_state.encoded_view_urns),
-        ]:
-            (
-                overlap_count,
-                old_count,
-                _,
-            ) = StaleEntityCheckpointStateBase.get_entity_overlap_and_cardinalities(
-                new_entities=new_entities, old_entities=old_entities
-            )
-            overlap_count_all += overlap_count
-            old_count_all += old_count
-        if old_count_all:
-            return overlap_count * 100.0 / old_count_all
-        return 0.0
+        return StaleEntityCheckpointStateBase.compute_percent_entities_changed(
+            [
+                (
+                    self.encoded_assertion_urns,
+                    old_checkpoint_state.encoded_assertion_urns,
+                ),
+                (
+                    self.encoded_container_urns,
+                    old_checkpoint_state.encoded_container_urns,
+                ),
+                (self.encoded_table_urns, old_checkpoint_state.encoded_table_urns),
+                (self.encoded_view_urns, old_checkpoint_state.encoded_view_urns),
+            ]
+        )

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Dict, Generic, Iterable, List, Optional, Type, TypeVar, cast
+from typing import Dict, Generic, Iterable, List, Optional, Tuple, Type, TypeVar, cast
 
 import pydantic
 
@@ -33,6 +33,12 @@ class StatefulStaleMetadataRemovalConfig(StatefulIngestionConfig):
     remove_stale_metadata: bool = pydantic.Field(
         default=True,
         description=f"Soft-deletes the entities of type {', '.join(_entity_types)} in the last successful run but missing in the current run with stateful_ingestion enabled.",
+    )
+    fail_safe_threshold: float = pydantic.Field(
+        default=20.0,
+        description="Prevents large amount of soft deletes & the state from committing from accidental changes to the source configuration if the relative change percent in entities compared to the previous state is above the 'fail_safe_threshold'.",
+        le=100.0,  # mypy does not work with pydantic.confloat. This is the recommended work-around.
+        ge=0.0,
     )
 
 
@@ -82,6 +88,23 @@ class StaleEntityCheckpointStateBase(CheckpointStateBase, ABC, Generic[Derived])
         :return: an iterable to the set of urns present in this checkpoing state but not in the other_checkpoint.
         """
         pass
+
+    @abstractmethod
+    def get_percent_entities_changed(self, old_checkpoint_state: Derived) -> float:
+        """
+        Returns the percentage of entities that have changed relative to `old_checkpoint_state`.
+        :param old_checkpoint_state: the old checkpoint state to compute the relative change percent against.
+        :return: (|intersection(self, old_checkpoint_state)| * 100.0 / |old_checkpoint_state|)
+        """
+        pass
+
+    @staticmethod
+    def get_entity_overlap_and_cardinalities(
+        new_entities: List[str], old_entities: List[str]
+    ) -> Tuple[int, int, int]:
+        new_set = set(new_entities)
+        old_set = set(old_entities)
+        return len(new_set.intersection(old_set)), len(old_set), len(new_set)
 
 
 class StaleEntityRemovalHandler(
@@ -217,6 +240,26 @@ class StaleEntityRemovalHandler(
         cur_checkpoint_state = cast(
             StaleEntityCheckpointStateBase, cur_checkpoint.state
         )
+
+        # Check if the entity delta is below the fail-safe threshold.
+        entity_difference_percent = cur_checkpoint_state.get_percent_entities_changed(
+            last_checkpoint_state
+        )
+        assert self.stateful_ingestion_config
+        if (
+            entity_difference_percent
+            > self.stateful_ingestion_config.fail_safe_threshold
+        ):
+            # Log the failure. This would prevent the current state from getting committed.
+            self.source.get_report().report_failure(
+                "Stateful Ingestion",
+                f"Fail safe mode triggered, entity difference percent:{entity_difference_percent}"
+                " > fail_safe_threshold:{self.stateful_ingestion_config.fail_safe_threshold}",
+            )
+            # Bail so that we don't emit the stale entity removal workunits.
+            return
+
+        # Everything looks good, emit the soft-deletion workunits
         for type in self.state_type_class.get_supported_types():
             for urn in last_checkpoint_state.get_urns_not_in(
                 type=type, other_checkpoint_state=cur_checkpoint_state

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -273,6 +273,7 @@ def test_dbt_stateful(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
         "stateful_ingestion": {
             "enabled": True,
             "remove_stale_metadata": True,
+            "fail_safe_threshold": 100.0,
             "state_provider": {
                 "type": "datahub",
                 "config": {"datahub_api": {"server": GMS_SERVER}},
@@ -388,6 +389,7 @@ def test_dbt_state_backward_compatibility(
         "stateful_ingestion": {
             "enabled": True,
             "remove_stale_metadata": True,
+            "fail_safe_threshold": 100.0,
             "state_provider": {
                 "type": "datahub",
                 "config": {"datahub_api": {"server": GMS_SERVER}},
@@ -528,6 +530,7 @@ def test_dbt_stateful_tests(pytestconfig, tmp_path, mock_time, mock_datahub_grap
         "stateful_ingestion": {
             "enabled": True,
             "remove_stale_metadata": True,
+            "fail_safe_threshold": 100.0,
             "state_provider": {
                 "type": "datahub",
                 "config": {"datahub_api": {"server": GMS_SERVER}},

--- a/metadata-ingestion/tests/integration/kafka/test_kafka_state.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka_state.py
@@ -116,6 +116,7 @@ def test_kafka_ingest_with_stateful(
             "stateful_ingestion": {
                 "enabled": True,
                 "remove_stale_metadata": True,
+                "fail_safe_threshold": 100.0,
                 "state_provider": {
                     "type": "datahub",
                     "config": {"datahub_api": {"server": GMS_SERVER}},

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -248,6 +248,7 @@ def test_glue_stateful(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
         "stateful_ingestion": {
             "enabled": True,
             "remove_stale_metadata": True,
+            "fail_safe_threshold": 100.0,
             "state_provider": {
                 "type": "datahub",
                 "config": {"datahub_api": {"server": GMS_SERVER}},

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -183,7 +183,10 @@ class KafkaSourceTest(object):
                 kafka_source_patcher.is_local = True
                 KafkaSource.create(
                     {
-                        "stateful_ingestion": {"enabled": "true"},
+                        "stateful_ingestion": {
+                            "enabled": "true",
+                            "fail_safe_threshold": 100.0,
+                        },
                         "connection": {"bootstrap": "localhost:9092"},
                     },
                     ctx,

--- a/smoke-test/tests/test_stateful_ingestion.py
+++ b/smoke-test/tests/test_stateful_ingestion.py
@@ -59,6 +59,7 @@ def test_stateful_ingestion(wait_for_healthchecks):
         "stateful_ingestion": {
             "enabled": True,
             "remove_stale_metadata": True,
+            "fail_safe_threshold": 100.0,
             "state_provider": {
                 "type": "datahub",
                 "config": {"datahub_api": {"server": get_gms_url()}},


### PR DESCRIPTION
This PR adds fail-safe mode to the stateful ingestion `Stale Entity Removal` use-case.

If the percentage of entities that have changed in the current run relative to the previous state is above the configurable `fail_safe_threshold`, then the fail-safe mode will trigger and
1. the stale entity removal work units won't be emitted corresponding the removed entities in the current run.
2. the latest state won't be committed.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)