### PR TITLE
fix(glossary) Improve business glossary loading performance

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryNode/ChildrenTab.tsx
+++ b/datahub-web-react/src/app/entity/glossaryNode/ChildrenTab.tsx
@@ -11,6 +11,8 @@ function ChildrenTab() {
     const { entityData } = useEntityData();
     const entityRegistry = useEntityRegistry();
 
+    if (!entityData) return <></>;
+
     const childNodes = entityData?.children?.relationships
         .filter((child) => child.entity?.type === EntityType.GlossaryNode)
         .sort((nodeA, nodeB) => sortGlossaryNodes(entityRegistry, nodeA.entity, nodeB.entity))

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/NodeItem.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/NodeItem.tsx
@@ -1,4 +1,4 @@
-import { FolderOutlined, RightOutlined, DownOutlined } from '@ant-design/icons';
+import { FolderOutlined, RightOutlined, DownOutlined, LoadingOutlined } from '@ant-design/icons';
 import styled from 'styled-components/macro';
 import React, { useState, useEffect } from 'react';
 import { ANTD_GRAY } from '../../entity/shared/constants';
@@ -45,6 +45,17 @@ const ChildrenWrapper = styled.div`
     padding-left: 12px;
 `;
 
+const LoadingWrapper = styled.div`
+    padding: 8px;
+    display: flex;
+    justify-content: center;
+
+    svg {
+        height: 15px;
+        width: 15px;
+    }
+`;
+
 interface Props {
     node: GlossaryNode;
     isSelecting?: boolean;
@@ -63,7 +74,7 @@ function NodeItem(props: Props) {
     const [areChildrenVisible, setAreChildrenVisible] = useState(false);
     const entityRegistry = useEntityRegistry();
     const { entityData } = useEntityData();
-    const { data } = useGetGlossaryNodeQuery({
+    const { data, loading } = useGetGlossaryNodeQuery({
         variables: { urn: node.urn },
         skip: !areChildrenVisible || shouldHideNode,
     });
@@ -126,24 +137,33 @@ function NodeItem(props: Props) {
                     </NameWrapper>
                 )}
             </NodeWrapper>
-            {areChildrenVisible && data && data.glossaryNode && (
-                <ChildrenWrapper>
-                    {(childNodes as GlossaryNode[]).map((child) => (
-                        <NodeItem
-                            node={child}
-                            isSelecting={isSelecting}
-                            hideTerms={hideTerms}
-                            openToEntity={openToEntity}
-                            nodeUrnToHide={nodeUrnToHide}
-                            selectTerm={selectTerm}
-                            selectNode={selectNode}
-                        />
-                    ))}
-                    {!hideTerms &&
-                        (childTerms as GlossaryTerm[]).map((child) => (
-                            <TermItem term={child} isSelecting={isSelecting} selectTerm={selectTerm} />
-                        ))}
-                </ChildrenWrapper>
+            {areChildrenVisible && (
+                <>
+                    {!data && loading && (
+                        <LoadingWrapper>
+                            <LoadingOutlined />
+                        </LoadingWrapper>
+                    )}
+                    {data && data.glossaryNode && (
+                        <ChildrenWrapper>
+                            {(childNodes as GlossaryNode[]).map((child) => (
+                                <NodeItem
+                                    node={child}
+                                    isSelecting={isSelecting}
+                                    hideTerms={hideTerms}
+                                    openToEntity={openToEntity}
+                                    nodeUrnToHide={nodeUrnToHide}
+                                    selectTerm={selectTerm}
+                                    selectNode={selectNode}
+                                />
+                            ))}
+                            {!hideTerms &&
+                                (childTerms as GlossaryTerm[]).map((child) => (
+                                    <TermItem term={child} isSelecting={isSelecting} selectTerm={selectTerm} />
+                                ))}
+                        </ChildrenWrapper>
+                    )}
+                </>
             )}
         </ItemWrapper>
     );

--- a/datahub-web-react/src/app/glossary/GlossaryEntitiesList.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryEntitiesList.tsx
@@ -27,7 +27,7 @@ function GlossaryEntitiesList(props: Props) {
                     name={node.properties?.name || ''}
                     urn={node.urn}
                     type={node.type}
-                    count={(node as GlossaryNodeFragment).children?.count}
+                    count={(node as GlossaryNodeFragment).children?.total}
                 />
             ))}
             {terms.map((term) => (

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -19,8 +19,8 @@ fragment glossaryNode on GlossaryNode {
     properties {
         name
     }
-    children: relationships(input: { types: ["IsPartOf"], direction: INCOMING, start: 0, count: 1000 }) {
-        count
+    children: relationships(input: { types: ["IsPartOf"], direction: INCOMING, start: 0, count: 10000 }) {
+        total
     }
 }
 

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -1,3 +1,11 @@
+fragment childGlossaryTerm on GlossaryTerm {
+    name
+    hierarchicalName
+    properties {
+        name
+    }
+}
+
 query getGlossaryNode($urn: String!) {
     glossaryNode(urn: $urn) {
         urn
@@ -17,19 +25,19 @@ query getGlossaryNode($urn: String!) {
                 types: ["IsPartOf"]
                 direction: INCOMING
                 start: 0
-                count: 1000
+                count: 10000
             }
         ) {
-            count
             relationships {
                 direction
                 entity {
                     type
+                    urn
                     ... on GlossaryNode {
                         ...glossaryNode
                     }
                     ... on GlossaryTerm {
-                        ...glossaryTerm
+                        ...childGlossaryTerm
                     }
                 }
             }


### PR DESCRIPTION
Improves the performance of our business glossary by reducing the amount of information we're fetching from the server. We were overfetching and getting data that we didn't use that more than doubled the amount of trips to the graph index. This should significantly improve loading times for larger glossaries with lots of terms under nodes.

I also add a loading spinner on the side when data is loading and fix loading UI on a term group page to not show the "empty glossary" state when data is still loading.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)