### PR TITLE
fix: quickstart failed due to command not found

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -217,8 +217,7 @@ def _attempt_stop(quickstart_compose_file: List[pathlib.Path]) -> None:
     if compose_files_for_stopping:
         # docker-compose stop
         base_command: List[str] = [
-            "docker",
-            "compose",
+            "docker-compose",
             *itertools.chain.from_iterable(
                 ("-f", f"{path}") for path in compose_files_for_stopping
             ),
@@ -654,8 +653,7 @@ def quickstart(
     )
 
     base_command: List[str] = [
-        "docker",
-        "compose",
+        "docker-compose",
         *itertools.chain.from_iterable(
             ("-f", f"{path}") for path in quickstart_compose_file
         ),


### PR DESCRIPTION
I believe the newer `docker` doesn't have `compose` command. Therefore, we should use `docker-compose` instead.

```
[2022-10-21 02:50:11,125] ERROR    {datahub.entrypoints:192} -
Traceback (most recent call last):
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/entrypoints.py", line 149, in main
    sys.exit(datahub(standalone_mode=False, **kwargs))
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/upgrade/upgrade.py", line 386, in async_wrapper
    loop.run_until_complete(run_func_check_upgrade())
  File "/usr/lib64/python3.7/asyncio/base_events.py", line 587, in run_until_complete
    return future.result()
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/upgrade/upgrade.py", line 373, in run_func_check_upgrade
    ret = await the_one_future
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/upgrade/upgrade.py", line 367, in run_inner_func
    None, functools.partial(func, *args, **kwargs)
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/telemetry/telemetry.py", line 347, in wrapper
    raise e
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/telemetry/telemetry.py", line 299, in wrapper
    res = func(*args, **kwargs)
  File "/home/ec2-user/datahub/venv3/lib/python3.7/site-packages/datahub/cli/docker_cli.py", line 730, in quickstart
    env=_docker_subprocess_env(),
  File "/usr/lib64/python3.7/subprocess.py", line 512, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['docker', 'compose', '-f', '/home/ec2-user/.datahub/quickstart/docker-compose.yml', '-p', 'datahub', 'logs']' returned non-zero exit status 125.
[2022-10-21 02:50:11,125] ERROR    {datahub.entrypoints:196} - Command failed:
	Command '['docker', 'compose', '-f', '/home/ec2-user/.datahub/quickstart/docker-compose.yml', '-p', 'datahub', 'logs']' returned non-zero exit status 125..
	Run with --debug to get full stacktrace.
	e.g. 'datahub --debug docker quickstart'
```



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)