### PR TITLE
fix(adv search): fixing typo in es utils

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -33,7 +33,7 @@ public class ESUtils {
 
   // we use this to make sure we filter for editable & non-editable fields
   public static final String[][] EDITABLE_FIELD_TO_QUERY_PAIRS = {
-      {"fieldGlossaryTags", "editedFieldGlossaryTags"},
+      {"fieldTags", "editedFieldTags"},
       {"fieldGlossaryTerms", "editedFieldGlossaryTerms"},
       {"fieldDescriptions", "editedFieldDescriptions"},
       {"description", "editedDescription"},


### PR DESCRIPTION
Making sure that es utils properly does query expansion for edited tags.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
