### PR TITLE
fix(ui): Fix formatNumber to send any input when conditions are not met

### DIFF
--- a/datahub-web-react/src/app/shared/formatNumber.ts
+++ b/datahub-web-react/src/app/shared/formatNumber.ts
@@ -3,7 +3,7 @@ export function formatNumber(n) {
     if (n >= 1e3 && n < 1e6) return `${+(n / 1e3).toFixed(1)}k`;
     if (n >= 1e6 && n < 1e9) return `${+(n / 1e6).toFixed(1)}M`;
     if (n >= 1e9) return `${+(n / 1e9).toFixed(1)}B`;
-    return '';
+    return n;
 }
 
 export function formatNumberWithoutAbbreviation(n) {


### PR DESCRIPTION
**Issue:** In the search page, when the facet count is > 10000, the formatNumber is returning '' in the SearchFilterLabel.
**Fix:** If the input doesn't satisfy any of the checks, then return the input value.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)