### PR TITLE
fix(ui): remove margin-top from domains container

### DIFF
--- a/datahub-web-react/src/app/home/HomePageRecommendations.tsx
+++ b/datahub-web-react/src/app/home/HomePageRecommendations.tsx
@@ -65,7 +65,6 @@ const NoMetadataContainer = styled.div`
 `;
 
 const DomainsRecomendationContainer = styled.div`
-    margin-top: -48px;
     margin-bottom: 32px;
     max-width: 1000px;
     min-width: 750px;


### PR DESCRIPTION
`margin-top` config should be removed because it causes the overlapping between Pinned and Domains containers.  
Ref: https://datahubspace.slack.com/archives/CV2UXSE9L/p1666259877634369

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)