### PR TITLE
fix(dataset): improve glossary term load performance for datasets

### DIFF
--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -1,3 +1,38 @@
+fragment simplifiedGlossaryTerms on GlossaryTerms {
+    terms {
+        term {
+            urn
+            name
+            type
+            hierarchicalName
+            properties {
+                name
+                description
+                definition
+                termSource
+                customProperties {
+                    key
+                    value
+                }
+            }
+            ownership {
+                ...ownershipFields
+            }
+            parentNodes {
+                count
+                nodes {
+                    urn
+                    type
+                    properties {
+                        name
+                    }
+                }
+            }
+        }
+        associatedUrn
+    }
+}
+
 query getDataProfiles($urn: String!, $limit: Int, $startTime: Long, $endTime: Long) {
     dataset(urn: $urn) {
         urn
@@ -49,7 +84,7 @@ fragment nonSiblingDatasetFields on Dataset {
                 ...globalTagsFields
             }
             glossaryTerms {
-                ...glossaryTerms
+                ...simplifiedGlossaryTerms
             }
         }
     }

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -98,7 +98,7 @@ fragment nonSiblingDatasetFields on Dataset {
         ...globalTagsFields
     }
     glossaryTerms {
-        ...glossaryTerms
+        ...simplifiedGlossaryTerms
     }
     subTypes {
         typeNames


### PR DESCRIPTION
Improves the performance of loading datasets by reducing the amount of information being fetched from the graph database. Data was being fetched that wasn't used and resulted in potentially hundreds of calls to the graph database. This issue is explained more in issue #6395.

The heavy use of fragments in the affected portion of the graphql query means that the problematic code (in the [glossaryNode fragment](https://github.com/datahub-project/datahub/blob/master/datahub-web-react/src/graphql/fragments.graphql#:~:text=%7D-,fragment%20glossaryNode%20on%20GlossaryNode%20%7B,%7D,-fragment%20glossaryTerm%20on)) cannot be changed directly as this additional information is needed by other queries which use this fragment, namely [getGlossaryNode()](https://github.com/datahub-project/datahub/blob/master/datahub-web-react/src/graphql/glossaryNode.graphql#:~:text=query%20getGlossaryNode). Additionally, the glossaryNode fragment is four levels of abstraction away from the primary fragment of the getDataset() query ([nonSiblingDatasetFields](https://github.com/datahub-project/datahub/blob/master/datahub-web-react/src/graphql/dataset.graphql#:~:text=fragment%20nonSiblingDatasetFields) -> glossaryTerms -> glossaryTerm -> parentNodesFields -> glossaryNode). Instead of creating four new fragments for one change at the fourth layer, I combined them into a single new fragment which can then be inserted as a whole into the getDataset() query. If this is not preferred or if the fragment could be better named as something else, then I can make those changes.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
