### PR TITLE
feat(mutations): adding editable schema metadata to charts and dashboards

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateDescriptionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateDescriptionResolver.java
@@ -28,6 +28,10 @@ public class UpdateDescriptionResolver implements DataFetcher<CompletableFuture<
     switch (targetUrn.getEntityType()) {
       case Constants.DATASET_ENTITY_NAME:
         return updateDatasetDescription(targetUrn, input, environment.getContext());
+      case Constants.CHART_ENTITY_NAME:
+        return updateChartDescription(targetUrn, input, environment.getContext());
+      case Constants.DASHBOARD_ENTITY_NAME:
+        return updateDashboardDescription(targetUrn, input, environment.getContext());
       case Constants.CONTAINER_ENTITY_NAME:
         return updateContainerDescription(targetUrn, input, environment.getContext());
       case Constants.DOMAIN_ENTITY_NAME:
@@ -108,6 +112,62 @@ public class UpdateDescriptionResolver implements DataFetcher<CompletableFuture<
   }
 
   private CompletableFuture<Boolean> updateDatasetDescription(Urn targetUrn, DescriptionUpdateInput input, QueryContext context) {
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (!DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, targetUrn)) {
+        throw new AuthorizationException(
+            "Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+
+      if (input.getSubResourceType() == null) {
+        throw new IllegalArgumentException("Update description without subresource is not currently supported");
+      }
+
+      DescriptionUtils.validateFieldDescriptionInput(targetUrn, input.getSubResource(), input.getSubResourceType(),
+          _entityService);
+
+      try {
+        Urn actor = CorpuserUrn.createFromString(context.getActorUrn());
+        DescriptionUtils.updateFieldDescription(input.getDescription(), targetUrn, input.getSubResource(), actor,
+            _entityService);
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to perform update against input {}, {}", input.toString(), e.getMessage());
+        throw new RuntimeException(String.format("Failed to perform update against input %s", input.toString()), e);
+      }
+    });
+  }
+
+  private CompletableFuture<Boolean> updateChartDescription(Urn targetUrn, DescriptionUpdateInput input, QueryContext context) {
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (!DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, targetUrn)) {
+        throw new AuthorizationException(
+            "Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+
+      if (input.getSubResourceType() == null) {
+        throw new IllegalArgumentException("Update description without subresource is not currently supported");
+      }
+
+      DescriptionUtils.validateFieldDescriptionInput(targetUrn, input.getSubResource(), input.getSubResourceType(),
+          _entityService);
+
+      try {
+        Urn actor = CorpuserUrn.createFromString(context.getActorUrn());
+        DescriptionUtils.updateFieldDescription(input.getDescription(), targetUrn, input.getSubResource(), actor,
+            _entityService);
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to perform update against input {}, {}", input.toString(), e.getMessage());
+        throw new RuntimeException(String.format("Failed to perform update against input %s", input.toString()), e);
+      }
+    });
+  }
+
+  private CompletableFuture<Boolean> updateDashboardDescription(Urn targetUrn, DescriptionUpdateInput input, QueryContext context) {
 
     return CompletableFuture.supplyAsync(() -> {
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -72,7 +72,8 @@ public class ChartType implements SearchableEntityType<Chart, String>, Browsable
         DOMAINS_ASPECT_NAME,
         DEPRECATION_ASPECT_NAME,
         DATA_PLATFORM_INSTANCE_ASPECT_NAME,
-        INPUT_FIELDS_ASPECT_NAME
+        INPUT_FIELDS_ASPECT_NAME,
+        EDITABLE_SCHEMA_METADATA_ASPECT_NAME
     );
     private static final Set<String> FACET_FIELDS = ImmutableSet.of("access", "queryType", "tool", "type");
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java
@@ -32,6 +32,7 @@ import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.SystemMetadataUtils;
+import com.linkedin.datahub.graphql.types.dataset.mappers.EditableSchemaMetadataMapper;
 import com.linkedin.datahub.graphql.types.domain.DomainAssociationMapper;
 import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
@@ -42,6 +43,7 @@ import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.metadata.key.ChartKey;
 import com.linkedin.metadata.key.DataPlatformKey;
 import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.schema.EditableSchemaMetadata;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -89,6 +91,8 @@ public class ChartMapper implements ModelMapper<EntityResponse, Chart> {
             dataset.setDataPlatformInstance(DataPlatformInstanceAspectMapper.map(new DataPlatformInstance(dataMap))));
         mappingHelper.mapToResult(INPUT_FIELDS_ASPECT_NAME, (chart, dataMap) ->
             chart.setInputFields(InputFieldsMapper.map(new InputFields(dataMap), entityUrn)));
+        mappingHelper.mapToResult(EDITABLE_SCHEMA_METADATA_ASPECT_NAME, (chart, dataMap) ->
+            chart.setEditableInputFieldMetadata(EditableSchemaMetadataMapper.map(new EditableSchemaMetadata(dataMap), entityUrn)));
 
         return mappingHelper.getResult();
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -74,7 +74,8 @@ public class DashboardType implements SearchableEntityType<Dashboard, String>, B
         DEPRECATION_ASPECT_NAME,
         DATA_PLATFORM_INSTANCE_ASPECT_NAME,
         INPUT_FIELDS_ASPECT_NAME,
-        SUB_TYPES_ASPECT_NAME
+        SUB_TYPES_ASPECT_NAME,
+        EDITABLE_SCHEMA_METADATA_ASPECT_NAME
     );
     private static final Set<String> FACET_FIELDS = ImmutableSet.of("access", "tool");
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java
@@ -31,6 +31,7 @@ import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.SystemMetadataUtils;
+import com.linkedin.datahub.graphql.types.dataset.mappers.EditableSchemaMetadataMapper;
 import com.linkedin.datahub.graphql.types.domain.DomainAssociationMapper;
 import com.linkedin.datahub.graphql.types.glossary.mappers.GlossaryTermsMapper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
@@ -41,6 +42,7 @@ import com.linkedin.entity.EnvelopedAspectMap;
 import com.linkedin.metadata.key.DashboardKey;
 import com.linkedin.metadata.key.DataPlatformKey;
 import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.schema.EditableSchemaMetadata;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -88,6 +90,8 @@ public class DashboardMapper implements ModelMapper<EntityResponse, Dashboard> {
         mappingHelper.mapToResult(INPUT_FIELDS_ASPECT_NAME, (dashboard, dataMap) ->
             dashboard.setInputFields(InputFieldsMapper.map(new InputFields(dataMap), entityUrn)));
         mappingHelper.mapToResult(SUB_TYPES_ASPECT_NAME, this::mapSubTypes);
+        mappingHelper.mapToResult(EDITABLE_SCHEMA_METADATA_ASPECT_NAME, (dashboard, dataMap) ->
+            dashboard.setEditableInputFieldMetadata(EditableSchemaMetadataMapper.map(new EditableSchemaMetadata(dataMap), entityUrn)));
 
         return mappingHelper.getResult();
     }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -4367,6 +4367,11 @@ type Dashboard implements EntityWithRelationships & Entity & BrowsableEntity {
     Sub Types of the dashboard
     """
     subTypes: SubTypes
+
+    """
+    Editable information on top of dashboard input fields
+    """
+    editableInputFieldMetadata: EditableSchemaMetadata
 }
 
 """
@@ -4652,6 +4657,11 @@ type Chart implements EntityWithRelationships & Entity & BrowsableEntity {
     Input fields to power the chart
     """
     inputFields: InputFields
+
+    """
+    Editable information on top of chart input fields
+    """
+    editableInputFieldMetadata: EditableSchemaMetadata
 }
 
 """
@@ -6727,7 +6737,12 @@ enum SubResourceType {
     """
     A Dataset field or column
     """
-    DATASET_FIELD
+    DATASET_FIELD @deprecated(reason: "Other entities can have fields as well- adding a more generic field subtype")
+
+    """
+    A field on a set of fields attached to an entity
+    """
+    FIELD,
 }
 
 

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
@@ -31,7 +31,7 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
                                 description: DOMPurify.sanitize(updatedDescription),
                                 resourceUrn: urn,
                                 subResource: record.fieldPath,
-                                subResourceType: SubResourceType.DatasetField,
+                                subResourceType: SubResourceType.Field,
                             },
                         },
                     }).then(refetch)

