### PR TITLE
fix(docs): fix custom transformer example interface

### DIFF
--- a/metadata-ingestion/docs/transformer/dataset_transformer.md
+++ b/metadata-ingestion/docs/transformer/dataset_transformer.md
@@ -763,13 +763,12 @@ Then define your class to return a list of custom properties, for example:
   import logging
   from typing import Dict
   from datahub.ingestion.transformer.add_dataset_properties import AddDatasetPropertiesResolverBase
-  from datahub.metadata.schema_classes import DatasetSnapshotClass
-  
+
   class MyPropertiesResolver(AddDatasetPropertiesResolverBase):
-      def get_properties_to_add(self, current: DatasetSnapshotClass) -> Dict[str, str]:
+      def get_properties_to_add(self, entity_urn: str) -> Dict[str, str]:
           ### Add custom logic here        
           properties= {'my_custom_property': 'property value'}
-          logging.info(f"Adding properties: {properties} to dataset: {current.urn}.")
+          logging.info(f"Adding properties: {properties} to dataset: {entity_urn}.")
           return properties
   ```
 


### PR DESCRIPTION
The interface changed in #5514 to switch from DatasetSnapshotClass to entity_urn as string.
Updated the docs accordingly

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)