### PR TITLE
fix(ui) Disable deleting Term Groups with children

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -124,7 +124,7 @@ function EntityDropdown(props: Props) {
         ? platformPrivileges.manageGlossaries
         : me?.platformPrivileges.manageGlossaries;
     const pageUrl = window.location.href;
-    const isDeleteDisabled = !!entityData?.children?.count;
+    const isDeleteDisabled = !!entityData?.children?.total;
 
     /**
      * A default path to redirect to if the entity is deleted.

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -30,6 +30,7 @@ query getGlossaryNode($urn: String!) {
                 count: 10000
             }
         ) {
+            total
             relationships {
                 direction
                 entity {


### PR DESCRIPTION
If a term group has children, disable the ability to delete it from the UI. This is a degradation from another fix, just putting it back to how it was.

Soon we'd like to allow the ability to delete the whole tree underneath the node, but this is a quick revert to the way things used to work.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
