### PR TITLE
fix(schema-history): remove unnecessary margin on version selector

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaHeader.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaHeader.tsx
@@ -108,12 +108,6 @@ const StyledQuestionCircleOutlined = styled(QuestionCircleOutlined)`
     }
 `;
 
-const StyledCaretDownOutlined = styled(CaretDownOutlined)`
-    &&& {
-        margin-top: 8px;
-    }
-`;
-
 const StyledInput = styled(Input)`
     border-radius: 70px;
     max-width: 300px;
@@ -275,7 +269,7 @@ export default function SchemaHeader({
                                     });
                                 }}
                                 data-testid="schema-version-selector-dropdown"
-                                suffixIcon={<StyledCaretDownOutlined />}
+                                suffixIcon={<CaretDownOutlined />}
                             >
                                 {renderOptions()}
                             </SchemaBlameSelector>


### PR DESCRIPTION
## Screenshots
_Before_
![image](https://user-images.githubusercontent.com/19418814/199796026-b3487cbe-23b8-4314-9de0-d9527a9e05be.png)
_After_
![image](https://user-images.githubusercontent.com/19418814/199796123-42996dd2-ac77-48ec-88b9-ae51b77c37dc.png)

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
