### PR TITLE
fix(ingest): ignore usage and operation for snowflake datasets withou…

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -76,7 +76,7 @@ class SnowflakeV2Config(SnowflakeConfig, SnowflakeUsageConfig):
         )
         include_table_lineage = values.get("include_table_lineage")
 
-        # TODO: Allow lineage extraction irrespective of basic schema extraction,
+        # TODO: Allow lineage extraction and profiling irrespective of basic schema extraction,
         # as it seems possible with some refractor
         if not include_technical_schema and any(
             [include_profiles, delete_detection_enabled, include_table_lineage]

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
@@ -46,7 +46,6 @@ class SnowflakeProfiler(SnowflakeCommonMixin):
                 "max_overflow", self.config.profiling.max_workers
             )
 
-        # Otherwise, if column level profiling is enabled, use  GE profiler.
         for db in databases:
             if not self.config.database_pattern.allowed(db.name):
                 continue
@@ -236,6 +235,7 @@ class SnowflakeProfiler(SnowflakeCommonMixin):
         if len(ge_profile_requests) == 0:
             return
 
+        # Otherwise, if column level profiling is enabled, use  GE profiler.
         ge_profiler = self.get_profiler_instance(db_name)
         yield from ge_profiler.generate_profiles(
             ge_profile_requests, max_workers, platform, profiler_args

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
@@ -92,7 +92,9 @@ class SnowflakeUsageExtractor(SnowflakeQueryMixin, SnowflakeCommonMixin):
         self.report: SnowflakeV2Report = report
         self.logger = logger
 
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+    def get_workunits(
+        self, discovered_datasets: List[str]
+    ) -> Iterable[MetadataWorkUnit]:
         conn = self.config.get_connection()
 
         logger.info("Checking usage date ranges")
@@ -107,18 +109,20 @@ class SnowflakeUsageExtractor(SnowflakeQueryMixin, SnowflakeCommonMixin):
         # Now, we report the usage as well as operation metadata even if user email is absent
 
         if self.config.include_usage_stats:
-            yield from self.get_usage_workunits(conn)
+            yield from self.get_usage_workunits(conn, discovered_datasets)
 
         if self.config.include_operational_stats:
             # Generate the operation workunits.
             access_events = self._get_snowflake_history(conn)
             for event in access_events:
-                yield from self._get_operation_aspect_work_unit(event)
+                yield from self._get_operation_aspect_work_unit(
+                    event, discovered_datasets
+                )
 
         conn.close()
 
     def get_usage_workunits(
-        self, conn: SnowflakeConnection
+        self, conn: SnowflakeConnection, discovered_datasets: List[str]
     ) -> Iterable[MetadataWorkUnit]:
 
         with PerfTimer() as timer:
@@ -144,6 +148,15 @@ class SnowflakeUsageExtractor(SnowflakeQueryMixin, SnowflakeCommonMixin):
             ):
                 continue
 
+            dataset_identifier = self.get_dataset_identifier_from_qualified_name(
+                row["OBJECT_NAME"]
+            )
+            if dataset_identifier not in discovered_datasets:
+                logger.debug(
+                    f"Skipping usage for table {dataset_identifier}, as table schema is not accessible"
+                )
+                continue
+
             stats = DatasetUsageStatistics(
                 timestampMillis=int(row["BUCKET_START_TIME"].timestamp() * 1000),
                 eventGranularity=TimeWindowSize(
@@ -161,7 +174,7 @@ class SnowflakeUsageExtractor(SnowflakeQueryMixin, SnowflakeCommonMixin):
             )
             dataset_urn = make_dataset_urn_with_platform_instance(
                 self.platform,
-                self.get_dataset_identifier_from_qualified_name(row["OBJECT_NAME"]),
+                dataset_identifier,
                 self.config.platform_instance,
                 self.config.env,
             )
@@ -276,7 +289,7 @@ class SnowflakeUsageExtractor(SnowflakeQueryMixin, SnowflakeCommonMixin):
                     )
 
     def _get_operation_aspect_work_unit(
-        self, event: SnowflakeJoinedAccessEvent
+        self, event: SnowflakeJoinedAccessEvent, discovered_datasets: List[str]
     ) -> Iterable[MetadataWorkUnit]:
         if event.query_start_time and event.query_type in OPERATION_STATEMENT_TYPES:
             start_time = event.query_start_time
@@ -292,9 +305,20 @@ class SnowflakeUsageExtractor(SnowflakeQueryMixin, SnowflakeCommonMixin):
             for obj in event.objects_modified:
 
                 resource = obj.objectName
+
+                dataset_identifier = self.get_dataset_identifier_from_qualified_name(
+                    resource
+                )
+
+                if dataset_identifier not in discovered_datasets:
+                    logger.debug(
+                        f"Skipping operations for table {dataset_identifier}, as table schema is not accessible"
+                    )
+                    continue
+
                 dataset_urn = make_dataset_urn_with_platform_instance(
                     self.platform,
-                    self.get_dataset_identifier_from_qualified_name(resource),
+                    dataset_identifier,
                     self.config.platform_instance,
                     self.config.env,
                 )


### PR DESCRIPTION
…t schema

Currently if role has access to account usage tables, usage for all tables (including deleted and not accessible tables) are ingested. This PR takes care not to ingest usage for such datasets in datahub. Usage will be ingested only for tables for which schema is accessible.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)