### PR TITLE
fix(ui) Fix filters in embedded list search component

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -10,6 +10,18 @@ import { useEntityQueryParams } from '../../../containers/profile/utils';
 import { EmbeddedListSearch } from './EmbeddedListSearch';
 import { UnionType } from '../../../../../search/utils/constants';
 
+const FILTER = 'filter';
+
+function getParamsWithoutFilters(params: QueryString.ParsedQuery<string>) {
+    const paramsCopy = { ...params };
+    Object.keys(paramsCopy).forEach((key) => {
+        if (key.startsWith(FILTER)) {
+            delete paramsCopy[key];
+        }
+    });
+    return paramsCopy;
+}
+
 type Props = {
     emptySearchQuery?: string | null;
     fixedFilter?: FacetFilterInput | null;
@@ -43,7 +55,8 @@ export const EmbeddedListSearchSection = ({
     const entityQueryParams = useEntityQueryParams();
 
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
-    const baseParams = { ...params, ...entityQueryParams };
+    const paramsWithoutFilters = getParamsWithoutFilters(params);
+    const baseParams = { ...entityQueryParams, ...paramsWithoutFilters };
     const query: string = params?.query as string;
     const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
     const unionType: UnionType = Number(params.unionType as any as UnionType) || UnionType.AND;


### PR DESCRIPTION
Remove filters from `baseParams` so that we can properly remove filters from the EmbeddedListSearch component. If query params are not starting with `filter` then we want to keep them so they don't get overwritten on the Lineage Tab for impact analysis.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
