### PR TITLE
feat(ui) Add documentation to term/node creation modal

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
@@ -47,8 +47,6 @@ function CreateGlossaryEntityModal(props: Props) {
     const [createGlossaryTermMutation] = useCreateGlossaryTermMutation();
     const [createGlossaryNodeMutation] = useCreateGlossaryNodeMutation();
 
-    const sanitizedDocumentation = DOMPurify.sanitize(documentation);
-
     function createGlossaryEntity() {
         const mutation =
             entityType === EntityType.GlossaryTerm ? createGlossaryTermMutation : createGlossaryNodeMutation;
@@ -158,7 +156,7 @@ function CreateGlossaryEntityModal(props: Props) {
                 >
                     <StyledButton type="link" onClick={() => setIsDocumentationModalVisible(true)}>
                         <EditOutlined />
-                        {sanitizedDocumentation ? 'Edit' : 'Add'} Documentation
+                        {documentation ? 'Edit' : 'Add'} Documentation
                     </StyledButton>
                     {isDocumentationModalVisible && (
                         <DescriptionModal

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components/macro';
+import { EditOutlined } from '@ant-design/icons';
 import { message, Button, Input, Modal, Typography, Form } from 'antd';
+import DOMPurify from 'dompurify';
 import {
     useCreateGlossaryTermMutation,
     useCreateGlossaryNodeMutation,
@@ -10,6 +12,7 @@ import { useEntityRegistry } from '../../../useEntityRegistry';
 import NodeParentSelect from './NodeParentSelect';
 import { useEntityData, useRefetch } from '../EntityContext';
 import analytics, { EventType } from '../../../analytics';
+import DescriptionModal from '../components/legacy/DescriptionModal';
 
 const StyledItem = styled(Form.Item)`
     margin-bottom: 0;
@@ -17,6 +20,10 @@ const StyledItem = styled(Form.Item)`
 
 const OptionalWrapper = styled.span`
     font-weight: normal;
+`;
+
+const StyledButton = styled(Button)`
+    padding: 0;
 `;
 
 interface Props {
@@ -32,21 +39,27 @@ function CreateGlossaryEntityModal(props: Props) {
     const entityRegistry = useEntityRegistry();
     const [stagedName, setStagedName] = useState('');
     const [selectedParentUrn, setSelectedParentUrn] = useState(entityData.urn);
+    const [documentation, setDocumentation] = useState('');
+    const [isDocumentationModalVisible, setIsDocumentationModalVisible] = useState(false);
     const [createButtonDisabled, setCreateButtonDisabled] = useState(true);
     const refetch = useRefetch();
 
     const [createGlossaryTermMutation] = useCreateGlossaryTermMutation();
     const [createGlossaryNodeMutation] = useCreateGlossaryNodeMutation();
 
+    const sanitizedDocumentation = DOMPurify.sanitize(documentation);
+
     function createGlossaryEntity() {
         const mutation =
             entityType === EntityType.GlossaryTerm ? createGlossaryTermMutation : createGlossaryNodeMutation;
 
+        const sanitizedDescription = DOMPurify.sanitize(documentation);
         mutation({
             variables: {
                 input: {
                     name: stagedName,
                     parentNode: selectedParentUrn || null,
+                    description: sanitizedDescription || null,
                 },
             },
         })
@@ -73,6 +86,11 @@ function CreateGlossaryEntityModal(props: Props) {
                 message.error({ content: `Failed to create: \n ${e.message || ''}`, duration: 3 });
             });
         onClose();
+    }
+
+    function addDocumentation(description: string) {
+        setDocumentation(description);
+        setIsDocumentationModalVisible(false);
     }
 
     return (
@@ -131,6 +149,26 @@ function CreateGlossaryEntityModal(props: Props) {
                         />
                     </StyledItem>
                 </Form.Item>
+                <StyledItem
+                    label={
+                        <Typography.Text strong>
+                            Documentation <OptionalWrapper>(optional)</OptionalWrapper>
+                        </Typography.Text>
+                    }
+                >
+                    <StyledButton type="link" onClick={() => setIsDocumentationModalVisible(true)}>
+                        <EditOutlined />
+                        {sanitizedDocumentation ? 'Edit' : 'Add'} Documentation
+                    </StyledButton>
+                    {isDocumentationModalVisible && (
+                        <DescriptionModal
+                            title="Add Documenataion"
+                            onClose={() => setIsDocumentationModalVisible(false)}
+                            onSubmit={addDocumentation}
+                            description={documentation}
+                        />
+                    )}
+                </StyledItem>
             </Form>
         </Modal>
     );


### PR DESCRIPTION
When creating Terms and Nodes, now allow users to input their desired documentation so they don't have to immediately do and add it afterwords. All the backend/graphql stuff is already in place for this so it's just adding this piece to the modal.

Here we are:
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/28656603/198123790-e430a6fe-d0d9-4603-afe4-f0af5ea0b6c7.png">

**When clicking add documentation:**
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/28656603/198124214-560b411d-4d42-4398-a244-553570510bf4.png">

**After adding it, it now says "Edit Documentation" which you can click to see your documentation or edit it**
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/28656603/198124363-43346f81-464e-4168-a758-c46b9ffe0e2f.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)