### PR TITLE
fix(mae): use JAVA_TOOL_OPTIONS instead of JDK_JAVA_OPTIONS

### DIFF
--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -34,13 +34,13 @@ if [[ ${GRAPH_SERVICE_IMPL:-} != elasticsearch ]] && [[ ${SKIP_NEO4J_CHECK:-fals
   dockerize_args+=("-wait" "$NEO4J_HOST")
 fi
 
-JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS:-}${JAVA_OPTS:+ JAVA_OPTS}${JMX_OPTS:+ JMX_OPTS}"
+JAVA_TOOL_OPTIONS="${JDK_JAVA_OPTIONS:-}${JAVA_OPTS:+ JAVA_OPTS}${JMX_OPTS:+ JMX_OPTS}"
 if [[ ${ENABLE_OTEL:-false} == true ]]; then
-  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS -javaagent:opentelemetry-javaagent-all.jar"
+  JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -javaagent:opentelemetry-javaagent-all.jar"
 fi
 if [[ ${ENABLE_PROMETHEUS:-false} == true ]]; then
-  JDK_JAVA_OPTIONS="$JDK_JAVA_OPTIONS -javaagent:jmx_prometheus_javaagent.jar=4318:/datahub/datahub-mae-consumer/scripts/prometheus-config.yaml"
+  JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -javaagent:jmx_prometheus_javaagent.jar=4318:/datahub/datahub-mae-consumer/scripts/prometheus-config.yaml"
 fi
 
-export JDK_JAVA_OPTIONS
+export JAVA_TOOL_OPTIONS
 exec dockerize "${dockerize_args[@]}" java -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar


### PR DESCRIPTION
JDK_JAVA_OPTIONS is loaded twice by java (probably alpine bug).
As a workaround using: JAVA_TOOL_OPTIONS



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)