### PR TITLE
fix(ui) Fix two lineage visualization bugs

### DIFF
--- a/datahub-web-react/src/app/lineage/utils/layoutTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/layoutTree.ts
@@ -33,6 +33,7 @@ function layoutNodesForOneDirection(
     collapsedColumnsNodes: any,
     nodesToRender: VizNode[],
     edgesToRender: VizEdge[],
+    renderedNodeUrns: Set<string>,
 ) {
     const nodesByUrn: Record<string, VizNode> = {};
     const xModifier = direction === Direction.Downstream ? 1 : UPSTREAM_X_MODIFIER;
@@ -100,7 +101,6 @@ function layoutNodesForOneDirection(
                     ) + VERTICAL_SPACE_BETWEEN_NODES;
 
                 nodesByUrn[node.urn] = vizNodeForNode;
-                nodesToRender.push(vizNodeForNode);
                 nodesInNextLayer = [
                     ...nodesInNextLayer,
                     ...(node.children?.map((child) => ({
@@ -108,6 +108,10 @@ function layoutNodesForOneDirection(
                         node: child,
                     })) || []),
                 ];
+                if (!renderedNodeUrns.has(node.urn)) {
+                    nodesToRender.push(vizNodeForNode);
+                    renderedNodeUrns.add(node.urn);
+                }
             }
 
             if (parent) {
@@ -349,6 +353,7 @@ export default function layoutTree(
     nodesByUrn: Record<string, VizNode>;
     layers: number;
 } {
+    const renderedNodeUrns = new Set<string>();
     const nodesToRender: VizNode[] = [];
     const edgesToRender: VizEdge[] = [];
 
@@ -362,6 +367,7 @@ export default function layoutTree(
         collapsedColumnsNodes,
         nodesToRender,
         edgesToRender,
+        renderedNodeUrns,
     );
 
     const { numInCurrentLayer: numDownstream, nodesByUrn: downstreamNodesByUrn } = layoutNodesForOneDirection(
@@ -374,6 +380,7 @@ export default function layoutTree(
         collapsedColumnsNodes,
         nodesToRender,
         edgesToRender,
+        renderedNodeUrns,
     );
 
     const nodesByUrn = { ...upstreamNodesByUrn, ...downstreamNodesByUrn };

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
@@ -9,7 +9,6 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.entity.EntityService;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
@@ -142,8 +142,7 @@ public class SiblingGraphService {
     }).collect(Collectors.toList());
 
     entityLineageResult.setRelationships(new LineageRelationshipArray(filteredRelationships));
-    entityLineageResult.setTotal(filteredRelationships.size());
-//    entityLineageResult.setTotal(entityLineageResult.getTotal() + (existingResult != null ? existingResult.getTotal() : 0));
+    entityLineageResult.setTotal(entityLineageResult.getTotal() + (existingResult != null ? existingResult.getTotal() : 0));
     entityLineageResult.setCount(filteredRelationships.size());
     return entityLineageResult;
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
@@ -7,6 +7,8 @@ import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.entity.EntityService;
+
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,11 +94,14 @@ public class SiblingGraphService {
       EntityLineageResult entityLineageResult,
       EntityLineageResult existingResult
   ) {
-    // 1) remove the source entities siblings from this entity's downstreams
+    Set<Urn> existingResultUrns = existingResult != null ?
+        existingResult.getRelationships().stream().map(LineageRelationship::getEntity).collect(Collectors.toSet()) : new HashSet<>();
+
+    // 1) remove duplicates and the source entities siblings from this entity's downstreams
     List<LineageRelationship> filteredRelationships = entityLineageResult.getRelationships()
         .stream()
-        .filter(lineageRelationship -> !allSiblingsInGroup.contains(lineageRelationship.getEntity())
-            || lineageRelationship.getEntity().equals(urn))
+        .filter(lineageRelationship -> !existingResultUrns.contains(lineageRelationship.getEntity()) &&
+            (!allSiblingsInGroup.contains(lineageRelationship.getEntity()) || lineageRelationship.getEntity().equals(urn)))
         .collect(Collectors.toList());
 
     // 2) combine this entity's lineage with the lineage we've already seen

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
@@ -259,7 +259,7 @@ public class SiblingGraphServiceTest {
     EntityLineageResult expectedResult = mockResult.clone();
     expectedResult.setTotal(3);
     expectedResult.setCount(2);
-    expectedResult.setRelationships(new LineageRelationshipArray(relationship1, relationship2));
+    expectedResult.setRelationships(new LineageRelationshipArray(relationship2, relationship1));
 
     EntityLineageResult upstreamLineage = service.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1);
 

--- a/smoke-test/tests/cypress/cypress/integration/siblings/siblings.js
+++ b/smoke-test/tests/cypress/cypress/integration/siblings/siblings.js
@@ -117,11 +117,10 @@ describe('siblings', () => {
     // check the names
     cy.get('text:contains(raw_orders)').should('have.length', 1);
     cy.get('text:contains(customers)').should('have.length', 1);
-    // center counts twice since we secretely render two center nodes
-    cy.get('text:contains(stg_orders)').should('have.length', 2);
+    cy.get('text:contains(stg_orders)').should('have.length', 1);
 
     // check the platform
-    cy.get('svg').get('text:contains(dbt & BigQuery)').should('have.length', 5);
+    cy.get('svg').get('text:contains(dbt & BigQuery)').should('have.length', 4);
   });
 
   it('can separate results in lineage if flag is set', () => {
@@ -137,12 +136,12 @@ describe('siblings', () => {
 
     // check the names
     cy.get('text:contains(raw_orders)').should('have.length', 1);
-    // center counts twice since we secretely render two center nodes, plus the downstream bigquery
-    cy.get('text:contains(stg_orders)').should('have.length', 3);
+    // center node plus the downstream bigquery
+    cy.get('text:contains(stg_orders)').should('have.length', 2);
 
     // check the platform
     cy.get('svg').get('text:contains(dbt & BigQuery)').should('have.length', 0);
-    cy.get('svg').get('text:contains(Dbt)').should('have.length', 3);
+    cy.get('svg').get('text:contains(Dbt)').should('have.length', 2);
     cy.get('svg').get('text:contains(Bigquery)').should('have.length', 1);
   });
 });


### PR DESCRIPTION
Fixes two bugs we've seen with lineage visualization for a bit now.

1. Switching your base/center node (by double clicking another node) causes a duplicate of the previous base node and weird dragging behavior. Fix this on the frontend by adding a check to ensure we don't render the same node twice. When we were drawing the tree, we were rendering the base node two times (once for upstream and once for downstream), and that would throw off our tree causing a duplication of the previous node if we had a previous base node.
2. Sometimes dragging nodes would cause replication of arrows/edges between nodes looking very weird. This would only happen when Compress Lineage was on (so we would get lineage for all siblings and combine them). What was happening is that if two siblings have the same lineage nodes, we returned all of them from the backend resulting in duplicate leaf nodes. We would then have multiple edges rendered between two nodes causing a lag/breaking dragging. I fix this by only returning distinct nodes when getting sibling lineage.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)