### PR TITLE
fix(ingestion): fix percent change computation in stale_entity_removal

### DIFF
--- a/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stale_entity_removal_handler.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stale_entity_removal_handler.py
@@ -1,0 +1,51 @@
+from typing import Dict, List, Tuple
+
+import pytest
+
+from datahub.ingestion.source.state.stale_entity_removal_handler import (
+    StaleEntityCheckpointStateBase,
+)
+
+OldNewEntLists = List[Tuple[List[str], List[str]]]
+
+old_new_ent_tests: Dict[str, Tuple[OldNewEntLists, float]] = {
+    "no_change_empty_old_and_new": ([([], [])], 0.0),
+    "no_change_empty_old_and_non_empty_new": ([(["a"], [])], 0.0),
+    "no_change_non_empty_old_new_equals_old": (
+        [(["a", "b", "c"], ["c", "b", "a"])],
+        0.0,
+    ),
+    "no_change_non_empty_old_new_superset_old": (
+        [(["a", "b", "c", "d"], ["c", "b", "a"])],
+        0.0,
+    ),
+    "change_25_percent_delta": ([(["a", "b", "c"], ["d", "c", "b", "a"])], 25.0),
+    "change_50_percent_delta": (
+        [
+            (
+                ["b", "a"],
+                ["a", "b", "c", "d"],
+            )
+        ],
+        50.0,
+    ),
+    "change_75_percent_delta": ([(["a"], ["a", "b", "c", "d"])], 75.0),
+    "change_100_percent_delta_empty_new": ([([], ["a", "b", "c", "d"])], 100.0),
+    "change_100_percent_delta_non_empty_new": ([(["e"], ["a", "b", "c", "d"])], 100.0),
+}
+
+
+@pytest.mark.parametrize(
+    "new_old_entity_list, expected_percent_change",
+    old_new_ent_tests.values(),
+    ids=old_new_ent_tests.keys(),
+)
+def test_change_percent(
+    new_old_entity_list: OldNewEntLists, expected_percent_change: float
+) -> None:
+    actual_percent_change = (
+        StaleEntityCheckpointStateBase.compute_percent_entities_changed(
+            new_old_entity_list
+        )
+    )
+    assert actual_percent_change == expected_percent_change


### PR DESCRIPTION
1. Fixes the bug in percent change computation for stale entity removal
2. Changes the `fail_safe_threshold` value to 20.0 from 95.0 per our discussion.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)