### PR TITLE
fix(schema filter): fix schema infinite rerender

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -48,6 +48,9 @@ export type Props = {
     expandedRowsFromFilter?: Set<string>;
     filterText?: string;
 };
+
+const EMPTY_SET: Set<string> = new Set();
+
 export default function SchemaTable({
     rows,
     schemaMetadata,
@@ -56,7 +59,7 @@ export default function SchemaTable({
     editMode = true,
     schemaFieldBlameList,
     showSchemaAuditView,
-    expandedRowsFromFilter = new Set(),
+    expandedRowsFromFilter = EMPTY_SET,
     filterText = '',
 }: Props): JSX.Element {
     const hasUsageStats = useMemo(() => (usageStats?.aggregations?.fields?.length || 0) > 0, [usageStats]);


### PR DESCRIPTION
If no `expandedRowsFromFilter` is provided then the schema will infinite rerender. This breaks Chart pages for Looker charts with inputs.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)