--- a/datahub-web-react/src/app/entity/shared/tabs/Entity/InputFieldsTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Entity/InputFieldsTab.tsx
@@ -26,17 +26,19 @@ export const InputFieldsTab = () => {
         return groupByFieldPath(ungroupedRows, { showKeySchema: false });
     }, [ungroupedRows]);
 
+    const editableSchemaMetadata: any = entityData?.editableInputFieldMetadata || undefined;
+
     return (
         <>
             <SchemaTableContainer>
                 {rows && rows.length > 0 ? (
                     <>
-                        <SchemaEditableContext.Provider value={false}>
+                        <SchemaEditableContext.Provider value>
                             <SchemaTable
                                 schemaMetadata={null}
                                 rows={rows}
-                                editMode={false}
-                                editableSchemaMetadata={null}
+                                editMode
+                                editableSchemaMetadata={editableSchemaMetadata}
                                 usageStats={null}
                                 schemaFieldBlameList={null}
                                 showSchemaAuditView={false}

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -79,6 +79,7 @@ export type GenericEntityProperties = {
     entityTypeOverride?: Maybe<string>;
     /** Dataset specific- TODO, migrate these out */
     editableSchemaMetadata?: Maybe<EditableSchemaMetadata>;
+    editableInputFieldMetadata?: Maybe<EditableSchemaMetadata>;
     editableProperties?: Maybe<DatasetEditableProperties>;
     autoRenderAspects?: Maybe<Array<RawAspect>>;
     upstream?: Maybe<EntityLineageResult>;

--- a/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
@@ -112,7 +112,7 @@ export default function TagTermGroup({
                                 tagUrn: tagToRemove.urn,
                                 resourceUrn: tagAssociationToRemove.associatedUrn || entityUrn || '',
                                 subResource: entitySubresource,
-                                subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
+                                subResourceType: entitySubresource ? SubResourceType.Field : null,
                             },
                         },
                     })
@@ -149,7 +149,7 @@ export default function TagTermGroup({
                                 termUrn: termToRemove.term.urn,
                                 resourceUrn: termToRemove.associatedUrn || entityUrn || '',
                                 subResource: entitySubresource,
-                                subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
+                                subResourceType: entitySubresource ? SubResourceType.Field : null,
                             },
                         },
                     })
