### PR TITLE
refactor(ingest): remove typing workarounds

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/committable.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/committable.py
@@ -11,17 +11,10 @@ class CommitPolicy(Enum):
 
 
 @dataclass
-class _CommittableConcrete:
+class Committable(ABC):
     name: str
     commit_policy: CommitPolicy
-    committed: bool
-
-
-# The concrete portion Committable is separated from the abstract portion due to
-# https://github.com/python/mypy/issues/5374#issuecomment-568335302.
-class Committable(_CommittableConcrete, ABC):
-    def __init__(self, name: str, commit_policy: CommitPolicy):
-        super(Committable, self).__init__(name, commit_policy, committed=False)
+    committed: bool = False
 
     @abstractmethod
     def commit(self) -> None:
@@ -34,25 +27,15 @@ StateType = TypeVar("StateType")
 FilterType = TypeVar("FilterType")
 
 
-class _StatefulCommittableConcrete(Generic[StateType]):
-    def __init__(self, state_to_commit: StateType):
-        self.state_to_commit: StateType = state_to_commit
-
-
 class StatefulCommittable(
     Committable,
-    _StatefulCommittableConcrete[StateType],
     Generic[StateKeyType, StateType, FilterType],
 ):
     def __init__(
         self, name: str, commit_policy: CommitPolicy, state_to_commit: StateType
     ):
-        # _ConcreteCommittable will be the first from this class.
-        super(StatefulCommittable, self).__init__(
-            name=name, commit_policy=commit_policy
-        )
-        # _StatefulCommittableConcrete will be after _CommittableConcrete in the __mro__.
-        super(_CommittableConcrete, self).__init__(state_to_commit=state_to_commit)
+        super().__init__(name=name, commit_policy=commit_policy)
+        self.state_to_commit: StateType = state_to_commit
 
     def has_successfully_committed(self) -> bool:
         return bool(not self.state_to_commit or self.committed)

--- a/metadata-ingestion/src/datahub/ingestion/api/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/common.py
@@ -33,14 +33,9 @@ class EndOfStream(ControlRecord):
 
 
 @dataclass
-class _WorkUnitId(metaclass=ABCMeta):
+class WorkUnit(metaclass=ABCMeta):
     id: str
 
-
-# For information on why the WorkUnit class is structured this way
-# and is separating the dataclass portion from the abstract methods, see
-# https://github.com/python/mypy/issues/5374#issuecomment-568335302.
-class WorkUnit(_WorkUnitId, metaclass=ABCMeta):
     @abstractmethod
     def get_metadata(self) -> dict:
         pass

--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -114,8 +114,7 @@ class Extractor(Generic[WorkUnitType, ExtractorConfig], Closeable, metaclass=ABC
         pass
 
 
-# See https://github.com/python/mypy/issues/5374 for why we suppress this mypy error.
-@dataclass  # type: ignore[misc]
+@dataclass
 class Source(Closeable, metaclass=ABCMeta):
     ctx: PipelineContext
 


### PR DESCRIPTION
Possible now that we're on mypy 0.980. It used to have issues with `@dataclass` on abstract classes, but was fixed by https://github.com/python/mypy/pull/13398.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)