### PR TITLE
feat(privileges) Create privileges to allow for managing children of entities

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -107,6 +107,7 @@ import com.linkedin.datahub.graphql.resolvers.domain.ListDomainsResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.SetDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.UnsetDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.entity.EntityExistsResolver;
+import com.linkedin.datahub.graphql.resolvers.entity.EntityPrivilegesResolver;
 import com.linkedin.datahub.graphql.resolvers.glossary.AddRelatedTermsResolver;
 import com.linkedin.datahub.graphql.resolvers.glossary.CreateGlossaryNodeResolver;
 import com.linkedin.datahub.graphql.resolvers.glossary.CreateGlossaryTermResolver;
@@ -1007,12 +1008,14 @@ public class GmsGraphQLEngine {
         builder.type("GlossaryTerm", typeWiring -> typeWiring
             .dataFetcher("schemaMetadata", new AspectResolver())
             .dataFetcher("parentNodes", new ParentNodesResolver(entityClient))
+            .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
         );
     }
 
     private void configureGlossaryNodeResolvers(final RuntimeWiring.Builder builder) {
         builder.type("GlossaryNode", typeWiring -> typeWiring
             .dataFetcher("parentNodes", new ParentNodesResolver(entityClient))
+            .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
         );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -800,7 +800,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("reportOperation", new ReportOperationResolver(this.entityClient))
             .dataFetcher("createGlossaryTerm", new CreateGlossaryTermResolver(this.entityClient, this.entityService))
             .dataFetcher("createGlossaryNode", new CreateGlossaryNodeResolver(this.entityClient, this.entityService))
-            .dataFetcher("updateParentNode", new UpdateParentNodeResolver(entityService))
+            .dataFetcher("updateParentNode", new UpdateParentNodeResolver(this.entityService, this.entityClient))
             .dataFetcher("deleteGlossaryEntity",
                 new DeleteGlossaryEntityResolver(this.entityClient, this.entityService))
             .dataFetcher("updateName", new UpdateNameResolver(entityService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -803,7 +803,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("updateParentNode", new UpdateParentNodeResolver(this.entityService, this.entityClient))
             .dataFetcher("deleteGlossaryEntity",
                 new DeleteGlossaryEntityResolver(this.entityClient, this.entityService))
-            .dataFetcher("updateName", new UpdateNameResolver(entityService))
+            .dataFetcher("updateName", new UpdateNameResolver(this.entityService, this.entityClient))
             .dataFetcher("addRelatedTerms", new AddRelatedTermsResolver(this.entityService))
             .dataFetcher("removeRelatedTerms", new RemoveRelatedTermsResolver(this.entityService))
             .dataFetcher("createNativeUserResetToken", new CreateNativeUserResetTokenResolver(this.nativeUserService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -5,24 +5,15 @@ import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.Authorizer;
 import com.datahub.authorization.ResourceSpec;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.entity.EntityResponse;
-import com.linkedin.entity.client.EntityClient;
-import com.linkedin.glossary.GlossaryNodeInfo;
-import com.linkedin.glossary.GlossaryTermInfo;
-import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
-import com.linkedin.r2.RemoteInvocationException;
 
-import java.net.URISyntaxException;
 import java.time.Clock;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import static com.linkedin.datahub.graphql.resolvers.AuthUtils.*;
 import static com.linkedin.metadata.Constants.*;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -5,14 +5,24 @@ import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.Authorizer;
 import com.datahub.authorization.ResourceSpec;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.glossary.GlossaryNodeInfo;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.r2.RemoteInvocationException;
+
+import java.net.URISyntaxException;
 import java.time.Clock;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import static com.linkedin.datahub.graphql.resolvers.AuthUtils.*;
 import static com.linkedin.metadata.Constants.*;
@@ -62,33 +72,6 @@ public class AuthorizationUtils {
 
   public static boolean canManageDomains(@Nonnull QueryContext context) {
     return isAuthorized(context, Optional.empty(), PoliciesConfig.MANAGE_DOMAINS_PRIVILEGE);
-  }
-
-  public static boolean canManageGlossaries(@Nonnull QueryContext context) {
-    return isAuthorized(context, Optional.empty(), PoliciesConfig.MANAGE_GLOSSARIES_PRIVILEGE);
-  }
-
-  /**
-   * Returns true if the current user is able to create, delete, or move Glossary Terms and Nodes under a parent Node.
-   * They can do this with either the global MANAGE_GLOSSARIES privilege, or if they have the MANAGE_CHILDREN privilege
-   * on the relevant parent node in the Glossary.
-   */
-  public static boolean canManageGlossaryEntity(@Nonnull QueryContext context, Urn parentNodeUrn) {
-    if (canManageGlossaries(context)) {
-      return true;
-    }
-
-    final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
-        ALL_PRIVILEGES_GROUP,
-        new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.MANAGE_CHILDREN_PRIVILEGE.getType()))
-    ));
-
-    return AuthorizationUtils.isAuthorized(
-        context.getAuthorizer(),
-        context.getActorUrn(),
-        parentNodeUrn.getEntityType(),
-        parentNodeUrn.toString(),
-        orPrivilegeGroups);
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -69,6 +69,29 @@ public class AuthorizationUtils {
   }
 
   /**
+   * Returns true if the current user is able to create, delete, or move Glossary Terms and Nodes under a parent Node.
+   * They can do this with either the global MANAGE_GLOSSARIES privilege, or if they have the MANAGE_CHILDREN privilege
+   * on the relevant parent node in the Glossary.
+   */
+  public static boolean canManageGlossaryEntity(@Nonnull QueryContext context, Urn parentNodeUrn) {
+    if (canManageGlossaries(context)) {
+      return true;
+    }
+
+    final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
+        ALL_PRIVILEGES_GROUP,
+        new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.MANAGE_CHILDREN_PRIVILEGE.getType()))
+    ));
+
+    return AuthorizationUtils.isAuthorized(
+        context.getAuthorizer(),
+        context.getActorUrn(),
+        parentNodeUrn.getEntityType(),
+        parentNodeUrn.toString(),
+        orPrivilegeGroups);
+  }
+
+  /**
    * Returns true if the current used is able to create Tags. This is true if the user has the 'Manage Tags' or 'Create Tags' platform privilege.
    */
   public static boolean canCreateTags(@Nonnull QueryContext context) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/AccessTokenUtil.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/auth/AccessTokenUtil.java
