### PR TITLE
Enable Owner Type for Glossary Node + Domain 

### DIFF
--- a/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
@@ -85,9 +85,6 @@ export class DomainEntity implements Entity<Domain> {
                 },
                 {
                     component: SidebarOwnerSection,
-                    properties: {
-                        hideOwnerType: true,
-                    },
                 },
             ]}
         />

--- a/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
@@ -80,9 +80,6 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
                     },
                     {
                         component: SidebarOwnerSection,
-                        properties: {
-                            hideOwnerType: true,
-                        },
                     },
                 ]}
                 customNavBar={<GlossaryEntitiesPath />}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/ownershipUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/ownershipUtils.ts
@@ -8,17 +8,17 @@ export const OWNERSHIP_DISPLAY_TYPES = [
     {
         type: OwnershipType.TechnicalOwner,
         name: 'Technical Owner',
-        description: 'Involved in the production, maintenance, or distribution of the asset.',
+        description: 'Involved in the production, maintenance, or distribution of the asset(s).',
     },
     {
         type: OwnershipType.BusinessOwner,
         name: 'Business Owner',
-        description: 'Principle stakeholders or domain experts associated with the asset.',
+        description: 'Principle stakeholders or domain experts associated with the asset(s).',
     },
     {
         type: OwnershipType.DataSteward,
         name: 'Data Steward',
-        description: 'Involved in governance of the asset.',
+        description: 'Involved in governance of the asset(s).',
     },
     {
         type: OwnershipType.None,


### PR DESCRIPTION
## Summary

Based on multiple requests, we are enabling Ownership Type on Glossary Node + Domains. We already have for all asset types + Glossary Terms.

## Status

Ready for review

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
