### PR TITLE
feat(lineage) Add column-level impact analysis feature

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
@@ -25,6 +25,7 @@ import com.linkedin.datahub.graphql.generated.MLModel;
 import com.linkedin.datahub.graphql.generated.MLModelGroup;
 import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
 import com.linkedin.datahub.graphql.generated.Notebook;
+import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
 import com.linkedin.datahub.graphql.generated.Tag;
 import com.linkedin.datahub.graphql.generated.Test;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
@@ -162,6 +163,11 @@ public class UrnToEntityMapper implements ModelMapper<com.linkedin.common.urn.Ur
       partialEntity = new DataHubPolicy();
       ((DataHubPolicy) partialEntity).setUrn(input.toString());
       ((DataHubPolicy) partialEntity).setType(EntityType.DATAHUB_POLICY);
+    }
+    if (input.getEntityType().equals(SCHEMA_FIELD_ENTITY_NAME)) {
+      partialEntity = new SchemaFieldEntity();
+      ((SchemaFieldEntity) partialEntity).setUrn(input.toString());
+      ((SchemaFieldEntity) partialEntity).setType(EntityType.SCHEMA_FIELD);
     }
     return partialEntity;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/ForeignKeyConstraintMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/ForeignKeyConstraintMapper.java
@@ -5,9 +5,12 @@ import com.linkedin.datahub.graphql.generated.Dataset;
 import com.linkedin.datahub.graphql.generated.ForeignKeyConstraint;
 import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.stream.Collectors;
 
 
