### PR TITLE
feat(ui): Changes to allow editable display name for datasets and editable business label for schema fields

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -755,7 +755,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("updatePolicy", new UpsertPolicyResolver(this.entityClient))
             .dataFetcher("deletePolicy", new DeletePolicyResolver(this.entityClient))
             .dataFetcher("updateDescription", new UpdateDescriptionResolver(entityService))
-            .dataFetcher("updateLabel", new UpdateLabelResolver(entityService))
+            .dataFetcher("updateDatasetFieldLabel", new UpdateLabelResolver(entityService))
             .dataFetcher("addOwner", new AddOwnerResolver(entityService))
             .dataFetcher("addOwners", new AddOwnersResolver(entityService))
             .dataFetcher("batchAddOwners", new BatchAddOwnersResolver(entityService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -98,6 +98,7 @@ import com.linkedin.datahub.graphql.resolvers.dataset.DatasetHealthResolver;
 import com.linkedin.datahub.graphql.resolvers.dataset.DatasetStatsSummaryResolver;
 import com.linkedin.datahub.graphql.resolvers.dataset.DatasetUsageStatsResolver;
 import com.linkedin.datahub.graphql.resolvers.deprecation.UpdateDeprecationResolver;
+import com.linkedin.datahub.graphql.resolvers.mutate.UpdateLabelResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.CreateDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.DeleteDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.DomainEntitiesResolver;
@@ -754,6 +755,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("updatePolicy", new UpsertPolicyResolver(this.entityClient))
             .dataFetcher("deletePolicy", new DeletePolicyResolver(this.entityClient))
             .dataFetcher("updateDescription", new UpdateDescriptionResolver(entityService))
+            .dataFetcher("updateLabel", new UpdateLabelResolver(entityService))
             .dataFetcher("addOwner", new AddOwnerResolver(entityService))
             .dataFetcher("addOwners", new AddOwnersResolver(entityService))
             .dataFetcher("batchAddOwners", new BatchAddOwnersResolver(entityService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -68,6 +68,10 @@ public class AuthorizationUtils {
     return isAuthorized(context, Optional.empty(), PoliciesConfig.MANAGE_GLOSSARIES_PRIVILEGE);
   }
 
+  public static boolean canUpdateEntityName(@Nonnull QueryContext context) {
+    return isAuthorized(context, Optional.empty(), PoliciesConfig.UPDATE_ENTITY_NAME_PRIVILEGE);
+  }
+
   /**
    * Returns true if the current used is able to create Tags. This is true if the user has the 'Manage Tags' or 'Create Tags' platform privilege.
    */

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/MeResolver.java
@@ -72,6 +72,7 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
         platformPrivileges.setCreateDomains(AuthorizationUtils.canCreateDomains(context));
         platformPrivileges.setCreateTags(AuthorizationUtils.canCreateTags(context));
         platformPrivileges.setManageTags(AuthorizationUtils.canManageTags(context));
+        platformPrivileges.setUpdateEntityName(canUpdateEntityName(context));
 
         // Construct and return authenticated user object.
         final AuthenticatedUser authUser = new AuthenticatedUser();
@@ -146,6 +147,14 @@ public class MeResolver implements DataFetcher<CompletableFuture<AuthenticatedUs
   private boolean canManageUserCredentials(@Nonnull QueryContext context) {
     return isAuthorized(context.getAuthorizer(), context.getActorUrn(),
         PoliciesConfig.MANAGE_USER_CREDENTIALS_PRIVILEGE);
+  }
+
+    /**
+   * Returns true if the authenticated user has privileges to update entity name
+   */
+  
+  private boolean canUpdateEntityName(final QueryContext context) {
+    return isAuthorized(context.getAuthorizer(), context.getActorUrn(), PoliciesConfig.UPDATE_ENTITY_NAME_PRIVILEGE);
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateLabelResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateLabelResolver.java
@@ -1,0 +1,83 @@
+package com.linkedin.datahub.graphql.resolvers.mutate;
+
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.LabelUpdateInput;
+import com.linkedin.datahub.graphql.generated.SubResourceType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class UpdateLabelResolver implements DataFetcher<CompletableFuture<Boolean>> {
+  private final EntityService _entityService;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+    final LabelUpdateInput input = bindArgument(environment.getArgument("input"), LabelUpdateInput.class);
+    Urn targetUrn = Urn.createFromString(input.getResourceUrn());
+    log.info("Updating label. input: {}", input.toString());
+    log.info("Target URN: {}", targetUrn.toString());
+    switch (targetUrn.getEntityType()) {
+      case Constants.DATASET_ENTITY_NAME:
+        return updateDatasetLabel(targetUrn, input, environment.getContext());
+      default:
+        throw new RuntimeException(
+            String.format("Failed to update label. Unsupported resource type %s provided.", targetUrn));
+    }
+  }
+
+  private CompletableFuture<Boolean> updateDatasetLabel(Urn targetUrn, LabelUpdateInput input, QueryContext context) {
+    return CompletableFuture.supplyAsync(() -> {
+      
+      if (!DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, targetUrn)) {
+        throw new AuthorizationException(
+            "Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+
+      if (input.getSubResourceType() == null) {
+        throw new IllegalArgumentException("Update label without subresource is not currently supported");
+      }
+
+      validateFieldLabelInput(targetUrn, input.getSubResource(), input.getSubResourceType(), _entityService);
+
+      try {
+        Urn actor = CorpuserUrn.createFromString(context.getActorUrn());
+        log.info("UpdateFieldLabel: {}", input.getLabel());
+        LabelUtils.updateFieldLabel(input.getLabel(), targetUrn, input.getSubResource(), actor,
+            _entityService);
+        return true;
+      } catch (Exception e) {
+        log.error("Failed to perform update against input {}, {}", input.toString(), e.getMessage());
+        throw new RuntimeException(String.format("Failed to perform update against input %s", input.toString()), e);
+      }
+    });
+  }
+
+  private static Boolean validateFieldLabelInput(
+      Urn resourceUrn,
+      String subResource,
+      SubResourceType subResourceType,
+      EntityService entityService
+  ) {
+    if (!entityService.exists(resourceUrn)) {
+      throw new IllegalArgumentException(String.format("Failed to update %s. %s does not exist.", resourceUrn, resourceUrn));
+    }
+
+    validateSubresourceExists(resourceUrn, subResource, subResourceType, entityService);
+
+    return true;
+  }
+
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateLabelResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateLabelResolver.java
@@ -4,7 +4,7 @@ import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
-import com.linkedin.datahub.graphql.generated.LabelUpdateInput;
+import com.linkedin.datahub.graphql.generated.DatasetFieldLabelUpdateInput;
 import com.linkedin.datahub.graphql.generated.SubResourceType;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
@@ -25,20 +25,20 @@ public class UpdateLabelResolver implements DataFetcher<CompletableFuture<Boolea
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
-    final LabelUpdateInput input = bindArgument(environment.getArgument("input"), LabelUpdateInput.class);
+    final DatasetFieldLabelUpdateInput input = bindArgument(environment.getArgument("input"), DatasetFieldLabelUpdateInput.class);
     Urn targetUrn = Urn.createFromString(input.getResourceUrn());
     log.info("Updating label. input: {}", input.toString());
     log.info("Target URN: {}", targetUrn.toString());
     switch (targetUrn.getEntityType()) {
       case Constants.DATASET_ENTITY_NAME:
-        return updateDatasetLabel(targetUrn, input, environment.getContext());
+        return updateDatasetFieldLabel(targetUrn, input, environment.getContext());
       default:
         throw new RuntimeException(
             String.format("Failed to update label. Unsupported resource type %s provided.", targetUrn));
     }
   }
 
-  private CompletableFuture<Boolean> updateDatasetLabel(Urn targetUrn, LabelUpdateInput input, QueryContext context) {
+  private CompletableFuture<Boolean> updateDatasetFieldLabel(Urn targetUrn, DatasetFieldLabelUpdateInput input, QueryContext context) {
     return CompletableFuture.supplyAsync(() -> {
       
       if (!DescriptionUtils.isAuthorizedToUpdateFieldDescription(context, targetUrn)) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
@@ -29,6 +29,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
 
 
@@ -159,6 +160,22 @@ public class LabelUtils {
       addTermsIfNotExists(editableFieldInfo.getGlossaryTerms(), labelUrns);
       persistAspect(resourceUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
     }
+  }
+
+  public static void updateFieldLabel(
+    String newLabel,
+    Urn resourceUrn,
+    String fieldPath,
+    Urn actor,
+    EntityService entityService
+  ) {
+    EditableSchemaMetadata editableSchemaMetadata =
+        (EditableSchemaMetadata) getAspectFromEntity(
+            resourceUrn.toString(), EDITABLE_SCHEMA_METADATA, entityService, new EditableSchemaMetadata());
+    EditableSchemaFieldInfo editableFieldInfo = getFieldInfoFromSchema(editableSchemaMetadata, fieldPath);
+
+    editableFieldInfo.setLabel(newLabel);
+    persistAspect(resourceUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
   }
 
   private static TagAssociationArray removeTagsIfExists(GlobalTags tags, List<Urn> tagUrns) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -132,6 +132,7 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
         }
         properties.setQualifiedName(gmsProperties.getQualifiedName());
         dataset.setProperties(properties);
+        dataset.setName(properties.getName());
         dataset.setDescription(properties.getDescription());
         if (gmsProperties.getUri() != null) {
             dataset.setUri(gmsProperties.getUri().toString());
@@ -141,6 +142,7 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
     private void mapEditableDatasetProperties(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
         final EditableDatasetProperties editableDatasetProperties = new EditableDatasetProperties(dataMap);
         final DatasetEditableProperties editableProperties = new DatasetEditableProperties();
+        editableProperties.setName(editableDatasetProperties.getName());
         editableProperties.setDescription(editableDatasetProperties.getDescription());
         dataset.setEditableProperties(editableProperties);
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetUpdateInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetUpdateInputMapper.java
@@ -99,6 +99,7 @@ public class DatasetUpdateInputMapper implements InputModelMapper<DatasetUpdateI
 
     if (datasetUpdateInput.getEditableProperties() != null) {
       final EditableDatasetProperties editableDatasetProperties = new EditableDatasetProperties();
+      editableDatasetProperties.setName(datasetUpdateInput.getEditableProperties().getName());
       editableDatasetProperties.setDescription(datasetUpdateInput.getEditableProperties().getDescription());
       editableDatasetProperties.setLastModified(auditStamp);
       editableDatasetProperties.setCreated(auditStamp);
@@ -116,6 +117,11 @@ public class DatasetUpdateInputMapper implements InputModelMapper<DatasetUpdateI
     if (schemaFieldInfo.getDescription() != null) {
       output.setDescription(schemaFieldInfo.getDescription());
     }
+
+    if (schemaFieldInfo.getLabel() != null) {
+      output.setLabel(schemaFieldInfo.getLabel());
+    }
+    
     output.setFieldPath(schemaFieldInfo.getFieldPath());
 
     if (schemaFieldInfo.getGlobalTags() != null) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetUpdateInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetUpdateInputMapper.java
@@ -99,8 +99,12 @@ public class DatasetUpdateInputMapper implements InputModelMapper<DatasetUpdateI
 
     if (datasetUpdateInput.getEditableProperties() != null) {
       final EditableDatasetProperties editableDatasetProperties = new EditableDatasetProperties();
-      editableDatasetProperties.setName(datasetUpdateInput.getEditableProperties().getName());
-      editableDatasetProperties.setDescription(datasetUpdateInput.getEditableProperties().getDescription());
+      if (datasetUpdateInput.getEditableProperties().getName() != null) {
+        editableDatasetProperties.setName(datasetUpdateInput.getEditableProperties().getName());
+      }
+       if (datasetUpdateInput.getEditableProperties().getDescription() != null) {
+        editableDatasetProperties.setDescription(datasetUpdateInput.getEditableProperties().getDescription());
+      }
       editableDatasetProperties.setLastModified(auditStamp);
       editableDatasetProperties.setCreated(auditStamp);
       proposals.add(updateMappingHelper.aspectToProposal(editableDatasetProperties, EDITABLE_DATASET_PROPERTIES_ASPECT_NAME));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/EditableSchemaFieldInfoMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/EditableSchemaFieldInfoMapper.java
@@ -27,6 +27,9 @@ public class EditableSchemaFieldInfoMapper {
         if (input.hasDescription()) {
             result.setDescription((input.getDescription()));
         }
+        if (input.hasLabel()) {
+            result.setLabel((input.getLabel()));
+        }
         if (input.hasFieldPath()) {
             result.setFieldPath((input.getFieldPath()));
         }

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -101,6 +101,11 @@ type PlatformPrivileges {
   Whether the user should be able to create and delete all Tags
   """
   manageTags: Boolean!
+
+  """
+  Whether the user should be able to update entity name
+  """
+  updateEntityName: Boolean!
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -363,7 +363,7 @@ type Mutation {
     """
     Updates the label of a resource. Currently only supports Dataset Schema Fields
     """
-    updateLabel(input: LabelUpdateInput!): Boolean
+    updateDatasetFieldLabel(input: DatasetFieldLabelUpdateInput!): Boolean
 
     """
     Remove a user. Requires Manage Users & Groups Platform Privilege
@@ -7134,7 +7134,7 @@ input DescriptionUpdateInput {
 """
 Updates the label of a resource. Currently supports DatasetField labels only
 """
-input LabelUpdateInput {
+input DatasetFieldLabelUpdateInput {
     """
     The new label
     """
@@ -7146,9 +7146,9 @@ input LabelUpdateInput {
     resourceUrn: String!
 
     """
-    An optional sub resource type
+    Sub resource type
     """
-    subResourceType: SubResourceType
+    subResourceType: SubResourceType!
 
     """
     A sub resource identifier, eg dataset field path

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -361,6 +361,11 @@ type Mutation {
     updateDescription(input: DescriptionUpdateInput!): Boolean
 
     """
+    Updates the label of a resource. Currently only supports Dataset Schema Fields
+    """
+    updateLabel(input: LabelUpdateInput!): Boolean
+
+    """
     Remove a user. Requires Manage Users & Groups Platform Privilege
     """
     removeUser(urn: String!): Boolean
@@ -2441,6 +2446,11 @@ type EditableSchemaFieldInfo {
     fieldPath: String!
 
     """
+    Human readable label for the field
+    """
+    label: String
+
+    """
     Edited description of the field
     """
     description: String
@@ -2558,6 +2568,11 @@ Dataset properties that are editable via the UI This represents logical metadata
 as opposed to technical metadata
 """
 type DatasetEditableProperties {
+    """
+    Display name of the Dataset
+    """
+    name: String
+
     """
     Description of the Dataset
     """
@@ -3789,6 +3804,11 @@ input EditableSchemaFieldInfoUpdate {
     description: String
 
     """
+    Edited label of the field
+    """
+    label: String
+
+    """
     Tags associated with the field
     """
     globalTags: GlobalTagsUpdate
@@ -3798,6 +3818,11 @@ input EditableSchemaFieldInfoUpdate {
 Update to writable Dataset fields
 """
 input DatasetEditablePropertiesUpdate {
+    """
+    Display name of the Dataset
+    """
+    name: String
+
     """
     Writable description aka documentation for a Dataset
     """
@@ -7092,6 +7117,31 @@ input DescriptionUpdateInput {
 
     """
     The primary key of the resource to attach the description to, eg dataset urn
+    """
+    resourceUrn: String!
+
+    """
+    An optional sub resource type
+    """
+    subResourceType: SubResourceType
+
+    """
+    A sub resource identifier, eg dataset field path
+    """
+    subResource: String
+}
+
+"""
+Updates the label of a resource. Currently supports DatasetField labels only
+"""
+input LabelUpdateInput {
+    """
+    The new label
+    """
+    label: String!
+
+    """
+    The primary key of the resource to attach the label to, eg dataset urn
     """
     resourceUrn: String!
 

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -3433,4 +3433,5 @@ export const platformPrivileges: PlatformPrivileges = {
     manageTags: true,
     createTags: true,
     createDomains: true,
+    updateEntityName: true,
 };

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -233,7 +233,7 @@ export class DatasetEntity implements Entity<Dataset> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.properties?.name || data.name}
+                name={data.editableProperties?.name || data.properties?.name || data.name}
                 origin={data.origin}
                 subtype={data.subTypes?.typeNames?.[0]}
                 description={data.editableProperties?.description || data.properties?.description}
@@ -256,7 +256,7 @@ export class DatasetEntity implements Entity<Dataset> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.properties?.name || data.name}
+                name={data.editableProperties?.name || data.properties?.name || data.name}
                 origin={data.origin}
                 description={data.editableProperties?.description || data.properties?.description}
                 platformName={data.platform.properties?.displayName || data.platform.name}
@@ -299,7 +299,7 @@ export class DatasetEntity implements Entity<Dataset> {
     };
 
     displayName = (data: Dataset) => {
-        return data?.properties?.name || data.name || data.urn;
+        return data?.editableProperties?.name || data?.properties?.name || data.name || data.urn;
     };
 
     platformLogoUrl = (data: Dataset) => {

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -211,6 +211,7 @@ export class DatasetEntity implements Entity<Dataset> {
                     component: SidebarRecommendationsSection,
                 },
             ]}
+            isNameEditable
         />
     );
 

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaLabelField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaLabelField.tsx
@@ -1,0 +1,196 @@
+import { Typography, message, Button } from 'antd';
+import { EditOutlined } from '@ant-design/icons';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { FetchResult } from '@apollo/client';
+
+import { UpdateDatasetMutation } from '../../../../../../graphql/dataset.generated';
+import UpdateDescriptionModal from '../../../../shared/components/legacy/DescriptionModal';
+import StripMarkdownText, { removeMarkdown } from '../../../../shared/components/styled/StripMarkdownText';
+import MarkdownViewer from '../../../../shared/components/legacy/MarkdownViewer';
+import SchemaEditableContext from '../../../../../shared/SchemaEditableContext';
+import { useEntityData } from '../../../../shared/EntityContext';
+import { useGetAuthenticatedUser } from '../../../../../useGetAuthenticatedUser';
+import analytics, { EventType, EntityActionType } from '../../../../../analytics';
+
+const EditIcon = styled(EditOutlined)`
+    cursor: pointer;
+    display: none;
+`;
+
+const AddNewLabel = styled(Button)`
+    display: none;
+    margin: -4px;
+    width: 140px;
+`;
+
+const ExpandedActions = styled.div`
+    height: 10px;
+`;
+
+const LabelContainer = styled.div`
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    min-height: 22px;
+    &:hover ${EditIcon} {
+        display: inline-block;
+    }
+
+    &:hover ${AddNewLabel} {
+        display: block;
+    }
+    & ins.diff {
+        background-color: #b7eb8f99;
+        text-decoration: none;
+        &:hover {
+            background-color: #b7eb8faa;
+        }
+    }
+    & del.diff {
+        background-color: #ffa39e99;
+        text-decoration: line-through;
+        &: hover {
+            background-color: #ffa39eaa;
+        }
+    }
+`;
+
+const LabelText = styled(MarkdownViewer)`
+    padding-right: 8px;
+    display: block;
+`;
+
+const EditedLabel = styled(Typography.Text)`
+    position: absolute;
+    right: -10px;
+    top: -15px;
+    color: rgba(150, 150, 150, 0.5);
+    font-style: italic;
+`;
+
+const ReadLessText = styled(Typography.Link)`
+    margin-right: 4px;
+`;
+
+type Props = {
+    label: string;
+    original?: string | null;
+    onUpdate: (
+        label: string,
+    ) => Promise<FetchResult<UpdateDatasetMutation, Record<string, any>, Record<string, any>> | void>;
+    isEdited?: boolean;
+};
+
+const ABBREVIATED_LIMIT = 40;
+
+export default function LabelField({ label, onUpdate, isEdited = false, original }: Props) {
+    const [showAddModal, setShowAddModal] = useState(false);
+    const overLimit = removeMarkdown(label).length > 80;
+    const [expanded, setExpanded] = useState(!overLimit);
+    const isSchemaEditableFromContext = React.useContext(SchemaEditableContext);
+    const onCloseModal = () => setShowAddModal(false);
+    const { urn, entityType, entityData } = useEntityData();
+
+    const user = useGetAuthenticatedUser();
+    const ownerExists = entityData?.ownership?.owners?.some(
+        (owner) => (owner?.owner?.urn as string) === (user?.corpUser?.urn as string),
+    );
+    const isSchemaEditable = ownerExists ? isSchemaEditableFromContext : false;
+
+    const sendAnalytics = () => {
+        analytics.event({
+            type: EventType.EntityActionEvent,
+            actionType: EntityActionType.UpdateSchemaDescription,
+            entityType,
+            entityUrn: urn,
+        });
+    };
+
+    const onUpdateModal = async (newLabel: string | null) => {
+        message.loading({ content: 'Updating...' });
+        try {
+            await onUpdate(newLabel || '');
+            message.destroy();
+            message.success({ content: 'Updated!', duration: 2 });
+            sendAnalytics();
+        } catch (e: unknown) {
+            message.destroy();
+            if (e instanceof Error) message.error({ content: `Update Failed! \n ${e.message || ''}`, duration: 2 });
+        }
+        onCloseModal();
+    };
+
+    const EditButton =
+        (isSchemaEditable && label && <EditIcon twoToneColor="#52c41a" onClick={() => setShowAddModal(true)} />) ||
+        undefined;
+
+    const showAddLabel = isSchemaEditable && !label;
+    const displayLabel = `<b>Business Label:</b> ${label}`;
+
+    return (
+        <LabelContainer>
+            {expanded ? (
+                <>
+                    {!!label && <LabelText source={displayLabel} />}
+                    {!!label && (
+                        <ExpandedActions>
+                            {overLimit && (
+                                <ReadLessText
+                                    onClick={() => {
+                                        setExpanded(false);
+                                    }}
+                                >
+                                    Read Less
+                                </ReadLessText>
+                            )}
+                            {EditButton}
+                        </ExpandedActions>
+                    )}
+                </>
+            ) : (
+                <>
+                    <StripMarkdownText
+                        limit={ABBREVIATED_LIMIT}
+                        readMore={
+                            <>
+                                <Typography.Link
+                                    onClick={() => {
+                                        setExpanded(true);
+                                    }}
+                                >
+                                    Read More
+                                </Typography.Link>
+                            </>
+                        }
+                        suffix={EditButton}
+                    >
+                        {displayLabel}
+                    </StripMarkdownText>
+                </>
+            )}
+
+            {isSchemaEditable && isEdited && <EditedLabel>(edited)</EditedLabel>}
+            {showAddModal && (
+                <div>
+                    <UpdateDescriptionModal
+                        title={label ? 'Update business label' : 'Add business label'}
+                        description={label}
+                        original={original || ''}
+                        onClose={onCloseModal}
+                        onSubmit={onUpdateModal}
+                        isAddDesc={!label}
+                        useTextEditor
+                    />
+                </div>
+            )}
+            {showAddLabel && (
+                <AddNewLabel type="text" onClick={() => setShowAddModal(true)}>
+                    + Add Business Label
+                </AddNewLabel>
+            )}
+        </LabelContainer>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
@@ -1,4 +1,4 @@
-import { Typography, Modal, Button, Form } from 'antd';
+import { Typography, Modal, Button, Form, Input } from 'antd';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import MDEditor from '@uiw/react-md-editor';
@@ -26,9 +26,18 @@ type Props = {
     onClose: () => void;
     onSubmit: (description: string) => void;
     isAddDesc?: boolean;
+    useTextEditor?: boolean | undefined;
 };
 
-export default function UpdateDescriptionModal({ title, description, original, onClose, onSubmit, isAddDesc }: Props) {
+export default function UpdateDescriptionModal({
+    title,
+    description,
+    original,
+    onClose,
+    onSubmit,
+    isAddDesc,
+    useTextEditor = false,
+}: Props) {
     const [updatedDesc, setDesc] = useState(description || original || '');
 
     return (
@@ -47,40 +56,60 @@ export default function UpdateDescriptionModal({ title, description, original, o
                 </>
             }
         >
-            <Form layout="vertical">
-                {isAddDesc ? (
-                    <Form.Item>
-                        <MarkDownHelpLink href="https://joplinapp.org/markdown" target="_blank" type="secondary">
-                            markdown supported
-                        </MarkDownHelpLink>
-                        <MDEditor
-                            style={{ fontWeight: 400 }}
-                            value={updatedDesc}
-                            onChange={(v) => setDesc(v || '')}
-                            preview="live"
-                            height={400}
-                        />
-                    </Form.Item>
-                ) : (
-                    <Form.Item>
-                        <MarkDownHelpLink href="https://joplinapp.org/markdown" target="_blank" type="secondary">
-                            markdown supported
-                        </MarkDownHelpLink>
-                        <MDEditor
-                            style={{ fontWeight: 400 }}
-                            value={updatedDesc}
-                            onChange={(v) => setDesc(v || '')}
-                            preview="live"
-                            height={400}
-                        />
-                    </Form.Item>
-                )}
-                {!isAddDesc && description && original && (
-                    <Form.Item label={<FormLabel>Original:</FormLabel>}>
-                        <DescriptionMarkdown source={original || ''} />
-                    </Form.Item>
-                )}
-            </Form>
+            {!useTextEditor && (
+                <Form layout="vertical">
+                    {isAddDesc ? (
+                        <Form.Item>
+                            <MarkDownHelpLink href="https://joplinapp.org/markdown" target="_blank" type="secondary">
+                                markdown supported
+                            </MarkDownHelpLink>
+                            <MDEditor
+                                style={{ fontWeight: 400 }}
+                                value={updatedDesc}
+                                onChange={(v) => setDesc(v || '')}
+                                preview="live"
+                                height={400}
+                            />
+                        </Form.Item>
+                    ) : (
+                        <Form.Item>
+                            <MarkDownHelpLink href="https://joplinapp.org/markdown" target="_blank" type="secondary">
+                                markdown supported
+                            </MarkDownHelpLink>
+                            <MDEditor
+                                style={{ fontWeight: 400 }}
+                                value={updatedDesc}
+                                onChange={(v) => setDesc(v || '')}
+                                preview="live"
+                                height={400}
+                            />
+                        </Form.Item>
+                    )}
+                    {!isAddDesc && description && original && (
+                        <Form.Item label={<FormLabel>Original:</FormLabel>}>
+                            <DescriptionMarkdown source={original || ''} />
+                        </Form.Item>
+                    )}
+                </Form>
+            )}
+            {useTextEditor && (
+                <Form layout="vertical">
+                    {!original && (
+                        <Form.Item name="textDesc" wrapperCol={{ span: 20 }} initialValue={updatedDesc || ''}>
+                            <Input
+                                style={{ width: '100%' }}
+                                placeholder="Enter business label for field"
+                                onChange={(v) => setDesc(v.target.value || '')}
+                                value={updatedDesc || ''}
+                            />
+                        </Form.Item>
+                    )}
+
+                    {!isAddDesc && description && original && (
+                        <Form.Item label={<FormLabel>Original:</FormLabel>}>{original}</Form.Item>
+                    )}
+                </Form>
+            )}
         </Modal>
     );
 }

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -10,13 +10,13 @@ import EntityDropdown, { EntityMenuItems } from '../../../EntityDropdown/EntityD
 import PlatformContent from './PlatformContent';
 import { getPlatformName } from '../../../utils';
 import { useGetAuthenticatedUser } from '../../../../../useGetAuthenticatedUser';
-import { AuthenticatedUser, EntityType, PlatformPrivileges } from '../../../../../../types.generated';
+import { EntityType, PlatformPrivileges } from '../../../../../../types.generated';
 import EntityCount from './EntityCount';
 import EntityName from './EntityName';
 import CopyUrn from '../../../../../shared/CopyUrn';
 import { DeprecationPill } from '../../../components/styled/DeprecationPill';
 import CompactContext from '../../../../../shared/CompactContext';
-import { EntitySubHeaderSection, GenericEntityProperties } from '../../../types';
+import { EntitySubHeaderSection } from '../../../types';
 import EntityActions, { EntityActionItem } from '../../../entity/EntityActions';
 
 const TitleWrapper = styled.div`
@@ -69,25 +69,15 @@ const ExternalUrlButton = styled(Button)`
     padding-right: 12px;
 `;
 
-export function getCanEditName(
-    entityType: EntityType,
-    privileges?: PlatformPrivileges,
-    me?: AuthenticatedUser,
-    entityData?: GenericEntityProperties,
-) {
+export function getCanEditName(entityType: EntityType, privileges?: PlatformPrivileges) {
     switch (entityType) {
-        case EntityType.Dataset: {
-            const ownerExists = entityData?.ownership?.owners?.some(
-                (owner) => (owner?.owner?.urn as string) === (me?.corpUser?.urn as string),
-            );
-            const isAdmin = me?.platformPrivileges.manageIngestion;
-            return ownerExists || isAdmin;
-        }
         case EntityType.GlossaryTerm:
         case EntityType.GlossaryNode:
             return privileges?.manageGlossaries;
         case EntityType.Domain:
             return privileges?.manageDomains;
+        case EntityType.Dataset:
+            return privileges?.updateEntityName;
         default:
             return false;
     }
@@ -127,14 +117,7 @@ export const EntityHeader = ({
         });
     };
 
-    const canEditName =
-        isNameEditable &&
-        getCanEditName(
-            entityType,
-            me?.platformPrivileges as PlatformPrivileges,
-            me as AuthenticatedUser,
-            entityData as GenericEntityProperties,
-        );
+    const canEditName = isNameEditable && getCanEditName(entityType, me?.platformPrivileges as PlatformPrivileges);
 
     return (
         <>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -69,8 +69,12 @@ const ExternalUrlButton = styled(Button)`
     padding-right: 12px;
 `;
 
-export function getCanEditName(entityType: EntityType, me: AuthenticatedUser, entityData?: GenericEntityProperties) {
-    const privileges = me?.platformPrivileges as PlatformPrivileges;
+export function getCanEditName(
+    entityType: EntityType,
+    privileges?: PlatformPrivileges,
+    me?: AuthenticatedUser,
+    entityData?: GenericEntityProperties,
+) {
     switch (entityType) {
         case EntityType.Dataset: {
             const ownerExists = entityData?.ownership?.owners?.some(
@@ -124,7 +128,13 @@ export const EntityHeader = ({
     };
 
     const canEditName =
-        isNameEditable && getCanEditName(entityType, me as AuthenticatedUser, entityData as GenericEntityProperties);
+        isNameEditable &&
+        getCanEditName(
+            entityType,
+            me?.platformPrivileges as PlatformPrivileges,
+            me as AuthenticatedUser,
+            entityData as GenericEntityProperties,
+        );
 
     return (
         <>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
@@ -3,8 +3,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components/macro';
 import { useUpdateNameMutation } from '../../../../../../graphql/mutations.generated';
 import { useEntityRegistry } from '../../../../../useEntityRegistry';
-import { useEntityData, useEntityUpdate, useRefetch } from '../../../EntityContext';
-import { GenericEntityUpdate } from '../../../types';
+import { useEntityData, useRefetch } from '../../../EntityContext';
 
 const EntityTitle = styled(Typography.Title)`
     margin-right: 10px;
@@ -39,26 +38,8 @@ function EntityName(props: Props) {
 
     const [updateName] = useUpdateNameMutation();
 
-    const updateEntity = useEntityUpdate<GenericEntityUpdate>();
-
-    const updateEditableName = (entityNameUpdate, mutationUrn) => {
-        const entityDescription = entityData
-            ? entityRegistry.getGenericEntityProperties(entityType, entityData)?.editableProperties?.description
-            : '';
-        return updateEntity?.({
-            variables: {
-                urn: mutationUrn,
-                input: { editableProperties: { name: entityNameUpdate, description: entityDescription || '' } },
-            },
-        });
-    };
-
     const saveName = async (name) => {
-        if (entityType !== 'DATASET') {
-            updateName({ variables: { input: { name, urn } } });
-        } else {
-            updateEditableName(name, urn);
-        }
+        updateName({ variables: { input: { name, urn } } });
     };
 
     const handleSaveName = async (name: string) => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import DOMPurify from 'dompurify';
 import { EditableSchemaMetadata, SchemaField, SubResourceType } from '../../../../../../../types.generated';
 import DescriptionField from '../../../../../dataset/profile/schema/components/SchemaDescriptionField';
+import LabelField from '../../../../../dataset/profile/schema/components/SchemaLabelField';
 import { pathMatchesNewPath } from '../../../../../dataset/profile/schema/utils/utils';
-import { useUpdateDescriptionMutation } from '../../../../../../../graphql/mutations.generated';
+import { useUpdateDescriptionMutation, useUpdateLabelMutation } from '../../../../../../../graphql/mutations.generated';
 import { useMutationUrn, useRefetch } from '../../../../EntityContext';
 
 export default function useDescriptionRenderer(editableSchemaMetadata: EditableSchemaMetadata | null | undefined) {
     const urn = useMutationUrn();
     const refetch = useRefetch();
     const [updateDescription] = useUpdateDescriptionMutation();
+    const [updateLabel] = useUpdateLabelMutation();
 
     return (description: string, record: SchemaField): JSX.Element => {
         const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
@@ -17,26 +19,50 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
         );
         const displayedDescription = relevantEditableFieldInfo?.description || description;
         const sanitizedDescription = DOMPurify.sanitize(displayedDescription);
-        const original = record.description ? DOMPurify.sanitize(record.description) : undefined;
+        const originalDescription = record.description ? DOMPurify.sanitize(record.description) : undefined;
+
+        const displayedLabel = relevantEditableFieldInfo?.label || '';
+        const sanitizedLabel = DOMPurify.sanitize(displayedLabel);
+        const originalLabel = record.label ? DOMPurify.sanitize(record.label) : undefined;
 
         return (
-            <DescriptionField
-                description={sanitizedDescription}
-                original={original}
-                isEdited={!!relevantEditableFieldInfo?.description}
-                onUpdate={(updatedDescription) =>
-                    updateDescription({
-                        variables: {
-                            input: {
-                                description: DOMPurify.sanitize(updatedDescription),
-                                resourceUrn: urn,
-                                subResource: record.fieldPath,
-                                subResourceType: SubResourceType.DatasetField,
+            <>
+                <LabelField
+                    label={sanitizedLabel}
+                    original={originalLabel}
+                    isEdited={!!relevantEditableFieldInfo?.label}
+                    onUpdate={(updatedLabel) =>
+                        updateLabel({
+                            variables: {
+                                input: {
+                                    label: DOMPurify.sanitize(updatedLabel),
+                                    resourceUrn: urn,
+                                    subResource: record.fieldPath,
+                                    subResourceType: SubResourceType.DatasetField,
+                                },
                             },
-                        },
-                    }).then(refetch)
-                }
-            />
+                        }).then(refetch)
+                    }
+                />
+                <br />
+                <DescriptionField
+                    description={sanitizedDescription}
+                    original={originalDescription}
+                    isEdited={!!relevantEditableFieldInfo?.description}
+                    onUpdate={(updatedDescription) =>
+                        updateDescription({
+                            variables: {
+                                input: {
+                                    description: DOMPurify.sanitize(updatedDescription),
+                                    resourceUrn: urn,
+                                    subResource: record.fieldPath,
+                                    subResourceType: SubResourceType.DatasetField,
+                                },
+                            },
+                        }).then(refetch)
+                    }
+                />
+            </>
         );
     };
 }

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
@@ -4,14 +4,17 @@ import { EditableSchemaMetadata, SchemaField, SubResourceType } from '../../../.
 import DescriptionField from '../../../../../dataset/profile/schema/components/SchemaDescriptionField';
 import LabelField from '../../../../../dataset/profile/schema/components/SchemaLabelField';
 import { pathMatchesNewPath } from '../../../../../dataset/profile/schema/utils/utils';
-import { useUpdateDescriptionMutation, useUpdateLabelMutation } from '../../../../../../../graphql/mutations.generated';
+import {
+    useUpdateDescriptionMutation,
+    useUpdateDatasetFieldLabelMutation,
+} from '../../../../../../../graphql/mutations.generated';
 import { useMutationUrn, useRefetch } from '../../../../EntityContext';
 
 export default function useDescriptionRenderer(editableSchemaMetadata: EditableSchemaMetadata | null | undefined) {
     const urn = useMutationUrn();
     const refetch = useRefetch();
     const [updateDescription] = useUpdateDescriptionMutation();
-    const [updateLabel] = useUpdateLabelMutation();
+    const [updateFieldLabel] = useUpdateDatasetFieldLabelMutation();
 
     return (description: string, record: SchemaField): JSX.Element => {
         const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
@@ -32,7 +35,7 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
                     original={originalLabel}
                     isEdited={!!relevantEditableFieldInfo?.label}
                     onUpdate={(updatedLabel) =>
-                        updateLabel({
+                        updateFieldLabel({
                             variables: {
                                 input: {
                                     label: DOMPurify.sanitize(updatedLabel),

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -27,19 +27,27 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
         ? editedDescriptions[mutationUrn]
         : entityData?.editableProperties?.description || entityData?.properties?.description || '';
 
-    const editableName = entityData?.editableProperties?.name || '';
-
     const [updatedDescription, setUpdatedDescription] = useState(description);
     const [isDescriptionUpdated, setIsDescriptionUpdated] = useState(editedDescriptions.hasOwnProperty(mutationUrn));
     const [cancelModalVisible, setCancelModalVisible] = useState(false);
 
     const updateDescriptionLegacy = () => {
         const sanitizedDescription = DOMPurify.sanitize(updatedDescription);
+        if (entityData?.editableProperties?.name) {
+            return updateEntity?.({
+                variables: {
+                    urn: mutationUrn,
+                    input: {
+                        editableProperties: {
+                            name: entityData?.editableProperties?.name,
+                            description: sanitizedDescription,
+                        },
+                    },
+                },
+            });
+        }
         return updateEntity?.({
-            variables: {
-                urn: mutationUrn,
-                input: { editableProperties: { name: editableName, description: sanitizedDescription || '' } },
-            },
+            variables: { urn: mutationUrn, input: { editableProperties: { description: sanitizedDescription || '' } } },
         });
     };
 

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -27,6 +27,8 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
         ? editedDescriptions[mutationUrn]
         : entityData?.editableProperties?.description || entityData?.properties?.description || '';
 
+    const editableName = entityData?.editableProperties?.name || '';
+
     const [updatedDescription, setUpdatedDescription] = useState(description);
     const [isDescriptionUpdated, setIsDescriptionUpdated] = useState(editedDescriptions.hasOwnProperty(mutationUrn));
     const [cancelModalVisible, setCancelModalVisible] = useState(false);
@@ -34,7 +36,10 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
     const updateDescriptionLegacy = () => {
         const sanitizedDescription = DOMPurify.sanitize(updatedDescription);
         return updateEntity?.({
-            variables: { urn: mutationUrn, input: { editableProperties: { description: sanitizedDescription || '' } } },
+            variables: {
+                urn: mutationUrn,
+                input: { editableProperties: { name: editableName, description: sanitizedDescription || '' } },
+            },
         });
     };
 

--- a/datahub-web-react/src/graphql/browse.graphql
+++ b/datahub-web-react/src/graphql/browse.graphql
@@ -17,6 +17,7 @@ query getBrowseResults($input: BrowseInput!) {
                     description
                 }
                 editableProperties {
+                    name
                     description
                 }
                 platform {

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -44,6 +44,7 @@ fragment nonSiblingDatasetFields on Dataset {
     editableSchemaMetadata {
         editableSchemaFieldInfo {
             fieldPath
+            label
             description
             globalTags {
                 ...globalTagsFields

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -207,6 +207,7 @@ fragment nonRecursiveDatasetFields on Dataset {
         externalUrl
     }
     editableProperties {
+        name
         description
     }
     ownership {
@@ -221,6 +222,7 @@ fragment nonRecursiveDatasetFields on Dataset {
     editableSchemaMetadata {
         editableSchemaFieldInfo {
             fieldPath
+            label
             description
             globalTags {
                 ...globalTagsFields

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -158,6 +158,7 @@ fragment lineageNodeProperties on EntityWithRelationships {
             qualifiedName
         }
         editableProperties {
+            name
             description
         }
         platform {

--- a/datahub-web-react/src/graphql/me.graphql
+++ b/datahub-web-react/src/graphql/me.graphql
@@ -39,6 +39,7 @@ query getMe {
             manageTags
             createDomains
             createTags
+            updateEntityName
         }
     }
 }

--- a/datahub-web-react/src/graphql/mutations.graphql
+++ b/datahub-web-react/src/graphql/mutations.graphql
@@ -58,6 +58,10 @@ mutation updateDescription($input: DescriptionUpdateInput!) {
     updateDescription(input: $input)
 }
 
+mutation updateLabel($input: LabelUpdateInput!) {
+    updateLabel(input: $input)
+}
+
 mutation setDomain($entityUrn: String!, $domainUrn: String!) {
     setDomain(entityUrn: $entityUrn, domainUrn: $domainUrn)
 }

--- a/datahub-web-react/src/graphql/mutations.graphql
+++ b/datahub-web-react/src/graphql/mutations.graphql
@@ -58,8 +58,8 @@ mutation updateDescription($input: DescriptionUpdateInput!) {
     updateDescription(input: $input)
 }
 
-mutation updateLabel($input: LabelUpdateInput!) {
-    updateLabel(input: $input)
+mutation updateDatasetFieldLabel($input: DatasetFieldLabelUpdateInput!) {
+    updateDatasetFieldLabel(input: $input)
 }
 
 mutation setDomain($entityUrn: String!, $domainUrn: String!) {

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -9,6 +9,7 @@ fragment entityPreview on Entity {
             ...platformFields
         }
         editableProperties {
+            name
             description
         }
         platformNativeType

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -204,6 +204,7 @@ fragment searchResultFields on Entity {
             ...dataPlatformInstanceFields
         }
         editableProperties {
+            name
             description
         }
         platformNativeType

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/EditableDatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/EditableDatasetProperties.pdl
@@ -19,4 +19,13 @@ record EditableDatasetProperties includes ChangeAuditStamps {
     "fieldName": "editedDescription",
   }
   description: optional string
+
+  /**
+   * Display name of the Dataset
+   */
+  @Searchable = {
+    "fieldType": "TEXT_PARTIAL",
+    "fieldName": "editedName",
+  }
+  name: optional string
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/schema/EditableSchemaFieldInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/schema/EditableSchemaFieldInfo.pdl
@@ -23,6 +23,17 @@ record EditableSchemaFieldInfo {
   description: optional string
 
   /**
+   * Label of the field. Provides a more human-readable name for the field than field path. Some sources will
+   * provide this metadata but not all sources have the concept of a label.
+   */
+  @Searchable = {
+    "fieldName": "editedFieldLabels",
+    "fieldType": "TEXT",
+    "boostScore": 0.2
+  }
+  label: optional string
+
+  /**
    * Tags associated with the field
    */
   @Relationship = {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -2764,6 +2764,16 @@
                 "fieldType" : "TEXT"
               }
             }, {
+              "name" : "label",
+              "type" : "string",
+              "doc" : "Label of the field. Provides a more human-readable name for the field than field path. Some sources will\nprovide this metadata but not all sources have the concept of a label.",
+              "optional" : true,
+              "Searchable" : {
+                "boostScore" : 0.2,
+                "fieldName" : "editedFieldLabels",
+                "fieldType" : "TEXT"
+              }
+            }, {
               "name" : "globalTags",
               "type" : "com.linkedin.common.GlobalTags",
               "doc" : "Tags associated with the field",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -1883,6 +1883,15 @@
         "fieldName" : "editedDescription",
         "fieldType" : "TEXT"
       }
+    }, {
+      "name" : "name",
+      "type" : "string",
+      "doc" : "Display name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "fieldName" : "editedName",
+        "fieldType" : "TEXT_PARTIAL"
+      }
     } ],
     "Aspect" : {
       "name" : "editableDatasetProperties"
@@ -3134,6 +3143,16 @@
                           "Searchable" : {
                             "boostScore" : 0.1,
                             "fieldName" : "editedFieldDescriptions",
+                            "fieldType" : "TEXT"
+                          }
+                        }, {
+                          "name" : "label",
+                          "type" : "string",
+                          "doc" : "Label of the field. Provides a more human-readable name for the field than field path. Some sources will\nprovide this metadata but not all sources have the concept of a label.",
+                          "optional" : true,
+                          "Searchable" : {
+                            "boostScore" : 0.2,
+                            "fieldName" : "editedFieldLabels",
                             "fieldType" : "TEXT"
                           }
                         }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -2510,6 +2510,16 @@
                 "fieldType" : "TEXT"
               }
             }, {
+              "name" : "label",
+              "type" : "string",
+              "doc" : "Label of the field. Provides a more human-readable name for the field than field path. Some sources will\nprovide this metadata but not all sources have the concept of a label.",
+              "optional" : true,
+              "Searchable" : {
+                "boostScore" : 0.2,
+                "fieldName" : "editedFieldLabels",
+                "fieldType" : "TEXT"
+              }
+            }, {
               "name" : "globalTags",
               "type" : "com.linkedin.common.GlobalTags",
               "doc" : "Tags associated with the field",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -1883,6 +1883,15 @@
         "fieldName" : "editedDescription",
         "fieldType" : "TEXT"
       }
+    }, {
+      "name" : "name",
+      "type" : "string",
+      "doc" : "Display name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "fieldName" : "editedName",
+        "fieldType" : "TEXT_PARTIAL"
+      }
     } ],
     "Aspect" : {
       "name" : "editableDatasetProperties"
@@ -3128,6 +3137,16 @@
                           "Searchable" : {
                             "boostScore" : 0.1,
                             "fieldName" : "editedFieldDescriptions",
+                            "fieldType" : "TEXT"
+                          }
+                        }, {
+                          "name" : "label",
+                          "type" : "string",
+                          "doc" : "Label of the field. Provides a more human-readable name for the field than field path. Some sources will\nprovide this metadata but not all sources have the concept of a label.",
+                          "optional" : true,
+                          "Searchable" : {
+                            "boostScore" : 0.2,
+                            "fieldName" : "editedFieldLabels",
                             "fieldType" : "TEXT"
                           }
                         }, {

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -98,6 +98,11 @@ public class PoliciesConfig {
       "Create Global Announcements",
       "Create new Global Announcements.");
 
+  public static final Privilege UPDATE_ENTITY_NAME_PRIVILEGE = Privilege.of(
+      "UPDATE_ENTITY_NAME",
+      "Update Entity Name",
+      "Update entity name");
+
   public static final List<Privilege> PLATFORM_PRIVILEGES = ImmutableList.of(
       MANAGE_POLICIES_PRIVILEGE,
       MANAGE_USERS_AND_GROUPS_PRIVILEGE,
@@ -112,6 +117,7 @@ public class PoliciesConfig {
       MANAGE_USER_CREDENTIALS_PRIVILEGE,
       MANAGE_TAGS_PRIVILEGE,
       CREATE_TAGS_PRIVILEGE,
+      UPDATE_ENTITY_NAME_PRIVILEGE,
       CREATE_DOMAINS_PRIVILEGE, CREATE_GLOBAL_ANNOUNCEMENTS_PRIVILEGE
   );
 


### PR DESCRIPTION
Summary: In reference to the discussion in Slack with @shirshanka and @gabe-lyons, creating this PR to allow for editable searchable name (aka display name) for datasets and to allow for presenting and being able to edit label (aka business label) at the schema field level. Please see example screenshots below.

Examples:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/49811128/195210479-7301b16e-67dc-4db7-8ce7-ce08dc7307fc.png">

<img width="558" alt="image" src="https://user-images.githubusercontent.com/49811128/195210549-898b905c-f6cc-4634-884c-e4634475e221.png">

<img width="811" alt="image" src="https://user-images.githubusercontent.com/49811128/195210658-b472e90f-f9b9-4a63-8dda-9a94e092cd70.png">

<img width="867" alt="image" src="https://user-images.githubusercontent.com/49811128/195210718-97dae145-0534-4ce9-8bb9-b7797c9edb90.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)