### PR TITLE
fix(oidc): Avoid storing Pac4j profile in cookie 

### DIFF
--- a/datahub-frontend/app/controllers/SsoCallbackController.java
+++ b/datahub-frontend/app/controllers/SsoCallbackController.java
@@ -40,6 +40,7 @@ public class SsoCallbackController extends CallbackController {
       @Nonnull AuthServiceClient authClient) {
     _ssoManager = ssoManager;
     setDefaultUrl("/"); // By default, redirects to Home Page on log in.
+    setSaveInSession(false);
     setCallbackLogic(new SsoCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient));
   }
 

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -51,9 +51,3 @@ DATAHUB_AKKA_MAX_HEADER_COUNT=64
 
 # Change to override max header value length defaults
 DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH=8k
-
-AUTH_OIDC_ENABLED=true
-AUTH_OIDC_CLIENT_ID=0oa6957b1o9dVm3JM5d7
-AUTH_OIDC_CLIENT_SECRET=wObio8oYQUtaLIGw5DMG6gB1dc3uXIpJTNMkXZhe
-AUTH_OIDC_DISCOVERY_URI=https://dev-76500509.okta.com/.well-known/openid-configuration
-AUTH_OIDC_BASE_URL=http://localhost:9002

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -51,3 +51,9 @@ DATAHUB_AKKA_MAX_HEADER_COUNT=64
 
 # Change to override max header value length defaults
 DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH=8k
+
+AUTH_OIDC_ENABLED=true
+AUTH_OIDC_CLIENT_ID=0oa6957b1o9dVm3JM5d7
+AUTH_OIDC_CLIENT_SECRET=wObio8oYQUtaLIGw5DMG6gB1dc3uXIpJTNMkXZhe
+AUTH_OIDC_DISCOVERY_URI=https://dev-76500509.okta.com/.well-known/openid-configuration
+AUTH_OIDC_BASE_URL=http://localhost:9002


### PR DESCRIPTION
**Summary**
- Previously we stored the entire pac4j OIDC profile in the user cookie, in encrypted form. This sometimes caused the OIDC cookie to grow too large, when attributes grew beyond a certain size. In this PR we remove that cookie, as it's not strictly required for subsequent requests.


**Status**
Ready for review 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)