+@Slf4j
 public class ForeignKeyConstraintMapper {
   private ForeignKeyConstraintMapper() { }
 
@@ -34,7 +37,12 @@ public class ForeignKeyConstraintMapper {
 
   private static SchemaFieldEntity mapSchemaFieldEntity(Urn schemaFieldUrn) {
     SchemaFieldEntity result = new SchemaFieldEntity();
-    result.setParent(schemaFieldUrn.getEntityKey().get(0));
+    try {
+      Urn resourceUrn = Urn.createFromString(schemaFieldUrn.getEntityKey().get(0));
+      result.setParent(UrnToEntityMapper.map(resourceUrn));
+    } catch (Exception e) {
+      log.error("Error converting schemaField parent urn string to Urn", e);
+    }
     result.setFieldPath(schemaFieldUrn.getEntityKey().get(1));
     return result;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/ForeignKeyConstraintMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/ForeignKeyConstraintMapper.java
@@ -41,7 +41,7 @@ public class ForeignKeyConstraintMapper {
       Urn resourceUrn = Urn.createFromString(schemaFieldUrn.getEntityKey().get(0));
       result.setParent(UrnToEntityMapper.map(resourceUrn));
     } catch (Exception e) {
-      log.error("Error converting schemaField parent urn string to Urn", e);
+      throw new RuntimeException("Error converting schemaField parent urn string to Urn", e);
     }
     result.setFieldPath(schemaFieldUrn.getEntityKey().get(1));
     return result;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
@@ -1,10 +1,12 @@
 package com.linkedin.datahub.graphql.types.mappers;
 
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.DoubleMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.generated.AggregationMetadata;
 import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityPath;
 import com.linkedin.datahub.graphql.generated.FacetMetadata;
 import com.linkedin.datahub.graphql.generated.MatchedField;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResult;
@@ -47,9 +49,15 @@ public class UrnSearchAcrossLineageResultsMapper<T extends RecordTemplate, E ext
         .setEntity(UrnToEntityMapper.map(searchEntity.getEntity()))
         .setInsights(getInsightsFromFeatures(searchEntity.getFeatures()))
         .setMatchedFields(getMatchedFieldEntry(searchEntity.getMatchedFields()))
-        .setPaths(searchEntity.getPaths().stream().map(path -> path.stream().map(Urn::toString).collect(Collectors.toList())).collect(Collectors.toList()))
+        .setPaths(searchEntity.getPaths().stream().map(this::mapPath).collect(Collectors.toList()))
         .setDegree(searchEntity.getDegree())
         .build();
+  }
+
+  private EntityPath mapPath(UrnArray path) {
+    EntityPath entityPath = new EntityPath();
+    entityPath.setPath(path.stream().map(UrnToEntityMapper::map).collect(Collectors.toList()));
+    return entityPath;
   }
 
   private FacetMetadata mapFacet(com.linkedin.metadata.search.AggregationMetadata aggregationMetadata) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
@@ -1,7 +1,6 @@
 package com.linkedin.datahub.graphql.types.mappers;
 
 import com.linkedin.common.UrnArray;
-import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.DoubleMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.generated.AggregationMetadata;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.types.mappers;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.DoubleMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.generated.AggregationMetadata;
@@ -46,7 +47,7 @@ public class UrnSearchAcrossLineageResultsMapper<T extends RecordTemplate, E ext
         .setEntity(UrnToEntityMapper.map(searchEntity.getEntity()))
         .setInsights(getInsightsFromFeatures(searchEntity.getFeatures()))
         .setMatchedFields(getMatchedFieldEntry(searchEntity.getMatchedFields()))
-        .setPath(searchEntity.getPath().stream().map(UrnToEntityMapper::map).collect(Collectors.toList()))
+        .setPaths(searchEntity.getPaths().stream().map(path -> path.stream().map(Urn::toString).collect(Collectors.toList())).collect(Collectors.toList()))
         .setDegree(searchEntity.getDegree())
         .build();
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/schemafield/SchemaFieldType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/schemafield/SchemaFieldType.java
@@ -1,0 +1,71 @@
+package com.linkedin.datahub.graphql.types.schemafield;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
+import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import graphql.execution.DataFetcherResult;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class SchemaFieldType implements com.linkedin.datahub.graphql.types.EntityType<SchemaFieldEntity, String> {
+
+  public SchemaFieldType() { }
+
+  @Override
+  public EntityType type() {
+    return EntityType.SCHEMA_FIELD;
+  }
+
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
+
+  @Override
+  public Class<SchemaFieldEntity> objectClass() {
+    return SchemaFieldEntity.class;
+  }
+
+  @Override
+  public List<DataFetcherResult<SchemaFieldEntity>> batchLoad(@Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> schemaFieldUrns = urns.stream()
+        .map(UrnUtils::getUrn)
+        .collect(Collectors.toList());
+
+    try {
+      return schemaFieldUrns.stream()
+          .map(this::mapSchemaFieldUrn)
+          .map(schemaFieldEntity -> DataFetcherResult.<SchemaFieldEntity>newResult()
+              .data(schemaFieldEntity)
+              .build()
+          )
+          .collect(Collectors.toList());
+
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load schemaField entity", e);
+    }
+  }
+
+  private SchemaFieldEntity mapSchemaFieldUrn(Urn urn) {
+    try {
+      SchemaFieldEntity result = new SchemaFieldEntity();
+      result.setUrn(urn.toString());
+      result.setType(EntityType.SCHEMA_FIELD);
+      result.setFieldPath(urn.getEntityKey().get(1));
+      Urn parentUrn = Urn.createFromString(urn.getEntityKey().get(0));
+      result.setParent(UrnToEntityMapper.map(parentUrn));
+      return result;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to load schemaField entity", e);
+    }
+  }
+
+}
+

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -705,14 +705,11 @@ enum EntityType {
     DATAHUB_ROLE
 
     """
-<<<<<<< HEAD
     A DataHub Post
     """
     POST
 
     """
-=======
->>>>>>> 1f594e3cc7 (make changes to return hydrated parent in schemaField path and fix build error)
     A Schema Field
     """
     SCHEMA_FIELD

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -705,11 +705,14 @@ enum EntityType {
     DATAHUB_ROLE
 
     """
+<<<<<<< HEAD
     A DataHub Post
     """
     POST
 
     """
+=======
+>>>>>>> 1f594e3cc7 (make changes to return hydrated parent in schemaField path and fix build error)
     A Schema Field
     """
     SCHEMA_FIELD
@@ -2343,11 +2346,16 @@ type KeyValueSchema {
 Standalone schema field entity. Differs from the SchemaField struct because it is not directly nested inside a
 schema field
 """
-type SchemaFieldEntity {
+type SchemaFieldEntity implements Entity {
     """
     Primary key of the schema field
     """
     urn: String!
+
+    """
+    A standard Entity Type
+    """
+    type: EntityType!
 
     """
     Field path identifying the field in its dataset
@@ -2355,9 +2363,14 @@ type SchemaFieldEntity {
     fieldPath: String!
 
     """
-    The primary key of the field's parent.
+    The field's parent.
     """
-    parent: String!
+    parent: Entity!
+
+    """
+    Granular API for querying edges extending from this entity
+    """
+    relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -312,13 +312,24 @@ type SearchAcrossLineageResult {
   """
   Optional list of entities between the source and destination node
   """
-  paths: [[String]]
+  paths: [EntityPath]
 
   """
   Degree of relationship (number of hops to get to entity)
   """
   degree: Int!
 }
+
+"""
+An overview of the field that was matched in the entity search document
+"""
+type EntityPath {
+    """
+    Path of entities between source and destination nodes
+    """
+    path: [Entity]
+}
+
 
 """
 An overview of the field that was matched in the entity search document

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -312,7 +312,7 @@ type SearchAcrossLineageResult {
   """
   Optional list of entities between the source and destination node
   """
-  path: [Entity!]
+  paths: [[String]]
 
   """
   Degree of relationship (number of hops to get to entity)

--- a/datahub-web-react/src/app/entity/dataset/profile/stories/sampleSchema.ts
+++ b/datahub-web-react/src/app/entity/dataset/profile/stories/sampleSchema.ts
@@ -204,14 +204,16 @@ export const sampleSchemaWithPkFk: SchemaMetadata = {
             sourceFields: [
                 {
                     urn: 'datasetUrn',
-                    parent: 'dataset',
+                    type: EntityType.Dataset,
+                    parent: { urn: 'test', type: EntityType.Dataset },
                     fieldPath: 'shipping_address',
                 },
             ],
             foreignFields: [
                 {
                     urn: dataset3.urn,
-                    parent: dataset3.name,
+                    type: EntityType.Dataset,
+                    parent: { urn: dataset3.name, type: EntityType.Dataset },
                     fieldPath: 'address',
                 },
             ],

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -31,7 +31,7 @@ export enum EntityMenuItems {
     MOVE,
 }
 
-const MenuIcon = styled(MoreOutlined)<{ fontSize?: number }>`
+export const MenuIcon = styled(MoreOutlined)<{ fontSize?: number }>`
     display: flex;
     justify-content: center;
     align-items: center;

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -127,6 +127,8 @@ export const EmbeddedListSearchResults = ({
                                     // when we add impact analysis, we will want to pipe the path to each element to the result this
                                     // eslint-disable-next-line @typescript-eslint/dot-notation
                                     degree: searchResult['degree'],
+                                    // eslint-disable-next-line @typescript-eslint/dot-notation
+                                    paths: searchResult['paths'],
                                 })) || []
                             }
                             isSelectMode={isSelectMode}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -11,7 +11,7 @@ import { SearchFiltersSection } from '../../../../../search/SearchFiltersSection
 
 const SearchBody = styled.div`
     height: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     display: flex;
 `;
 

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -40,9 +40,10 @@ export const EmbeddedListSearchSection = ({
 }: Props) => {
     const history = useHistory();
     const location = useLocation();
-    const baseParams = useEntityQueryParams();
+    const entityQueryParams = useEntityQueryParams();
 
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
+    const baseParams = { ...params, ...entityQueryParams };
     const query: string = params?.query as string;
     const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
     const unionType: UnionType = Number(params.unionType as any as UnionType) || UnionType.AND;

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
@@ -30,11 +30,11 @@ export const navigateToEntitySearchUrl = ({
 
     const search = QueryString.stringify(
         {
+            ...baseParams,
             ...filtersToQueryStringParams(constructedFilters),
             query: newQuery,
             page: newPage,
             unionType,
-            ...baseParams,
         },
         { arrayFormat: 'comma' },
     );

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -21,6 +21,7 @@ import { SchemaRow } from './components/SchemaRow';
 import { FkContext } from './utils/selectedFkContext';
 import useSchemaBlameRenderer from './utils/useSchemaBlameRenderer';
 import { ANTD_GRAY } from '../../../constants';
+import MenuColumn from './components/MenuColumn';
 
 const TableContainer = styled.div`
     &&& .ant-table-tbody > tr > .ant-table-cell-with-append {
@@ -163,6 +164,14 @@ export default function SchemaTable({
         render: usageStatsRenderer,
     };
 
+    const menuColumn = {
+        width: '5%',
+        title: '',
+        dataIndex: '',
+        key: 'menu',
+        render: (field: SchemaField) => <MenuColumn field={field} />,
+    };
+
     let allColumns: ColumnsType<ExtendedSchemaFields> = [fieldColumn, descriptionColumn, tagColumn, termColumn];
 
     if (hasUsageStats) {
@@ -172,6 +181,8 @@ export default function SchemaTable({
     if (showSchemaAuditView) {
         allColumns = [...allColumns, blameColumn];
     }
+
+    allColumns = [...allColumns, menuColumn];
 
     const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
 

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/MenuColumn.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/MenuColumn.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { VscGraphLeft } from 'react-icons/vsc';
+import styled from 'styled-components/macro';
+import { Dropdown, Menu } from 'antd';
+import { MenuIcon } from '../../../../EntityDropdown/EntityDropdown';
+import { useRouteToTab } from '../../../../EntityContext';
+import { SchemaField } from '../../../../../../../types.generated';
+
+export const ImpactAnalysisIcon = styled(VscGraphLeft)`
+    transform: scaleX(-1);
+    font-size: 18px;
+`;
+
+const MenuItem = styled.div`
+    align-items: center;
+    display: flex;
+    font-size: 12px;
+    padding: 0 4px;
+    color: #262626;
+`;
+
+interface Props {
+    field: SchemaField;
+}
+
+export default function MenuColumn({ field }: Props) {
+    const routeToTab = useRouteToTab();
+
+    return (
+        <Dropdown
+            overlay={
+                <Menu>
+                    <Menu.Item key="0">
+                        <MenuItem
+                            onClick={() => routeToTab({ tabName: 'Lineage', tabParams: { column: field.fieldPath } })}
+                        >
+                            <ImpactAnalysisIcon /> &nbsp; See Column Lineage
+                        </MenuItem>
+                    </Menu.Item>
+                </Menu>
+            }
+            trigger={['click']}
+        >
+            <MenuIcon fontSize={16} />
+        </Dropdown>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
@@ -15,16 +15,16 @@ const StyledSelect = styled(Select)`
 
 interface Props {
     selectedColumn?: string;
-    isShowingColumnSelect: boolean;
+    isColumnLevelLineage: boolean;
     setSelectedColumn: (column: any) => void;
-    setIsShowingColumnSelect: (isShowing: boolean) => void;
+    setIsColumnLevelLineage: (isShowing: boolean) => void;
 }
 
 export default function ColumnsLineageSelect({
     selectedColumn,
-    isShowingColumnSelect,
+    isColumnLevelLineage,
     setSelectedColumn,
-    setIsShowingColumnSelect,
+    setIsColumnLevelLineage,
 }: Props) {
     const { entityData } = useEntityData();
     const location = useLocation();
@@ -35,11 +35,11 @@ export default function ColumnsLineageSelect({
         setSelectedColumn(column);
     }
 
-    const columnButtonTooltip = isShowingColumnSelect ? 'Hide column level lineage' : 'Show column level lineage';
+    const columnButtonTooltip = isColumnLevelLineage ? 'Hide column level lineage' : 'Show column level lineage';
 
     return (
         <>
-            {isShowingColumnSelect && (
+            {isColumnLevelLineage && (
                 <StyledSelect
                     value={selectedColumn}
                     onChange={selectColumn}
@@ -53,7 +53,7 @@ export default function ColumnsLineageSelect({
                 </StyledSelect>
             )}
             <Tooltip title={columnButtonTooltip}>
-                <Button type="text" onClick={() => setIsShowingColumnSelect(!isShowingColumnSelect)}>
+                <Button type="text" onClick={() => setIsColumnLevelLineage(!isColumnLevelLineage)}>
                     <ImpactAnalysisIcon />
                 </Button>
             </Tooltip>

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
@@ -1,0 +1,62 @@
+import { Button, Select, Tooltip } from 'antd';
+import * as React from 'react';
+import styled from 'styled-components/macro';
+import { useHistory, useLocation } from 'react-router';
+import { ImpactAnalysisIcon } from '../Dataset/Schema/components/MenuColumn';
+import updateQueryParams from '../../../../shared/updateQueryParams';
+import { downgradeV2FieldPath } from '../../../dataset/profile/schema/utils/utils';
+import { useEntityData } from '../../EntityContext';
+
+const StyledSelect = styled(Select)`
+    margin-right: 5px;
+    min-width: 140px;
+    max-width: 200px;
+`;
+
+interface Props {
+    selectedColumn?: string;
+    isShowingColumnSelect: boolean;
+    setSelectedColumn: (column: any) => void;
+    setIsShowingColumnSelect: (isShowing: boolean) => void;
+}
+
+export default function ColumnsLineageSelect({
+    selectedColumn,
+    isShowingColumnSelect,
+    setSelectedColumn,
+    setIsShowingColumnSelect,
+}: Props) {
+    const { entityData } = useEntityData();
+    const location = useLocation();
+    const history = useHistory();
+
+    function selectColumn(column: any) {
+        updateQueryParams({ column }, location, history);
+        setSelectedColumn(column);
+    }
+
+    const columnButtonTooltip = isShowingColumnSelect ? 'Hide column level lineage' : 'Show column level lineage';
+
+    return (
+        <>
+            {isShowingColumnSelect && (
+                <StyledSelect
+                    value={selectedColumn}
+                    onChange={selectColumn}
+                    showSearch
+                    allowClear
+                    placeholder="Select column"
+                >
+                    {entityData?.schemaMetadata?.fields.map((field) => (
+                        <Select.Option value={field.fieldPath}>{downgradeV2FieldPath(field.fieldPath)}</Select.Option>
+                    ))}
+                </StyledSelect>
+            )}
+            <Tooltip title={columnButtonTooltip}>
+                <Button type="text" onClick={() => setIsShowingColumnSelect(!isShowingColumnSelect)}>
+                    <ImpactAnalysisIcon />
+                </Button>
+            </Tooltip>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
@@ -1,6 +1,7 @@
 import { Button, Select, Tooltip } from 'antd';
 import * as React from 'react';
 import styled from 'styled-components/macro';
+import { blue } from '@ant-design/colors';
 import { useHistory, useLocation } from 'react-router';
 import { ImpactAnalysisIcon } from '../Dataset/Schema/components/MenuColumn';
 import updateQueryParams from '../../../../shared/updateQueryParams';
@@ -11,6 +12,25 @@ const StyledSelect = styled(Select)`
     margin-right: 5px;
     min-width: 140px;
     max-width: 200px;
+`;
+
+const StyledButton = styled(Button)<{ isSelected: boolean }>`
+    transition: color 0s;
+    display: flex;
+    align-items: center;
+
+    ${(props) =>
+        props.isSelected &&
+        `
+        color: ${blue[5]};
+        &:focus, &:hover {
+            color: ${blue[5]};
+        }
+    `};
+`;
+
+const TextWrapper = styled.span`
+    margin-left: 8px;
 `;
 
 interface Props {
@@ -53,13 +73,15 @@ export default function ColumnsLineageSelect({
                 </StyledSelect>
             )}
             <Tooltip title={columnButtonTooltip}>
-                <Button
+                <StyledButton
                     type="text"
                     onClick={() => setIsColumnLevelLineage(!isColumnLevelLineage)}
                     data-testid="column-lineage-toggle"
+                    isSelected={isColumnLevelLineage}
                 >
                     <ImpactAnalysisIcon />
-                </Button>
+                    <TextWrapper>Column Lineage</TextWrapper>
+                </StyledButton>
             </Tooltip>
         </>
     );

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
@@ -53,7 +53,11 @@ export default function ColumnsLineageSelect({
                 </StyledSelect>
             )}
             <Tooltip title={columnButtonTooltip}>
-                <Button type="text" onClick={() => setIsColumnLevelLineage(!isColumnLevelLineage)}>
+                <Button
+                    type="text"
+                    onClick={() => setIsColumnLevelLineage(!isColumnLevelLineage)}
+                    data-testid="column-lineage-toggle"
+                >
                     <ImpactAnalysisIcon />
                 </Button>
             </Tooltip>

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ImpactAnalysis.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ImpactAnalysis.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import * as QueryString from 'query-string';
 import { useLocation } from 'react-router';
-import styled from 'styled-components';
-
 import { useSearchAcrossLineageQuery } from '../../../../../graphql/search.generated';
 import { EntityType, FacetFilterInput, LineageDirection } from '../../../../../types.generated';
 import { ENTITY_FILTER_NAME } from '../../../../search/utils/constants';
@@ -11,10 +9,6 @@ import { SearchCfg } from '../../../../../conf';
 import analytics, { EventType } from '../../../../analytics';
 import generateUseSearchResultsViaRelationshipHook from './generateUseSearchResultsViaRelationshipHook';
 import { EmbeddedListSearchSection } from '../../components/styled/search/EmbeddedListSearchSection';
-
-const ImpactAnalysisWrapper = styled.div`
-    flex: 1;
-`;
 
 type Props = {
     urn: string;
@@ -60,15 +54,13 @@ export const ImpactAnalysis = ({ urn, direction }: Props) => {
     }, [query, data, loading]);
 
     return (
-        <ImpactAnalysisWrapper>
-            <EmbeddedListSearchSection
-                useGetSearchResults={generateUseSearchResultsViaRelationshipHook({
-                    urn,
-                    direction,
-                })}
-                defaultShowFilters
-                defaultFilters={[{ field: 'degree', values: ['1'] }]}
-            />
-        </ImpactAnalysisWrapper>
+        <EmbeddedListSearchSection
+            useGetSearchResults={generateUseSearchResultsViaRelationshipHook({
+                urn,
+                direction,
+            })}
+            defaultShowFilters
+            defaultFilters={[{ field: 'degree', values: ['1'] }]}
+        />
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTab.tsx
@@ -48,7 +48,7 @@ export const LineageTab = ({
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
     const [lineageDirection, setLineageDirection] = useState<LineageDirection>(properties.defaultDirection);
     const [selectedColumn, setSelectedColumn] = useState<string | undefined>(params?.column as string);
-    const [isShowingColumnSelect, setIsShowingColumnSelect] = useState(!!params?.column);
+    const [isColumnLevelLineage, setIsColumnLevelLineage] = useState(!!params?.column);
 
     const routeToLineage = useCallback(() => {
         history.push(getEntityPath(entityType, urn, entityRegistry, true, false));
@@ -56,7 +56,7 @@ export const LineageTab = ({
 
     const selectedV1FieldPath = downgradeV2FieldPath(selectedColumn) || '';
     const selectedColumnUrn = generateSchemaFieldUrn(selectedV1FieldPath, urn);
-    const impactAnalysisUrn = isShowingColumnSelect && selectedColumnUrn ? selectedColumnUrn : urn;
+    const impactAnalysisUrn = isColumnLevelLineage && selectedColumnUrn ? selectedColumnUrn : urn;
 
     return (
         <>
@@ -80,9 +80,9 @@ export const LineageTab = ({
                 <RightButtonsWrapper>
                     <ColumnsLineageSelect
                         selectedColumn={selectedColumn}
-                        isShowingColumnSelect={isShowingColumnSelect}
+                        isColumnLevelLineage={isColumnLevelLineage}
                         setSelectedColumn={setSelectedColumn}
-                        setIsShowingColumnSelect={setIsShowingColumnSelect}
+                        setIsColumnLevelLineage={setIsColumnLevelLineage}
                     />
                     <Button type="text" onClick={routeToLineage}>
                         <PartitionOutlined />
@@ -90,7 +90,7 @@ export const LineageTab = ({
                     </Button>
                 </RightButtonsWrapper>
             </StyledTabToolbar>
-            <LineageTabContext.Provider value={{ selectedColumn, lineageDirection }}>
+            <LineageTabContext.Provider value={{ isColumnLevelLineage, selectedColumn, lineageDirection }}>
                 <ImpactAnalysis urn={impactAnalysisUrn} direction={lineageDirection as LineageDirection} />
             </LineageTabContext.Provider>
         </>

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTab.tsx
@@ -14,6 +14,7 @@ import { LineageDirection } from '../../../../../types.generated';
 import { generateSchemaFieldUrn } from './utils';
 import { downgradeV2FieldPath } from '../../../dataset/profile/schema/utils/utils';
 import ColumnsLineageSelect from './ColumnLineageSelect';
+import { LineageTabContext } from './LineageTabContext';
 
 const StyledTabToolbar = styled(TabToolbar)`
     justify-content: space-between;
@@ -89,7 +90,9 @@ export const LineageTab = ({
                     </Button>
                 </RightButtonsWrapper>
             </StyledTabToolbar>
-            <ImpactAnalysis urn={impactAnalysisUrn} direction={lineageDirection as LineageDirection} />
+            <LineageTabContext.Provider value={{ selectedColumn, lineageDirection }}>
+                <ImpactAnalysis urn={impactAnalysisUrn} direction={lineageDirection as LineageDirection} />
+            </LineageTabContext.Provider>
         </>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTabContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTabContext.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { LineageDirection } from '../../../../../types.generated';
+
+export const LineageTabContext = React.createContext<LineageTabContextType>({
+    lineageDirection: LineageDirection.Downstream,
+    selectedColumn: undefined,
+});
+
+type LineageTabContextType = {
+    lineageDirection: LineageDirection;
+    selectedColumn?: string;
+};

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTabContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/LineageTabContext.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { LineageDirection } from '../../../../../types.generated';
 
 export const LineageTabContext = React.createContext<LineageTabContextType>({
+    isColumnLevelLineage: false,
     lineageDirection: LineageDirection.Downstream,
     selectedColumn: undefined,
 });
 
 type LineageTabContextType = {
+    isColumnLevelLineage: boolean;
     lineageDirection: LineageDirection;
     selectedColumn?: string;
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/utils.ts
@@ -1,0 +1,4 @@
+export function generateSchemaFieldUrn(fieldPath: string | undefined, resourceUrn: string) {
+    if (!fieldPath) return null;
+    return `urn:li:schemaField:(${resourceUrn},${fieldPath})`;
+}

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -15,6 +15,7 @@ import {
     Deprecation,
     Domain,
     ParentNodesResult,
+    EntityPath,
 } from '../../types.generated';
 import TagTermGroup from '../shared/tags/TagTermGroup';
 import { ANTD_GRAY } from '../entity/shared/constants';
@@ -28,6 +29,7 @@ import { ExpandedActorGroup } from '../entity/shared/components/styled/ExpandedA
 import { DeprecationPill } from '../entity/shared/components/styled/DeprecationPill';
 import { PreviewType } from '../entity/Entity';
 import ExternalUrlButton from '../entity/shared/ExternalUrlButton';
+import EntityPaths from './EntityPaths/EntityPaths';
 
 const PreviewContainer = styled.div`
     display: flex;
@@ -182,6 +184,8 @@ interface Props {
     parentContainers?: ParentContainersResult | null;
     parentNodes?: ParentNodesResult | null;
     previewType?: Maybe<PreviewType>;
+    paths?: EntityPath[];
+    urn?: string;
 }
 
 export default function DefaultPreviewCard({
@@ -219,6 +223,8 @@ export default function DefaultPreviewCard({
     platforms,
     logoUrls,
     previewType,
+    paths,
+    urn,
 }: Props) {
     // sometimes these lists will be rendered inside an entity container (for example, in the case of impact analysis)
     // in those cases, we may want to enrich the preview w/ context about the container entity
@@ -302,6 +308,7 @@ export default function DefaultPreviewCard({
                     {!!degree && entityCount && <PlatformDivider />}
                     <EntityCount entityCount={entityCount} />
                 </TitleContainer>
+                {paths && paths.length > 0 && <EntityPaths paths={paths} resultEntityUrn={urn || ''} degree={degree} />}
                 {description && description.length > 0 && (
                     <DescriptionContainer>
                         <NoMarkdownViewer
@@ -345,27 +352,29 @@ export default function DefaultPreviewCard({
                     </InsightContainer>
                 )}
             </LeftColumn>
-            <RightColumn>
-                {topUsers && topUsers?.length > 0 && (
-                    <>
+            {shouldShowRightColumn && (
+                <RightColumn>
+                    {topUsers && topUsers?.length > 0 && (
+                        <>
+                            <UserListContainer>
+                                <UserListTitle strong>Top Users</UserListTitle>
+                                <div>
+                                    <ExpandedActorGroup actors={topUsers} max={2} />
+                                </div>
+                            </UserListContainer>
+                        </>
+                    )}
+                    {(topUsers?.length || 0) > 0 && (owners?.length || 0) > 0 && <UserListDivider type="vertical" />}
+                    {owners && owners?.length > 0 && (
                         <UserListContainer>
-                            <UserListTitle strong>Top Users</UserListTitle>
+                            <UserListTitle strong>Owners</UserListTitle>
                             <div>
-                                <ExpandedActorGroup actors={topUsers} max={2} />
+                                <ExpandedActorGroup actors={owners.map((owner) => owner.owner)} max={2} />
                             </div>
                         </UserListContainer>
-                    </>
-                )}
-                {(topUsers?.length || 0) > 0 && (owners?.length || 0) > 0 && <UserListDivider type="vertical" />}
-                {owners && owners?.length > 0 && (
-                    <UserListContainer>
-                        <UserListTitle strong>Owners</UserListTitle>
-                        <div>
-                            <ExpandedActorGroup actors={owners.map((owner) => owner.owner)} max={2} />
-                        </div>
-                    </UserListContainer>
-                )}
-            </RightColumn>
+                    )}
+                </RightColumn>
+            )}
         </PreviewContainer>
     );
 }

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -185,7 +185,6 @@ interface Props {
     parentNodes?: ParentNodesResult | null;
     previewType?: Maybe<PreviewType>;
     paths?: EntityPath[];
-    urn?: string;
 }
 
 export default function DefaultPreviewCard({
@@ -224,7 +223,6 @@ export default function DefaultPreviewCard({
     logoUrls,
     previewType,
     paths,
-    urn,
 }: Props) {
     // sometimes these lists will be rendered inside an entity container (for example, in the case of impact analysis)
     // in those cases, we may want to enrich the preview w/ context about the container entity

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -308,7 +308,7 @@ export default function DefaultPreviewCard({
                     {!!degree && entityCount && <PlatformDivider />}
                     <EntityCount entityCount={entityCount} />
                 </TitleContainer>
-                {paths && paths.length > 0 && <EntityPaths paths={paths} resultEntityUrn={urn || ''} degree={degree} />}
+                {paths && paths.length > 0 && <EntityPaths paths={paths} resultEntityUrn={urn || ''} />}
                 {description && description.length > 0 && (
                     <DescriptionContainer>
                         <NoMarkdownViewer

--- a/datahub-web-react/src/app/preview/EntityPaths/ColumnPathsText.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/ColumnPathsText.tsx
@@ -1,0 +1,67 @@
+import { Tooltip } from 'antd';
+import React, { useContext } from 'react';
+import styled from 'styled-components/macro';
+import { EntityPath, EntityType, LineageDirection, SchemaFieldEntity } from '../../../types.generated';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { LineageTabContext } from '../../entity/shared/tabs/Lineage/LineageTabContext';
+import ColumnsRelationshipText from './ColumnsRelationshipText';
+import DisplayedColumns from './DisplayedColumns';
+
+export const ResultText = styled.span`
+    &:hover {
+        border-bottom: 1px solid black;
+        cursor: pointer;
+    }
+`;
+
+const DescriptionWrapper = styled.span`
+    color: ${ANTD_GRAY[8]};
+`;
+
+export function getDisplayedColumns(paths: EntityPath[], resultEntityUrn: string) {
+    return paths
+        .map((path) =>
+            path.path?.filter(
+                (entity) =>
+                    entity?.type === EntityType.SchemaField &&
+                    (entity as SchemaFieldEntity).parent.urn === resultEntityUrn,
+            ),
+        )
+        .flat();
+}
+
+interface Props {
+    paths: EntityPath[];
+    resultEntityUrn: string;
+    openModal: () => void;
+}
+
+export default function ColumnPathsText({ paths, resultEntityUrn, openModal }: Props) {
+    const { lineageDirection } = useContext(LineageTabContext);
+
+    const displayedColumns = getDisplayedColumns(paths, resultEntityUrn);
+
+    return (
+        <>
+            <DescriptionWrapper>
+                {lineageDirection === LineageDirection.Downstream ? 'Downstream' : 'Upstream'} column
+                {displayedColumns.length > 1 && 's'}
+            </DescriptionWrapper>
+            : &nbsp;
+            <ResultText onClick={openModal}>
+                <Tooltip
+                    title={
+                        <span>
+                            Click to see column path{paths.length > 1 && 's'} from{' '}
+                            <ColumnsRelationshipText displayedColumns={displayedColumns} />
+                        </span>
+                    }
+                >
+                    <span>
+                        <DisplayedColumns displayedColumns={displayedColumns} />
+                    </span>
+                </Tooltip>
+            </ResultText>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/preview/EntityPaths/ColumnsRelationshipText.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/ColumnsRelationshipText.tsx
@@ -1,0 +1,37 @@
+import { Maybe } from 'graphql/jsutils/Maybe';
+import React, { useContext } from 'react';
+import styled from 'styled-components/macro';
+import { Entity, LineageDirection } from '../../../types.generated';
+import { downgradeV2FieldPath } from '../../entity/dataset/profile/schema/utils/utils';
+import { LineageTabContext } from '../../entity/shared/tabs/Lineage/LineageTabContext';
+import DisplayedColumns from './DisplayedColumns';
+
+const ColumnNameWrapper = styled.span<{ isBlack?: boolean }>`
+    font-family: 'Roboto Mono', monospace;
+    font-weight: bold;
+    ${(props) => props.isBlack && 'color: black;'}
+`;
+
+interface Props {
+    displayedColumns: (Maybe<Entity> | undefined)[];
+}
+
+export default function ColumnsRelationshipText({ displayedColumns }: Props) {
+    const { selectedColumn, lineageDirection } = useContext(LineageTabContext);
+
+    return (
+        <>
+            {lineageDirection === LineageDirection.Downstream ? (
+                <span>
+                    <ColumnNameWrapper>{downgradeV2FieldPath(selectedColumn)}</ColumnNameWrapper> to&nbsp;
+                    <DisplayedColumns displayedColumns={displayedColumns} />
+                </span>
+            ) : (
+                <span>
+                    <DisplayedColumns displayedColumns={displayedColumns} /> to{' '}
+                    <ColumnNameWrapper>{downgradeV2FieldPath(selectedColumn)}</ColumnNameWrapper>
+                </span>
+            )}
+        </>
+    );
+}

--- a/datahub-web-react/src/app/preview/EntityPaths/ColumnsRelationshipText.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/ColumnsRelationshipText.tsx
@@ -19,17 +19,19 @@ interface Props {
 export default function ColumnsRelationshipText({ displayedColumns }: Props) {
     const { selectedColumn, lineageDirection } = useContext(LineageTabContext);
 
+    const displayedFieldPath = downgradeV2FieldPath(selectedColumn);
+
     return (
         <>
             {lineageDirection === LineageDirection.Downstream ? (
                 <span>
-                    <ColumnNameWrapper>{downgradeV2FieldPath(selectedColumn)}</ColumnNameWrapper> to&nbsp;
+                    <ColumnNameWrapper>{displayedFieldPath}</ColumnNameWrapper> to&nbsp;
                     <DisplayedColumns displayedColumns={displayedColumns} />
                 </span>
             ) : (
                 <span>
                     <DisplayedColumns displayedColumns={displayedColumns} /> to{' '}
-                    <ColumnNameWrapper>{downgradeV2FieldPath(selectedColumn)}</ColumnNameWrapper>
+                    <ColumnNameWrapper>{displayedFieldPath}</ColumnNameWrapper>
                 </span>
             )}
         </>

--- a/datahub-web-react/src/app/preview/EntityPaths/DisplayedColumns.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/DisplayedColumns.tsx
@@ -1,0 +1,38 @@
+import { Maybe } from 'graphql/jsutils/Maybe';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { Entity, EntityType, SchemaFieldEntity } from '../../../types.generated';
+import { downgradeV2FieldPath } from '../../entity/dataset/profile/schema/utils/utils';
+import { useEntityRegistry } from '../../useEntityRegistry';
+
+const ColumnNameWrapper = styled.span<{ isBlack?: boolean }>`
+    font-family: 'Roboto Mono', monospace;
+    font-weight: bold;
+    ${(props) => props.isBlack && 'color: black;'}
+`;
+
+interface Props {
+    displayedColumns: (Maybe<Entity> | undefined)[];
+}
+
+export default function DisplayedColumns({ displayedColumns }: Props) {
+    const entityRegistry = useEntityRegistry();
+
+    return (
+        <span>
+            {displayedColumns.map((entity, index) => {
+                if (entity) {
+                    return (
+                        <ColumnNameWrapper>
+                            {entity.type === EntityType.SchemaField
+                                ? downgradeV2FieldPath((entity as SchemaFieldEntity).fieldPath)
+                                : entityRegistry.getDisplayName(entity.type, entity)}
+                            {index !== displayedColumns.length - 1 && ', '}
+                        </ColumnNameWrapper>
+                    );
+                }
+                return null;
+            })}
+        </span>
+    );
+}

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
@@ -12,10 +12,9 @@ const EntityPathsWrapper = styled.div`
 interface Props {
     paths: EntityPath[];
     resultEntityUrn: string;
-    degree?: number;
 }
 
-export default function EntityPaths({ paths, resultEntityUrn, degree }: Props) {
+export default function EntityPaths({ paths, resultEntityUrn }: Props) {
     const { isColumnLevelLineage } = useContext(LineageTabContext);
     const [isPathsModalVisible, setIsPathsModalVisible] = useState(false);
 

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
@@ -15,10 +15,10 @@ interface Props {
 }
 
 export default function EntityPaths({ paths, resultEntityUrn }: Props) {
-    const { isColumnLevelLineage } = useContext(LineageTabContext);
+    const { isColumnLevelLineage, selectedColumn } = useContext(LineageTabContext);
     const [isPathsModalVisible, setIsPathsModalVisible] = useState(false);
 
-    if (!isColumnLevelLineage) return null;
+    if (!isColumnLevelLineage || !selectedColumn) return null;
 
     return (
         <>

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
@@ -16,12 +16,11 @@ interface Props {
 }
 
 export default function EntityPaths({ paths, resultEntityUrn, degree }: Props) {
-    const { selectedColumn } = useContext(LineageTabContext);
+    const { isColumnLevelLineage } = useContext(LineageTabContext);
     const [isPathsModalVisible, setIsPathsModalVisible] = useState(false);
 
-    const isColumnLineage = !!selectedColumn;
-    if (!isColumnLineage) return null;
-    if (!isColumnLineage && degree && degree === 1) return null;
+    if (!isColumnLevelLineage) return null;
+    if (!isColumnLevelLineage && degree && degree === 1) return null;
 
     return (
         <>

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
@@ -20,7 +20,6 @@ export default function EntityPaths({ paths, resultEntityUrn, degree }: Props) {
     const [isPathsModalVisible, setIsPathsModalVisible] = useState(false);
 
     if (!isColumnLevelLineage) return null;
-    if (!isColumnLevelLineage && degree && degree === 1) return null;
 
     return (
         <>

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPaths.tsx
@@ -1,0 +1,44 @@
+import React, { useContext, useState } from 'react';
+import styled from 'styled-components/macro';
+import { EntityPath } from '../../../types.generated';
+import { LineageTabContext } from '../../entity/shared/tabs/Lineage/LineageTabContext';
+import ColumnPathsText from './ColumnPathsText';
+import EntityPathsModal from './EntityPathsModal';
+
+const EntityPathsWrapper = styled.div`
+    margin-bottom: 5px;
+`;
+
+interface Props {
+    paths: EntityPath[];
+    resultEntityUrn: string;
+    degree?: number;
+}
+
+export default function EntityPaths({ paths, resultEntityUrn, degree }: Props) {
+    const { selectedColumn } = useContext(LineageTabContext);
+    const [isPathsModalVisible, setIsPathsModalVisible] = useState(false);
+
+    const isColumnLineage = !!selectedColumn;
+    if (!isColumnLineage) return null;
+    if (!isColumnLineage && degree && degree === 1) return null;
+
+    return (
+        <>
+            <EntityPathsWrapper>
+                <ColumnPathsText
+                    paths={paths}
+                    resultEntityUrn={resultEntityUrn}
+                    openModal={() => setIsPathsModalVisible(true)}
+                />
+            </EntityPathsWrapper>
+            {isPathsModalVisible && (
+                <EntityPathsModal
+                    paths={paths}
+                    resultEntityUrn={resultEntityUrn}
+                    hideModal={() => setIsPathsModalVisible(false)}
+                />
+            )}
+        </>
+    );
+}

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPathsModal.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPathsModal.tsx
@@ -1,0 +1,47 @@
+import { Modal } from 'antd';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { EntityPath } from '../../../types.generated';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { getDisplayedColumns } from './ColumnPathsText';
+import ColumnsRelationshipText from './ColumnsRelationshipText';
+
+const StyledModal = styled(Modal)`
+    width: 70vw;
+    max-width: 850px;
+`;
+
+const Header = styled.div`
+    color: ${ANTD_GRAY[8]};
+    font-size: 16px;
+    padding-top: 8px;
+`;
+
+interface Props {
+    paths: EntityPath[];
+    resultEntityUrn: string;
+    hideModal: () => void;
+}
+
+export default function EntityPathsModal({ paths, resultEntityUrn, hideModal }: Props) {
+    const displayedColumns = getDisplayedColumns(paths, resultEntityUrn);
+
+    return (
+        <StyledModal
+            title={
+                <Header>
+                    Column path{paths.length > 1 && 's'} from{' '}
+                    <ColumnsRelationshipText displayedColumns={displayedColumns} />
+                </Header>
+            }
+            width="75vw"
+            visible
+            onCancel={hideModal}
+            onOk={hideModal}
+            footer={null}
+            bodyStyle={{ padding: '16px 24px' }}
+        >
+            {/* TODO: next PR display CompactEntityNameList with tweaks */}
+        </StyledModal>
+    );
+}

--- a/datahub-web-react/src/app/preview/EntityPaths/EntityPathsModal.tsx
+++ b/datahub-web-react/src/app/preview/EntityPaths/EntityPathsModal.tsx
@@ -1,14 +1,25 @@
 import { Modal } from 'antd';
 import React from 'react';
 import styled from 'styled-components/macro';
-import { EntityPath } from '../../../types.generated';
+import { Entity, EntityPath } from '../../../types.generated';
 import { ANTD_GRAY } from '../../entity/shared/constants';
+import { CompactEntityNameList } from '../../recommendations/renderer/component/CompactEntityNameList';
 import { getDisplayedColumns } from './ColumnPathsText';
 import ColumnsRelationshipText from './ColumnsRelationshipText';
 
 const StyledModal = styled(Modal)`
     width: 70vw;
     max-width: 850px;
+`;
+
+const PathWrapper = styled.div`
+    display: inline-block;
+    margin: 15px 0 15px -4px;
+    padding: 20px;
+    border: 1px solid ${ANTD_GRAY[4]};
+    border-radius: 8px;
+    box-shadow: 1px 1px 12px 4px #0000000d;
+    width: 100%;
 `;
 
 const Header = styled.div`
@@ -41,7 +52,11 @@ export default function EntityPathsModal({ paths, resultEntityUrn, hideModal }: 
             footer={null}
             bodyStyle={{ padding: '16px 24px' }}
         >
-            {/* TODO: next PR display CompactEntityNameList with tweaks */}
+            {paths.map((path) => (
+                <PathWrapper>
+                    <CompactEntityNameList entities={path.path as Entity[]} showArrows />
+                </PathWrapper>
+            ))}{' '}
         </StyledModal>
     );
 }

--- a/datahub-web-react/src/app/recommendations/renderer/component/CompactEntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/CompactEntityNameList.tsx
@@ -1,54 +1,82 @@
+import { ArrowRightOutlined } from '@ant-design/icons';
 import React from 'react';
+import styled from 'styled-components/macro';
 import { useHistory } from 'react-router';
-import { Entity } from '../../../../types.generated';
+import { Entity, EntityType, SchemaFieldEntity } from '../../../../types.generated';
 import { IconStyleType } from '../../../entity/Entity';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { EntityPreviewTag } from './EntityPreviewTag';
 import { HoverEntityTooltip } from './HoverEntityTooltip';
+import { ANTD_GRAY } from '../../../entity/shared/constants';
+
+const NameWrapper = styled.span<{ addMargin }>`
+    display: inline-flex;
+    align-items: center;
+    ${(props) => props.addMargin && 'margin: 2px 0;'}
+`;
+
+const StyledArrow = styled(ArrowRightOutlined)`
+    color: ${ANTD_GRAY[8]};
+    margin: 0 4px;
+`;
 
 type Props = {
     entities: Array<Entity>;
     onClick?: (index: number) => void;
     linkUrlParams?: Record<string, string | boolean>;
     showTooltips?: boolean;
+    showArrows?: boolean;
 };
-export const CompactEntityNameList = ({ entities, onClick, linkUrlParams, showTooltips = true }: Props) => {
+export const CompactEntityNameList = ({ entities, onClick, linkUrlParams, showTooltips = true, showArrows }: Props) => {
     const entityRegistry = useEntityRegistry();
     const history = useHistory();
 
     return (
         <>
-            {entities.map((entity, index) => {
-                if (!entity) return <></>;
+            {entities.map((mappedEntity, index) => {
+                if (!mappedEntity) return <></>;
+                let entity = mappedEntity;
+                let columnName;
+                if (entity.type === EntityType.SchemaField) {
+                    const { parent, fieldPath } = entity as SchemaFieldEntity;
+                    entity = parent;
+                    columnName = fieldPath;
+                }
 
+                const isLastEntityInList = index === entities.length - 1;
+                const showArrow = showArrows && !isLastEntityInList;
                 const genericProps = entityRegistry.getGenericEntityProperties(entity.type, entity);
                 const platformLogoUrl = genericProps?.platform?.properties?.logoUrl;
                 const displayName = entityRegistry.getDisplayName(entity.type, entity);
                 const fallbackIcon = entityRegistry.getIcon(entity.type, 12, IconStyleType.ACCENT);
                 const url = entityRegistry.getEntityUrl(entity.type, entity.urn, linkUrlParams);
                 return (
-                    <span
-                        onClickCapture={(e) => {
-                            // prevents the search links from taking over
-                            e.preventDefault();
-                            history.push(url);
-                        }}
-                    >
-                        <HoverEntityTooltip entity={entity} canOpen={showTooltips}>
-                            <span data-testid={`compact-entity-link-${entity.urn}`}>
-                                <EntityPreviewTag
-                                    displayName={displayName}
-                                    url={url}
-                                    platformLogoUrl={platformLogoUrl || undefined}
-                                    platformLogoUrls={genericProps?.siblingPlatforms?.map(
-                                        (platform) => platform.properties?.logoUrl,
-                                    )}
-                                    logoComponent={fallbackIcon}
-                                    onClick={() => onClick?.(index)}
-                                />
-                            </span>
-                        </HoverEntityTooltip>
-                    </span>
+                    <NameWrapper addMargin={showArrow}>
+                        <span
+                            onClickCapture={(e) => {
+                                // prevents the search links from taking over
+                                e.preventDefault();
+                                history.push(url);
+                            }}
+                        >
+                            <HoverEntityTooltip entity={entity} canOpen={showTooltips}>
+                                <span data-testid={`compact-entity-link-${entity.urn}`}>
+                                    <EntityPreviewTag
+                                        displayName={displayName}
+                                        url={url}
+                                        platformLogoUrl={platformLogoUrl || undefined}
+                                        platformLogoUrls={genericProps?.siblingPlatforms?.map(
+                                            (platform) => platform.properties?.logoUrl,
+                                        )}
+                                        logoComponent={fallbackIcon}
+                                        onClick={() => onClick?.(index)}
+                                        columnName={columnName}
+                                    />
+                                </span>
+                            </HoverEntityTooltip>
+                        </span>
+                        {showArrow && <StyledArrow />}
+                    </NameWrapper>
                 );
             })}
         </>

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Divider, List, Checkbox } from 'antd';
 import styled from 'styled-components';
-import { Entity } from '../../../../types.generated';
+import { Entity, EntityPath } from '../../../../types.generated';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import DefaultPreviewCard from '../../../preview/DefaultPreviewCard';
 import { IconStyleType } from '../../../entity/Entity';
@@ -60,6 +60,7 @@ const ThinDivider = styled(Divider)`
 
 type AdditionalProperties = {
     degree?: number;
+    paths?: EntityPath[];
 };
 
 type Props = {
@@ -154,6 +155,8 @@ export const EntityNameList = ({
                                 entityCount={entityCount}
                                 degree={additionalProperties?.degree}
                                 deprecation={deprecation}
+                                paths={additionalProperties?.paths}
+                                urn={entity.urn}
                             />
                         </ListItem>
                         <ThinDivider />

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -156,7 +156,6 @@ export const EntityNameList = ({
                                 degree={additionalProperties?.degree}
                                 deprecation={deprecation}
                                 paths={additionalProperties?.paths}
-                                urn={entity.urn}
                             />
                         </ListItem>
                         <ThinDivider />

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityPreviewTag.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityPreviewTag.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Image, Tag } from 'antd';
+import { Divider, Image, Tag } from 'antd';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Maybe } from 'graphql/jsutils/Maybe';
+import { ANTD_GRAY } from '../../../entity/shared/constants';
 
 const EntityTag = styled(Tag)`
     margin: 4px;
@@ -34,6 +35,16 @@ const DisplayNameContainer = styled.span`
     padding-right: 4px;
 `;
 
+const ColumnName = styled.span`
+    font-family: 'Roboto Mono', monospace;
+    font-weight: bold;
+`;
+
+export const StyledDivider = styled(Divider)`
+    background-color: ${ANTD_GRAY[6]};
+    margin: 0 7px;
+`;
+
 type Props = {
     displayName: string;
     url: string;
@@ -41,6 +52,7 @@ type Props = {
     platformLogoUrls?: Maybe<string>[];
     logoComponent?: React.ReactNode;
     onClick?: () => void;
+    columnName?: string;
 };
 
 export const EntityPreviewTag = ({
@@ -50,6 +62,7 @@ export const EntityPreviewTag = ({
     platformLogoUrls,
     logoComponent,
     onClick,
+    columnName,
 }: Props) => {
     return (
         <Link to={url} onClick={onClick}>
@@ -69,6 +82,12 @@ export const EntityPreviewTag = ({
                     </IconContainer>
                     <DisplayNameContainer>
                         <span className="test-mini-preview-class">{displayName}</span>
+                        {columnName && (
+                            <>
+                                <StyledDivider type="vertical" />
+                                <ColumnName>{columnName}</ColumnName>
+                            </>
+                        )}
                     </DisplayNameContainer>
                 </TitleContainer>
             </EntityTag>

--- a/datahub-web-react/src/app/shared/updateQueryParams.ts
+++ b/datahub-web-react/src/app/shared/updateQueryParams.ts
@@ -1,0 +1,20 @@
+import * as QueryString from 'query-string';
+import { Location, History } from 'history';
+
+type QueryParam = {
+    [key: string]: string | undefined;
+};
+
+export default function updateQueryParams(newParams: QueryParam, location: Location, history: History) {
+    const parsedParams = QueryString.parse(location.search, { arrayFormat: 'comma' });
+    const updatedParams = {
+        ...parsedParams,
+        ...newParams,
+    };
+    const stringifiedParams = QueryString.stringify(updatedParams, { arrayFormat: 'comma' });
+
+    history.push({
+        pathname: location.pathname,
+        search: stringifiedParams,
+    });
+}

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -760,6 +760,15 @@ fragment searchResults on SearchResults {
     }
 }
 
+fragment schemaFieldEntityFields on SchemaFieldEntity {
+    urn
+    type
+    fieldPath
+    parent {
+        ...searchResultFields
+    }
+}
+
 fragment searchAcrossRelationshipResults on SearchAcrossLineageResults {
     start
     count
@@ -775,6 +784,14 @@ fragment searchAcrossRelationshipResults on SearchAcrossLineageResults {
         insights {
             text
             icon
+        }
+        paths {
+            path {
+                ...searchResultFields
+                ... on SchemaFieldEntity {
+                    ...schemaFieldEntityFields
+                }
+            }
         }
         degree
     }

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/LineageRegistry.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/LineageRegistry.java
@@ -107,10 +107,24 @@ public class LineageRegistry {
       return Collections.emptyList();
     }
 
+    if (entityName.equals("schemaField")) {
+      return getSchemaFieldRelationships(direction);
+    }
+
     if (direction == LineageDirection.UPSTREAM) {
       return spec.getUpstreamEdges();
     }
     return spec.getDownstreamEdges();
+  }
+
+  private List<EdgeInfo> getSchemaFieldRelationships(LineageDirection direction) {
+    List<EdgeInfo> schemaFieldEdges = new ArrayList<>();
+    if (direction == LineageDirection.UPSTREAM) {
+      schemaFieldEdges.add(new EdgeInfo("DownstreamOf", RelationshipDirection.OUTGOING, "schemafield"));
+    } else {
+      schemaFieldEdges.add(new EdgeInfo("DownstreamOf", RelationshipDirection.INCOMING, "schemafield"));
+    }
+    return schemaFieldEdges;
   }
 
   @Value

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -48,6 +48,7 @@ public class Constants {
   public static final String INVITE_TOKEN_ENTITY_NAME = "inviteToken";
   public static final String DATAHUB_ROLE_ENTITY_NAME = "dataHubRole";
   public static final String POST_ENTITY_NAME = "post";
+  public static final String SCHEMA_FIELD_ENTITY_NAME = "schemaField";
 
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -24,8 +24,6 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -238,7 +236,9 @@ public class ESGraphQueryDAO {
 
   private UrnArrayArray getAndUpdatePaths(UrnArrayArray existingPaths, Urn parentUrn, Urn childUrn, RelationshipDirection direction) {
     try {
-      UrnArrayArray currentPaths = existingPaths.stream().filter(path -> path.get(direction == RelationshipDirection.OUTGOING ? 0 : path.size() - 1).equals(parentUrn)).collect(Collectors.toCollection(UrnArrayArray::new));
+      UrnArrayArray currentPaths = existingPaths.stream()
+          .filter(path -> path.get(direction == RelationshipDirection.OUTGOING ? 0 : path.size() - 1).equals(parentUrn))
+          .collect(Collectors.toCollection(UrnArrayArray::new));
       UrnArrayArray resultPaths = new UrnArrayArray();
       if (currentPaths.size() > 0) {
         for (UrnArray path : currentPaths) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -223,12 +223,23 @@ public class ESGraphQueryDAO {
         getQueryForLineage(urns, edgesPerEntityType.getOrDefault(entityType, Collections.emptyList()), graphFilters)));
     SearchResponse response = executeSearchQuery(finalQuery, 0, MAX_ELASTIC_RESULT);
     Set<Urn> entityUrnSet = new HashSet<>(entityUrns);
+    populateSchemaFieldEdges(direction, edgesPerEntityType);
     // Get all valid edges given the set of urns to hop from
     Set<Pair<String, EdgeInfo>> validEdges = edgesPerEntityType.entrySet()
         .stream()
         .flatMap(entry -> entry.getValue().stream().map(edgeInfo -> Pair.of(entry.getKey(), edgeInfo)))
         .collect(Collectors.toSet());
     return extractRelationships(entityUrnSet, response, validEdges, visitedEntities, numHops);
+  }
+
+  private void populateSchemaFieldEdges(LineageDirection direction, Map<String, List<EdgeInfo>> edgesPerEntityType) {
+    List<EdgeInfo> schemaFieldEdgeInfos = new ArrayList<>();
+    if (direction == LineageDirection.UPSTREAM) {
+      schemaFieldEdgeInfos.add(new EdgeInfo("DownstreamOf", RelationshipDirection.OUTGOING, "schemafield"));
+    } else {
+      schemaFieldEdgeInfos.add(new EdgeInfo("DownstreamOf", RelationshipDirection.INCOMING, "schemafield"));
+    }
+    edgesPerEntityType.put("schemaField", schemaFieldEdgeInfos);
   }
 
   // Given set of edges and the search response, extract all valid edges that originate from the input entityUrns
@@ -251,6 +262,7 @@ public class ESGraphQueryDAO {
         if (!visitedEntities.contains(destinationUrn) && validEdges.contains(
             Pair.of(sourceUrn.getEntityType(), new EdgeInfo(type, RelationshipDirection.OUTGOING, destinationUrn.getEntityType().toLowerCase())))) {
           visitedEntities.add(destinationUrn);
+          // TODO: Set paths here once we start generating it
           result.add(new LineageRelationship().setType(type).setEntity(destinationUrn).setDegree(numHops));
         }
       }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -228,23 +228,12 @@ public class ESGraphQueryDAO {
         getQueryForLineage(urns, edgesPerEntityType.getOrDefault(entityType, Collections.emptyList()), graphFilters)));
     SearchResponse response = executeSearchQuery(finalQuery, 0, MAX_ELASTIC_RESULT);
     Set<Urn> entityUrnSet = new HashSet<>(entityUrns);
-    populateSchemaFieldEdges(direction, edgesPerEntityType);
     // Get all valid edges given the set of urns to hop from
     Set<Pair<String, EdgeInfo>> validEdges = edgesPerEntityType.entrySet()
         .stream()
         .flatMap(entry -> entry.getValue().stream().map(edgeInfo -> Pair.of(entry.getKey(), edgeInfo)))
         .collect(Collectors.toSet());
     return extractRelationships(entityUrnSet, response, validEdges, visitedEntities, numHops, existingPaths);
-  }
-
-  private void populateSchemaFieldEdges(LineageDirection direction, Map<String, List<EdgeInfo>> edgesPerEntityType) {
-    List<EdgeInfo> schemaFieldEdgeInfos = new ArrayList<>();
-    if (direction == LineageDirection.UPSTREAM) {
-      schemaFieldEdgeInfos.add(new EdgeInfo("DownstreamOf", RelationshipDirection.OUTGOING, "schemafield"));
-    } else {
-      schemaFieldEdgeInfos.add(new EdgeInfo("DownstreamOf", RelationshipDirection.INCOMING, "schemafield"));
-    }
-    edgesPerEntityType.put("schemaField", schemaFieldEdgeInfos);
   }
 
   private UrnArrayArray getAndUpdatePaths(UrnArrayArray existingPaths, Urn parentUrn, Urn childUrn, RelationshipDirection direction) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.search;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.linkedin.common.UrnArrayArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.Constants;
@@ -121,7 +122,9 @@ public class LineageSearchService {
       if (existingRelationship == null) {
         urnToRelationship.put(relationship.getEntity(), relationship);
       } else {
-        existingRelationship.setPath(existingRelationship.getPath()); // TODO: Update once path is changed to paths and is hydrated
+        UrnArrayArray paths = existingRelationship.getPaths();
+        paths.addAll(relationship.getPaths());
+        existingRelationship.setPaths(paths);
       }
     }
     return urnToRelationship;
@@ -268,7 +271,7 @@ public class LineageSearchService {
       @Nullable LineageRelationship lineageRelationship) {
     LineageSearchEntity entity = new LineageSearchEntity(searchEntity.data());
     if (lineageRelationship != null) {
-      entity.setPath(lineageRelationship.getPath());
+      entity.setPaths(lineageRelationship.getPaths());
       entity.setDegree(lineageRelationship.getDegree());
     }
     return entity;

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -40,7 +40,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.cache.Cache;
 
 
-@Slf4j
 @RequiredArgsConstructor
 @Slf4j
 public class LineageSearchService {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -156,7 +156,11 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
     }
   }
 
-  private void updateFineGrainedEdgesAndRelationships(RecordTemplate aspect, List<Edge> edgesToAdd, HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded) {
+  private void updateFineGrainedEdgesAndRelationships(
+      RecordTemplate aspect,
+      List<Edge> edgesToAdd,
+      HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded
+  ) {
     UpstreamLineage upstreamLineage = new UpstreamLineage(aspect.data());
     if (upstreamLineage.getFineGrainedLineages() != null) {
       for (FineGrainedLineage fineGrainedLineage : upstreamLineage.getFineGrainedLineages()) {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -299,7 +299,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
     if (urnToRelationshipTypesBeingAdded.size() > 0) {
       for (Map.Entry<Urn, Set<String>> entry : urnToRelationshipTypesBeingAdded.entrySet()) {
         _graphService.removeEdgesFromNode(entry.getKey(), new ArrayList<>(entry.getValue()),
-            newRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+            createRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
       }
     }
   }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.dataset.FineGrainedLineage;
+import com.linkedin.dataset.UpstreamLineage;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.gms.factory.common.GraphServiceFactory;
 import com.linkedin.gms.factory.common.SystemMetadataServiceFactory;
@@ -38,6 +40,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +70,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
   private final EntityRegistry _entityRegistry;
   private final SearchDocumentTransformer _searchDocumentTransformer;
 
+  public static final String DOWNSTREAM_OF = "DownstreamOf";
   private static final Set<ChangeType> VALID_CHANGE_TYPES =
       Stream.of(
           ChangeType.UPSERT,
@@ -152,15 +156,40 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
     }
   }
 
-  private Pair<List<Edge>, Set<String>> getEdgesAndRelationshipTypesFromAspect(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
-    final Set<String> relationshipTypesBeingAdded = new HashSet<>();
+  private void updateFineGrainedEdgesAndRelationships(RecordTemplate aspect, List<Edge> edgesToAdd, HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded) {
+    UpstreamLineage upstreamLineage = new UpstreamLineage(aspect.data());
+    if (upstreamLineage.getFineGrainedLineages() != null) {
+      for (FineGrainedLineage fineGrainedLineage : upstreamLineage.getFineGrainedLineages()) {
+        if (!fineGrainedLineage.hasDownstreams() || !fineGrainedLineage.hasUpstreams()) {
+          break;
+        }
+        for (Urn downstream : fineGrainedLineage.getDownstreams()) {
+          for (Urn upstream : fineGrainedLineage.getUpstreams()) {
+            edgesToAdd.add(new Edge(downstream, upstream, DOWNSTREAM_OF));
+            Set<String> relationshipTypes = urnToRelationshipTypesBeingAdded.getOrDefault(downstream, new HashSet<>());
+            relationshipTypes.add(DOWNSTREAM_OF);
+            urnToRelationshipTypesBeingAdded.put(downstream, relationshipTypes);
+          }
+        }
+      }
+    }
+  }
+
+  private Pair<List<Edge>, HashMap<Urn, Set<String>>> getEdgesAndRelationshipTypesFromAspect(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
     final List<Edge> edgesToAdd = new ArrayList<>();
+    final HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded = new HashMap<>();
+
+    if (aspectSpec.getName().equals(Constants.UPSTREAM_LINEAGE_ASPECT_NAME)) {
+      updateFineGrainedEdgesAndRelationships(aspect, edgesToAdd, urnToRelationshipTypesBeingAdded);
+    }
 
     Map<RelationshipFieldSpec, List<Object>> extractedFields =
         FieldExtractor.extractFields(aspect, aspectSpec.getRelationshipFieldSpecs());
 
     for (Map.Entry<RelationshipFieldSpec, List<Object>> entry : extractedFields.entrySet()) {
-      relationshipTypesBeingAdded.add(entry.getKey().getRelationshipName());
+      Set<String> relationshipTypes = urnToRelationshipTypesBeingAdded.getOrDefault(urn, new HashSet<>());
+      relationshipTypes.add(entry.getKey().getRelationshipName());
+      urnToRelationshipTypesBeingAdded.put(urn, relationshipTypes);
       for (Object fieldValue : entry.getValue()) {
         try {
           edgesToAdd.add(
@@ -170,23 +199,25 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
         }
       }
     }
-    return Pair.of(edgesToAdd, relationshipTypesBeingAdded);
+    return Pair.of(edgesToAdd, urnToRelationshipTypesBeingAdded);
   }
 
   /**
    * Process snapshot and update graph index
    */
   private void updateGraphService(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
-    Pair<List<Edge>, Set<String>> edgeAndRelationTypes =
+    Pair<List<Edge>, HashMap<Urn, Set<String>>> edgeAndRelationTypes =
         getEdgesAndRelationshipTypesFromAspect(urn, aspectSpec, aspect);
 
     final List<Edge> edgesToAdd = edgeAndRelationTypes.getFirst();
-    final Set<String> relationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
+    final HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
 
-    log.debug("Here's the relationship types found {}", relationshipTypesBeingAdded);
-    if (relationshipTypesBeingAdded.size() > 0) {
-      _graphService.removeEdgesFromNode(urn, new ArrayList<>(relationshipTypesBeingAdded),
-          newRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+    log.debug("Here's the relationship types found {}", urnToRelationshipTypesBeingAdded);
+    if (urnToRelationshipTypesBeingAdded.size() > 0) {
+      for (Map.Entry<Urn, Set<String>> entry : urnToRelationshipTypesBeingAdded.entrySet()) {
+        _graphService.removeEdgesFromNode(entry.getKey(), new ArrayList<>(entry.getValue()),
+            newRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+      }
       edgesToAdd.forEach(edge -> _graphService.addEdge(edge));
     }
   }
@@ -260,13 +291,15 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
       return;
     }
 
-    Pair<List<Edge>, Set<String>> edgeAndRelationTypes =
+    Pair<List<Edge>, HashMap<Urn, Set<String>>> edgeAndRelationTypes =
         getEdgesAndRelationshipTypesFromAspect(urn, aspectSpec, aspect);
 
-    final Set<String> relationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
-    if (relationshipTypesBeingAdded.size() > 0) {
-      _graphService.removeEdgesFromNode(urn, new ArrayList<>(relationshipTypesBeingAdded),
-          createRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+    final HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
+    if (urnToRelationshipTypesBeingAdded.size() > 0) {
+      for (Map.Entry<Urn, Set<String>> entry : urnToRelationshipTypesBeingAdded.entrySet()) {
+        _graphService.removeEdgesFromNode(entry.getKey(), new ArrayList<>(entry.getValue()),
+            newRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+      }
     }
   }
 

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -163,6 +163,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
         if (!fineGrainedLineage.hasDownstreams() || !fineGrainedLineage.hasUpstreams()) {
           break;
         }
+        // for every downstream, create an edge with each of the upstreams
         for (Urn downstream : fineGrainedLineage.getDownstreams()) {
           for (Urn upstream : fineGrainedLineage.getUpstreams()) {
             edgesToAdd.add(new Edge(downstream, upstream, DOWNSTREAM_OF));

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -181,6 +181,8 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
     final HashMap<Urn, Set<String>> urnToRelationshipTypesBeingAdded = new HashMap<>();
 
     if (aspectSpec.getName().equals(Constants.UPSTREAM_LINEAGE_ASPECT_NAME)) {
+      // we need to manually set schemaField <-> schemaField edges for fineGrainedLineage since
+      // @Relationship only links between the parent entity urn and something else.
       updateFineGrainedEdgesAndRelationships(aspect, edgesToAdd, urnToRelationshipTypesBeingAdded);
     }
 

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/graph/LineageRelationship.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/graph/LineageRelationship.pdl
@@ -18,8 +18,15 @@ record LineageRelationship {
   entity: Urn
 
   /**
+   * Optional list of entities between the source and destination node.
+   * There can be multiple paths from the source to the destination.
+   */
+  paths: array[array[Urn]] = []
+
+  /**
    * Optional list of entities between the source and destination node
    */
+  @deprecated
   path: array[Urn] = []
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/LineageSearchEntity.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/LineageSearchEntity.pdl
@@ -8,8 +8,15 @@ import com.linkedin.common.Urn
 record LineageSearchEntity includes SearchEntity {
 
   /**
+   * Optional list of entities between the source and destination node.
+   * There can be multiple paths from the source to the destination.
+   */
+  paths: array[array[Urn]] = []
+
+  /**
    * Optional list of entities between the source and destination node
    */
+  @deprecated
   path: array[Urn] = []
 
   /**

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -5511,13 +5511,25 @@
       } ]
     } ],
     "fields" : [ {
+      "name" : "paths",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "array",
+          "items" : "com.linkedin.common.Urn"
+        }
+      },
+      "doc" : "Optional list of entities between the source and destination node.\nThere can be multiple paths from the source to the destination.",
+      "default" : [ [ ] ]
+    }, {
       "name" : "path",
       "type" : {
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "Optional list of entities between the source and destination node",
-      "default" : [ ]
+      "default" : [ ],
+      "deprecated" : true
     }, {
       "name" : "degree",
       "type" : "int",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
@@ -113,13 +113,25 @@
             "type" : "com.linkedin.common.Urn",
             "doc" : "Entity that is related via lineage"
           }, {
+            "name" : "paths",
+            "type" : {
+              "type" : "array",
+              "items" : {
+                "type" : "array",
+                "items" : "com.linkedin.common.Urn"
+              }
+            },
+            "doc" : "Optional list of entities between the source and destination node.\nThere can be multiple paths from the source to the destination.",
+            "default" : [ [ ] ]
+          }, {
             "name" : "path",
             "type" : {
               "type" : "array",
               "items" : "com.linkedin.common.Urn"
             },
             "doc" : "Optional list of entities between the source and destination node",
-            "default" : [ ]
+            "default" : [ ],
+            "deprecated" : true
           }, {
             "name" : "degree",
             "type" : "int",

--- a/smoke-test/tests/cypress/cypress/integration/lineage/impact_analysis.js
+++ b/smoke-test/tests/cypress/cypress/integration/lineage/impact_analysis.js
@@ -55,4 +55,29 @@ describe("impact analysis", () => {
     cy.contains("User Creations").should("not.exist");
     cy.contains("User Deletions");
   });
+
+  it("can view column level impact analysis and turn it off", () => {
+    cy.login();
+    cy.visit(
+      "/dataset/urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)/Lineage?column=%5Bversion%3D2.0%5D.%5Btype%3Dboolean%5D.field_bar&is_lineage_mode=false"
+    );
+
+    // impact analysis can take a beat- don't want to time out here
+    cy.wait(5000);
+
+    cy.contains("SampleCypressHdfsDataset");
+    cy.contains("Downstream column: shipment_info");
+    cy.contains("some-cypress-feature-1").should("not.exist");
+    cy.contains("Baz Chart 1").should("not.exist");
+
+    // find button to turn off column-level impact analysis
+    cy.get('[data-testid="column-lineage-toggle"]').click({ force: true });
+
+    cy.wait(2000);
+
+    cy.contains("SampleCypressHdfsDataset");
+    cy.contains("Downstream column: shipment_info").should("not.exist");
+    cy.contains("some-cypress-feature-1");
+    cy.contains("Baz Chart 1");
+  });
 });

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -189,6 +189,19 @@
                   "dataset": "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD)",
                   "type": "TRANSFORMED"
                 }
+              ],
+              "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:kafka,SampleCypressKafkaDataset,PROD),field_bar)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleCypressHdfsDataset,PROD),shipment_info)"
+                    ],
+                    "confidenceScore": 1.0
+                }
               ]
             }
           },


### PR DESCRIPTION
Adds the ability to view impact analysis specifically at the column level. You can now select a column to view impact analysis on from the schema tab with a new menu or select from a dropdown on the lineage tab. You'll see the impacted columns and you can even click on the column name in order to see the whole path for how you get between the two columns.

This involved some changes to the how we index upstream lineage. We now check if the upstream lineage aspect that we're indexing has fineGrainedLineage, and if so, we draw edges manually between the two `schemaField`s. That way we can query to get edges based on a `schemaField` urn.

**Unforunately this means that for those users that already have fineGrainedLineage ingested, they will need to restore their indices in order to get old fineGrainedLineage data to work with impact analysis**

Here's some screenshots for how this looks in action:

**The new column menu**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/28656603/197604917-c427fe50-bb4c-4e86-93d3-4e3b87c5f0c4.png">

**Viewing impact analysis for the `email` column**
<img width="1441" alt="image" src="https://user-images.githubusercontent.com/28656603/197605003-84f69832-7ef7-4ff3-a504-844777dbec3d.png">

**The paths modal to see the full path between entities and their columns (all of these happen to be named `email`)**
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/28656603/197605220-a632ce2a-e1d4-4bb6-b0fe-ad5e07605c43.png">



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)