### PR TITLE
fix(impact analysis): fixing filtering on impact analysis + cypress tests

### DIFF
--- a/datahub-web-react/src/app/entity/domain/DomainEntitiesTab.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntitiesTab.tsx
@@ -11,7 +11,7 @@ export const DomainEntitiesTab = () => {
     if (entityType === EntityType.Domain) {
         fixedFilter = {
             field: 'domains',
-            value: urn,
+            values: [urn],
         };
     }
 

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -115,7 +115,7 @@ export const EmbeddedListSearch = ({
                 start: (page - 1) * SearchCfg.RESULTS_PER_PAGE,
                 count: SearchCfg.RESULTS_PER_PAGE,
                 filters: [],
-                orFilters: generateOrFilters(unionType, filtersWithoutEntities),
+                orFilters: generateOrFilters(unionType, finalFilters),
             },
         },
         skip: true,
@@ -133,7 +133,7 @@ export const EmbeddedListSearch = ({
                 start: (page - 1) * numResultsPerPage,
                 count: numResultsPerPage,
                 filters: [],
-                orFilters: generateOrFilters(unionType, filtersWithoutEntities),
+                orFilters: generateOrFilters(unionType, finalFilters),
             },
         },
     });

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/generateUseSearchResultsViaRelationshipHook.ts
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/generateUseSearchResultsViaRelationshipHook.ts
@@ -12,7 +12,7 @@ export default function generateUseSearchResultsViaRelationshipHook({
     return function useGetSearchResultsViaSearchAcrossLineage(params: GetSearchResultsParams) {
         const {
             variables: {
-                input: { types, query, start, count, filters },
+                input: { types, query, start, count, filters, orFilters },
             },
         } = params;
 
@@ -26,6 +26,7 @@ export default function generateUseSearchResultsViaRelationshipHook({
                     start,
                     count,
                     filters,
+                    orFilters,
                 },
             },
         });
@@ -42,6 +43,7 @@ export default function generateUseSearchResultsViaRelationshipHook({
                         start: refetchStart,
                         count: refetchCount,
                         filters: refetchFilters,
+                        orFilters: refetchOrFilters,
                     },
                 } = refetchParams;
                 return refetch({
@@ -53,6 +55,7 @@ export default function generateUseSearchResultsViaRelationshipHook({
                         start: refetchStart,
                         count: refetchCount,
                         filters: refetchFilters,
+                        orFilters: refetchOrFilters,
                     },
                 }).then((res) => res.data.searchAcrossLineage);
             },

--- a/smoke-test/tests/cypress/cypress/integration/lineage/impact_analysis.js
+++ b/smoke-test/tests/cypress/cypress/integration/lineage/impact_analysis.js
@@ -1,14 +1,58 @@
-describe('mutations', () => {
-  it('can create and add a tag to dataset and visit new tag page', () => {
+describe("impact analysis", () => {
+  it("can see 1 hop of lineage by default", () => {
     cy.login();
-    cy.visit('/dataset/urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)/Lineage?is_lineage_mode=false');
-    // click to show more relationships now that we default to 1 degree of dependency
-    cy.contains('3+').click({ force: true });
+    cy.visit(
+      "/dataset/urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)/Lineage?is_lineage_mode=false"
+    );
 
     // impact analysis can take a beat- don't want to time out here
     cy.wait(5000);
 
-    cy.contains('User Creations');
-    cy.contains('User Deletions');
-   });
+    cy.contains("User Creations").should("not.exist");
+    cy.contains("User Deletions").should("not.exist");
+  });
+
+  it("can see lineage multiple hops away", () => {
+    cy.login();
+    cy.visit(
+      "/dataset/urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)/Lineage?is_lineage_mode=false"
+    );
+    // click to show more relationships now that we default to 1 degree of dependency
+    cy.contains("3+").click({ force: true });
+
+    // impact analysis can take a beat- don't want to time out here
+    cy.wait(5000);
+
+    cy.contains("User Creations");
+    cy.contains("User Deletions");
+  });
+
+  it("can filter the lineage results as well", () => {
+    cy.login();
+    cy.visit(
+      "/dataset/urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)/Lineage?is_lineage_mode=false"
+    );
+    // click to show more relationships now that we default to 1 degree of dependency
+    cy.contains("3+").click({ force: true });
+
+    cy.wait(5000);
+
+    cy.contains("Advanced").click();
+
+    cy.contains("Add Filter").click();
+
+    // impact analysis can take a beat- don't want to time out here
+    cy.wait(5000);
+
+    cy.get('[data-testid="adv-search-add-filter-description"]').click({
+      force: true,
+    });
+
+    cy.get('[data-testid="edit-text-input"]').type("fct_users_deleted");
+
+    cy.get('[data-testid="edit-text-done-btn"]').click({ force: true });
+
+    cy.contains("User Creations").should("not.exist");
+    cy.contains("User Deletions");
+  });
 });


### PR DESCRIPTION
Fixed a bug that was introduced with a final refactor of the filters. Also adding a few cypress tests to cover common cases of impact analysis to prevent this from happening in the future.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)