### PR TITLE
feat(ingest): aws - support extra args to role config

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -333,7 +333,7 @@ mypy_stubs = {
     "types-cachetools",
     # versions 0.1.13 and 0.1.14 seem to have issues
     "types-click==0.1.12",
-    "boto3-stubs[s3,glue,sagemaker]",
+    "boto3-stubs[s3,glue,sagemaker,sts]",
     "types-tabulate",
     # avrogen package requires this
     "types-pytz",

--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -19,6 +19,16 @@ class ConfigModel(BaseModel):
         )  # needed to allow cached_property to work. See https://github.com/samuelcolvin/pydantic/issues/1241 for more info.
 
 
+class PermissiveConfigModel(ConfigModel):
+    # A permissive config model that allows extra fields.
+    # This is useful for cases where we want to strongly type certain fields,
+    # but still allow the user to pass in arbitrary fields that we don't care about.
+    # It is usually used for argument bags that are passed through to third-party libraries.
+
+    class Config:
+        extra = Extra.allow
+
+
 class TransformerSemantics(ConfigEnum):
     """Describes semantics for aspect changes"""
 


### PR DESCRIPTION
- Adds support for `external_id` and other options in `assume_role`
- Makes it possible to use assume_role in conjunction with the other credential configs.
- Improves docs for all AWS config options.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)