### PR TITLE
feat(ui): display entity names in browser tab titles

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -74,6 +74,7 @@
         "react": "^17.0.0",
         "react-color": "^2.19.3",
         "react-dom": "^17.0.0",
+        "react-helmet": "^6.1.0",
         "react-highlighter": "^0.4.3",
         "react-icons": "4.3.1",
         "react-js-cron": "^2.1.0",

--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { ApolloClient, ApolloProvider, createHttpLink, InMemoryCache, ServerError } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
 import { ThemeProvider } from 'styled-components';
+import { Helmet } from 'react-helmet';
 import './App.less';
 import { Routes } from './app/Routes';
 import EntityRegistry from './app/entity/EntityRegistry';
@@ -107,6 +108,9 @@ const App: React.VFC = () => {
     return (
         <ThemeProvider theme={dynamicThemeConfig}>
             <Router>
+                <Helmet>
+                    <title>{dynamicThemeConfig.content.title}</title>
+                </Helmet>
                 <EntityRegistryContext.Provider value={entityRegistry}>
                     <ApolloProvider client={client}>
                         <Routes />

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -33,6 +33,7 @@ import { BrowserWrapper, MAX_BROWSER_WIDTH, MIN_BROWSWER_WIDTH } from '../../../
 import { combineEntityDataWithSiblings, useIsSeparateSiblingsMode } from '../../siblingUtils';
 import { EntityActionItem } from '../../entity/EntityActions';
 import { ErrorSection } from '../../../../shared/error/ErrorSection';
+import { EntityHead } from '../../../../shared/EntityHead';
 
 type Props<T, U> = {
     urn: string;
@@ -297,6 +298,7 @@ export const EntityProfile = <T, U>({
             }}
         >
             <>
+                <EntityHead />
                 {customNavBar}
                 {showBrowseBar && !customNavBar && <EntityProfileNavBar urn={urn} entityType={entityType} />}
                 {entityData?.status?.removed === true && (

--- a/datahub-web-react/src/app/shared/EntityHead.tsx
+++ b/datahub-web-react/src/app/shared/EntityHead.tsx
@@ -6,12 +6,15 @@ import { capitalizeFirstLetterOnly } from './textUtil';
 
 export const EntityHead = () => {
     const entityRegistry = useEntityRegistry();
-    const entityData = useEntityData();
+    const { entityType, entityData } = useEntityData();
 
-    const entityDisplayName = entityRegistry.getDisplayName(entityData.entityType, entityData.entityData);
+    if (!entityData) {
+        return null;
+    }
+
+    const entityDisplayName = entityRegistry.getDisplayName(entityType, entityData);
     const type =
-        capitalizeFirstLetterOnly(entityData?.entityData?.subTypes?.typeNames?.[0]) ||
-        entityRegistry.getEntityName(entityData.entityType);
+        capitalizeFirstLetterOnly(entityData?.subTypes?.typeNames?.[0]) || entityRegistry.getEntityName(entityType);
 
     return (
         <Helmet>

--- a/datahub-web-react/src/app/shared/EntityHead.tsx
+++ b/datahub-web-react/src/app/shared/EntityHead.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useEntityData } from '../entity/shared/EntityContext';
+import { useEntityRegistry } from '../useEntityRegistry';
+import { capitalizeFirstLetterOnly } from './textUtil';
+
+export const EntityHead = () => {
+    const entityRegistry = useEntityRegistry();
+    const entityData = useEntityData();
+
+    const entityDisplayName = entityRegistry.getDisplayName(entityData.entityType, entityData.entityData);
+    const type =
+        capitalizeFirstLetterOnly(entityData?.entityData?.subTypes?.typeNames?.[0]) ||
+        entityRegistry.getEntityName(entityData.entityType);
+
+    return (
+        <Helmet>
+            <title>
+                {entityDisplayName} | {type}
+            </title>
+        </Helmet>
+    );
+};

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -13976,6 +13976,21 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
+
 react-highlighter@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/react-highlighter/-/react-highlighter-0.4.3.tgz#e32c84d053259c30ca72c615aa759036d0d23048"
@@ -14137,6 +14152,11 @@ react-select@^5.1.0:
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react-syntax-highlighter@^15.4.4:
   version "15.4.4"


### PR DESCRIPTION
Currently it's hard for users to navigate DataHub when there's multiple tabs opened because all the tab titles would be labelled 'DataHub'. This PR helps to resolve this UX by adding the Entity's Name and SubType/Type to the browser tab's title in the format:

@aezomz 

```
# e.g. datahub_really_large_dag | Pipeline, category_view | View
<entityName> | <subType or type>
```

## Changes
- Added `react-helmet` to help manage the `<title />`
- Added `<EntityHead />` to render entity titles
- Added `<title />` on `App.tsx` to allow falling back to default title when navigating away from the entity page


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)