### PR TITLE
Install openjdk in base ingestion image

### DIFF
--- a/docker/datahub-ingestion/base.Dockerfile
+++ b/docker/datahub-ingestion/base.Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     zip \
     unzip \
     ldap-utils \
+    openjdk-11-jre-headless \
     && curl -L https://github.com/treff7es/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-${DOCKERIZE_ARCH}-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv \
     && python -m pip install --upgrade pip wheel setuptools==57.5.0 \
     && curl -Lk -o /root/librdkafka-${LIBRDKAFKA_VERSION}.tar.gz https://github.com/edenhill/librdkafka/archive/v${LIBRDKAFKA_VERSION}.tar.gz \


### PR DESCRIPTION
The `acryldata/datahub-ingestion` image is missing Java, meaning that the Kafka connect ingestion can't be run. This is fixed in the PR by installing openjdk 11 JRE in the base ingestion image. This fixes https://github.com/datahub-project/datahub/issues/6310 and possibly also https://github.com/datahub-project/datahub/issues/4741

The fix was tested like this:
```
docker build -t acryldata/datahub-ingestion-base  -f docker/datahub-ingestion/base.Dockerfile .
docker build -t acryldata/datahub-ingestion  -f docker/datahub-ingestion/Dockerfile .

docker run -it --entrypoint="/bin/bash" acryldata/datahub-ingestion 
$ java --version 
> openjdk 11.0.16 2022-07-19
> OpenJDK Runtime Environment (build 11.0.16+8-post-Debian-1deb11u1)
> OpenJDK 64-Bit Server VM (build 11.0.16+8-post-Debian-1deb11u1, mixed mode)

$ exit

docker run -it --user root -v /my/path/recipes:/temp acryldata/datahub-ingestion ingest run --dry-run -c /temp/kafka-connect-to-datahub-kafka.yml
> [2022-11-04 13:22:39,391] INFO     {datahub.cli.ingest_cli:167} - DataHub CLI version: 
> [2022-11-04 13:22:39,419] INFO     {datahub.ingestion.run.pipeline:174} - Sink configured successfully. 
> [2022-11-04 13:22:39,825] INFO     {datahub.ingestion.source.kafka_connect:877} - Connection to <URL> is ok
> [2022-11-04 13:22:39,990] INFO     {datahub.ingestion.run.pipeline:197} - Source configured successfully.
> [2022-11-04 13:22:39,991] INFO     {datahub.cli.ingest_cli:120} - Starting metadata ingestion
> ...
>  Pipeline finished successfully; produced X events in 9.25 seconds.
```
 
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
