### PR TITLE
feat(secrets) Allow creating secrets with multiline values in the UI

### DIFF
--- a/datahub-web-react/src/app/ingest/secret/SecretBuilderModal.tsx
+++ b/datahub-web-react/src/app/ingest/secret/SecretBuilderModal.tsx
@@ -41,6 +41,11 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
         querySelectorToExecuteClick: '#createSecretButton',
     });
 
+    function resetValues() {
+        setSecretBuilderState({});
+        form.resetFields();
+    }
+
     return (
         <Modal
             width={540}
@@ -55,7 +60,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                     </Button>
                     <Button
                         id="createSecretButton"
-                        onClick={() => onSubmit?.(secretBuilderState, () => setSecretBuilderState({}))}
+                        onClick={() => onSubmit?.(secretBuilderState, resetValues)}
                         disabled={createButtonEnabled}
                     >
                         Create
@@ -65,7 +70,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
         >
             <Form
                 form={form}
-                initialValues={{}}
+                initialValues={initialState}
                 layout="vertical"
                 onFieldsChange={() =>
                     setCreateButtonEnabled(form.getFieldsError().some((field) => field.errors.length > 0))
@@ -110,10 +115,11 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                         ]}
                         hasFeedback
                     >
-                        <Input.Password
+                        <Input.TextArea
                             placeholder="The value of your secret"
                             value={secretBuilderState.value}
                             onChange={(event) => setValue(event.target.value)}
+                            autoComplete="false"
                         />
                     </Form.Item>
                 </Form.Item>


### PR DESCRIPTION
Previously we had a regular input as the value field for secrets. Then we changed that to type "Password" so that the browser doesn't automatically remember the value (for security reasons). However we also want to allow mutliline secret values (like ssh keys) so the values field is now a textarea. Browsers don't automatically save textarea values like they do for inputs, so we will be good there security-wise. Just to be safe I put `autoComplete="false" to ensure the browser isn't saving this value.

On top of that I fixed a bug where after you save a secret and open up the modal again, the old values remained populated. We needed to be calling `form.resetValues` as well as resetting the state.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)