### PR TITLE
build(ingest): remove markupsafe dep and bump pytest-docker

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -366,7 +366,7 @@ base_dev_requirements = {
     "pytest>=6.2.2",
     "pytest-asyncio>=0.16.0",
     "pytest-cov>=2.8.1",
-    "pytest-docker>=0.10.3,<0.12",
+    "pytest-docker[docker-compose-v1]>=1.0.1",
     "deepdiff",
     "requests-mock",
     "freezegun",

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -46,11 +46,6 @@ framework_common = {
     "types-termcolor>=1.0.0",
     "psutil>=5.8.0",
     "ratelimiter",
-    # Markupsafe breaking change broke Jinja and some other libs
-    # Pinning it to a version which works even though we are not using explicitly
-    # https://github.com/aws/aws-sam-cli/issues/3661
-    # Airflow compatibility: https://github.com/apache/airflow/blob/2.2.2/setup.cfg#L125
-    "markupsafe>=1.1.1,<=2.0.1",
     "Deprecated",
     "types-Deprecated",
     "humanfriendly",

--- a/metadata-ingestion/tests/test_helpers/docker_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/docker_helpers.py
@@ -43,15 +43,19 @@ def wait_for_port(
 
 
 @pytest.fixture(scope="module")
-def docker_compose_runner(docker_compose_project_name, docker_cleanup):
+def docker_compose_runner(
+    docker_compose_command, docker_compose_project_name, docker_setup, docker_cleanup
+):
     @contextlib.contextmanager
     def run(
         compose_file_path: Union[str, list], key: str
     ) -> pytest_docker.plugin.Services:
         with pytest_docker.plugin.get_docker_services(
-            compose_file_path,
-            f"{docker_compose_project_name}-{key}",
-            docker_cleanup,
+            docker_compose_command=docker_compose_command,
+            docker_compose_file=compose_file_path,
+            docker_compose_project_name=f"{docker_compose_project_name}-{key}",
+            docker_setup=docker_setup,
+            docker_cleanup=docker_cleanup,
         ) as docker_services:
             yield docker_services
 


### PR DESCRIPTION
This will help improve compat with newer versions of Airflow.

**markupsafe**: It looks like the aws-sam-cli package has updated their versions appropriately, which means that we are clear to remove this. Note: I'm not sure where we're actually depending on aws-sam-cli, since it never gets installed for me locally despite all sources being enabled.

**pytest-docker**: This was a simple upgrade - moving to 1.x introduced some extra non-defaulted parameters, so we just needed to fill those out.

Previous PRs:
- https://github.com/datahub-project/datahub/pull/4188
- https://github.com/datahub-project/datahub/pull/4388
- https://github.com/datahub-project/datahub/pull/4639


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)