### PR TITLE
feat(lineage): show fully qualified task name in lineage UI

### DIFF
--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -22,6 +22,24 @@ const getDataJobPlatformName = (data?: DataJob): string => {
     return data?.dataFlow?.platform?.properties?.displayName || data?.dataFlow?.platform?.name || '';
 };
 
+const getExpandedNameForDataJob = (entity: DataJob): string => {
+    const name = entity?.properties?.name || '';
+    const flowName = entity?.dataFlow?.properties?.name;
+
+    // if we have no name, just return blank. this should not happen, so dont try & construct a name
+    if (name === '') {
+        return name;
+    }
+
+    // if we have a flow name, return the full name of flow.task
+    if (flowName) {
+        return `${flowName}.${name}`;
+    }
+
+    // otherwise, just return the task name (same as non-expanded)
+    return name;
+};
+
 /**
  * Definition of the DataHub DataJob entity.
  */
@@ -178,6 +196,7 @@ export class DataJobEntity implements Entity<DataJob> {
         return {
             urn: entity?.urn,
             name: entity?.properties?.name || '',
+            expandedName: getExpandedNameForDataJob(entity),
             type: EntityType.DataJob,
             icon: entity?.dataFlow?.platform?.properties?.logoUrl || '',
             platform: entity?.dataFlow?.platform,

--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -17,27 +17,10 @@ import { getDataForEntityType } from '../shared/containers/profile/utils';
 import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domain/SidebarDomainSection';
 import { RunsTab } from './tabs/RunsTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
+import { DataFlowEntity } from '../dataFlow/DataFlowEntity';
 
 const getDataJobPlatformName = (data?: DataJob): string => {
     return data?.dataFlow?.platform?.properties?.displayName || data?.dataFlow?.platform?.name || '';
-};
-
-const getExpandedNameForDataJob = (entity: DataJob): string => {
-    const name = entity?.properties?.name;
-    const flowName = entity?.dataFlow?.properties?.name;
-
-    // if we have no name, just return blank. this should not happen, so dont try & construct a name
-    if (!name) {
-        return '';
-    }
-
-    // if we have a flow name, return the full name of flow.task
-    if (flowName) {
-        return `${flowName}.${name}`;
-    }
-
-    // otherwise, just return the task name (same as non-expanded)
-    return name;
 };
 
 /**
@@ -192,11 +175,29 @@ export class DataJobEntity implements Entity<DataJob> {
         );
     };
 
+    getExpandedNameForDataJob = (entity: DataJob): string => {
+        const name = this.displayName(entity);
+        const flowName = entity?.dataFlow ? new DataFlowEntity().displayName(entity?.dataFlow) : undefined;
+
+        // if we have no name, just return blank. this should not happen, so dont try & construct a name
+        if (!name) {
+            return '';
+        }
+
+        // if we have a flow name, return the full name of flow.task
+        if (flowName) {
+            return `${flowName}.${name}`;
+        }
+
+        // otherwise, just return the task name (same as non-expanded)
+        return name;
+    };
+
     getLineageVizConfig = (entity: DataJob) => {
         return {
             urn: entity?.urn,
-            name: entity?.properties?.name || '',
-            expandedName: getExpandedNameForDataJob(entity),
+            name: this.displayName(entity),
+            expandedName: this.getExpandedNameForDataJob(entity),
             type: EntityType.DataJob,
             icon: entity?.dataFlow?.platform?.properties?.logoUrl || '',
             platform: entity?.dataFlow?.platform,

--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -23,12 +23,12 @@ const getDataJobPlatformName = (data?: DataJob): string => {
 };
 
 const getExpandedNameForDataJob = (entity: DataJob): string => {
-    const name = entity?.properties?.name || '';
+    const name = entity?.properties?.name;
     const flowName = entity?.dataFlow?.properties?.name;
 
     // if we have no name, just return blank. this should not happen, so dont try & construct a name
-    if (name === '') {
-        return name;
+    if (!name) {
+        return '';
     }
 
     // if we have a flow name, return the full name of flow.task

--- a/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
+++ b/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
@@ -375,7 +375,7 @@ describe('constructTree', () => {
             children: [
                 {
                     name: 'DataJobInfoName',
-                    expandedName: undefined,
+                    expandedName: 'DataFlowInfoName.DataJobInfoName',
                     type: EntityType.DataJob,
                     unexploredChildren: 0,
                     urn: dataJob1.urn,


### PR DESCRIPTION
Allows option to see full name of a task (data flow . task) in lineage viz.

<img width="1075" alt="CleanShot 2022-10-05 at 11 08 54@2x" src="https://user-images.githubusercontent.com/2455694/194131294-f86eda0e-e34a-46ff-b985-0c0d2eb0c120.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)