### PR TITLE
fix(ingest): fetch workbook tags in workbooks graphql query

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -47,6 +47,9 @@ workbook_graphql_query = """
       uri
       createdAt
       updatedAt
+      tags {
+          name
+      }
       sheets {
         id
         name

--- a/metadata-ingestion/tests/integration/tableau/setup/workbooksConnection_all.json
+++ b/metadata-ingestion/tests/integration/tableau/setup/workbooksConnection_all.json
@@ -995,6 +995,11 @@
                     "uri": "sites/4989/workbooks/15619",
                     "createdAt": "2021-12-17T20:28:31Z",
                     "updatedAt": "2022-01-18T16:14:34Z",
+                    "tags": [
+                        {
+                            "name": "TagSheet3"
+                        }
+                    ],
                     "sheets": [
                         {
                             "id": "8a6a269a-d6de-fae4-5050-513255b40ffc",

--- a/metadata-ingestion/tests/integration/tableau/tableau_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_mces_golden.json
@@ -530,6 +530,20 @@
     }
 },
 {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:fad3de4b86519c3edeb685215fe0bab1",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "value": "{\"tags\": [{\"tag\": \"urn:li:tag:TAGSHEET3\"}]}",
+        "contentType": "application/json"
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "tableau-test"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
             "urn": "urn:li:chart:(tableau,8a6a269a-d6de-fae4-5050-513255b40ffc)",


### PR DESCRIPTION
The code to populate the tags is already in place, however the graphql query was not fetching the tags earlier.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)