### PR TITLE
fix(assertion tab): fixing up regression in assertion resolver

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 public class ResolverUtils {
 
     private static final Set<String> KEYWORD_EXCLUDED_FILTERS = ImmutableSet.of(
-        "status",
         "runId"
     );
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 public class ResolverUtils {
 
     private static final Set<String> KEYWORD_EXCLUDED_FILTERS = ImmutableSet.of(
+        "status",
         "runId"
     );
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -131,10 +132,19 @@ public class ResolverUtils {
         return new Filter().setOr(new ConjunctiveCriterionArray(new ConjunctiveCriterion().setAnd(new CriterionArray(andCriterions))));
     }
 
-    // Translates a FacetFilterInput (graphql input class) into Criterion (our internal model)
     public static Criterion criterionFromFilter(final FacetFilterInput filter) {
+        return criterionFromFilter(filter, false);
+    }
+
+    // Translates a FacetFilterInput (graphql input class) into Criterion (our internal model)
+    public static Criterion criterionFromFilter(final FacetFilterInput filter, final Boolean skipKeywordSuffix) {
         Criterion result = new Criterion();
-        result.setField(getFilterField(filter.getField()));
+
+        if (skipKeywordSuffix) {
+            result.setField(filter.getField());
+        } else {
+            result.setField(getFilterField(filter.getField()));
+        }
 
         // `value` is deprecated in place of `values`- this is to support old query patterns. If values is provided,
         // this statement will be skipped

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolver.java
@@ -94,7 +94,7 @@ public class AssertionRunEventResolver implements DataFetcher<CompletableFuture<
   }
 
   @Nullable
-  private Filter buildFilter(@Nullable FilterInput filtersInput, @Nullable final String status) {
+  public static Filter buildFilter(@Nullable FilterInput filtersInput, @Nullable final String status) {
     if (filtersInput == null && status == null) {
       return null;
     }
@@ -109,7 +109,7 @@ public class AssertionRunEventResolver implements DataFetcher<CompletableFuture<
       facetFilters.addAll(filtersInput.getAnd());
     }
     return new Filter().setOr(new ConjunctiveCriterionArray(new ConjunctiveCriterion().setAnd(new CriterionArray(facetFilters.stream()
-        .map(filter -> criterionFromFilter(filter))
+        .map(filter -> criterionFromFilter(filter, true))
         .collect(Collectors.toList())))));
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/TimeSeriesAspectResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/TimeSeriesAspectResolver.java
@@ -110,7 +110,7 @@ public class TimeSeriesAspectResolver implements DataFetcher<CompletableFuture<L
       return null;
     }
     return new Filter().setOr(new ConjunctiveCriterionArray(new ConjunctiveCriterion().setAnd(new CriterionArray(maybeFilters.getAnd().stream()
-        .map(filter -> criterionFromFilter(filter))
+        .map(filter -> criterionFromFilter(filter, true))
         .collect(Collectors.toList())))));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolverTest.java
@@ -51,7 +51,7 @@ public class AssertionRunEventResolverTest {
         Mockito.eq(10L),
         Mockito.eq(5),
         Mockito.eq(false),
-        Mockito.any(Filter.class),
+        Mockito.eq(AssertionRunEventResolver.buildFilter(null, AssertionRunStatus.COMPLETE.toString())),
         Mockito.any(Authentication.class)
     )).thenReturn(
         ImmutableList.of(


### PR DESCRIPTION
This pr: https://github.com/datahub-project/datahub/commit/ce90310dd0c7cc8506006cb667bbd7d4deb2070b

Introduced a change where filter creation added the `.keyword` suffix to the elasticsearch query for status. However, based on the es mapping of this timeseries index, the `status` field of the assertion run result was not a `.keyword` field.

Reverting this.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)