### PR TITLE
feat(frontend): add custom ssl truststore settings

### DIFF
--- a/docker/datahub-frontend/env/docker.env
+++ b/docker/datahub-frontend/env/docker.env
@@ -11,6 +11,11 @@ JAVA_OPTS=-Xms512m -Xmx512m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf
 #DATAHUB_GMS_USE_SSL=true
 #DATAHUB_GMS_SSL_PROTOCOL=
 
+# Uncomment and set custom SSL truststore settings
+# SSL_TRUSTSTORE_FILE=datahub-frontend/conf/truststore.jks
+# SSL_TRUSTSTORE_TYPE=jks
+# SSL_TRUSTSTORE_PASSWORD=MyTruststorePassword
+
 # Uncomment to enable Metadata Service Authentication
 # METADATA_SERVICE_AUTH_ENABLED=true
 

--- a/docker/datahub-frontend/start.sh
+++ b/docker/datahub-frontend/start.sh
@@ -12,17 +12,17 @@ if [[ ${ENABLE_OTEL:-false} == true ]]; then
 fi
 
 TRUSTSTORE_FILE=""
-if [ ! -z $SSL_TRUSTSTORE_FILE ]; then
+if [[ ! -z ${SSL_TRUSTSTORE_FILE:-} ]]; then
   TRUSTSTORE_FILE="-Djavax.net.ssl.trustStore=$SSL_TRUSTSTORE_FILE"
 fi
 
 TRUSTSTORE_TYPE=""
-if [ ! -z $SSL_TRUSTSTORE_TYPE ]; then
+if [[ ! -z ${SSL_TRUSTSTORE_TYPE:-} ]]; then
   TRUSTSTORE_TYPE="-Djavax.net.ssl.trustStoreType=$SSL_TRUSTSTORE_TYPE"
 fi
 
 TRUSTSTORE_PASSWORD=""
-if [ ! -z $SSL_TRUSTSTORE_PASSWORD ]; then
+if [[ ! -z ${SSL_TRUSTSTORE_PASSWORD:-} ]]; then
   TRUSTSTORE_PASSWORD="-Djavax.net.ssl.trustStorePassword=$SSL_TRUSTSTORE_PASSWORD"
 fi
 

--- a/docker/datahub-frontend/start.sh
+++ b/docker/datahub-frontend/start.sh
@@ -11,6 +11,21 @@ if [[ ${ENABLE_OTEL:-false} == true ]]; then
   OTEL_AGENT="-javaagent:/opentelemetry-javaagent-all.jar"
 fi
 
+TRUSTSTORE_FILE=""
+if [ ! -z $SSL_TRUSTSTORE_FILE ]; then
+  TRUSTSTORE_FILE="-Djavax.net.ssl.trustStore=$SSL_TRUSTSTORE_FILE"
+fi
+
+TRUSTSTORE_TYPE=""
+if [ ! -z $SSL_TRUSTSTORE_TYPE ]; then
+  TRUSTSTORE_TYPE="-Djavax.net.ssl.trustStoreType=$SSL_TRUSTSTORE_TYPE"
+fi
+
+TRUSTSTORE_PASSWORD=""
+if [ ! -z $SSL_TRUSTSTORE_PASSWORD ]; then
+  TRUSTSTORE_PASSWORD="-Djavax.net.ssl.trustStorePassword=$SSL_TRUSTSTORE_PASSWORD"
+fi
+
 # make sure there is no whitespace at the beginning and the end of 
 # this string
 export JAVA_OPTS="-Xms512m \
@@ -20,7 +35,8 @@ export JAVA_OPTS="-Xms512m \
    -Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf \
    -Dlogback.configurationFile=datahub-frontend/conf/logback.xml \
    -Dlogback.debug=false \
-   ${PROMETHEUS_AGENT:-} ${OTEL_AGENT:-}
+   ${PROMETHEUS_AGENT:-} ${OTEL_AGENT:-} \
+   ${TRUSTSTORE_FILE:-} ${TRUSTSTORE_TYPE:-} ${TRUSTSTORE_PASSWORD:-} \
    -Dpidfile.path=/dev/null"
 
 exec ./datahub-frontend/bin/datahub-frontend


### PR DESCRIPTION
Add custom truststore settings. It is required for frontend to use self-signed certificates to connect 3rd party services

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)