### PR TITLE
perf(search): temporarily disable fetching input fields for search results

### DIFF
--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -378,9 +378,6 @@ fragment searchResultFields on Entity {
                 }
             }
         }
-        inputFields {
-            ...inputFieldsFields
-        }
         subTypes {
             typeNames
         }
@@ -445,9 +442,6 @@ fragment searchResultFields on Entity {
                     pictureLink
                 }
             }
-        }
-        inputFields {
-            ...inputFieldsFields
         }
     }
     ... on DataFlow {


### PR DESCRIPTION
We fetch input fields to enrich search snippets when relevant, but its causing some perf issues for large dashboards. Temporarily disabling that fetch for now.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)