### PR TITLE
fix(ui): two small ux fixes

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/DatasetSearchSnippet.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetSearchSnippet.tsx
@@ -6,6 +6,7 @@ import { TagSummary } from './shared/TagSummary';
 import { TermSummary } from './shared/TermSummary';
 import { FIELDS_TO_HIGHLIGHT } from './search/highlights';
 import { getMatchPrioritizingPrimary } from '../shared/utils';
+import { downgradeV2FieldPath } from './profile/schema/utils/utils';
 
 type Props = {
     matchedFields: MatchedField[];
@@ -23,6 +24,8 @@ export const DatasetSearchSnippet = ({ matchedFields }: Props) => {
             snippet = <TagSummary urn={matchedField.value} />;
         } else if (matchedField.value.includes('urn:li:glossaryTerm')) {
             snippet = <TermSummary urn={matchedField.value} />;
+        } else if (matchedField.name === 'fieldPaths') {
+            snippet = <b>{downgradeV2FieldPath(matchedField.value)}</b>;
         } else {
             snippet = <b>{matchedField.value}</b>;
         }

--- a/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
@@ -1,6 +1,10 @@
 import { dataset3WithLineage, dataset4WithLineage } from '../../../../Mocks';
 import { EntityType } from '../../../../types.generated';
-import { combineEntityDataWithSiblings, combineSiblingsInSearchResults } from '../siblingUtils';
+import {
+    combineEntityDataWithSiblings,
+    combineSiblingsInSearchResults,
+    shouldEntityBeTreatedAsPrimary,
+} from '../siblingUtils';
 
 const usageStats = {
     buckets: [
@@ -70,7 +74,11 @@ const datasetPrimary = {
             },
         ],
     },
+    siblings: {
+        isPrimary: true,
+    },
 };
+
 const datasetUnprimary = {
     ...dataset4WithLineage,
     usageStats,
@@ -98,12 +106,31 @@ const datasetUnprimary = {
             },
         ],
     },
+    siblings: {
+        isPrimary: false,
+    },
 };
 
 const datasetPrimaryWithSiblings = {
     ...datasetPrimary,
     siblings: {
         isPrimary: true,
+        siblings: [datasetUnprimary],
+    },
+};
+
+const datasetUnprimaryWithPrimarySiblings = {
+    ...datasetUnprimary,
+    siblings: {
+        isPrimary: false,
+        siblings: [datasetPrimary],
+    },
+};
+
+const datasetUnprimaryWithNoPrimarySiblings = {
+    ...datasetUnprimary,
+    siblings: {
+        isPrimary: false,
         siblings: [datasetUnprimary],
     },
 };
@@ -430,14 +457,6 @@ const searchResultWithSiblings = [
     },
 ];
 
