### PR TITLE
fix(mae-consumer): Set proper variable expansion for JMX_OPTS and JAVA_OPTS in MAE docker

### DIFF
--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -34,7 +34,7 @@ if [[ ${GRAPH_SERVICE_IMPL:-} != elasticsearch ]] && [[ ${SKIP_NEO4J_CHECK:-fals
   dockerize_args+=("-wait" "$NEO4J_HOST")
 fi
 
-JAVA_TOOL_OPTIONS="${JDK_JAVA_OPTIONS:-}${JAVA_OPTS:+ JAVA_OPTS}${JMX_OPTS:+ JMX_OPTS}"
+JAVA_TOOL_OPTIONS="${JDK_JAVA_OPTIONS:-}${JAVA_OPTS:+ $JAVA_OPTS}${JMX_OPTS:+ $JMX_OPTS}"
 if [[ ${ENABLE_OTEL:-false} == true ]]; then
   JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -javaagent:opentelemetry-javaagent-all.jar"
 fi


### PR DESCRIPTION
JMX_OPTS and JAVA_OPTS are properly expanded in start.sh script of MAE docker image. Before they were missing dollar sign (`$`) and instead of being expanded, in case they were defined, they were passed as strings causing exception like below in MAE container:
```
Picked up JAVA_TOOL_OPTIONS:  JMX_OPTS
Unrecognized option: JMX_OPTS
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