@@ -6,6 +6,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 
+
 public class AccessTokenUtil {
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -1,0 +1,98 @@
+package com.linkedin.datahub.graphql.resolvers.entity;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityPrivileges;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.glossary.GlossaryNodeInfo;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+
+public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<EntityPrivileges>> {
+
+  private final EntityClient _entityClient;
+
+  public EntityPrivilegesResolver(final EntityClient entityClient) {
+    _entityClient = entityClient;
+  }
+
+  @Override
+  public CompletableFuture<EntityPrivileges> get(DataFetchingEnvironment environment) {
+    final QueryContext context = environment.getContext();
+    final String urnString = ((Entity) environment.getSource()).getUrn();
+    final Urn urn = UrnUtils.getUrn(urnString);
+
+    return CompletableFuture.supplyAsync(() -> {
+      switch (urn.getEntityType()) {
+        case Constants.GLOSSARY_TERM_ENTITY_NAME:
+          return getGlossaryTermPrivileges(urn, context);
+        case Constants.GLOSSARY_NODE_ENTITY_NAME:
+          return getGlossaryNodePrivileges(urn, context);
+      }
+      return new EntityPrivileges();
+    });
+  }
+
+  private EntityPrivileges getGlossaryTermPrivileges(Urn termUrn, QueryContext context) {
+    final EntityPrivileges result = new EntityPrivileges();
+    result.setCanManageEntity(false);
+    if (AuthorizationUtils.canManageGlossaries(context)) {
+      result.setCanManageEntity(true);
+      return result;
+    }
+    try {
+      EntityResponse response = _entityClient.getV2(Constants.GLOSSARY_TERM_ENTITY_NAME, termUrn,
+          ImmutableSet.of(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME), context.getAuthentication());
+      if (response.getAspects().get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME) != null) {
+        GlossaryTermInfo termInfo = new GlossaryTermInfo(response.getAspects()
+            .get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME).getValue().data());
+        if (termInfo.hasParentNode()) {
+          Boolean canManage = AuthorizationUtils.canManageGlossaryEntity(context, termInfo.getParentNode());
+          result.setCanManageEntity(canManage);
+        }
+      }
+      return result;
+    } catch (URISyntaxException | RemoteInvocationException e) {
+      throw new RuntimeException("Failed to fetch Glossary Term to check for privileges", e);
+    }
+  }
+
+  private EntityPrivileges getGlossaryNodePrivileges(Urn nodeUrn, QueryContext context) {
+    final EntityPrivileges result = new EntityPrivileges();
+    result.setCanManageEntity(false);
+    if (AuthorizationUtils.canManageGlossaries(context)) {
+      result.setCanManageEntity(true);
+      result.setCanManageChildren(true);
+      return result;
+    }
+    Boolean canManageChildren = AuthorizationUtils.canManageGlossaryEntity(context, nodeUrn);
+    result.setCanManageChildren(canManageChildren);
+    // get parent node to see if you can manage this entity
+    try {
+      EntityResponse response = _entityClient.getV2(Constants.GLOSSARY_NODE_ENTITY_NAME, nodeUrn,
+          ImmutableSet.of(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME), context.getAuthentication());
+      if (response.getAspects().get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME) != null) {
+        GlossaryNodeInfo nodeInfo = new GlossaryNodeInfo(response.getAspects()
+            .get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME).getValue().data());
+        if (nodeInfo.hasParentNode()) {
+          Boolean canManage = AuthorizationUtils.canManageGlossaryEntity(context, nodeInfo.getParentNode());
+          result.setCanManageEntity(canManage);
+        }
+      }
+      return result;
+    } catch (URISyntaxException | RemoteInvocationException e) {
+      throw new RuntimeException("Failed to fetch Glossary Node to check for privileges", e);
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -1,24 +1,20 @@
 package com.linkedin.datahub.graphql.resolvers.entity;
 
-import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityPrivileges;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
-import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.glossary.GlossaryNodeInfo;
-import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.metadata.Constants;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import lombok.extern.slf4j.Slf4j;
 
-import java.net.URISyntaxException;
 import java.util.concurrent.CompletableFuture;
 
+@Slf4j
 public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<EntityPrivileges>> {
 
   private final EntityClient _entityClient;
@@ -39,8 +35,10 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
           return getGlossaryTermPrivileges(urn, context);
         case Constants.GLOSSARY_NODE_ENTITY_NAME:
           return getGlossaryNodePrivileges(urn, context);
+        default:
+          log.warn("Tried to get entity privileges for entity type {} but nothing is implemented for it yet", urn.getEntityType());
+          return new EntityPrivileges();
       }
-      return new EntityPrivileges();
     });
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -49,9 +49,9 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
       result.setCanManageEntity(true);
       return result;
     }
-    Urn parentNodeUrn = GlossaryUtils.getTermParentUrn(termUrn, context, _entityClient);
+    Urn parentNodeUrn = GlossaryUtils.getParentUrn(termUrn, context, _entityClient);
     if (parentNodeUrn != null) {
-      Boolean canManage = GlossaryUtils.canManageGlossaryEntity(context, parentNodeUrn);
+      Boolean canManage = GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn);
       result.setCanManageEntity(canManage);
     }
     return result;
@@ -65,12 +65,12 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
       result.setCanManageChildren(true);
       return result;
     }
-    Boolean canManageChildren = GlossaryUtils.canManageGlossaryEntity(context, nodeUrn);
+    Boolean canManageChildren = GlossaryUtils.canManageChildrenEntities(context, nodeUrn);
     result.setCanManageChildren(canManageChildren);
 
-    Urn parentNodeUrn = GlossaryUtils.getNodeParentUrn(nodeUrn, context, _entityClient);
+    Urn parentNodeUrn = GlossaryUtils.getParentUrn(nodeUrn, context, _entityClient);
     if (parentNodeUrn != null) {
-      Boolean canManage = GlossaryUtils.canManageGlossaryEntity(context, parentNodeUrn);
+      Boolean canManage = GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn);
       result.setCanManageEntity(canManage);
     }
     return result;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolver.java
@@ -5,10 +5,10 @@ import com.linkedin.common.urn.GlossaryTermUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.RelatedTermsInput;
 import com.linkedin.datahub.graphql.generated.TermRelationshipType;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.glossary.GlossaryRelatedTerms;
