### PR TITLE
fix(glossary) Improve performance when getting root glossary terms

### DIFF
--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components/macro';
 import { useGetRootGlossaryNodesQuery, useGetRootGlossaryTermsQuery } from '../../../graphql/glossary.generated';
-import { GlossaryNode, GlossaryTerm } from '../../../types.generated';
+import { ChildGlossaryTermFragment } from '../../../graphql/glossaryNode.generated';
+import { GlossaryNode } from '../../../types.generated';
 import { sortGlossaryNodes } from '../../entity/glossaryNode/utils';
 import { sortGlossaryTerms } from '../../entity/glossaryTerm/utils';
 import { useEntityRegistry } from '../../useEntityRegistry';
@@ -18,7 +19,7 @@ const BrowserWrapper = styled.div`
 
 interface Props {
     rootNodes?: GlossaryNode[];
-    rootTerms?: GlossaryTerm[];
+    rootTerms?: ChildGlossaryTermFragment[];
     isSelecting?: boolean;
     hideTerms?: boolean;
     openToEntity?: boolean;

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/TermItem.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/TermItem.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
 import { useEntityData } from '../../entity/shared/EntityContext';
-import { GlossaryTerm } from '../../../types.generated';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { ANTD_GRAY } from '../../entity/shared/constants';
+import { ChildGlossaryTermFragment } from '../../../graphql/glossaryNode.generated';
 
 const TermWrapper = styled.div`
     font-weight: normal;
@@ -44,7 +44,7 @@ export const NameWrapper = styled.span<{ showSelectStyles?: boolean }>`
 `;
 
 interface Props {
-    term: GlossaryTerm;
+    term: ChildGlossaryTermFragment;
     isSelecting?: boolean;
     selectTerm?: (urn: string, displayName: string) => void;
 }

--- a/datahub-web-react/src/app/glossary/GlossaryEntitiesList.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryEntitiesList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 import { GlossaryNodeFragment } from '../../graphql/fragments.generated';
+import { ChildGlossaryTermFragment } from '../../graphql/glossaryNode.generated';
 import { GlossaryNode, GlossaryTerm } from '../../types.generated';
 import { useEntityRegistry } from '../useEntityRegistry';
 import GlossaryEntityItem from './GlossaryEntityItem';
@@ -13,7 +14,7 @@ const EntitiesWrapper = styled.div`
 
 interface Props {
     nodes: (GlossaryNode | GlossaryNodeFragment)[];
-    terms: GlossaryTerm[];
+    terms: (GlossaryTerm | ChildGlossaryTermFragment)[];
 }
 
 function GlossaryEntitiesList(props: Props) {

--- a/datahub-web-react/src/graphql/glossary.graphql
+++ b/datahub-web-react/src/graphql/glossary.graphql
@@ -4,7 +4,7 @@ query getRootGlossaryTerms {
         start
         total
         terms {
-            ...glossaryTerm
+            ...childGlossaryTerm
         }
     }
 }

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -1,4 +1,6 @@
 fragment childGlossaryTerm on GlossaryTerm {
+    urn
+    type
     name
     hierarchicalName
     properties {


### PR DESCRIPTION
Similar to the previous glossary performance PR, this reduces overfetching when getting root glossary terms to minimize the number of trips to our graph index. Now, fetch only the fields we need for the UI.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)