-// const datasetUnprimaryWithSiblings = {
-//     ...datasetUnprimary,
-//     siblings: {
-//         isPrimary: true,
-//         siblings: [datasetPrimary],
-//     },
-// };
-
 describe('siblingUtils', () => {
     describe('combineEntityDataWithSiblings', () => {
         it('combines my metadata with my siblings', () => {
@@ -471,6 +490,20 @@ describe('siblingUtils', () => {
             expect(result?.[0]?.matchedEntities?.[1]?.urn).toEqual(
                 'urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.raw_orders,PROD)',
             );
+        });
+    });
+
+    describe('shouldEntityBeTreatedAsPrimary', () => {
+        it('will say a primary entity is primary', () => {
+            expect(shouldEntityBeTreatedAsPrimary(datasetPrimaryWithSiblings)).toBeTruthy();
+        });
+
+        it('will say a un-primary entity is not primary', () => {
+            expect(shouldEntityBeTreatedAsPrimary(datasetUnprimaryWithPrimarySiblings)).toBeFalsy();
+        });
+
+        it('will say a un-primary entity is primary if it has no primary sibling', () => {
+            expect(shouldEntityBeTreatedAsPrimary(datasetUnprimaryWithNoPrimarySiblings)).toBeTruthy();
         });
     });
 });

--- a/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
@@ -459,7 +459,7 @@ const searchResultWithSiblings = [
 
 describe('siblingUtils', () => {
     describe('combineEntityDataWithSiblings', () => {
-        it('combines my metadata with my siblings', () => {
+        it('combines my metadata with my siblings as primary', () => {
             const baseEntity = { dataset: datasetPrimaryWithSiblings };
             expect(baseEntity.dataset.usageStats).toBeNull();
             const combinedData = combineEntityDataWithSiblings(baseEntity);
@@ -476,6 +476,17 @@ describe('siblingUtils', () => {
 
             // will take secondary string properties in the case of empty string
             expect(combinedData.dataset.properties.description).toEqual('primary description');
+
+            // will stay primary
+            expect(combinedData.dataset.siblings.isPrimary).toBeTruthy();
+        });
+
+        it('combines my metadata with my siblings as secondary', () => {
+            const baseEntity = { dataset: datasetUnprimaryWithPrimarySiblings };
+            const combinedData = combineEntityDataWithSiblings(baseEntity);
+
+            // will stay secondary
+            expect(combinedData.dataset.siblings.isPrimary).toBeFalsy();
         });
     });
 

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -122,6 +122,24 @@ export const getEntitySiblingData = <T>(baseEntity: T): Maybe<SiblingProperties>
     return extractedBaseEntity?.['siblings'];
 };
 
+// should the entity's metadata win out against its siblings?
+export const shouldEntityBeTreatedAsPrimary = (extractedBaseEntity: { siblings?: SiblingProperties | null }) => {
+    const siblingAspect = extractedBaseEntity?.siblings;
+
+    const siblingsList = siblingAspect?.siblings || [];
+
+    // if the entity is marked as primary, take its metadata first
+    const isPrimarySibling = !!siblingAspect?.isPrimary;
+
+    // if no entity in the cohort is primary, just have the entity whos urn is navigated
+    // to be primary
+    const hasAnyPrimarySibling = siblingsList.find((sibling) => !!(sibling as any)?.siblings?.isPrimary) !== undefined;
+
+    const isPrimary = isPrimarySibling || !hasAnyPrimarySibling;
+
+    return isPrimary;
+};
+
 export const combineEntityDataWithSiblings = <T>(baseEntity: T): T => {
     if (!baseEntity) {
         return baseEntity;
@@ -137,7 +155,8 @@ export const combineEntityDataWithSiblings = <T>(baseEntity: T): T => {
 
     // eslint-disable-next-line @typescript-eslint/dot-notation
     const siblings: T[] = siblingAspect?.siblings || [];
-    const isPrimary = !!extractedBaseEntity?.siblings?.isPrimary;
+
+    const isPrimary = shouldEntityBeTreatedAsPrimary(extractedBaseEntity);
 
     const combinedBaseEntity: any = siblings.reduce(
         (prev, current) =>

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -92,7 +92,8 @@ const customMerge = (isPrimary, key) => {
     if (key === 'upstream' || key === 'downstream') {
         return (_secondary, primary) => primary;
     }
-    if (key === 'platform') {
+    // take the platform & siblings of whichever entity we're merging with, rather than the primary
+    if (key === 'platform' || key === 'siblings') {
         return (secondary, primary) => (isPrimary ? primary : secondary);
     }
     if (key === 'tags' || key === 'terms' || key === 'assertions' || key === 'customProperties' || key === 'owners') {

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -206,6 +206,9 @@ fragment nonSiblingDatasetFields on Dataset {
             }
         }
     }
+    siblings {
+      isPrimary
+    }
 }
 
 mutation updateDataset($urn: String!, $input: DatasetUpdateInput!) {


### PR DESCRIPTION
1) When there is no primary sibling, whichever urn is being fetch in the query wins out. Added tests for this logic as well.

2) Downgrade field paths in search snippets.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
