### PR TITLE
fix(lineage) Fix possible null pointer exception in UpstreamLineagesMapper

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UpstreamLineagesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UpstreamLineagesMapper.java
@@ -30,14 +30,18 @@ public class UpstreamLineagesMapper {
 
     for (FineGrainedLineage fineGrainedLineage : upstreamLineage.getFineGrainedLineages()) {
       com.linkedin.datahub.graphql.generated.FineGrainedLineage resultEntry = new com.linkedin.datahub.graphql.generated.FineGrainedLineage();
-      resultEntry.setUpstreams(fineGrainedLineage.getUpstreams().stream()
-          .filter(entry -> entry.getEntityType().equals("schemaField"))
-          .map(entry -> mapDatasetSchemaField(entry)).collect(
-          Collectors.toList()));
-      resultEntry.setDownstreams(fineGrainedLineage.getDownstreams().stream()
-          .filter(entry -> entry.getEntityType().equals("schemaField"))
-          .map(entry ->  mapDatasetSchemaField(entry)).collect(
-          Collectors.toList()));
+      if (fineGrainedLineage.hasUpstreams()) {
+        resultEntry.setUpstreams(fineGrainedLineage.getUpstreams().stream()
+            .filter(entry -> entry.getEntityType().equals("schemaField"))
+            .map(entry -> mapDatasetSchemaField(entry)).collect(
+            Collectors.toList()));
+      }
+      if (fineGrainedLineage.hasDownstreams()) {
+        resultEntry.setDownstreams(fineGrainedLineage.getDownstreams().stream()
+            .filter(entry -> entry.getEntityType().equals("schemaField"))
+            .map(entry ->  mapDatasetSchemaField(entry)).collect(
+            Collectors.toList()));
+      }
       result.add(resultEntry);
     }
     return result;


### PR DESCRIPTION
If there's no upstreams or downstreams on fineGrainedLineage then we get a null pointer exception. Adds a check to ensure they exist before mapping them to the final result object.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)