### PR TITLE
fix(ui) Properly display column-level lineage with v2 field paths

### DIFF
--- a/datahub-web-react/src/app/lineage/utils/useSortColumnsBySelectedField.ts
+++ b/datahub-web-react/src/app/lineage/utils/useSortColumnsBySelectedField.ts
@@ -2,7 +2,12 @@ import { useContext, useEffect } from 'react';
 import usePrevious from '../../shared/usePrevious';
 import { NUM_COLUMNS_PER_PAGE } from '../constants';
 import { FetchedEntity } from '../types';
-import { getHighlightedColumnsForNode, sortColumnsByDefault, sortRelatedLineageColumns } from './columnLineageUtils';
+import {
+    convertFieldsToV1FieldPath,
+    getHighlightedColumnsForNode,
+    sortColumnsByDefault,
+    sortRelatedLineageColumns,
+} from './columnLineageUtils';
 import { LineageExplorerContext } from './LineageExplorerContext';
 
 export default function useSortColumnsBySelectedField(fetchedEntities: { [x: string]: FetchedEntity }) {
@@ -35,7 +40,7 @@ export default function useSortColumnsBySelectedField(fetchedEntities: { [x: str
                     updatedColumnsByUrn = sortColumnsByDefault(
                         updatedColumnsByUrn,
                         columns,
-                        fetchedEntity.schemaMetadata.fields,
+                        convertFieldsToV1FieldPath(fetchedEntity.schemaMetadata.fields),
                         urn,
                     );
                 }


### PR DESCRIPTION
Fixes column-level lineage with v2 field paths to always use v1 field paths. This is necessary because `fineGrainedLineage` always produces v1 field paths while `schemaMetadata` on the entity uses v2 field paths. So we just need to be consistent here. So I always convert fields to v1 field paths when creating our source of truth `columnsByUrn`.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)