### PR TITLE
fix(ingest): fix log line interpolation

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -368,7 +368,9 @@ class Pipeline:
                 except SystemExit:
                     raise
                 except Exception as e:
-                    logger.error("Failed to process some records. Continuing.", exc_info=e)
+                    logger.error(
+                        "Failed to process some records. Continuing.", exc_info=e
+                    )
 
                 self.extractor.close()
                 if not self.dry_run:

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -353,7 +353,7 @@ class Pipeline:
                     if self._time_to_print():
                         self.pretty_print_summary(currently_running=True)
                 except Exception as e:
-                    logger.warning("Failed to print summary", e)
+                    logger.warning(f"Failed to print summary {e}")
 
                 if not self.dry_run:
                     self.sink.handle_work_unit_start(wu)
@@ -368,7 +368,7 @@ class Pipeline:
                 except SystemExit:
                     raise
                 except Exception as e:
-                    logger.error("Failed to process some records. Continuing.", e)
+                    logger.error("Failed to process some records. Continuing.", exc_info=e)
 
                 self.extractor.close()
                 if not self.dry_run:
@@ -393,7 +393,7 @@ class Pipeline:
             self.final_status = "completed"
         except (SystemExit, RuntimeError) as e:
             self.final_status = "cancelled"
-            logger.error("Caught error", e)
+            logger.error("Caught error", exc_info=e)
             raise
         finally:
             if callback and hasattr(callback, "close"):


### PR DESCRIPTION
Without this, logging calls will throw an error.

We really should add linting for this, but only pylint has logging-format-interpolation and the flake8 support for this warning is lacking.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
