### PR TITLE
feat(ui) Allow a user to type in a custom value in ingestion Secret Fields

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/SecretField/SecretField.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/SecretField/SecretField.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Divider, Form, Select } from 'antd';
+import { AutoComplete, Divider, Form } from 'antd';
 import styled from 'styled-components/macro';
 import { Secret } from '../../../../../../types.generated';
 import CreateSecretButton from './CreateSecretButton';
@@ -80,6 +80,8 @@ function SecretFieldTooltip({ tooltipLabel }: { tooltipLabel?: string | ReactNod
 }
 
 function SecretField({ field, secrets, removeMargin, refetchSecrets }: SecretFieldProps) {
+    const options = secrets.map((secret) => ({ value: `\${${secret.name}}`, label: secret.name }));
+
     return (
         <StyledFormItem
             name={field.name}
@@ -89,10 +91,10 @@ function SecretField({ field, secrets, removeMargin, refetchSecrets }: SecretFie
             removeMargin={!!removeMargin}
             isSecretField
         >
-            <Select
-                showSearch
+            <AutoComplete
                 placeholder={field.placeholder}
-                filterOption={(input, option) => !!option?.children.toLowerCase().includes(input.toLowerCase())}
+                filterOption={(input, option) => !!option?.value.toLowerCase().includes(input.toLowerCase())}
+                options={options}
                 dropdownRender={(menu) => (
                     <>
                         {menu}
@@ -100,13 +102,7 @@ function SecretField({ field, secrets, removeMargin, refetchSecrets }: SecretFie
                         <CreateSecretButton refetchSecrets={refetchSecrets} />
                     </>
                 )}
-            >
-                {secrets.map((secret) => (
-                    <Select.Option key={secret.urn} value={`\${${secret.name}}`}>
-                        {secret.name}
-                    </Select.Option>
-                ))}
-            </Select>
+            />
         </StyledFormItem>
     );
 }

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
@@ -56,7 +56,7 @@ function clearFieldAndParents(recipe: any, fieldPath: string | string[]) {
 export function setFieldValueOnRecipe(recipe: any, value: any, fieldPath: string | string[]) {
     const updatedRecipe = { ...recipe };
     if (value !== undefined) {
-        if (!value) {
+        if (value === null || value === '') {
             clearFieldAndParents(updatedRecipe, fieldPath);
             return updatedRecipe;
         }

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
@@ -56,7 +56,7 @@ function clearFieldAndParents(recipe: any, fieldPath: string | string[]) {
 export function setFieldValueOnRecipe(recipe: any, value: any, fieldPath: string | string[]) {
     const updatedRecipe = { ...recipe };
     if (value !== undefined) {
-        if (value === null) {
+        if (!value) {
             clearFieldAndParents(updatedRecipe, fieldPath);
             return updatedRecipe;
         }


### PR DESCRIPTION
Now allow users to type whatever text they want in secret field while still being able to select from a list of existing secrets and create a secret on the fly.

Do this by changing the input type from `Select` to `AutoComplete` with the secrets as options to select and filter down from (if you start typing). If you don't select anything from the dropdown, we store whatever it is that you're typing as your value then.

Things still look the same.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)