@@ -368,7 +368,7 @@ export default function TagTermGroup({
                         {
                             resourceUrn: entityUrn,
                             subResource: entitySubresource,
-                            subResourceType: entitySubresource ? SubResourceType.DatasetField : null,
+                            subResourceType: entitySubresource ? SubResourceType.Field : null,
                         },
                     ]}
                 />

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -94,6 +94,18 @@ query getChart($urn: String!) {
         inputFields {
             ...inputFieldsFields
         }
+        editableInputFieldMetadata {
+            editableSchemaFieldInfo {
+                fieldPath
+                description
+                globalTags {
+                    ...globalTagsFields
+                }
+                glossaryTerms {
+                    ...glossaryTerms
+                }
+            }
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -426,6 +426,18 @@ fragment dashboardFields on Dashboard {
     inputFields {
         ...inputFieldsFields
     }
+    editableInputFieldMetadata {
+        editableSchemaFieldInfo {
+            fieldPath
+            description
+            globalTags {
+                ...globalTagsFields
+            }
+            glossaryTerms {
+                ...glossaryTerms
+            }
+        }
+    }
     subTypes {
         typeNames
     }

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -59,6 +59,7 @@ entities:
       - deprecation
       - inputFields
       - chartUsageStatistics
+      - editableSchemaMetadata
   - name: dashboard
     keyAspect: dashboardKey
     aspects:
@@ -68,6 +69,7 @@ entities:
       - dashboardUsageStatistics
       - inputFields
       - subTypes
+      - editableSchemaMetadata
   - name: notebook
     doc: Notebook represents a combination of query, text, chart and etc. This is in BETA version
     keyAspect: notebookKey

--- a/smoke-test/tests/cypress/cypress/integration/mutations/mutations.js
+++ b/smoke-test/tests/cypress/cypress/integration/mutations/mutations.js
@@ -2,7 +2,7 @@ describe("mutations", () => {
   before(() => {
     // warm up elastic by issuing a `*` search
     cy.login();
-    cy.visit("http://localhost:9002/search?query=%2A");
+    cy.visit("/search?query=%2A");
     cy.wait(5000);
   });
 
@@ -165,6 +165,40 @@ describe("mutations", () => {
     cy.get('[data-testid="schema-field-event_name-terms"]').within(() =>
       cy.contains("Add Term").click({ force: true })
     );
+
+    cy.focused().type("CypressTerm");
+
+    cy.get(".ant-select-item-option-content").within(() =>
+      cy.contains("CypressTerm").click({ force: true })
+    );
+
+    cy.get('[data-testid="add-tag-term-from-modal-btn"]').click({
+      force: true,
+    });
+    cy.get('[data-testid="add-tag-term-from-modal-btn"]').should("not.exist");
+
+    cy.contains("CypressTerm");
+
+    cy.get(
+      'a[href="/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressTerm"]'
+    ).within(() => cy.get("span[aria-label=close]").click({ force: true }));
+    cy.contains("Yes").click({ force: true });
+
+    cy.contains("CypressTerm").should("not.exist");
+  });
+
+  it("can add and remove terms from a chart input field", () => {
+    cy.login();
+    // make space for the glossary term column
+    cy.viewport(2000, 800);
+    cy.visit("/chart/urn:li:chart:(looker,cypress_baz1)/Fields");
+
+    cy.get(
+      '[data-testid="schema-field-lifetime_purchase_amount-terms"]'
+    ).trigger("mouseover", { force: true });
+    cy.get(
+      '[data-testid="schema-field-lifetime_purchase_amount-terms"]'
+    ).within(() => cy.contains("Add Term").click({ force: true }));
 
     cy.focused().type("CypressTerm");
 

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -790,16 +790,18 @@
               ],
               "primaryKeys": null,
               "foreignKeysSpecs": null,
-              "foreignKeys": [{
-                "name": "user id",
-                "foreignFields": [
-                  "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD),user_id)"
-                ],
-                "sourceFields": [
-                  "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),user_id)"
-                ],
-                "foreignDataset": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"
-              }]
+              "foreignKeys": [
+                {
+                  "name": "user id",
+                  "foreignFields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD),user_id)"
+                  ],
+                  "sourceFields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),user_id)"
+                  ],
+                  "foreignDataset": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"
+                }
+              ]
             }
           }
         ]
@@ -932,16 +934,18 @@
               ],
               "primaryKeys": null,
               "foreignKeysSpecs": null,
