### PR TITLE
feat(search): improved search snippet FE logic

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
 import { DatabaseFilled, DatabaseOutlined } from '@ant-design/icons';
-import { Typography } from 'antd';
 import { Dataset, DatasetProperties, EntityType, OwnershipType, SearchResult } from '../../../types.generated';
 import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '../Entity';
 import { Preview } from './preview/Preview';
-import { FIELDS_TO_HIGHLIGHT } from './search/highlights';
 import { EntityProfile } from '../shared/containers/profile/EntityProfile';
 import { GetDatasetQuery, useGetDatasetQuery, useUpdateDatasetMutation } from '../../../graphql/dataset.generated';
 import { GenericEntityProperties } from '../shared/types';
@@ -28,8 +26,7 @@ import { OperationsTab } from './profile/OperationsTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { SidebarSiblingsSection } from '../shared/containers/profile/sidebar/SidebarSiblingsSection';
 import { DatasetStatsSummarySubHeader } from './profile/stats/stats/DatasetStatsSummarySubHeader';
-import { TagSummary } from './shared/TagSummary';
-import { TermSummary } from './shared/TermSummary';
+import { DatasetSearchSnippet } from './DatasetSearchSnippet';
 
 const SUBTYPES = {
     VIEW: 'view',
@@ -256,18 +253,6 @@ export class DatasetEntity implements Entity<Dataset> {
         const data = result.entity as Dataset;
         const genericProperties = this.getGenericEntityProperties(data);
 
-        let snippet: React.ReactNode;
-
-        if (result.matchedFields.length > 0) {
-            if (result.matchedFields[0].value.includes('urn:li:tag')) {
-                snippet = <TagSummary urn={result.matchedFields[0].value} />;
-            } else if (result.matchedFields[0].value.includes('urn:li:glossaryTerm')) {
-                snippet = <TermSummary urn={result.matchedFields[0].value} />;
-            } else {
-                snippet = <b>{result.matchedFields[0].value}</b>;
-            }
-        }
-
         return (
             <Preview
                 urn={data.urn}
@@ -289,15 +274,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 subtype={data.subTypes?.typeNames?.[0]}
                 container={data.container}
                 parentContainers={data.parentContainers}
-                snippet={
-                    // Add match highlights only if all the matched fields are in the FIELDS_TO_HIGHLIGHT
-                    result.matchedFields.length > 0 &&
-                    result.matchedFields.every((field) => FIELDS_TO_HIGHLIGHT.has(field.name)) && (
-                        <Typography.Text>
-                            Matches {FIELDS_TO_HIGHLIGHT.get(result.matchedFields[0].name)} {snippet}
-                        </Typography.Text>
-                    )
-                }
+                snippet={<DatasetSearchSnippet matchedFields={result.matchedFields} />}
                 insights={result.insights}
                 externalUrl={data.properties?.externalUrl}
                 statsSummary={data.statsSummary}

--- a/datahub-web-react/src/app/entity/dataset/DatasetSearchSnippet.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetSearchSnippet.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Typography } from 'antd';
+import { MatchedField } from '../../../types.generated';
+import { TagSummary } from './shared/TagSummary';
+import { TermSummary } from './shared/TermSummary';
+import { FIELDS_TO_HIGHLIGHT } from './search/highlights';
+import { getMatchPrioritizingPrimary } from '../shared/utils';
+
+type Props = {
+    matchedFields: MatchedField[];
+};
+
+const LABEL_INDEX_NAME = 'fieldLabels';
+
+export const DatasetSearchSnippet = ({ matchedFields }: Props) => {
+    const matchedField = getMatchPrioritizingPrimary(matchedFields, LABEL_INDEX_NAME);
+
+    let snippet: React.ReactNode;
+
+    if (matchedField) {
+        if (matchedField.value.includes('urn:li:tag')) {
+            snippet = <TagSummary urn={matchedField.value} />;
+        } else if (matchedField.value.includes('urn:li:glossaryTerm')) {
+            snippet = <TermSummary urn={matchedField.value} />;
+        } else {
+            snippet = <b>{matchedField.value}</b>;
+        }
+    }
+
+    return matchedField ? (
+        <Typography.Text>
+            Matches {FIELDS_TO_HIGHLIGHT.get(matchedField.name)} {snippet}{' '}
+        </Typography.Text>
+    ) : null;
+};

--- a/datahub-web-react/src/app/entity/shared/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/utils.test.ts
@@ -1,0 +1,37 @@
+import { getMatchPrioritizingPrimary } from '../utils';
+
+const MOCK_MATCHED_FIELDS = [
+    {
+        name: 'fieldPaths',
+        value: 'rain',
+    },
+    {
+        name: 'description',
+        value: 'rainbow',
+    },
+    {
+        name: 'fieldPaths',
+        value: 'rainbow',
+    },
+    {
+        name: 'fieldPaths',
+        value: 'rainbows',
+    },
+];
+
+describe('utils', () => {
+    describe('getMatchPrioritizingPrimary', () => {
+        it('prioritizes exact match', () => {
+            global.window.location.search = 'query=rainbow';
+            const match = getMatchPrioritizingPrimary(MOCK_MATCHED_FIELDS, 'fieldPaths');
+            expect(match?.value).toEqual('rainbow');
+            expect(match?.name).toEqual('fieldPaths');
+        });
+        it('will accept first contains match', () => {
+            global.window.location.search = 'query=bow';
+            const match = getMatchPrioritizingPrimary(MOCK_MATCHED_FIELDS, 'fieldPaths');
+            expect(match?.value).toEqual('rainbow');
+            expect(match?.name).toEqual('fieldPaths');
+        });
+    });
+});

--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -1,3 +1,5 @@
+import * as QueryString from 'query-string';
+
 import { MatchedField } from '../../../types.generated';
 import { FIELDS_TO_HIGHLIGHT } from '../dataset/search/highlights';
 import { GenericEntityProperties } from './types';
@@ -83,18 +85,43 @@ export const isListSubset = (l1, l2): boolean => {
     return l1.every((result) => l2.indexOf(result) >= 0);
 };
 
-function sortMatchedFields(a: MatchedField, b: MatchedField) {
-    return 1;
+function normalize(value: string) {
+    return value.trim().toLowerCase();
+}
+
+function fromQueryGetBestMatch(selectedMatchedFields: MatchedField[], rawQuery: string) {
+    const query = normalize(rawQuery);
+    // first lets see if there's an exact match between a field value and the query
+    const exactMatch = selectedMatchedFields.find((field) => normalize(field.value) === query);
+    if (exactMatch) {
+        return exactMatch;
+    }
+
+    // if no exact match exists, we'll see if the entire query is contained in any of the values
+    const containedMatch = selectedMatchedFields.find((field) => normalize(field.value).includes(query));
+    if (containedMatch) {
+        return containedMatch;
+    }
+
+    // otherwise, just return whichever is first
+    return selectedMatchedFields[0];
 }
 
 export const getMatchPrioritizingPrimary = (
     matchedFields: MatchedField[],
     primaryField: string,
 ): MatchedField | undefined => {
-    const primaryMatch = matchedFields.find((field) => field.name === primaryField);
-    if (primaryMatch) {
-        return primaryMatch;
+    const { location } = window;
+    const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
+    const query: string = decodeURIComponent(params.query ? (params.query as string) : '');
+
+    const primaryMatches = matchedFields.filter((field) => field.name === primaryField);
+    if (primaryMatches.length > 0) {
+        return fromQueryGetBestMatch(primaryMatches, query);
     }
 
-    return matchedFields.filter((field) => FIELDS_TO_HIGHLIGHT.has(field.name)).sort(sortMatchedFields)[0];
+    return fromQueryGetBestMatch(
+        matchedFields.filter((field) => FIELDS_TO_HIGHLIGHT.has(field.name)),
+        query,
+    );
 };

--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -120,8 +120,7 @@ export const getMatchPrioritizingPrimary = (
         return fromQueryGetBestMatch(primaryMatches, query);
     }
 
-    return fromQueryGetBestMatch(
-        matchedFields.filter((field) => FIELDS_TO_HIGHLIGHT.has(field.name)),
-        query,
-    );
+    const matchesThatShouldBeShownOnFE = matchedFields.filter((field) => FIELDS_TO_HIGHLIGHT.has(field.name));
+
+    return fromQueryGetBestMatch(matchesThatShouldBeShownOnFE, query);
 };

--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -83,6 +83,10 @@ export const isListSubset = (l1, l2): boolean => {
     return l1.every((result) => l2.indexOf(result) >= 0);
 };
 
+function sortMatchedFields(a: MatchedField, b: MatchedField) {
+    return 1;
+}
+
 export const getMatchPrioritizingPrimary = (
     matchedFields: MatchedField[],
     primaryField: string,
@@ -92,5 +96,5 @@ export const getMatchPrioritizingPrimary = (
         return primaryMatch;
     }
 
-    return matchedFields.find((field) => FIELDS_TO_HIGHLIGHT.has(field.name));
+    return matchedFields.filter((field) => FIELDS_TO_HIGHLIGHT.has(field.name)).sort(sortMatchedFields)[0];
 };


### PR DESCRIPTION
1. We used to only show search snippets for datasets if there was no description or title match. Now, we will show them regardless.

2. We used to just pluck out the first search snippet that came back & was relevant. Now, we do a few passes to try and find the best search snippet based on your query.

Added some unit tests & comments since we are encoding some business logic in this utility.

<img width="1403" alt="CleanShot 2022-10-03 at 16 16 23@2x" src="https://user-images.githubusercontent.com/2455694/193702460-ab7538ef-1864-41e5-a73e-11d46a4f1cc1.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)