### PR TITLE
refactor(ingest) Remove s3a/s3/s3n Prefix from paths in the DatahubSparkListener

### DIFF
--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
@@ -19,7 +19,7 @@ public class HdfsPathDataset extends SparkDataset {
          do not have s3*:// in their name.  Remove this from the URI before setting the path.
        */
       if (scheme.equals("s3a") || scheme.equals("s3n")) {
-        toRemove = scheme + "://";
+        String toRemove = scheme + "://";
         return uri.toString().replace(toRemove, "");
       }
       return uri.toString();

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
@@ -16,7 +16,7 @@ public class HdfsPathDataset extends SparkDataset {
     String = uri.getScheme();
     if (includeScheme) {
       /* S3 paths ingested into Datahub through the S3 Data Lake Soure
-         do not have s3*:// in their name.  Remove this from the path before setting the path.
+         do not have s3*:// in their name.  Remove this from the URI before setting the path.
        */
       if (scheme.equals("s3a") || scheme.equals("s3n")) {
         toRemove = scheme + "://";

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/dataset/HdfsPathDataset.java
@@ -13,8 +13,15 @@ public class HdfsPathDataset extends SparkDataset {
 
   private static String getPath(Path path, boolean includeScheme) {
     URI uri = path.toUri();
-
+    String = uri.getScheme();
     if (includeScheme) {
+      /* S3 paths ingested into Datahub through the S3 Data Lake Soure
+         do not have s3*:// in their name.  Remove this from the path before setting the path.
+       */
+      if (scheme.equals("s3a") || scheme.equals("s3n")) {
+        toRemove = scheme + "://";
+        return uri.toString().replace(toRemove, "");
+      }
       return uri.toString();
     } else {
       return uri.getHost() + uri.getPath();


### PR DESCRIPTION
## Checklist
Remove s3a/s3/s3n Prefix from paths in the DatahubSparkListener.
The S3 metadata ingestion source does not have the `s3://` like prefixes at the beginning of their path.  Remove this before uploading to datahub.
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
