### PR TITLE
fix(frontend): refactoring AuthServiceClient

### DIFF
--- a/datahub-frontend/app/client/AuthServiceClient.java
+++ b/datahub-frontend/app/client/AuthServiceClient.java
@@ -1,6 +1,8 @@
 package client;
 
+import com.datahub.authentication.Authentication;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +15,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import play.mvc.Http;
-import com.datahub.authentication.Authentication;
 
 
 /**
@@ -66,11 +67,15 @@ public class AuthServiceClient {
     try {
 
       final String protocol = this.metadataServiceUseSsl ? "https" : "http";
-      final HttpPost request = new HttpPost(String.format("%s://%s:%s/%s", protocol, this.metadataServiceHost,
-          this.metadataServicePort, GENERATE_SESSION_TOKEN_ENDPOINT));
+      final HttpPost request = new HttpPost(
+          String.format("%s://%s:%s/%s", protocol, this.metadataServiceHost, this.metadataServicePort,
+              GENERATE_SESSION_TOKEN_ENDPOINT));
 
       // Build JSON request to generate a token on behalf of a user.
-      String json = String.format("{ \"%s\":\"%s\" }", USER_ID_FIELD, userId);
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final ObjectNode objectNode = objectMapper.createObjectNode();
+      objectNode.put(USER_ID_FIELD, userId);
+      final String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectNode);
       request.setEntity(new StringEntity(json));
 
       // Add authorization header with DataHub frontend system id and secret.
@@ -101,7 +106,6 @@ public class AuthServiceClient {
   /**
    * Call the Auth Service to create a native Datahub user.
    */
-  @Nonnull
   public boolean signUp(@Nonnull final String userUrn, @Nonnull final String fullName, @Nonnull final String email,
       @Nonnull final String title, @Nonnull final String password, @Nonnull final String inviteToken) {
     Objects.requireNonNull(userUrn, "userUrn must not be null");
@@ -115,15 +119,20 @@ public class AuthServiceClient {
     try {
 
       final String protocol = this.metadataServiceUseSsl ? "https" : "http";
-      final HttpPost request =
-          new HttpPost(String.format("%s://%s:%s/%s", protocol, this.metadataServiceHost, this.metadataServicePort,
+      final HttpPost request = new HttpPost(
+          String.format("%s://%s:%s/%s", protocol, this.metadataServiceHost, this.metadataServicePort,
               SIGN_UP_ENDPOINT));
 
       // Build JSON request to verify credentials for a native user.
-      String json =
-          String.format("{ \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\" }",
-              USER_URN_FIELD, userUrn, FULL_NAME_FIELD, fullName, EMAIL_FIELD, email, TITLE_FIELD, title,
-              PASSWORD_FIELD, password, INVITE_TOKEN_FIELD, inviteToken);
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final ObjectNode objectNode = objectMapper.createObjectNode();
+      objectNode.put(USER_URN_FIELD, userUrn);
+      objectNode.put(FULL_NAME_FIELD, fullName);
+      objectNode.put(EMAIL_FIELD, email);
+      objectNode.put(TITLE_FIELD, title);
+      objectNode.put(PASSWORD_FIELD, password);
+      objectNode.put(INVITE_TOKEN_FIELD, inviteToken);
+      final String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectNode);
       request.setEntity(new StringEntity(json));
 
       // Add authorization header with DataHub frontend system id and secret.
@@ -154,7 +163,6 @@ public class AuthServiceClient {
   /**
    * Call the Auth Service to reset credentials for a native DataHub user.
    */
-  @Nonnull
   public boolean resetNativeUserCredentials(@Nonnull final String userUrn, @Nonnull final String password,
       @Nonnull final String resetToken) {
     Objects.requireNonNull(userUrn, "userUrn must not be null");
@@ -170,9 +178,12 @@ public class AuthServiceClient {
               RESET_NATIVE_USER_CREDENTIALS_ENDPOINT));
 
       // Build JSON request to verify credentials for a native user.
-      String json =
-          String.format("{ \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\" }", USER_URN_FIELD, userUrn,
-              PASSWORD_FIELD, password, RESET_TOKEN_FIELD, resetToken);
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final ObjectNode objectNode = objectMapper.createObjectNode();
+      objectNode.put(USER_URN_FIELD, userUrn);
+      objectNode.put(PASSWORD_FIELD, password);
+      objectNode.put(RESET_TOKEN_FIELD, resetToken);
+      final String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectNode);
       request.setEntity(new StringEntity(json));
 
       // Add authorization header with DataHub frontend system id and secret.
@@ -203,7 +214,6 @@ public class AuthServiceClient {
   /**
    * Call the Auth Service to verify the credentials for a native Datahub user.
    */
-  @Nonnull
   public boolean verifyNativeUserCredentials(@Nonnull final String userUrn, @Nonnull final String password) {
     Objects.requireNonNull(userUrn, "userUrn must not be null");
     Objects.requireNonNull(password, "password must not be null");
@@ -217,8 +227,11 @@ public class AuthServiceClient {
               VERIFY_NATIVE_USER_CREDENTIALS_ENDPOINT));
 
       // Build JSON request to verify credentials for a native user.
-      String json =
-          String.format("{ \"%s\":\"%s\", \"%s\":\"%s\" }", USER_URN_FIELD, userUrn, PASSWORD_FIELD, password);
+      final ObjectMapper objectMapper = new ObjectMapper();
+      final ObjectNode objectNode = objectMapper.createObjectNode();
+      objectNode.put(USER_URN_FIELD, userUrn);
+      objectNode.put(PASSWORD_FIELD, password);
+      final String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(objectNode);
       request.setEntity(new StringEntity(json));
 
       // Add authorization header with DataHub frontend system id and secret.

--- a/datahub-frontend/conf/routes
+++ b/datahub-frontend/conf/routes
@@ -12,10 +12,10 @@ GET           /config                                                         co
 # Routes used exclusively by the React application.
 
 # Authentication in React
-GET           /authenticate                                                   controllers.AuthenticationController.authenticate()
-POST          /logIn                                                          controllers.AuthenticationController.logIn()
-POST          /signUp                                                         controllers.AuthenticationController.signUp()
-POST          /resetNativeUserCredentials                                     controllers.AuthenticationController.resetNativeUserCredentials()
+GET           /authenticate                                                   controllers.AuthenticationController.authenticate(request: Request)
+POST          /logIn                                                          controllers.AuthenticationController.logIn(request: Request)
+POST          /signUp                                                         controllers.AuthenticationController.signUp(request: Request)
+POST          /resetNativeUserCredentials                                     controllers.AuthenticationController.resetNativeUserCredentials(request: Request)
 GET           /callback/:protocol                                             controllers.SsoCallbackController.handleCallback(protocol: String)
 POST          /callback/:protocol                                             controllers.SsoCallbackController.handleCallback(protocol: String)
 GET           /logOut                                                         controllers.CentralLogoutController.executeLogout()


### PR DESCRIPTION
## Summary
Refactors AuthServiceClient to:
- Create JSON requests using Jackson ObjectMapper to guard against JSON injection
- Migrate away from using deprecated methods under the Play framework. Note there are a still few left to migrate

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)