-              "foreignKeys": [{
-                "name": "user id",
-                "foreignFields": [
-                  "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD),user_id)"
-                ],
-                "sourceFields": [
-                  "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),user_id)"
-                ],
-                "foreignDataset": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"
-              }]
+              "foreignKeys": [
+                {
+                  "name": "user id",
+                  "foreignFields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD),user_id)"
+                  ],
+                  "sourceFields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD),user_id)"
+                  ],
+                  "foreignDataset": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"
+                }
+              ]
             }
           },
           {
@@ -1148,16 +1152,18 @@
               ],
               "primaryKeys": ["user_name"],
               "foreignKeysSpecs": null,
-              "foreignKeys": [{
-                "name": "user session",
-                "foreignFields": [
-                  "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user_id)"
-                ],
-                "sourceFields": [
-                  "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_deleted,PROD),user_id)"
-                ],
-                "foreignDataset": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD)"
-              }]
+              "foreignKeys": [
+                {
+                  "name": "user session",
+                  "foreignFields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user_id)"
+                  ],
+                  "sourceFields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_deleted,PROD),user_id)"
+                  ],
+                  "foreignDataset": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD)"
+                }
+              ]
             }
           },
           {
@@ -1482,10 +1488,12 @@
           },
           {
             "com.linkedin.pegasus2avro.common.Ownership": {
-              "owners": [{
-                "owner": "urn:li:corpuser:jdoe",
-                "type": "DATAOWNER"
-              }],
+              "owners": [
+                {
+                  "owner": "urn:li:corpuser:jdoe",
+                  "type": "DATAOWNER"
+                }
+              ],
               "lastModified": {
                 "time": 1581407189000,
                 "actor": "urn:li:corpuser:jdoe"
@@ -1502,17 +1510,20 @@
     "proposedSnapshot": {
       "com.linkedin.pegasus2avro.metadata.snapshot.GlossaryNodeSnapshot": {
         "urn": "urn:li:glossaryNode:CypressNode",
-        "aspects": [{
-          "com.linkedin.pegasus2avro.glossary.GlossaryNodeInfo": {
-            "definition": "Provides basic concepts such as account, account holder, account provider, relationship manager that are commonly used by financial services providers to describe customers and to determine counterparty identities"
-          }
-        },
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.glossary.GlossaryNodeInfo": {
+              "definition": "Provides basic concepts such as account, account holder, account provider, relationship manager that are commonly used by financial services providers to describe customers and to determine counterparty identities"
+            }
+          },
           {
             "com.linkedin.pegasus2avro.common.Ownership": {
-              "owners": [{
-                "owner": "urn:li:corpuser:jdoe",
-                "type": "DATAOWNER"
-              }],
+              "owners": [
+                {
+                  "owner": "urn:li:corpuser:jdoe",
+                  "type": "DATAOWNER"
+                }
+              ],
               "lastModified": {
                 "time": 1581407189000,
                 "actor": "urn:li:corpuser:jdoe"
@@ -1524,7 +1535,7 @@
     },
     "proposedDelta": null
   },
-   {
+  {
     "auditHeader": null,
     "proposedSnapshot": {
       "com.linkedin.pegasus2avro.metadata.snapshot.TagSnapshot": {
@@ -1565,8 +1576,8 @@
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1622243780153, \"lastUpdatedTimestamp\": 1622243780153, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": []}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1622243780153, \"lastUpdatedTimestamp\": 1622243780153, \"actor\": \"urn:li:corpuser:harshal\", \"operationType\": \"CREATE\", \"affectedDatasets\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": null
   },
@@ -1582,7 +1593,8 @@
       "contentType": "application/json"
     },
     "systemMetadata": null
-  },{
+  },
+  {
     "auditHeader": null,
     "entityType": "dataProcessInstance",
     "entityUrn": "urn:li:dataProcessInstance:c39d6e424c70a1b3e8982535c68b5b5888",
@@ -1594,7 +1606,8 @@
       "contentType": "application/json"
     },
     "systemMetadata": null
-    },{
+  },
+  {
     "auditHeader": null,
     "entityType": "dataProcessInstance",
     "entityUrn": "urn:li:dataProcessInstance:c39d6e424c70a1b3e8982535c68b5b5888",
@@ -1606,7 +1619,8 @@
       "contentType": "application/json"
     },
     "systemMetadata": null
-  },{
+  },
+  {
     "auditHeader": null,
     "entityType": "dataProcessInstance",
     "entityUrn": "urn:li:dataProcessInstance:c39d6e424c70a1b3e8982535c68b5b5888",
@@ -1618,7 +1632,8 @@
       "contentType": "application/json"
     },
     "systemMetadata": null
-  },{
+  },
+  {
     "auditHeader": null,
     "entityType": "dataProcessInstance",
     "entityUrn": "urn:li:dataProcessInstance:c39d6e424c70a1b3e8982535c68b5b5888",
@@ -1642,7 +1657,9 @@
               "description": null,
               "dataType": "TEXT",
               "version": null,
-              "sources": ["urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)"]
+              "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)"
+              ]
             }
           },
           {
@@ -1667,7 +1684,9 @@
               "description": "this is a description from source system",
               "dataType": "ORDINAL",
               "version": null,
-              "sources": ["urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleCypressHdfsDataset,PROD)"]
+              "sources": [
+                "urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleCypressHdfsDataset,PROD)"
+              ]
             }
           },
           {
@@ -1689,9 +1708,7 @@
         "aspects": [
           {
             "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker/cypress-feature-table"
-              ]
+              "paths": ["/sagemaker/cypress-feature-table"]
             }
           },
           {
@@ -1750,7 +1767,9 @@
                 }
               ],
               "onlineMetrics": null,