@@ -38,7 +38,7 @@ public class AddRelatedTermsResolver implements DataFetcher<CompletableFuture<Bo
     final RelatedTermsInput input = bindArgument(environment.getArgument("input"), RelatedTermsInput.class);
 
     return CompletableFuture.supplyAsync(() -> {
-      if (AuthorizationUtils.canManageGlossaries(context)) {
+      if (GlossaryUtils.canManageGlossaries(context)) {
         try {
           final TermRelationshipType relationshipType = input.getRelationshipType();
           final Urn urn = Urn.createFromString(input.getUrn());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolver.java
@@ -46,7 +46,7 @@ public class CreateGlossaryNodeResolver implements DataFetcher<CompletableFuture
     final Urn parentNode = input.getParentNode() != null ? UrnUtils.getUrn(input.getParentNode()) : null;
 
     return CompletableFuture.supplyAsync(() -> {
-      if (GlossaryUtils.canManageGlossaryEntity(context, parentNode)) {
+      if (GlossaryUtils.canManageChildrenEntities(context, parentNode)) {
         try {
           final GlossaryNodeKey key = new GlossaryNodeKey();
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolver.java
@@ -1,13 +1,15 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import com.linkedin.common.urn.GlossaryNodeUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.CreateGlossaryEntityInput;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
 import com.linkedin.datahub.graphql.generated.OwnershipType;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.events.metadata.ChangeType;
@@ -41,9 +43,10 @@ public class CreateGlossaryNodeResolver implements DataFetcher<CompletableFuture
 
     final QueryContext context = environment.getContext();
     final CreateGlossaryEntityInput input = bindArgument(environment.getArgument("input"), CreateGlossaryEntityInput.class);
+    final Urn parentNode = input.getParentNode() != null ? UrnUtils.getUrn(input.getParentNode()) : null;
 
     return CompletableFuture.supplyAsync(() -> {
-      if (AuthorizationUtils.canManageGlossaries(context)) {
+      if (GlossaryUtils.canManageGlossaryEntity(context, parentNode)) {
         try {
           final GlossaryNodeKey key = new GlossaryNodeKey();
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolver.java
@@ -1,13 +1,15 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import com.linkedin.common.urn.GlossaryNodeUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.CreateGlossaryEntityInput;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
 import com.linkedin.datahub.graphql.generated.OwnershipType;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.events.metadata.ChangeType;
@@ -41,9 +43,10 @@ public class CreateGlossaryTermResolver implements DataFetcher<CompletableFuture
 
     final QueryContext context = environment.getContext();
     final CreateGlossaryEntityInput input = bindArgument(environment.getArgument("input"), CreateGlossaryEntityInput.class);
+    final Urn parentNode = input.getParentNode() != null ? UrnUtils.getUrn(input.getParentNode()) : null;
 
     return CompletableFuture.supplyAsync(() -> {
-      if (AuthorizationUtils.canManageGlossaries((context))) {
+      if (GlossaryUtils.canManageGlossaryEntity(context, parentNode)) {
         try {
           final GlossaryTermKey key = new GlossaryTermKey();
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolver.java
@@ -46,7 +46,7 @@ public class CreateGlossaryTermResolver implements DataFetcher<CompletableFuture
     final Urn parentNode = input.getParentNode() != null ? UrnUtils.getUrn(input.getParentNode()) : null;
 
     return CompletableFuture.supplyAsync(() -> {
-      if (GlossaryUtils.canManageGlossaryEntity(context, parentNode)) {
+      if (GlossaryUtils.canManageChildrenEntities(context, parentNode)) {
         try {
           final GlossaryTermKey key = new GlossaryTermKey();
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -31,7 +31,7 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
     final Urn parentNodeUrn = GlossaryUtils.getParentUrn(entityUrn, context, _entityClient);
 
     return CompletableFuture.supplyAsync(() -> {
-      if (GlossaryUtils.canManageGlossaryEntity(environment.getContext(), parentNodeUrn)) {
+      if (GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn)) {
         if (!_entityService.exists(entityUrn)) {
           throw new RuntimeException(String.format("This urn does not exist: %s", entityUrn));
         }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -5,7 +5,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -29,7 +29,7 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
   public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment) throws Exception {
     final QueryContext context = environment.getContext();
     final Urn entityUrn = Urn.createFromString(environment.getArgument("urn"));
-    final Urn parentNodeUrn = getParentNodeUrn(entityUrn, context);
+    final Urn parentNodeUrn = GlossaryUtils.getParentUrn(entityUrn, context, _entityClient);
 
     return CompletableFuture.supplyAsync(() -> {
       if (GlossaryUtils.canManageGlossaryEntity(environment.getContext(), parentNodeUrn)) {
@@ -56,15 +56,6 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
       }
       throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
     });
-  }
-
-  private Urn getParentNodeUrn(Urn entityUrn, QueryContext context) {
-    if (entityUrn.getEntityType().equals(Constants.GLOSSARY_TERM_ENTITY_NAME)) {
-      return GlossaryUtils.getTermParentUrn(entityUrn, context, _entityClient);
-    } else if (entityUrn.getEntityType().equals(Constants.GLOSSARY_NODE_ENTITY_NAME)) {
-      return GlossaryUtils.getNodeParentUrn(entityUrn, context, _entityClient);
-    }
-    return null;
   }
 }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolver.java
@@ -4,10 +4,10 @@ import com.linkedin.common.GlossaryTermUrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.RelatedTermsInput;
 import com.linkedin.datahub.graphql.generated.TermRelationshipType;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.glossary.GlossaryRelatedTerms;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
@@ -37,7 +37,7 @@ public class RemoveRelatedTermsResolver implements DataFetcher<CompletableFuture
     final RelatedTermsInput input = bindArgument(environment.getArgument("input"), RelatedTermsInput.class);
 
     return CompletableFuture.supplyAsync(() -> {
-      if (AuthorizationUtils.canManageGlossaries(context)) {
+      if (GlossaryUtils.canManageGlossaries(context)) {
         try {
           final TermRelationshipType relationshipType = input.getRelationshipType();
           final Urn urn = Urn.createFromString(input.getUrn());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateNameInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.domain.DomainProperties;
 import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.glossary.GlossaryNodeInfo;
@@ -62,7 +63,7 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
       UpdateNameInput input,
       QueryContext context
   ) {
-    if (AuthorizationUtils.canManageGlossaries(context)) {
+    if (GlossaryUtils.canManageGlossaries(context)) {
       try {
         GlossaryTermInfo glossaryTermInfo = (GlossaryTermInfo) getAspectFromEntity(
             targetUrn.toString(), Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, _entityService, null);
@@ -86,7 +87,7 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
       UpdateNameInput input,
       QueryContext context
   ) {
-    if (AuthorizationUtils.canManageGlossaries(context)) {
+    if (GlossaryUtils.canManageGlossaries(context)) {
       try {
         GlossaryNodeInfo glossaryNodeInfo = (GlossaryNodeInfo) getAspectFromEntity(
             targetUrn.toString(), Constants.GLOSSARY_NODE_INFO_ASPECT_NAME, _entityService, null);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
@@ -9,6 +9,7 @@ import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateNameInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.domain.DomainProperties;
+import com.linkedin.entity.client.EntityClient;
 import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.identity.CorpGroupInfo;
@@ -30,6 +31,7 @@ import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.persis
 public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityService _entityService;
+  private final EntityClient _entityClient;
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
@@ -63,7 +65,8 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
       UpdateNameInput input,
       QueryContext context
   ) {
-    if (GlossaryUtils.canManageGlossaries(context)) {
+    final Urn parentNodeUrn = GlossaryUtils.getParentUrn(targetUrn, context, _entityClient);
+    if (GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn)) {
       try {
         GlossaryTermInfo glossaryTermInfo = (GlossaryTermInfo) getAspectFromEntity(
             targetUrn.toString(), Constants.GLOSSARY_TERM_INFO_ASPECT_NAME, _entityService, null);
@@ -87,7 +90,8 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
       UpdateNameInput input,
       QueryContext context
   ) {
-    if (GlossaryUtils.canManageGlossaries(context)) {
+    final Urn parentNodeUrn = GlossaryUtils.getParentUrn(targetUrn, context, _entityClient);
+    if (GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn)) {
       try {
         GlossaryNodeInfo glossaryNodeInfo = (GlossaryNodeInfo) getAspectFromEntity(
             targetUrn.toString(), Constants.GLOSSARY_NODE_INFO_ASPECT_NAME, _entityService, null);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
@@ -48,7 +48,7 @@ public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<B
     return CompletableFuture.supplyAsync(() -> {
       Urn currentParentUrn = GlossaryUtils.getParentUrn(targetUrn, context, _entityClient);
       // need to be able to manage current parent node and new parent node
-      if (GlossaryUtils.canManageGlossaryEntity(context, currentParentUrn) && GlossaryUtils.canManageGlossaryEntity(context, parentNodeUrn)) {
+      if (GlossaryUtils.canManageChildrenEntities(context, currentParentUrn) && GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn)) {
         switch (targetUrn.getEntityType()) {
           case Constants.GLOSSARY_TERM_ENTITY_NAME:
             return updateGlossaryTermParentNode(targetUrn, parentNodeUrn, input, environment.getContext());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateParentNodeInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
+import com.linkedin.entity.client.EntityClient;
 import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.metadata.Constants;
@@ -27,10 +28,12 @@ import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.persis
 public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityService _entityService;
+  private final EntityClient _entityClient;
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
     final UpdateParentNodeInput input = bindArgument(environment.getArgument("input"), UpdateParentNodeInput.class);
+    final QueryContext context = environment.getContext();
     Urn targetUrn = Urn.createFromString(input.getResourceUrn());
     log.info("Updating parent node. input: {}", input.toString());
 
@@ -43,7 +46,9 @@ public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<B
       throw new IllegalArgumentException(String.format("Failed to update %s. %s either does not exist or is not a glossaryNode.", targetUrn, parentNodeUrn));
     }
     return CompletableFuture.supplyAsync(() -> {
-      if (GlossaryUtils.canManageGlossaries(environment.getContext())) {
+      Urn currentParentUrn = GlossaryUtils.getParentUrn(targetUrn, context, _entityClient);
+      // need to be able to manage current parent node and new parent node
+      if (GlossaryUtils.canManageGlossaryEntity(context, currentParentUrn) && GlossaryUtils.canManageGlossaryEntity(context, parentNodeUrn)) {
         switch (targetUrn.getEntityType()) {
           case Constants.GLOSSARY_TERM_ENTITY_NAME:
             return updateGlossaryTermParentNode(targetUrn, parentNodeUrn, input, environment.getContext());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
@@ -4,9 +4,9 @@ import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.GlossaryNodeUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.UpdateParentNodeInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.metadata.Constants;
@@ -43,7 +43,7 @@ public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<B
       throw new IllegalArgumentException(String.format("Failed to update %s. %s either does not exist or is not a glossaryNode.", targetUrn, parentNodeUrn));
     }
     return CompletableFuture.supplyAsync(() -> {
-      if (AuthorizationUtils.canManageGlossaries(environment.getContext())) {
+      if (GlossaryUtils.canManageGlossaries(environment.getContext())) {
         switch (targetUrn.getEntityType()) {
           case Constants.GLOSSARY_TERM_ENTITY_NAME:
             return updateGlossaryTermParentNode(targetUrn, parentNodeUrn, input, environment.getContext());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
@@ -85,4 +85,14 @@ public class GlossaryUtils {
       throw new RuntimeException("Failed to fetch Glossary Term to check for privileges", e);
     }
   }
+
+  public static Urn getParentUrn(Urn urn, QueryContext context, EntityClient entityClient) {
+    switch (urn.getEntityType()) {
+      case Constants.GLOSSARY_TERM_ENTITY_NAME:
+        return getTermParentUrn(urn, context, entityClient);
+      case Constants.GLOSSARY_NODE_ENTITY_NAME:
+        return getNodeParentUrn(urn, context, entityClient);
+    }
+    return null;
+  }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
@@ -14,6 +14,7 @@ import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.r2.RemoteInvocationException;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -22,6 +23,7 @@ import java.util.Optional;
 
 import static com.linkedin.datahub.graphql.resolvers.AuthUtils.ALL_PRIVILEGES_GROUP;
 
+@Slf4j
 public class GlossaryUtils {
 
   private GlossaryUtils() { }
@@ -60,7 +62,7 @@ public class GlossaryUtils {
     try {
       EntityResponse response = entityClient.getV2(Constants.GLOSSARY_TERM_ENTITY_NAME, termUrn,
           ImmutableSet.of(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME), context.getAuthentication());
-      if (response.getAspects().get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME) != null) {
+      if (response != null && response.getAspects().get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME) != null) {
         GlossaryTermInfo termInfo = new GlossaryTermInfo(response.getAspects()
             .get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME).getValue().data());
         return termInfo.getParentNode();
@@ -75,7 +77,7 @@ public class GlossaryUtils {
     try {
       EntityResponse response = entityClient.getV2(Constants.GLOSSARY_NODE_ENTITY_NAME, nodeUrn,
           ImmutableSet.of(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME), context.getAuthentication());
-      if (response.getAspects().get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME) != null) {
+      if (response != null && response.getAspects().get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME) != null) {
         GlossaryNodeInfo nodeInfo = new GlossaryNodeInfo(response.getAspects()
             .get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME).getValue().data());
         return nodeInfo.getParentNode();
@@ -92,7 +94,9 @@ public class GlossaryUtils {
         return getTermParentUrn(urn, context, entityClient);
       case Constants.GLOSSARY_NODE_ENTITY_NAME:
         return getNodeParentUrn(urn, context, entityClient);
+      default:
+        log.warn("Tried to get entity privileges for entity type {} but nothing is implemented for it yet", urn.getEntityType());
+        return null;
     }
-    return null;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
@@ -1,0 +1,88 @@
+package com.linkedin.datahub.graphql.resolvers.mutate.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.authorization.ConjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.authorization.DisjunctivePrivilegeGroup;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.glossary.GlossaryNodeInfo;
+import com.linkedin.glossary.GlossaryTermInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.r2.RemoteInvocationException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import static com.linkedin.datahub.graphql.resolvers.AuthUtils.ALL_PRIVILEGES_GROUP;
+
+public class GlossaryUtils {
+
+  private GlossaryUtils() { }
+
+  public static boolean canManageGlossaries(@Nonnull QueryContext context) {
+    return AuthorizationUtils.isAuthorized(context, Optional.empty(), PoliciesConfig.MANAGE_GLOSSARIES_PRIVILEGE);
+  }
+
+  /**
+   * Returns true if the current user is able to create, delete, or move Glossary Terms and Nodes under a parent Node.
+   * They can do this with either the global MANAGE_GLOSSARIES privilege, or if they have the MANAGE_CHILDREN privilege
+   * on the relevant parent node in the Glossary.
+   */
+  public static boolean canManageGlossaryEntity(@Nonnull QueryContext context, @Nullable Urn parentNodeUrn) {
+    if (canManageGlossaries(context)) {
+      return true;
+    }
+    if (parentNodeUrn == null) {
+      return false; // if no parent node, we must rely on the canManageGlossaries method above
+    }
+
+    final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
+        ALL_PRIVILEGES_GROUP,
+        new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.MANAGE_CHILDREN_PRIVILEGE.getType()))
+    ));
+
+    return AuthorizationUtils.isAuthorized(
+        context.getAuthorizer(),
+        context.getActorUrn(),
+        parentNodeUrn.getEntityType(),
+        parentNodeUrn.toString(),
+        orPrivilegeGroups);
+  }
+
+  public static Urn getTermParentUrn(Urn termUrn, QueryContext context, EntityClient entityClient) {
+    try {
+      EntityResponse response = entityClient.getV2(Constants.GLOSSARY_TERM_ENTITY_NAME, termUrn,
+          ImmutableSet.of(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME), context.getAuthentication());
+      if (response.getAspects().get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME) != null) {
+        GlossaryTermInfo termInfo = new GlossaryTermInfo(response.getAspects()
+            .get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME).getValue().data());
+        return termInfo.getParentNode();
+      }
+      return null;
+    } catch (URISyntaxException | RemoteInvocationException e) {
+      throw new RuntimeException("Failed to fetch Glossary Term to check for privileges", e);
+    }
+  }
+
+  public static Urn getNodeParentUrn(Urn nodeUrn, QueryContext context, EntityClient entityClient) {
+    try {
+      EntityResponse response = entityClient.getV2(Constants.GLOSSARY_NODE_ENTITY_NAME, nodeUrn,
+          ImmutableSet.of(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME), context.getAuthentication());
+      if (response.getAspects().get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME) != null) {
+        GlossaryNodeInfo nodeInfo = new GlossaryNodeInfo(response.getAspects()
+            .get(Constants.GLOSSARY_NODE_INFO_ASPECT_NAME).getValue().data());
+        return nodeInfo.getParentNode();
+      }
+      return null;
+    } catch (URISyntaxException | RemoteInvocationException e) {
+      throw new RuntimeException("Failed to fetch Glossary Term to check for privileges", e);
+    }
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/GlossaryUtils.java
@@ -21,8 +21,6 @@ import javax.annotation.Nullable;
 import java.net.URISyntaxException;
 import java.util.Optional;
 
-import static com.linkedin.datahub.graphql.resolvers.AuthUtils.ALL_PRIVILEGES_GROUP;
-
 @Slf4j
 public class GlossaryUtils {
 
@@ -50,7 +48,6 @@ public class GlossaryUtils {
     }
 
     final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
-        ALL_PRIVILEGES_GROUP,
         new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.MANAGE_GLOSSARY_CHILDREN_PRIVILEGE.getType()))
     ));
 

--- a/datahub-graphql-core/src/main/resources/auth.graphql
+++ b/datahub-graphql-core/src/main/resources/auth.graphql
@@ -238,3 +238,19 @@ type AccessTokenMetadata implements Entity {
   """
   relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
+
+"""
+Shared privileges object across entities. Not all privileges apply to every entity.
+"""
+type EntityPrivileges {
+  """
+  Whether or not a user can create child entities under a parent entity.
+  For example, can one create Terms/Node sunder a Glossary Node.
+  """
+  canManageChildren: Boolean
+
+  """
+  Whether or not a user can delete or move this entity.
+  """
+  canManageEntity: Boolean
+}

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1502,6 +1502,11 @@ type GlossaryTerm implements Entity {
     Recursively get the lineage of glossary nodes for this entity
     """
     parentNodes: ParentNodesResult
+
+    """
+    Privileges given to a user relevant to this entity
+    """
+    privileges: EntityPrivileges
 }
 
 """
@@ -1629,6 +1634,11 @@ type GlossaryNode implements Entity {
     Recursively get the lineage of glossary nodes for this entity
     """
     parentNodes: ParentNodesResult
+
+    """
+    Privileges given to a user relevant to this entity
+    """
+    privileges: EntityPrivileges
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolverTest.java
@@ -1,0 +1,119 @@
+package com.linkedin.datahub.graphql.resolvers.entity;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.EntityPrivileges;
+import com.linkedin.datahub.graphql.generated.GlossaryNode;
+import com.linkedin.datahub.graphql.generated.GlossaryTerm;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.CompletionException;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+public class EntityPrivilegesResolverTest {
+
+  final String glossaryTermUrn = "urn:li:glossaryTerm:11115397daf94708a8822b8106cfd451";
+  final String glossaryNodeUrn = "urn:li:glossaryNode:11115397daf94708a8822b8106cfd451";
+
+  private DataFetchingEnvironment setUpTestWithPermissions(Entity entity) {
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getSource()).thenReturn(entity);
+    return mockEnv;
+  }
+
+  @Test
+  public void testGetTermSuccessWithPermissions() throws Exception {
+    final GlossaryTerm glossaryTerm = new GlossaryTerm();
+    glossaryTerm.setUrn(glossaryTermUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithPermissions(glossaryTerm);
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    assertTrue(result.getCanManageEntity());
+  }
+
+  @Test
+  public void testGetNodeSuccessWithPermissions() throws Exception {
+    final GlossaryNode glossaryNode = new GlossaryNode();
+    glossaryNode.setUrn(glossaryNodeUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithPermissions(glossaryNode);
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    assertTrue(result.getCanManageEntity());
+    assertTrue(result.getCanManageChildren());
+  }
+
+  private DataFetchingEnvironment setUpTestWithoutPermissions(Entity entity) {
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    Mockito.when(mockEnv.getSource()).thenReturn(entity);
+    return mockEnv;
+  }
+
+  @Test
+  public void testGetTermSuccessWithoutPermissions() throws Exception {
+    final GlossaryTerm glossaryTerm = new GlossaryTerm();
+    glossaryTerm.setUrn(glossaryTermUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithoutPermissions(glossaryTerm);
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    assertFalse(result.getCanManageEntity());
+  }
+
+  @Test
+  public void testGetNodeSuccessWithoutPermissions() throws Exception {
+    final GlossaryNode glossaryNode = new GlossaryNode();
+    glossaryNode.setUrn(glossaryNodeUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithoutPermissions(glossaryNode);
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    EntityPrivileges result = resolver.get(mockEnv).get();
+
+    assertFalse(result.getCanManageEntity());
+    assertFalse(result.getCanManageChildren());
+  }
+
+  @Test
+  public void testGetFailure() throws Exception {
+    final GlossaryNode glossaryNode = new GlossaryNode();
+    glossaryNode.setUrn(glossaryNodeUrn);
+
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    DataFetchingEnvironment mockEnv = setUpTestWithoutPermissions(glossaryNode);
+
+    Mockito.doThrow(RemoteInvocationException.class).when(mockClient).getV2(
+        Mockito.eq(Constants.GLOSSARY_NODE_ENTITY_NAME),
+        Mockito.any(),
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+
+    EntityPrivilegesResolver resolver = new EntityPrivilegesResolver(mockClient);
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/GlossaryUtilsTest.java
@@ -1,0 +1,98 @@
+package com.linkedin.datahub.graphql.resolvers.glossary;
+
+import com.datahub.authorization.AuthorizationRequest;
+import com.datahub.authorization.AuthorizationResult;
+import com.datahub.authorization.Authorizer;
+import com.datahub.authorization.ResourceSpec;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.*;
+
+public class GlossaryUtilsTest {
+
+  private final String userUrn = "urn:li:corpuser:authorized";
+  private final QueryContext mockContext = Mockito.mock(QueryContext.class);
+  private final Authorizer mockAuthorizer = Mockito.mock(Authorizer.class);
+  private final Urn parentNodeUrn = UrnUtils.getUrn("urn:li:glossaryNode:parent_node");
+
+  private void setUpTests() {
+    Mockito.when(mockContext.getAuthorizer()).thenReturn(mockAuthorizer);
+    Mockito.when(mockContext.getActorUrn()).thenReturn(userUrn);
+  }
+
+  private void mockAuthRequest(String privilege, AuthorizationResult.Type allowOrDeny, ResourceSpec resourceSpec) {
+    final AuthorizationRequest authorizationRequest = new AuthorizationRequest(
+        userUrn,
+        privilege,
+        resourceSpec != null ? Optional.of(resourceSpec) : Optional.empty()
+    );
+    AuthorizationResult result = Mockito.mock(AuthorizationResult.class);
+    Mockito.when(result.getType()).thenReturn(allowOrDeny);
+    Mockito.when(mockAuthorizer.authorize(Mockito.eq(authorizationRequest))).thenReturn(result);
+  }
+
+  @Test
+  public void testCanManageGlossariesAuthorized() {
+    setUpTests();
+    mockAuthRequest("MANAGE_GLOSSARIES", AuthorizationResult.Type.ALLOW, null);
+
+    assertTrue(GlossaryUtils.canManageGlossaries(mockContext));
+  }
+
+  @Test
+  public void testCanManageGlossariesUnauthorized() {
+    setUpTests();
+    mockAuthRequest("MANAGE_GLOSSARIES", AuthorizationResult.Type.DENY, null);
+
+    assertFalse(GlossaryUtils.canManageGlossaries(mockContext));
+  }
+
+  @Test
+  public void testCanManageChildrenEntitiesWithManageGlossaries() {
+    setUpTests();
+    // they have the MANAGE_GLOSSARIES platform privilege
+    mockAuthRequest("MANAGE_GLOSSARIES", AuthorizationResult.Type.ALLOW, null);
+
+    assertTrue(GlossaryUtils.canManageChildrenEntities(mockContext, parentNodeUrn));
+  }
+
+  @Test
+  public void testCanManageChildrenEntitiesNoParentNode() {
+    setUpTests();
+    // they do NOT have the MANAGE_GLOSSARIES platform privilege
+    mockAuthRequest("MANAGE_GLOSSARIES", AuthorizationResult.Type.DENY, null);
+
+    assertFalse(GlossaryUtils.canManageChildrenEntities(mockContext, null));
+  }
+
+  @Test
+  public void testCanManageChildrenEntitiesAuthorized() {
+    setUpTests();
+    // they do NOT have the MANAGE_GLOSSARIES platform privilege
+    mockAuthRequest("MANAGE_GLOSSARIES", AuthorizationResult.Type.DENY, null);
+
+    final ResourceSpec resourceSpec = new ResourceSpec(parentNodeUrn.getEntityType(), parentNodeUrn.toString());
+    mockAuthRequest("MANAGE_GLOSSARY_CHILDREN", AuthorizationResult.Type.ALLOW, resourceSpec);
+
+    assertTrue(GlossaryUtils.canManageChildrenEntities(mockContext, parentNodeUrn));
+  }
+
+  @Test
+  public void testCanManageChildrenEntitiesUnauthorized() {
+    setUpTests();
+    // they do NOT have the MANAGE_GLOSSARIES platform privilege
+    mockAuthRequest("MANAGE_GLOSSARIES", AuthorizationResult.Type.DENY, null);
+
+    final ResourceSpec resourceSpec = new ResourceSpec(parentNodeUrn.getEntityType(), parentNodeUrn.toString());
+    mockAuthRequest("MANAGE_GLOSSARY_CHILDREN", AuthorizationResult.Type.DENY, resourceSpec);
+
+    assertFalse(GlossaryUtils.canManageChildrenEntities(mockContext, parentNodeUrn));
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
@@ -8,6 +8,7 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.UpdateNameInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateNameResolver;
 import com.linkedin.domain.DomainProperties;
+import com.linkedin.entity.client.EntityClient;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.glossary.GlossaryTermInfo;
@@ -63,11 +64,12 @@ public class UpdateNameResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
-    UpdateNameResolver resolver = new UpdateNameResolver(mockService);
+    UpdateNameResolver resolver = new UpdateNameResolver(mockService, mockClient);
     final MetadataChangeProposal proposal = setupTests(mockEnv, mockService);
 
     assertTrue(resolver.get(mockEnv).get());
@@ -77,6 +79,7 @@ public class UpdateNameResolverTest {
   @Test
   public void testGetSuccessForNode() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(NODE_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_FOR_NODE);
@@ -102,7 +105,7 @@ public class UpdateNameResolverTest {
     proposal.setAspect(GenericRecordUtils.serializeAspect(info));
     proposal.setChangeType(ChangeType.UPSERT);
 
-    UpdateNameResolver resolver = new UpdateNameResolver(mockService);
+    UpdateNameResolver resolver = new UpdateNameResolver(mockService, mockClient);
 
     assertTrue(resolver.get(mockEnv).get());
     verifyIngestProposal(mockService, 1, proposal);
@@ -111,6 +114,7 @@ public class UpdateNameResolverTest {
   @Test
   public void testGetSuccessForDomain() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(DOMAIN_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_FOR_DOMAIN);
@@ -136,7 +140,7 @@ public class UpdateNameResolverTest {
     proposal.setAspect(GenericRecordUtils.serializeAspect(properties));
     proposal.setChangeType(ChangeType.UPSERT);
 
-    UpdateNameResolver resolver = new UpdateNameResolver(mockService);
+    UpdateNameResolver resolver = new UpdateNameResolver(mockService, mockClient);
 
     assertTrue(resolver.get(mockEnv).get());
     verifyIngestProposal(mockService, 1, proposal);
@@ -145,11 +149,12 @@ public class UpdateNameResolverTest {
   @Test
   public void testGetFailureEntityDoesNotExist() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(false);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
-    UpdateNameResolver resolver = new UpdateNameResolver(mockService);
+    UpdateNameResolver resolver = new UpdateNameResolver(mockService, mockClient);
     setupTests(mockEnv, mockService);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateParentNodeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateParentNodeResolverTest.java
@@ -7,6 +7,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.UpdateParentNodeInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.UpdateParentNodeResolver;
+import com.linkedin.entity.client.EntityClient;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.glossary.GlossaryNodeInfo;
 import com.linkedin.glossary.GlossaryTermInfo;
@@ -63,12 +64,13 @@ public class UpdateParentNodeResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
     Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
-    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService);
+    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService, mockClient);
     final MetadataChangeProposal proposal = setupTests(mockEnv, mockService);
 
     assertTrue(resolver.get(mockEnv).get());
@@ -78,6 +80,7 @@ public class UpdateParentNodeResolverTest {
   @Test
   public void testGetSuccessForNode() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(NODE_URN))).thenReturn(true);
     Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
@@ -105,7 +108,7 @@ public class UpdateParentNodeResolverTest {
     proposal.setAspect(GenericRecordUtils.serializeAspect(info));
     proposal.setChangeType(ChangeType.UPSERT);
 
-    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService);
+    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService, mockClient);
 
     assertTrue(resolver.get(mockEnv).get());
     verifyIngestProposal(mockService, 1, proposal);
@@ -114,12 +117,13 @@ public class UpdateParentNodeResolverTest {
   @Test
   public void testGetFailureEntityDoesNotExist() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(false);
     Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
-    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService);
+    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService, mockClient);
     setupTests(mockEnv, mockService);
 
     assertThrows(IllegalArgumentException.class, () -> resolver.get(mockEnv).join());
@@ -129,12 +133,13 @@ public class UpdateParentNodeResolverTest {
   @Test
   public void testGetFailureNodeDoesNotExist() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
     Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN))).thenReturn(false);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
-    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService);
+    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService, mockClient);
     setupTests(mockEnv, mockService);
 
     assertThrows(IllegalArgumentException.class, () -> resolver.get(mockEnv).join());
@@ -144,12 +149,13 @@ public class UpdateParentNodeResolverTest {
   @Test
   public void testGetFailureParentIsNotNode() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
     Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INVALID_INPUT);
 
-    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService);
+    UpdateParentNodeResolver resolver = new UpdateParentNodeResolver(mockService, mockClient);
     setupTests(mockEnv, mockService);
 
     assertThrows(URISyntaxException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -199,7 +199,9 @@ function EntityDropdown(props: Props) {
                                     title={`Can't delete ${entityRegistry.getEntityName(
                                         entityType,
                                     )} with child entities.`}
-                                    overlayStyle={entityHasChildren ? {} : { display: 'none' }}
+                                    overlayStyle={
+                                        canManageGlossaryEntity && entityHasChildren ? {} : { display: 'none' }
+                                    }
                                 >
                                     <MenuItem>
                                         <DeleteOutlined /> &nbsp;Delete

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -11,14 +11,13 @@ import {
     PlusOutlined,
 } from '@ant-design/icons';
 import { Redirect } from 'react-router';
-import { EntityType, PlatformPrivileges } from '../../../../types.generated';
+import { EntityType } from '../../../../types.generated';
 import CreateGlossaryEntityModal from './CreateGlossaryEntityModal';
 import { UpdateDeprecationModal } from './UpdateDeprecationModal';
 import { useUpdateDeprecationMutation } from '../../../../graphql/mutations.generated';
 import MoveGlossaryEntityModal from './MoveGlossaryEntityModal';
 import { ANTD_GRAY } from '../constants';
 import { useEntityRegistry } from '../../../useEntityRegistry';
-import { useGetAuthenticatedUser } from '../../../useGetAuthenticatedUser';
 import useDeleteEntity from './useDeleteEntity';
 import { getEntityProfileDeleteRedirectPath } from '../../../shared/deleteUtils';
 

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -124,7 +124,9 @@ function EntityDropdown(props: Props) {
         ? platformPrivileges.manageGlossaries
         : me?.platformPrivileges.manageGlossaries;
     const pageUrl = window.location.href;
-    const isDeleteDisabled = !!entityData?.children?.total;
+    const entityHasChildren = !!entityData?.children?.total;
+    const canManageGlossaryEntity = !!entityData?.privileges?.canManageEntity;
+    const canCreateGlossaryEntity = !!entityData?.privileges?.canManageChildren;
 
     /**
      * A default path to redirect to if the entity is deleted.
@@ -164,7 +166,7 @@ function EntityDropdown(props: Props) {
                         {menuItems.has(EntityMenuItems.ADD_TERM) && (
                             <StyledMenuItem
                                 key="2"
-                                disabled={!canManageGlossaries}
+                                disabled={!canCreateGlossaryEntity}
                                 onClick={() => setIsCreateTermModalVisible(true)}
                             >
                                 <MenuItem>
@@ -175,7 +177,7 @@ function EntityDropdown(props: Props) {
                         {menuItems.has(EntityMenuItems.ADD_TERM_GROUP) && (
                             <StyledMenuItem
                                 key="3"
-                                disabled={!canManageGlossaries}
+                                disabled={!canCreateGlossaryEntity}
                                 onClick={() => setIsCreateNodeModalVisible(true)}
                             >
                                 <MenuItem>
@@ -197,14 +199,14 @@ function EntityDropdown(props: Props) {
                         {menuItems.has(EntityMenuItems.DELETE) && (
                             <StyledMenuItem
                                 key="5"
-                                disabled={isDeleteDisabled || !canManageGlossaries}
+                                disabled={entityHasChildren || !canManageGlossaryEntity}
                                 onClick={onDeleteEntity}
                             >
                                 <Tooltip
                                     title={`Can't delete ${entityRegistry.getEntityName(
                                         entityType,
                                     )} with child entities.`}
-                                    overlayStyle={isDeleteDisabled ? {} : { display: 'none' }}
+                                    overlayStyle={entityHasChildren ? {} : { display: 'none' }}
                                 >
                                     <MenuItem>
                                         <DeleteOutlined /> &nbsp;Delete

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -62,7 +62,6 @@ interface Props {
     entityType: EntityType;
     entityData?: any;
     menuItems: Set<EntityMenuItems>;
-    platformPrivileges?: PlatformPrivileges;
     size?: number;
     refetchForEntity?: () => void;
     refetchForTerms?: () => void;
@@ -77,7 +76,6 @@ function EntityDropdown(props: Props) {
         entityData,
         entityType,
         menuItems,
-        platformPrivileges,
         refetchForEntity,
         refetchForTerms,
         refetchForNodes,
@@ -87,7 +85,6 @@ function EntityDropdown(props: Props) {
     } = props;
 
     const entityRegistry = useEntityRegistry();
-    const me = useGetAuthenticatedUser(!!platformPrivileges);
     const [updateDeprecation] = useUpdateDeprecationMutation();
     const { onDeleteEntity, hasBeenDeleted } = useDeleteEntity(urn, entityType, entityData, onDelete);
 
@@ -120,9 +117,6 @@ function EntityDropdown(props: Props) {
         refetchForEntity?.();
     };
 
-    const canManageGlossaries = platformPrivileges
-        ? platformPrivileges.manageGlossaries
-        : me?.platformPrivileges.manageGlossaries;
     const pageUrl = window.location.href;
     const entityHasChildren = !!entityData?.children?.total;
     const canManageGlossaryEntity = !!entityData?.privileges?.canManageEntity;
@@ -188,7 +182,7 @@ function EntityDropdown(props: Props) {
                         {menuItems.has(EntityMenuItems.MOVE) && (
                             <StyledMenuItem
                                 key="4"
-                                disabled={!canManageGlossaries}
+                                disabled={!canManageGlossaryEntity}
                                 onClick={() => setIsMoveModalVisible(true)}
                             >
                                 <MenuItem>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityHeader.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityHeader.test.tsx
@@ -3,47 +3,92 @@ import { EntityType } from '../../../../../../types.generated';
 import { getCanEditName } from '../header/EntityHeader';
 
 describe('getCanEditName', () => {
+    const entityDataWithManagePrivileges = { privileges: { canManageEntity: true } };
+    const entityDataWithoutManagePrivileges = { privileges: { canManageEntity: false } };
+
     it('should return true for Terms if manageGlossaries privilege is true', () => {
-        const canEditName = getCanEditName(EntityType.GlossaryTerm, platformPrivileges);
+        const canEditName = getCanEditName(
+            EntityType.GlossaryTerm,
+            entityDataWithoutManagePrivileges,
+            platformPrivileges,
+        );
 
         expect(canEditName).toBe(true);
     });
 
-    it('should return false for Terms if manageGlossaries privilege is false', () => {
+    it('should return false for Terms if manageGlossaries privilege and canManageEntity is false', () => {
         const privilegesWithoutGlossaries = { ...platformPrivileges, manageGlossaries: false };
-        const canEditName = getCanEditName(EntityType.GlossaryTerm, privilegesWithoutGlossaries);
+        const canEditName = getCanEditName(
+            EntityType.GlossaryTerm,
+            entityDataWithoutManagePrivileges,
+            privilegesWithoutGlossaries,
+        );
 
         expect(canEditName).toBe(false);
+    });
+
+    it('should return true for Terms if manageGlossaries privilege is false but canManageEntity is true', () => {
+        const privilegesWithoutGlossaries = { ...platformPrivileges, manageGlossaries: false };
+        const canEditName = getCanEditName(
+            EntityType.GlossaryTerm,
+            entityDataWithManagePrivileges,
+            privilegesWithoutGlossaries,
+        );
+
+        expect(canEditName).toBe(true);
     });
 
     it('should return true for Nodes if manageGlossaries privilege is true', () => {
-        const canEditName = getCanEditName(EntityType.GlossaryNode, platformPrivileges);
+        const canEditName = getCanEditName(
+            EntityType.GlossaryNode,
+            entityDataWithoutManagePrivileges,
+            platformPrivileges,
+        );
 
         expect(canEditName).toBe(true);
     });
 
-    it('should return false for Nodes if manageGlossaries privilege is false', () => {
+    it('should return false for Nodes if manageGlossaries privilege and canManageEntity is false', () => {
         const privilegesWithoutGlossaries = { ...platformPrivileges, manageGlossaries: false };
-        const canEditName = getCanEditName(EntityType.GlossaryNode, privilegesWithoutGlossaries);
+        const canEditName = getCanEditName(
+            EntityType.GlossaryNode,
+            entityDataWithoutManagePrivileges,
+            privilegesWithoutGlossaries,
+        );
 
         expect(canEditName).toBe(false);
     });
 
+    it('should return true for Nodes if manageGlossaries privilege is false but canManageEntity is true', () => {
+        const privilegesWithoutGlossaries = { ...platformPrivileges, manageGlossaries: false };
+        const canEditName = getCanEditName(
+            EntityType.GlossaryNode,
+            entityDataWithManagePrivileges,
+            privilegesWithoutGlossaries,
+        );
+
+        expect(canEditName).toBe(true);
+    });
+
     it('should return true for Domains if manageDomains privilege is true', () => {
-        const canEditName = getCanEditName(EntityType.Domain, platformPrivileges);
+        const canEditName = getCanEditName(EntityType.Domain, entityDataWithoutManagePrivileges, platformPrivileges);
 
         expect(canEditName).toBe(true);
     });
 
     it('should return false for Domains if manageDomains privilege is false', () => {
         const privilegesWithoutDomains = { ...platformPrivileges, manageDomains: false };
-        const canEditName = getCanEditName(EntityType.Domain, privilegesWithoutDomains);
+        const canEditName = getCanEditName(
+            EntityType.Domain,
+            entityDataWithoutManagePrivileges,
+            privilegesWithoutDomains,
+        );
 
         expect(canEditName).toBe(false);
     });
 
     it('should return false for an unsupported entity', () => {
-        const canEditName = getCanEditName(EntityType.Chart, platformPrivileges);
+        const canEditName = getCanEditName(EntityType.Chart, entityDataWithManagePrivileges, platformPrivileges);
 
         expect(canEditName).toBe(false);
     });

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -13,7 +13,7 @@ import EntityName from './EntityName';
 import CopyUrn from '../../../../../shared/CopyUrn';
 import { DeprecationPill } from '../../../components/styled/DeprecationPill';
 import CompactContext from '../../../../../shared/CompactContext';
-import { EntitySubHeaderSection } from '../../../types';
+import { EntitySubHeaderSection, GenericEntityProperties } from '../../../types';
 import EntityActions, { EntityActionItem } from '../../../entity/EntityActions';
 import ExternalUrlButton from '../../../ExternalUrlButton';
 
@@ -55,11 +55,15 @@ const TopButtonsWrapper = styled.div`
     margin-bottom: 8px;
 `;
 
-export function getCanEditName(entityType: EntityType, privileges?: PlatformPrivileges) {
+export function getCanEditName(
+    entityType: EntityType,
+    entityData: GenericEntityProperties | null,
+    privileges?: PlatformPrivileges,
+) {
     switch (entityType) {
         case EntityType.GlossaryTerm:
         case EntityType.GlossaryNode:
-            return privileges?.manageGlossaries;
+            return privileges?.manageGlossaries || !!entityData?.privileges?.canManageEntity;
         case EntityType.Domain:
             return privileges?.manageDomains;
         default:
@@ -92,7 +96,8 @@ export const EntityHeader = ({
     const entityCount = entityData?.entityCount;
     const isCompact = React.useContext(CompactContext);
 
-    const canEditName = isNameEditable && getCanEditName(entityType, me?.platformPrivileges as PlatformPrivileges);
+    const canEditName =
+        isNameEditable && getCanEditName(entityType, entityData, me?.platformPrivileges as PlatformPrivileges);
 
     return (
         <>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -142,7 +142,6 @@ export const EntityHeader = ({
                                 menuItems={headerDropdownItems}
                                 refetchForEntity={refetch}
                                 refreshBrowser={refreshBrowser}
-                                platformPrivileges={me?.platformPrivileges as PlatformPrivileges}
                             />
                         )}
                     </TopButtonsWrapper>

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -32,6 +32,7 @@ import {
     DomainAssociation,
     InputFields,
     FineGrainedLineage,
+    EntityPrivileges,
 } from '../../../types.generated';
 import { FetchedEntity } from '../../lineage/types';
 
@@ -99,6 +100,7 @@ export type GenericEntityProperties = {
     lastIngested?: Maybe<number>;
     inputFields?: Maybe<InputFields>;
     fineGrainedLineages?: Maybe<FineGrainedLineage[]>;
+    privileges?: Maybe<EntityPrivileges>;
 };
 
 export type GenericEntityUpdate = {

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -22,6 +22,10 @@ query getGlossaryNode($urn: String!) {
         parentNodes {
             ...parentNodesFields
         }
+        privileges {
+            canManageEntity
+            canManageChildren
+        }
         children: relationships(
             input: {
                 types: ["IsPartOf"]

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -71,6 +71,9 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
         deprecation {
             ...deprecationFields
         }
+        privileges {
+            canManageEntity
+        }
     }
 }
 

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -250,9 +250,9 @@ public class PoliciesConfig {
       "The ability to change the contact information such as email & chat handles.");
 
   // Glossary Node Privileges
-  public static final Privilege MANAGE_CHILDREN_PRIVILEGE = Privilege.of(
-      "MANAGE_CHILDREN",
-      "Manage Children",
+  public static final Privilege MANAGE_GLOSSARY_CHILDREN_PRIVILEGE = Privilege.of(
+      "MANAGE_GLOSSARY_CHILDREN",
+      "Manage Glossary Children",
       "The ability to create and delete the children of this entity.");
 
   public static final ResourcePrivileges DATASET_PRIVILEGES = ResourcePrivileges.of(
@@ -363,7 +363,7 @@ public class PoliciesConfig {
           EDIT_ENTITY_DOC_LINKS_PRIVILEGE,
           EDIT_ENTITY_DEPRECATION_PRIVILEGE,
           EDIT_ENTITY_PRIVILEGE,
-          MANAGE_CHILDREN_PRIVILEGE)
+          MANAGE_GLOSSARY_CHILDREN_PRIVILEGE)
   );
 
   // Group Privileges

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -249,6 +249,12 @@ public class PoliciesConfig {
       "Edit Contact Information",
       "The ability to change the contact information such as email & chat handles.");
 
+  // Glossary Node Privileges
+  public static final Privilege MANAGE_CHILDREN_PRIVILEGE = Privilege.of(
+      "MANAGE_CHILDREN",
+      "Manage Children",
+      "The ability to create and delete the children of this entity.");
+
   public static final ResourcePrivileges DATASET_PRIVILEGES = ResourcePrivileges.of(
       "dataset",
       "Datasets",
@@ -356,7 +362,8 @@ public class PoliciesConfig {
           EDIT_ENTITY_DOCS_PRIVILEGE,
           EDIT_ENTITY_DOC_LINKS_PRIVILEGE,
           EDIT_ENTITY_DEPRECATION_PRIVILEGE,
-          EDIT_ENTITY_PRIVILEGE)
+          EDIT_ENTITY_PRIVILEGE,
+          MANAGE_CHILDREN_PRIVILEGE)
   );
 
   // Group Privileges


### PR DESCRIPTION
This PR does a few things, all with the goal of allowing users to manage children of entities using our permissions framework. Specifically, the desire was to allow a way for users to allow owners of Glossary Nodes to create, delete, and move Terms and Nodes underneath it. So this PR creates the generic privileges than apply to Nodes but could be applied to other entities. Same thing with a new GraphQL privileges object on an entity. Broken down:

- Create a new `Manage Children` privilege that's applied to Glossary Nodes right now
- Create utility class for Glossary entities to check privileges and other shared methods (including privileges for managing children)
- Create new `EntityPrivileges` object that can be returned on an entity itself
- Create new `EntityPrivilegesResolver` to resolve privileges of different entity types
- Update the frontend for Nodes and Terms to allow for creating, deleting, and moving child Terms and Nodes if a user has permissions.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
