### PR TITLE
refactor(ui): Refactor the Glossary Related Entities, Tag Profiles to use search filters instead of query API. 

### DIFF
--- a/datahub-web-react/src/app/entity/container/ContainerEntitiesTab.tsx
+++ b/datahub-web-react/src/app/entity/container/ContainerEntitiesTab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useEntityData } from '../shared/EntityContext';
 import { EmbeddedListSearchSection } from '../shared/components/styled/search/EmbeddedListSearchSection';
+import { UnionType } from '../../search/utils/constants';
 
 export const ContainerEntitiesTab = () => {
     const { urn } = useEntityData();
@@ -12,7 +13,10 @@ export const ContainerEntitiesTab = () => {
 
     return (
         <EmbeddedListSearchSection
-            fixedFilter={fixedFilter}
+            fixedFilters={{
+                unionType: UnionType.AND,
+                filters: [fixedFilter],
+            }}
             emptySearchQuery="*"
             placeholderText="Filter container entities..."
         />

--- a/datahub-web-react/src/app/entity/domain/DomainEntitiesTab.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntitiesTab.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useEntityData } from '../shared/EntityContext';
 import { EntityType } from '../../../types.generated';
 import { EmbeddedListSearchSection } from '../shared/components/styled/search/EmbeddedListSearchSection';
+import { UnionType } from '../../search/utils/constants';
 
 export const DomainEntitiesTab = () => {
     const { urn, entityType } = useEntityData();
@@ -17,7 +18,10 @@ export const DomainEntitiesTab = () => {
 
     return (
         <EmbeddedListSearchSection
-            fixedFilter={fixedFilter}
+            fixedFilters={{
+                unionType: UnionType.AND,
+                filters: [fixedFilter],
+            }}
             emptySearchQuery="*"
             placeholderText="Filter domain entities..."
         />

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedEntity.tsx
@@ -1,20 +1,49 @@
 import * as React from 'react';
+import { UnionType } from '../../../search/utils/constants';
 import { EmbeddedListSearchSection } from '../../shared/components/styled/search/EmbeddedListSearchSection';
 
 import { useEntityData } from '../../shared/EntityContext';
 
 export default function GlossaryRelatedEntity() {
     const { entityData }: any = useEntityData();
-    const glossaryTermHierarchicalName = entityData?.hierarchicalName;
-    let fixedQueryString = `glossaryTerms:"${glossaryTermHierarchicalName}" OR fieldGlossaryTerms:"${glossaryTermHierarchicalName}" OR editedFieldGlossaryTerms:"${glossaryTermHierarchicalName}"`;
+
+    const entityUrn = entityData?.urn;
+
+    const fixedOrFilters =
+        (entityUrn && [
+            {
+                field: 'glossaryTerms',
+                values: [entityUrn],
+            },
+            {
+                field: 'fieldGlossaryTerms',
+                values: [entityUrn],
+            },
+        ]) ||
+        [];
+
     entityData?.isAChildren?.relationships.forEach((term) => {
-        const name = term.entity?.hierarchicalName;
-        fixedQueryString += `OR glossaryTerms:"${name}" OR fieldGlossaryTerms:"${name}" OR editedFieldGlossaryTerms:"${name}"`;
+        const childUrn = term.entity?.urn;
+
+        if (childUrn) {
+            fixedOrFilters.push({
+                field: 'glossaryTerms',
+                values: [childUrn],
+            });
+
+            fixedOrFilters.push({
+                field: 'fieldGlossaryTerms',
+                values: [childUrn],
+            });
+        }
     });
 
     return (
         <EmbeddedListSearchSection
-            fixedQuery={fixedQueryString}
+            fixedFilters={{
+                unionType: UnionType.OR,
+                filters: fixedOrFilters,
+            }}
             emptySearchQuery="*"
             placeholderText="Filter entities..."
         />

--- a/datahub-web-react/src/app/entity/group/GroupAssets.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupAssets.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { UnionType } from '../../search/utils/constants';
 import { EmbeddedListSearchSection } from '../shared/components/styled/search/EmbeddedListSearchSection';
 
 const GroupAssetsWrapper = styled.div`
@@ -14,7 +15,10 @@ export const GroupAssets = ({ urn }: Props) => {
     return (
         <GroupAssetsWrapper>
             <EmbeddedListSearchSection
-                fixedFilter={{ field: 'owners', values: [urn] }}
+                fixedFilters={{
+                    unionType: UnionType.AND,
+                    filters: [{ field: 'owners', values: [urn] }],
+                }}
                 emptySearchQuery="*"
                 placeholderText="Filter entities..."
             />

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/DownloadAsCsvModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/DownloadAsCsvModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, Input, Modal } from 'antd';
 import { useLocation } from 'react-router';
 
-import { EntityType, FacetFilterInput, SearchAcrossEntitiesInput } from '../../../../../../types.generated';
+import { EntityType, OrFilter, SearchAcrossEntitiesInput } from '../../../../../../types.generated';
 import { SearchResultsInterface } from './types';
 import { getSearchCsvDownloadHeader, transformResultsToCsvRow } from './downloadAsCsvUtil';
 import { downloadRowsAsCsv } from '../../../../../search/utils/csvUtils';
@@ -15,7 +15,7 @@ type Props = {
         input: SearchAcrossEntitiesInput;
     }) => Promise<SearchResultsInterface | null | undefined>;
     entityFilters: EntityType[];
-    filters: FacetFilterInput[];
+    filters: OrFilter[];
     query: string;
     setIsDownloadingCsv: (isDownloadingCsv: boolean) => any;
     showDownloadAsCsvModal: boolean;
@@ -63,7 +63,7 @@ export default function DownloadAsCsvModal({
                     query,
                     start: SEARCH_PAGE_SIZE_FOR_DOWNLOAD * downloadPage,
                     count: SEARCH_PAGE_SIZE_FOR_DOWNLOAD,
-                    filters,
+                    orFilters: filters,
                 },
             }).then((refetchData) => {
                 console.log('fetched data for page number ', downloadPage);

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -52,7 +52,7 @@ export const addFixedQuery = (baseQuery: string, fixedQuery: string, emptyQuery:
 // responds.
 export const removeFixedFiltersFromFacets = (fixedFilters: FilterSet, facets: FacetMetadata[]) => {
     const fixedFields = fixedFilters.filters.map((filter) => filter.field);
-    return facets.filter((facet) => !(fixedFields.indexOf(facet.field) > -1));
+    return facets.filter((facet) => !fixedFields.includes(facet.field));
 };
 
 type Props = {

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -1,17 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { ApolloError } from '@apollo/client';
-import { EntityType, FacetFilterInput } from '../../../../../../types.generated';
+import { EntityType, FacetFilterInput, FacetMetadata } from '../../../../../../types.generated';
 import { ENTITY_FILTER_NAME, UnionType } from '../../../../../search/utils/constants';
 import { SearchCfg } from '../../../../../../conf';
 import { EmbeddedListSearchResults } from './EmbeddedListSearchResults';
 import EmbeddedListSearchHeader from './EmbeddedListSearchHeader';
 import { useGetSearchResultsForMultipleQuery } from '../../../../../../graphql/search.generated';
-import { GetSearchResultsParams, SearchResultsInterface } from './types';
+import { FilterSet, GetSearchResultsParams, SearchResultsInterface } from './types';
 import { isListSubset } from '../../../utils';
 import { EntityAndType } from '../../../types';
 import { Message } from '../../../../../shared/Message';
 import { generateOrFilters } from '../../../../../search/utils/generateOrFilters';
+import { mergeFilterSets } from '../../../../../search/utils/filterUtils';
 
 const Container = styled.div`
     display: flex;
@@ -31,6 +32,7 @@ function useWrappedSearchResults(params: GetSearchResultsParams) {
             refetch(refetchParams).then((res) => res.data.searchAcrossEntities),
     };
 }
+
 // the addFixedQuery checks and generate the query as per params pass to embeddedListSearch
 export const addFixedQuery = (baseQuery: string, fixedQuery: string, emptyQuery: string) => {
     let finalQuery = ``;
@@ -46,6 +48,13 @@ export const addFixedQuery = (baseQuery: string, fixedQuery: string, emptyQuery:
     return finalQuery;
 };
 
+// Simply remove the fields that were marked as fixed from the facets that the server
+// responds.
+export const removeFixedFiltersFromFacets = (fixedFilters: FilterSet, facets: FacetMetadata[]) => {
+    const fixedFields = fixedFilters.filters.map((filter) => filter.field);
+    return facets.filter((facet) => !(fixedFields.indexOf(facet.field) > -1));
+};
+
 type Props = {
     query: string;
     page: number;
@@ -56,7 +65,7 @@ type Props = {
     onChangePage: (page) => void;
     onChangeUnionType: (unionType: UnionType) => void;
     emptySearchQuery?: string | null;
-    fixedFilter?: FacetFilterInput | null;
+    fixedFilters?: FilterSet;
     fixedQuery?: string | null;
     placeholderText?: string | null;
     defaultShowFilters?: boolean;
@@ -81,7 +90,7 @@ export const EmbeddedListSearch = ({
     onChangePage,
     onChangeUnionType,
     emptySearchQuery,
-    fixedFilter,
+    fixedFilters,
     fixedQuery,
     placeholderText,
     defaultShowFilters,
@@ -97,7 +106,16 @@ export const EmbeddedListSearch = ({
     const filtersWithoutEntities: Array<FacetFilterInput> = filters.filter(
         (filter) => filter.field !== ENTITY_FILTER_NAME,
     );
-    const finalFilters = (fixedFilter && [...filtersWithoutEntities, fixedFilter]) || filtersWithoutEntities;
+
+    const baseFilters = {
+        unionType,
+        filters: filtersWithoutEntities,
+    };
+
+    const finalFilters =
+        (fixedFilters && mergeFilterSets(fixedFilters, baseFilters)) ||
+        generateOrFilters(unionType, filtersWithoutEntities);
+
     const entityFilters: Array<EntityType> = filters
         .filter((filter) => filter.field === ENTITY_FILTER_NAME)
         .flatMap((filter) => filter.values?.map((value) => value?.toUpperCase() as EntityType) || []);
@@ -114,8 +132,7 @@ export const EmbeddedListSearch = ({
                 query: finalQuery,
                 start: (page - 1) * SearchCfg.RESULTS_PER_PAGE,
                 count: SearchCfg.RESULTS_PER_PAGE,
-                filters: [],
-                orFilters: generateOrFilters(unionType, finalFilters),
+                orFilters: finalFilters,
             },
         },
         skip: true,
@@ -132,8 +149,7 @@ export const EmbeddedListSearch = ({
                 query: finalQuery,
                 start: (page - 1) * numResultsPerPage,
                 count: numResultsPerPage,
-                filters: [],
-                orFilters: generateOrFilters(unionType, finalFilters),
+                orFilters: finalFilters,
             },
         },
     });
@@ -183,8 +199,13 @@ export const EmbeddedListSearch = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // Filter out the persistent filter values
-    const filteredFilters = data?.facets?.filter((facet) => facet.field !== fixedFilter?.field) || [];
+    /**
+     * Compute the final Facet fields that we show in the left hand search Filters (aggregation).
+     *
+     * Do this by filtering out any fields that are included in the fixed filters.
+     */
+    const finalFacets =
+        (fixedFilters && removeFixedFiltersFromFacets(fixedFilters, data?.facets || [])) || data?.facets;
 
     return (
         <Container>
@@ -210,7 +231,7 @@ export const EmbeddedListSearch = ({
                 unionType={unionType}
                 loading={loading}
                 searchResponse={data}
-                filters={filteredFilters}
+                filters={finalFacets}
                 selectedFilters={filters}
                 onChangeFilters={onChangeFilters}
                 onChangePage={onChangePage}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
@@ -77,6 +77,7 @@ export default function EmbeddedListSearchHeader({
                     </Button>
                     <SearchAndDownloadContainer>
                         <SearchBar
+                            data-testid="embedded-search-bar"
                             initialQuery=""
                             placeholderText={placeholderText || 'Search entities...'}
                             suggestions={[]}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import TabToolbar from '../TabToolbar';
 import { SearchBar } from '../../../../../search/SearchBar';
 import { useEntityRegistry } from '../../../../../useEntityRegistry';
-import { EntityType, FacetFilterInput, SearchAcrossEntitiesInput } from '../../../../../../types.generated';
+import { EntityType, OrFilter, SearchAcrossEntitiesInput } from '../../../../../../types.generated';
 import { SearchResultsInterface } from './types';
 import SearchExtendedMenu from './SearchExtendedMenu';
 import { SearchSelectBar } from './SearchSelectBar';
@@ -36,7 +36,7 @@ type Props = {
         input: SearchAcrossEntitiesInput;
     }) => Promise<SearchResultsInterface | null | undefined>;
     entityFilters: EntityType[];
-    filters: FacetFilterInput[];
+    filters: OrFilter[];
     query: string;
     isSelectMode: boolean;
     isSelectAll: boolean;

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { FacetFilterInput } from '../../../../../../types.generated';
 import { EmbeddedListSearch } from './EmbeddedListSearch';
 import { UnionType } from '../../../../../search/utils/constants';
+import { FilterSet } from './types';
 
 const SearchContainer = styled.div`
     height: 500px;
@@ -18,7 +19,7 @@ const modalBodyStyle = {
 
 type Props = {
     emptySearchQuery?: string | null;
-    fixedFilter?: FacetFilterInput | null;
+    fixedFilters?: FilterSet;
     fixedQuery?: string | null;
     placeholderText?: string | null;
     defaultShowFilters?: boolean;
@@ -30,7 +31,7 @@ type Props = {
 
 export const EmbeddedListSearchModal = ({
     emptySearchQuery,
-    fixedFilter,
+    fixedFilters,
     fixedQuery,
     placeholderText,
     defaultShowFilters,
@@ -79,7 +80,7 @@ export const EmbeddedListSearchModal = ({
                     onChangePage={onChangePage}
                     onChangeUnionType={setUnionType}
                     emptySearchQuery={emptySearchQuery}
-                    fixedFilter={fixedFilter}
+                    fixedFilters={fixedFilters}
                     fixedQuery={fixedQuery}
                     placeholderText={placeholderText}
                     defaultShowFilters={defaultShowFilters}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -10,6 +10,18 @@ import { useEntityQueryParams } from '../../../containers/profile/utils';
 import { EmbeddedListSearch } from './EmbeddedListSearch';
 import { UnionType } from '../../../../../search/utils/constants';
 
+const FILTER = 'filter';
+
+function getParamsWithoutFilters(params: QueryString.ParsedQuery<string>) {
+    const paramsCopy = { ...params };
+    Object.keys(paramsCopy).forEach((key) => {
+        if (key.startsWith(FILTER)) {
+            delete paramsCopy[key];
+        }
+    });
+    return paramsCopy;
+}
+
 type Props = {
     emptySearchQuery?: string | null;
     fixedFilter?: FacetFilterInput | null;
@@ -43,7 +55,8 @@ export const EmbeddedListSearchSection = ({
     const entityQueryParams = useEntityQueryParams();
 
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
-    const baseParams = { ...params, ...entityQueryParams };
+    const paramsWithoutFilters = getParamsWithoutFilters(params);
+    const baseParams = { ...entityQueryParams, ...paramsWithoutFilters };
     const query: string = params?.query as string;
     const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
     const unionType: UnionType = Number(params.unionType as any as UnionType) || UnionType.AND;

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -5,7 +5,7 @@ import { ApolloError } from '@apollo/client';
 import { FacetFilterInput } from '../../../../../../types.generated';
 import useFilters from '../../../../../search/utils/useFilters';
 import { navigateToEntitySearchUrl } from './navigateToEntitySearchUrl';
-import { GetSearchResultsParams, SearchResultsInterface } from './types';
+import { FilterSet, GetSearchResultsParams, SearchResultsInterface } from './types';
 import { useEntityQueryParams } from '../../../containers/profile/utils';
 import { EmbeddedListSearch } from './EmbeddedListSearch';
 import { UnionType } from '../../../../../search/utils/constants';
@@ -24,7 +24,7 @@ function getParamsWithoutFilters(params: QueryString.ParsedQuery<string>) {
 
 type Props = {
     emptySearchQuery?: string | null;
-    fixedFilter?: FacetFilterInput | null;
+    fixedFilters?: FilterSet;
     fixedQuery?: string | null;
     placeholderText?: string | null;
     defaultShowFilters?: boolean;
@@ -41,7 +41,7 @@ type Props = {
 
 export const EmbeddedListSearchSection = ({
     emptySearchQuery,
-    fixedFilter,
+    fixedFilters,
     fixedQuery,
     placeholderText,
     defaultShowFilters,
@@ -82,8 +82,8 @@ export const EmbeddedListSearchSection = ({
             query,
             page: 1,
             filters: newFilters,
-            history,
             unionType,
+            history,
         });
     };
 
@@ -122,7 +122,7 @@ export const EmbeddedListSearchSection = ({
             onChangePage={onChangePage}
             onChangeUnionType={onChangeUnionType}
             emptySearchQuery={emptySearchQuery}
-            fixedFilter={fixedFilter}
+            fixedFilters={fixedFilters}
             fixedQuery={fixedQuery}
             placeholderText={placeholderText}
             defaultShowFilters={defaultShowFilters}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/SearchExtendedMenu.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/SearchExtendedMenu.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button, Dropdown, Menu } from 'antd';
 import { FormOutlined, MoreOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
-import { EntityType, FacetFilterInput, SearchAcrossEntitiesInput } from '../../../../../../types.generated';
+import { EntityType, OrFilter, SearchAcrossEntitiesInput } from '../../../../../../types.generated';
 import { SearchResultsInterface } from './types';
 import DownloadAsCsvButton from './DownloadAsCsvButton';
 import DownloadAsCsvModal from './DownloadAsCsvModal';
@@ -27,7 +27,7 @@ type Props = {
         input: SearchAcrossEntitiesInput;
     }) => Promise<SearchResultsInterface | null | undefined>;
     entityFilters: EntityType[];
-    filters: FacetFilterInput[];
+    filters: OrFilter[];
     query: string;
     setShowSelectMode?: (showSelectMode: boolean) => any;
 };

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
@@ -28,6 +28,10 @@ export const navigateToEntitySearchUrl = ({
         constructedFilters.push({ field: 'entity', values: [newType] });
     }
 
+    console.log(baseUrl);
+    console.log(baseParams);
+    console.log(JSON.stringify(newFilters));
+
     const search = QueryString.stringify(
         {
             ...baseParams,

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
@@ -28,10 +28,6 @@ export const navigateToEntitySearchUrl = ({
         constructedFilters.push({ field: 'entity', values: [newType] });
     }
 
-    console.log(baseUrl);
-    console.log(baseParams);
-    console.log(JSON.stringify(newFilters));
-
     const search = QueryString.stringify(
         {
             ...baseParams,

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/types.ts
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/types.ts
@@ -1,5 +1,6 @@
 import {
     Entity,
+    FacetFilterInput,
     FacetMetadata,
     MatchedField,
     Maybe,
@@ -7,6 +8,7 @@ import {
     SearchAcrossEntitiesInput,
     SearchInsight,
 } from '../../../../../../types.generated';
+import { UnionType } from '../../../../../search/utils/constants';
 
 export type GetSearchResultsParams = {
     variables: {
@@ -47,3 +49,11 @@ export enum SelectActionGroups {
     CHANGE_DEPRECATION,
     DELETE,
 }
+
+/**
+ * A fixed set of Filters, joined in conjunction or disjunction.
+ */
+export type FilterSet = {
+    unionType: UnionType;
+    filters: FacetFilterInput[];
+};

--- a/datahub-web-react/src/app/entity/user/UserAssets.tsx
+++ b/datahub-web-react/src/app/entity/user/UserAssets.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { UnionType } from '../../search/utils/constants';
 import { EmbeddedListSearchSection } from '../shared/components/styled/search/EmbeddedListSearchSection';
 
 const UserAssetsWrapper = styled.div`
@@ -15,7 +16,10 @@ export const UserAssets = ({ urn }: Props) => {
     return (
         <UserAssetsWrapper>
             <EmbeddedListSearchSection
-                fixedFilter={{ field: 'owners', values: [urn] }}
+                fixedFilters={{
+                    unionType: UnionType.AND,
+                    filters: [{ field: 'owners', values: [urn] }],
+                }}
                 emptySearchQuery="*"
                 placeholderText="Filter entities..."
             />

--- a/datahub-web-react/src/app/ingest/source/IngestedAssets.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestedAssets.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { useGetSearchResultsForMultipleQuery } from '../../../graphql/search.generated';
 import { EmbeddedListSearchModal } from '../../entity/shared/components/styled/search/EmbeddedListSearchModal';
 import { ANTD_GRAY } from '../../entity/shared/constants';
+import { UnionType } from '../../search/utils/constants';
 import { formatNumber } from '../../shared/formatNumber';
 import { Message } from '../../shared/Message';
 import { useEntityRegistry } from '../../useEntityRegistry';
@@ -135,7 +136,10 @@ export default function IngestedAssets({ id }: Props) {
             {showAssetSearch && (
                 <EmbeddedListSearchModal
                     searchBarStyle={{ width: 600, marginRight: 40 }}
-                    fixedFilter={{ field: 'runId', values: [id] }}
+                    fixedFilters={{
+                        unionType: UnionType.AND,
+                        filters: [{ field: 'runId', values: [id] }],
+                    }}
                     onClose={() => setShowAssetSearch(false)}
                 />
             )}

--- a/datahub-web-react/src/app/search/SearchFiltersSection.tsx
+++ b/datahub-web-react/src/app/search/SearchFiltersSection.tsx
@@ -71,7 +71,7 @@ export const SearchFiltersSection = ({
                         type="link"
                         onClick={() => setSeeAdvancedFilters(!seeAdvancedFilters)}
                     >
-                        {seeAdvancedFilters ? 'Filter' : 'Advanced'}
+                        {seeAdvancedFilters ? 'Basic' : 'Advanced'}
                     </Button>
                 </span>
             </FiltersHeader>

--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -24,6 +24,7 @@ import { EntityAndType } from '../entity/shared/types';
 import { ErrorSection } from '../shared/error/ErrorSection';
 import { UnionType } from './utils/constants';
 import { SearchFiltersSection } from './SearchFiltersSection';
+import { generateOrFilters } from './utils/generateOrFilters';
 
 const SearchBody = styled.div`
     display: flex;
@@ -161,7 +162,7 @@ export const SearchResults = ({
                                     <SearchExtendedMenu
                                         callSearchOnVariables={callSearchOnVariables}
                                         entityFilters={entityFilters}
-                                        filters={filtersWithoutEntities}
+                                        filters={generateOrFilters(unionType, filtersWithoutEntities)}
                                         query={query}
                                         setShowSelectMode={setIsSelectMode}
                                     />

--- a/datahub-web-react/src/app/search/__tests__/filterUtils.test.tsx
+++ b/datahub-web-react/src/app/search/__tests__/filterUtils.test.tsx
@@ -1,0 +1,218 @@
+import { UnionType } from '../utils/constants';
+import { mergeFilterSets } from '../utils/filterUtils';
+
+describe('filterUtils', () => {
+    describe('mergeFilterSets', () => {
+        it('merge conjunction and conjunction', () => {
+            const conjunction1 = {
+                unionType: UnionType.AND,
+                filters: [
+                    {
+                        field: 'a',
+                        values: ['1', '2'],
+                    },
+                    {
+                        field: 'b',
+                        values: ['1', '2'],
+                    },
+                ],
+            };
+            const conjunction2 = {
+                unionType: UnionType.AND,
+                filters: [
+                    {
+                        field: 'c',
+                        values: ['1', '2'],
+                    },
+                    {
+                        field: 'd',
+                        values: ['1', '2'],
+                    },
+                ],
+            };
+            const expectedResult = [
+                {
+                    and: [
+                        {
+                            field: 'a',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'b',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'c',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'd',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+            ];
+            expect(mergeFilterSets(conjunction1, conjunction2)).toEqual(expectedResult);
+        });
+        it('merge conjunction and disjunction', () => {
+            const conjunction = {
+                unionType: UnionType.AND,
+                filters: [
+                    {
+                        field: 'a',
+                        values: ['1', '2'],
+                    },
+                    {
+                        field: 'b',
+                        values: ['1', '2'],
+                    },
+                ],
+            };
+            const disjunction = {
+                unionType: UnionType.OR,
+                filters: [
+                    {
+                        field: 'c',
+                        values: ['1', '2'],
+                    },
+                    {
+                        field: 'd',
+                        values: ['1', '2'],
+                    },
+                ],
+            };
+            const expectedResult = [
+                {
+                    and: [
+                        {
+                            field: 'c',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'a',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'b',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+                {
+                    and: [
+                        {
+                            field: 'd',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'a',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'b',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+            ];
+            expect(mergeFilterSets(conjunction, disjunction)).toEqual(expectedResult);
+        });
+        it('merge disjunction and disjunction', () => {
+            const disjunction1 = {
+                unionType: UnionType.OR,
+                filters: [
+                    {
+                        field: 'a',
+                        values: ['1', '2'],
+                    },
+                    {
+                        field: 'b',
+                        values: ['1', '2'],
+                    },
+                ],
+            };
+            const disjunction2 = {
+                unionType: UnionType.OR,
+                filters: [
+                    {
+                        field: 'c',
+                        values: ['1', '2'],
+                    },
+                    {
+                        field: 'd',
+                        values: ['1', '2'],
+                    },
+                ],
+            };
+            const expectedResult = [
+                {
+                    and: [
+                        {
+                            field: 'a',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'c',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+                {
+                    and: [
+                        {
+                            field: 'a',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'd',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+                {
+                    and: [
+                        {
+                            field: 'b',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'c',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+                {
+                    and: [
+                        {
+                            field: 'b',
+                            values: ['1', '2'],
+                        },
+                        {
+                            field: 'd',
+                            values: ['1', '2'],
+                        },
+                    ],
+                },
+            ];
+            expect(mergeFilterSets(disjunction1, disjunction2)).toEqual(expectedResult);
+        });
+        it('bad arguments', () => {
+            expect(
+                mergeFilterSets(
+                    {
+                        unionType: UnionType.OR,
+                        filters: [{ field: 'field', values: [] }],
+                    },
+                    null!,
+                ),
+            ).toEqual([]);
+            expect(
+                mergeFilterSets(null!, {
+                    unionType: UnionType.OR,
+                    filters: [{ field: 'field', values: [] }],
+                }),
+            ).toEqual([]);
+            expect(mergeFilterSets(null!, null!)).toEqual([]);
+        });
+    });
+});

--- a/datahub-web-react/src/app/search/utils/constants.ts
+++ b/datahub-web-react/src/app/search/utils/constants.ts
@@ -29,8 +29,8 @@ export const FIELD_TO_LABEL = {
     domains: 'Domain',
     platform: 'Platform',
     fieldTags: 'Column Tag',
-    glossaryTerms: 'Term',
-    fieldGlossaryTerms: 'Column Term',
+    glossaryTerms: 'Glossary Term',
+    fieldGlossaryTerms: 'Column Glossary Term',
     fieldPaths: 'Column Name',
     description: 'Description',
     fieldDescriptions: 'Column Description',
@@ -46,7 +46,9 @@ export const FIELDS_THAT_USE_CONTAINS_OPERATOR = ['description', 'fieldDescripti
 
 export const ADVANCED_SEARCH_ONLY_FILTERS = [
     'fieldGlossaryTerms',
+    'editedFieldGlossaryTerms',
     'fieldTags',
+    'editedFieldTags',
     'fieldPaths',
     'description',
     'fieldDescriptions',

--- a/datahub-web-react/src/app/search/utils/filterUtils.ts
+++ b/datahub-web-react/src/app/search/utils/filterUtils.ts
@@ -19,7 +19,7 @@ import { UnionType } from './constants';
  * @param conjunction1 a conjunctive set of filters
  * @param conjunction2 a conjunctive set of filters
  */
-export const mergeConjunctions = (conjunction1: FacetFilterInput[], conjunction2: FacetFilterInput[]): OrFilter[] => {
+const mergeConjunctions = (conjunction1: FacetFilterInput[], conjunction2: FacetFilterInput[]): OrFilter[] => {
     return [
         {
             and: [...conjunction1, ...conjunction2],
@@ -55,7 +55,7 @@ export const mergeConjunctions = (conjunction1: FacetFilterInput[], conjunction2
  * @param disjunction1 a disjunctive set of filters
  * @param disjunction2 a disjunctive set of filters
  */
-export const mergeDisjunctions = (disjunction1: FacetFilterInput[], disjunction2: FacetFilterInput[]): OrFilter[] => {
+const mergeDisjunctions = (disjunction1: FacetFilterInput[], disjunction2: FacetFilterInput[]): OrFilter[] => {
     const finalOrFilters: OrFilter[] = [];
 
     disjunction1.forEach((d1) => {
@@ -90,10 +90,7 @@ export const mergeDisjunctions = (disjunction1: FacetFilterInput[], disjunction2
  * @param conjunction a conjunctive set of filters
  * @param disjunction a disjunctive set of filters
  */
-export const mergeConjunctionDisjunction = (
-    conjunction: FacetFilterInput[],
-    disjunction: FacetFilterInput[],
-): OrFilter[] => {
+const mergeConjunctionDisjunction = (conjunction: FacetFilterInput[], disjunction: FacetFilterInput[]): OrFilter[] => {
     const finalOrFilters: OrFilter[] = [];
 
     disjunction.forEach((filter) => {
@@ -115,7 +112,7 @@ export const mergeConjunctionDisjunction = (
  * @param orFilters the fixed set of filters in disjunction
  * @param baseFilters a base set of filters in either conjunction or disjunction
  */
-export const mergeOrFilters = (orFilters: FacetFilterInput[], baseFilters: FilterSet): OrFilter[] => {
+const mergeOrFilters = (orFilters: FacetFilterInput[], baseFilters: FilterSet): OrFilter[] => {
     // If the user-provided union type is AND, we need to treat differenty
     // than if user-provided union type is OR.
     if (baseFilters.unionType === UnionType.AND) {
@@ -135,7 +132,7 @@ export const mergeOrFilters = (orFilters: FacetFilterInput[], baseFilters: Filte
  * @param andFilters the fixed set of filters in conjunction
  * @param baseFilters a base set of filters in either conjunction or disjunction
  */
-export const mergeAndFilters = (andFilters: FacetFilterInput[], baseFilters: FilterSet): OrFilter[] => {
+const mergeAndFilters = (andFilters: FacetFilterInput[], baseFilters: FilterSet): OrFilter[] => {
     // If the user-provided union type is AND, we need to treat differenty
     // than if user-provided union type is OR.
     if (baseFilters.unionType === UnionType.AND) {
@@ -146,15 +143,19 @@ export const mergeAndFilters = (andFilters: FacetFilterInput[], baseFilters: Fil
 
 /**
  * Merges in a set of Fixed Filters with user-provided base filters.
+ * Both arguments are required.
  *
  * @param filterSet1 the fixed set of filters to be merged.
  * @param filterSet2 the set of base filters to merge into.
  */
 export const mergeFilterSets = (filterSet1: FilterSet, filterSet2: FilterSet): OrFilter[] => {
-    if (filterSet1.unionType === UnionType.AND) {
-        // Inject fixed AND filters.
-        return mergeAndFilters(filterSet1.filters, filterSet2);
+    if (filterSet1 && filterSet2) {
+        if (filterSet1.unionType === UnionType.AND) {
+            // Inject fixed AND filters.
+            return mergeAndFilters(filterSet1.filters, filterSet2);
+        }
+        // Inject fixed OR filters.
+        return mergeOrFilters(filterSet1.filters, filterSet2);
     }
-    // Inject fixed OR filters.
-    return mergeOrFilters(filterSet1.filters, filterSet2);
+    return [];
 };

--- a/datahub-web-react/src/app/search/utils/filterUtils.ts
+++ b/datahub-web-react/src/app/search/utils/filterUtils.ts
@@ -1,0 +1,160 @@
+import { FacetFilterInput, OrFilter } from '../../../types.generated';
+import { FilterSet } from '../../entity/shared/components/styled/search/types';
+import { UnionType } from './constants';
+
+/**
+ * Combines 2 sets of conjunctive filters in Disjunctive Normal Form
+ *
+ * Input:
+ *
+ *     conjunction1 -> [a, b]
+ *     conjunction2 -> [c, d]
+ *
+ * Output:
+ *
+ *   or: [{
+ *      and: [a, b, c, d]
+ *   }]
+ *
+ * @param conjunction1 a conjunctive set of filters
+ * @param conjunction2 a conjunctive set of filters
+ */
+export const mergeConjunctions = (conjunction1: FacetFilterInput[], conjunction2: FacetFilterInput[]): OrFilter[] => {
+    return [
+        {
+            and: [...conjunction1, ...conjunction2],
+        },
+    ];
+};
+
+/**
+ * Combines 2 sets of disjunctive filters in Disjunctive Normal Form
+ *
+ * Input:
+ *
+ *     disjunction1 -> [a, b]
+ *     disjunction2 -> [c, d]
+ *
+ * Output:
+ *
+ *   or: [
+ *      {
+ *          and: [a, c]
+ *      },
+ *      {
+ *          and: [a, d]
+ *      },
+ *      {
+ *          and: [b, c]
+ *      },
+ *      {
+ *          and: [b, d]
+ *      }
+ *   ]
+ *
+ * @param disjunction1 a disjunctive set of filters
+ * @param disjunction2 a disjunctive set of filters
+ */
+export const mergeDisjunctions = (disjunction1: FacetFilterInput[], disjunction2: FacetFilterInput[]): OrFilter[] => {
+    const finalOrFilters: OrFilter[] = [];
+
+    disjunction1.forEach((d1) => {
+        disjunction2.forEach((d2) => {
+            const andFilters = [d1, d2];
+            finalOrFilters.push({ and: andFilters });
+        });
+    });
+
+    return finalOrFilters;
+};
+
+/**
+ * Combines 2 sets of filters, one conjunctive and the other disjunctive in Disjunctive Normal Form
+ *
+ * Input:
+ *
+ *     conjunction -> [a, b]
+ *     disjunction -> [c, d]
+ *
+ * Output:
+ *
+ *   or: [
+ *      {
+ *        and: [a, b, c]
+ *      },
+ *      {
+ *        and: [a, b, d]
+ *      }
+ *   ]
+ *
+ * @param conjunction a conjunctive set of filters
+ * @param disjunction a disjunctive set of filters
+ */
+export const mergeConjunctionDisjunction = (
+    conjunction: FacetFilterInput[],
+    disjunction: FacetFilterInput[],
+): OrFilter[] => {
+    const finalOrFilters: OrFilter[] = [];
+
+    disjunction.forEach((filter) => {
+        const andFilters = [filter, ...conjunction];
+        finalOrFilters.push({ and: andFilters });
+    });
+
+    return finalOrFilters;
+};
+
+/**
+ * Merges the "fixed" set of disjunctive (OR) filters with a
+ * set of base filters that are themselves joined by a logical operator (AND, OR)
+ *
+ * It does this by producing a set of filters that model the Disjunctive Normal Form,
+ * which is a way of representing any boolean logical operator as an OR (disjunction) performed
+ * across a set of AND (conjunctions) conditions.
+ *
+ * @param orFilters the fixed set of filters in disjunction
+ * @param baseFilters a base set of filters in either conjunction or disjunction
+ */
+export const mergeOrFilters = (orFilters: FacetFilterInput[], baseFilters: FilterSet): OrFilter[] => {
+    // If the user-provided union type is AND, we need to treat differenty
+    // than if user-provided union type is OR.
+    if (baseFilters.unionType === UnionType.AND) {
+        return mergeConjunctionDisjunction(baseFilters.filters, orFilters);
+    }
+    return mergeDisjunctions(orFilters, baseFilters.filters);
+};
+
+/**
+ * Merges the "fixed" set of conjunctive (AND) filters with a
+ * set of base filters that are themselves joined by a logical operator (AND, OR)
+ *
+ * It does this by producing a set of filters that model the Disjunctive Normal Form,
+ * which is a way of representing any boolean logical operator as an OR (disjunction) performed
+ * across a set of AND (conjunctions) conditions.
+ *
+ * @param andFilters the fixed set of filters in conjunction
+ * @param baseFilters a base set of filters in either conjunction or disjunction
+ */
+export const mergeAndFilters = (andFilters: FacetFilterInput[], baseFilters: FilterSet): OrFilter[] => {
+    // If the user-provided union type is AND, we need to treat differenty
+    // than if user-provided union type is OR.
+    if (baseFilters.unionType === UnionType.AND) {
+        return mergeConjunctions(andFilters, baseFilters.filters);
+    }
+    return mergeConjunctionDisjunction(andFilters, baseFilters.filters);
+};
+
+/**
+ * Merges in a set of Fixed Filters with user-provided base filters.
+ *
+ * @param filterSet1 the fixed set of filters to be merged.
+ * @param filterSet2 the set of base filters to merge into.
+ */
+export const mergeFilterSets = (filterSet1: FilterSet, filterSet2: FilterSet): OrFilter[] => {
+    if (filterSet1.unionType === UnionType.AND) {
+        // Inject fixed AND filters.
+        return mergeAndFilters(filterSet1.filters, filterSet2);
+    }
+    // Inject fixed OR filters.
+    return mergeOrFilters(filterSet1.filters, filterSet2);
+};

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -425,19 +425,19 @@ public class SearchRequestHandler {
   }
 
   private void addCriteriaFiltersToAggregationMetadata(@Nonnull final CriterionArray criteria, @Nonnull final List<AggregationMetadata> originalMetadata) {
-    // For each criterion check whether its already appearing in aggregations
-    Map<String, AggregationMetadata> aggMetadataMap = originalMetadata.stream().collect(Collectors.toMap(
-        AggregationMetadata::getName, agg -> agg));
-
     for (Criterion criterion : criteria) {
-      addCriterionFiltersToAggregationMetadata(criterion, originalMetadata, aggMetadataMap);
+      addCriterionFiltersToAggregationMetadata(criterion, originalMetadata);
     }
   }
 
   private void addCriterionFiltersToAggregationMetadata(
       @Nonnull final Criterion criterion,
-      @Nonnull final List<AggregationMetadata> originalMetadata,
-      @Nonnull Map<String, AggregationMetadata> aggregationMetadataMap) {
+      @Nonnull final List<AggregationMetadata> aggregationMetadata) {
+
+    // We should never see duplicate aggregation for the same field in aggregation metadata list.
+    final Map<String, AggregationMetadata> aggregationMetadataMap = aggregationMetadata.stream().collect(Collectors.toMap(
+        AggregationMetadata::getName, agg -> agg));
+
     // Map a filter criterion to a facet field (e.g. domains.keyword -> domains)
     final String finalFacetField = toFacetField(criterion.getField());
 
@@ -453,6 +453,7 @@ public class SearchRequestHandler {
     }
 
     if (aggregationMetadataMap.containsKey(finalFacetField)) {
+
       /*
        * If we already have aggregations for the facet field, simply inject any missing values counts into the set.
        * If there are no results for a particular facet value, it will NOT be in the original aggregation set returned by
@@ -465,13 +466,15 @@ public class SearchRequestHandler {
         addMissingAggregationValueToAggregationMetadata(criterion.getValue(), originalAggMetadata);
       }
     } else {
+      System.out.println(String.format("I found a key NOT already in the map %s", finalFacetField));
+
       /*
        * If we do not have ANY aggregation for the facet field, then inject a new aggregation metadata object for the
        * facet field.
        * If there are no results for a particular facet, it will NOT be in the original aggregation set returned by
        * Elasticsearch.
        */
-      originalMetadata.add(buildAggregationMetadata(
+      aggregationMetadata.add(buildAggregationMetadata(
           finalFacetField,
           _filtersToDisplayName.getOrDefault(finalFacetField, finalFacetField),
           new LongMap(criterion.getValues().stream().collect(Collectors.toMap(i -> i, i -> 0L))),

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -453,7 +453,6 @@ public class SearchRequestHandler {
     }
 
     if (aggregationMetadataMap.containsKey(finalFacetField)) {
-
       /*
        * If we already have aggregations for the facet field, simply inject any missing values counts into the set.
        * If there are no results for a particular facet value, it will NOT be in the original aggregation set returned by
@@ -466,8 +465,6 @@ public class SearchRequestHandler {
         addMissingAggregationValueToAggregationMetadata(criterion.getValue(), originalAggMetadata);
       }
     } else {
-      System.out.println(String.format("I found a key NOT already in the map %s", finalFacetField));
-
       /*
        * If we do not have ANY aggregation for the facet field, then inject a new aggregation metadata object for the
        * facet field.

--- a/smoke-test/tests/cypress/cypress.json
+++ b/smoke-test/tests/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:9002/",
+  "baseUrl": "http://localhost:3000/",
   "chromeWebSecurity": false,
   "viewportHeight": 960,
   "viewportWidth": 1536,

--- a/smoke-test/tests/cypress/cypress.json
+++ b/smoke-test/tests/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:3000/",
+  "baseUrl": "http://localhost:9002/",
   "chromeWebSecurity": false,
   "viewportHeight": 960,
   "viewportWidth": 1536,

--- a/smoke-test/tests/cypress/cypress/integration/glossary/glossaryTerm.js
+++ b/smoke-test/tests/cypress/cypress/integration/glossary/glossaryTerm.js
@@ -1,0 +1,122 @@
+describe("glossaryTerm", () => {
+  it("can visit related entities", () => {
+    cy.login();
+    cy.visit("/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressColumnInfoType/Related%20Entities");
+    cy.wait(5000);
+    cy.contains("of 0").should("not.exist");
+    cy.contains(/of [0-9]+/);
+  });
+
+  it("can search related entities by query", () => {
+    cy.login();
+    cy.visit("/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressColumnInfoType/Related%20Entities");
+    cy.get('[placeholder="Filter entities..."]').click().type(
+      "logging{enter}"
+    );
+    cy.wait(5000);
+    cy.contains("of 0").should("not.exist");
+    cy.contains(/of 1/);
+    cy.contains("cypress_logging_events");
+    cy.contains("SampleCypressHdfsDataset").should("not.exist");
+  });
+
+  it("can apply filters on related entities", () => {
+    cy.login();
+    cy.visit("/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressColumnInfoType/Related%20Entities");
+    cy.wait(5000);
+    // Select tags filter
+    cy.contains("Filters").click();
+
+    cy.get('[data-testid="facet-tags-urn:li:tag:Cypress2"]').click({force: true})
+    cy.wait(3000);
+
+    // Unselect tags filter
+    cy.contains("cypress_logging_events").should("not.exist");
+    cy.contains("SampleCypressHdfsDataset");
+    cy.get('[data-testid="facet-tags-urn:li:tag:Cypress2"]').click({force: true})
+
+    cy.wait(3000);
+    cy.contains("cypress_logging_events");
+    cy.contains("SampleCypressHdfsDataset");
+  });
+
+  it("can search related entities by a specific tag using advanced search", () => {
+    cy.login();
+
+    cy.visit("/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressColumnInfoType/Related%20Entities");
+    cy.wait(3000);
+    cy.contains("Filters").click();
+    cy.contains("Advanced").click();
+    cy.contains("Add Filter").click();
+    cy.contains(/^Tag$/).click({ force: true });
+
+    cy.get('[data-testid="tag-term-modal-input"]').type("Cypress2");
+    cy.wait(2000);
+    cy.get('[data-testid="tag-term-option"]').click({ force: true });
+    cy.get('[data-testid="add-tag-term-from-modal-btn"]').click({
+      force: true,
+    });
+
+    cy.wait(2000);
+    cy.contains("SampleCypressHdfsDataset");
+    // Only 1 result.
+    cy.contains("of 1");
+  });
+
+  it("can search related entities by AND-ing two concepts using advanced search", () => {
+    cy.login();
+
+    cy.visit("/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressColumnInfoType/Related%20Entities");
+    cy.wait(3000);
+    cy.contains("Filters").click();
+    cy.contains("Advanced").click();
+    cy.contains("Add Filter").click();
+    cy.contains(/^Tag$/).click({ force: true });
+    cy.get('[data-testid="tag-term-modal-input"]').type("Cypress2");
+    cy.wait(2000);
+    cy.get('[data-testid="tag-term-option"]').click({ force: true });
+    cy.get('[data-testid="add-tag-term-from-modal-btn"]').click({
+      force: true,
+    });
+    cy.wait(2000);
+    cy.contains("Add Filter").click();
+    cy.get('[data-testid="adv-search-add-filter-description"]').click({
+      force: true,
+    });
+    cy.get('[data-testid="edit-text-input"]').type("my hdfs");
+    cy.get('[data-testid="edit-text-done-btn"]').click({ force: true });
+    cy.contains("SampleCypressHdfsDataset");
+    cy.contains("of 1");
+  });
+
+  it("can search related entities by OR-ing two concepts using advanced search", () => {
+    cy.login();
+
+    cy.visit("/glossaryTerm/urn:li:glossaryTerm:CypressNode.CypressColumnInfoType/Related%20Entities");
+    cy.wait(3000);
+    cy.contains("Filters").click();
+    cy.contains("Advanced").click();
+    cy.contains("Add Filter").click();
+    cy.get('[data-testid="adv-search-add-filter-description"]').click({
+      force: true,
+    });
+    cy.get('[data-testid="edit-text-input"]').type("single log event");
+    cy.get('[data-testid="edit-text-done-btn"]').click({ force: true });
+    cy.wait(2000);
+    cy.contains("Add Filter").click();
+    cy.contains(/^Tag$/).click({ force: true });
+    cy.get('[data-testid="tag-term-modal-input"]').type("Cypress2");
+    cy.wait(2000);
+    cy.get('[data-testid="tag-term-option"]').click({ force: true });
+    cy.get('[data-testid="add-tag-term-from-modal-btn"]').click({
+      force: true,
+    });
+    cy.wait(2000);
+
+    cy.contains("all filters").click();
+    cy.contains("any filter").click({ force: true });
+
+    cy.contains("SampleCypressHdfsDataset");
+    cy.contains("cypress_logging_events");
+  });
+});

--- a/smoke-test/tests/cypress/cypress/integration/search/search.js
+++ b/smoke-test/tests/cypress/cypress/integration/search/search.js
@@ -84,7 +84,7 @@ describe("search", () => {
 
     cy.contains("Add Filter").click();
 
-    cy.contains("Column Term").click({ force: true });
+    cy.contains("Column Glossary Term").click({ force: true });
 
     cy.get('[data-testid="tag-term-modal-input"]').type("CypressColumnInfo");
 
@@ -118,7 +118,7 @@ describe("search", () => {
 
     cy.contains("Add Filter").click();
 
-    cy.contains("Column Term").click({ force: true });
+    cy.contains("Column Glossary Term").click({ force: true });
 
     cy.get('[data-testid="tag-term-modal-input"]').type("CypressColumnInfo");
 
@@ -157,7 +157,7 @@ describe("search", () => {
 
     cy.contains("Add Filter").click();
 
-    cy.contains("Column Term").click({ force: true });
+    cy.contains("Column Glossary Term").click({ force: true });
 
     cy.get('[data-testid="tag-term-modal-input"]').type("CypressColumnInfo");
 

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -152,6 +152,16 @@
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hdfs,SampleCypressHdfsDataset,PROD)",
         "aspects": [
           {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "my hdfs dataset",
+              "uri": null,
+              "tags": [],
+              "customProperties": {
+                "encoding": "utf-8"
+              }
+            }
+          },
+          {
             "com.linkedin.pegasus2avro.common.BrowsePaths": {
               "paths": ["/prod/hdfs/SampleCypressHdfsDataset"]
             }
@@ -390,7 +400,7 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [{ "tag": "urn:li:tag:Cypress" },  { "tag": "urn:li:tag:Cypress2" }]
             }
           }
         ]
@@ -404,6 +414,17 @@
       "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
         "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "my hive dataset",
+              "uri": null,
+              "tags": [],
+              "customProperties": {
+                "prop1": "fakeprop",
+                "prop2": "pikachu"
+              }
+            }
+          },
           {
             "com.linkedin.pegasus2avro.common.Ownership": {
               "owners": [
@@ -1582,6 +1603,39 @@
             "com.linkedin.pegasus2avro.tag.TagProperties": {
               "name": "Cypress",
               "description": "Indicates the entity is for cypress integration test purposes"
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.Ownership": {
+              "owners": [
+                {
+                  "owner": "urn:li:corpuser:jdoe",
+                  "type": "DATAOWNER",
+                  "source": null
+                }
+              ],
+              "lastModified": {
+                "time": 1581407189000,
+                "actor": "urn:li:corpuser:jdoe",
+                "impersonator": null
+              }
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.TagSnapshot": {
+        "urn": "urn:li:tag:Cypress2",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.tag.TagProperties": {
+              "name": "Cypress 2",
+              "description": "Indicates the entity is #2 for cypress test purposes"
             }
           },
           {


### PR DESCRIPTION
## Summary

In this PR we remove dependency on the search query string for looking up entities related to a given glossary term or tag.  This makes the result set much more reliable, as previously special characters in the URN of a glossary or tag URN could cause failures to match at the indexing layer (do to how we tokenize the urn). This fixes those issues.

## Status

Ready to Review. Working on some final cypress tests to cover this. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