-              "mlFeatures": ["urn:li:mlFeature:(cypress-test-2,some-cypress-feature-1)"],
+              "mlFeatures": [
+                "urn:li:mlFeature:(cypress-test-2,some-cypress-feature-1)"
+              ],
               "tags": [],
               "deployments": [],
               "trainingJobs": [],
@@ -1762,9 +1781,7 @@
           },
           {
             "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker/cypress-model-package-group/cypress-model"
-              ]
+              "paths": ["/sagemaker/cypress-model-package-group/cypress-model"]
             }
           }
         ]
@@ -1810,9 +1827,7 @@
           },
           {
             "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker/cypress-model-package-group"
-              ]
+              "paths": ["/sagemaker/cypress-model-package-group"]
             }
           }
         ]
@@ -1820,5 +1835,19 @@
     },
     "proposedDelta": null,
     "systemMetadata": null
+  },
+  {
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(looker,cypress_baz1)",
+    "changeType": "UPSERT",
+    "aspectName": "inputFields",
+    "aspect": {
+      "value": "{\"fields\": [{\"schemaFieldUrn\": \"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,explore.active_customer_ltv,PROD),lifetime_purchase_amount)\", \"schemaField\": {\"fieldPath\": \"lifetime_purchase_amount\", \"nullable\": false, \"description\": \"The amount purchased by the user across their account history\", \"label\": \"Lifetime Purchase Amount\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"number\", \"recursive\": false, \"globalTags\": {\"tags\": []}, \"isPartOfKey\": false}}, {\"schemaFieldUrn\": \"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:looker,explore.active_customer_ltv,PROD),user_fk)\", \"schemaField\": {\"fieldPath\": \"users_fk\", \"nullable\": false, \"description\": \"\", \"label\": \"User Foreign Key\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"id\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:Dimension\"}]}, \"isPartOfKey\": false }}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1664391311867,
+      "runId": "looker-2022_09_28-11_55_08"
+    }
   }
 ]


### PR DESCRIPTION
This allows charts and dashboards to be able to update their input tags, terms and descriptions.

<img width="1077" alt="CleanShot 2022-10-04 at 15 27 13@2x" src="https://user-images.githubusercontent.com/2455694/193941628-7fe74a13-05cc-4ed1-8390-6ba46b4f21dd.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)