### PR TITLE
fix(ui) Improve HoverEntityTooltip and truncate parent glossary nodes

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/ParentNodesView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/ParentNodesView.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Typography, Tooltip } from 'antd';
+import { FolderOutlined, RightOutlined } from '@ant-design/icons';
+import { ANTD_GRAY } from '../../../../constants';
+import { EntityType, GlossaryNode } from '../../../../../../../types.generated';
+import useContentTruncation from '../../../../../../shared/useContentTruncation';
+import { useEntityRegistry } from '../../../../../../useEntityRegistry';
+
+export const StyledRightOutlined = styled(RightOutlined)`
+    color: ${ANTD_GRAY[7]};
+    font-size: 8px;
+    margin: 0 10px;
+`;
+
+// must display content in reverse to have ellipses at the beginning of content
+export const ParentNodesWrapper = styled.div`
+    align-items: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-direction: row-reverse;
+    display: flex;
+`;
+
+export const Ellipsis = styled.span`
+    color: ${ANTD_GRAY[7]};
+    margin-right: 2px;
+`;
+
+export const StyledTooltip = styled(Tooltip)`
+    display: flex;
+    white-space: nowrap;
+    overflow: hidden;
+`;
+
+const GlossaryNodeText = styled(Typography.Text)<{ color: string }>`
+    font-size: 12px;
+    line-height: 20px;
+    color: ${(props) => props.color};
+`;
+
+const GlossaryNodeIcon = styled(FolderOutlined)<{ color: string }>`
+    color: ${(props) => props.color};
+
+    &&& {
+        font-size: 12px;
+        margin-right: 4px;
+    }
+`;
+
+interface Props {
+    parentNodes?: GlossaryNode[] | null;
+}
+
+export default function ParentNodesView({ parentNodes }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const { contentRef, isContentTruncated } = useContentTruncation(parentNodes);
+
+    return (
+        <StyledTooltip
+            title={
+                <>
+                    {[...(parentNodes || [])]?.reverse()?.map((parentNode, idx) => (
+                        <>
+                            <GlossaryNodeIcon color="white" />
+                            <GlossaryNodeText color="white">
+                                {entityRegistry.getDisplayName(EntityType.GlossaryNode, parentNode)}
+                            </GlossaryNodeText>
+                            {idx + 1 !== parentNodes?.length && <StyledRightOutlined data-testid="right-arrow" />}
+                        </>
+                    ))}
+                </>
+            }
+            overlayStyle={isContentTruncated ? {} : { display: 'none' }}
+        >
+            {isContentTruncated && <Ellipsis>...</Ellipsis>}
+            <ParentNodesWrapper ref={contentRef}>
+                {[...(parentNodes || [])]?.map((parentNode, idx) => (
+                    <>
+                        <GlossaryNodeText color={ANTD_GRAY[7]}>
+                            {entityRegistry.getDisplayName(EntityType.GlossaryNode, parentNode)}
+                        </GlossaryNodeText>
+                        <GlossaryNodeIcon color={ANTD_GRAY[7]} />
+                        {idx + 1 !== parentNodes?.length && <StyledRightOutlined data-testid="right-arrow" />}
+                    </>
+                ))}
+            </ParentNodesWrapper>
+        </StyledTooltip>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentContainer.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 import { useEntityRegistry } from '../../../../../../useEntityRegistry';
 import { IconStyleType } from '../../../../../Entity';
 import { useEntityData } from '../../../../EntityContext';
@@ -8,6 +8,7 @@ import PlatformContentView from './PlatformContentView';
 import { GenericEntityProperties } from '../../../../types';
 import EntityRegistry from '../../../../../EntityRegistry';
 import { EntityType } from '../../../../../../../types.generated';
+import useContentTruncation from '../../../../../../shared/useContentTruncation';
 
 export function getDisplayedEntityType(
     entityData: GenericEntityProperties | null,
@@ -18,23 +19,6 @@ export function getDisplayedEntityType(
         (entityData?.subTypes?.typeNames?.length && capitalizeFirstLetterOnly(entityData?.subTypes.typeNames[0])) ||
         entityRegistry.getEntityName(entityType);
     return entityData?.entityTypeOverride || entityTypeCased || '';
-}
-
-export function useParentContainersTruncation(dataDependency: any) {
-    const parentContainersRef = useRef<HTMLDivElement>(null);
-    const [areContainersTruncated, setAreContainersTruncated] = useState(false);
-
-    useEffect(() => {
-        if (
-            parentContainersRef &&
-            parentContainersRef.current &&
-            parentContainersRef.current.scrollWidth > parentContainersRef.current.clientWidth
-        ) {
-            setAreContainersTruncated(true);
-        }
-    }, [dataDependency]);
-
-    return { parentContainersRef, areContainersTruncated };
 }
 
 function PlatformContentContainer() {
@@ -50,7 +34,7 @@ function PlatformContentContainer() {
     const displayedEntityType = getDisplayedEntityType(entityData, entityRegistry, entityType);
     const instanceId = entityData?.dataPlatformInstance?.instanceId;
 
-    const { parentContainersRef, areContainersTruncated } = useParentContainersTruncation(entityData);
+    const { contentRef, isContentTruncated } = useContentTruncation(entityData);
 
     return (
         <PlatformContentView
@@ -65,8 +49,8 @@ function PlatformContentContainer() {
             typeIcon={typeIcon}
             entityType={displayedEntityType}
             parentContainers={entityData?.parentContainers?.containers}
-            parentContainersRef={parentContainersRef}
-            areContainersTruncated={areContainersTruncated}
+            parentContainersRef={contentRef}
+            areContainersTruncated={isContentTruncated}
         />
     );
 }

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Typography, Image, Tooltip } from 'antd';
-import { FolderOutlined, RightOutlined } from '@ant-design/icons';
+import { Typography, Image } from 'antd';
 import { Maybe } from 'graphql/jsutils/Maybe';
 import { Container, GlossaryNode } from '../../../../../../../types.generated';
 import { ANTD_GRAY } from '../../../../constants';
 import ContainerLink from './ContainerLink';
 import { capitalizeFirstLetterOnly } from '../../../../../../shared/textUtil';
+import ParentNodesView, {
+    StyledRightOutlined,
+    ParentNodesWrapper as ParentContainersWrapper,
+    Ellipsis,
+    StyledTooltip,
+} from './ParentNodesView';
 
 const LogoIcon = styled.span`
     display: flex;
@@ -43,46 +48,6 @@ const PlatformDivider = styled.div`
     border-right: 1px solid ${ANTD_GRAY[4]};
     height: 18px;
     vertical-align: text-top;
-`;
-
-const StyledRightOutlined = styled(RightOutlined)`
-    color: ${ANTD_GRAY[7]};
-    font-size: 8px;
-    margin: 0 10px;
-`;
-
-const ParentContainersWrapper = styled.div`
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex-direction: row-reverse;
-    display: flex;
-`;
-
-const Ellipsis = styled.span`
-    color: ${ANTD_GRAY[7]};
-    margin-right: 2px;
-`;
-
-const StyledTooltip = styled(Tooltip)`
-    display: flex;
-    white-space: nowrap;
-    overflow: hidden;
-`;
-
-const GlossaryNodeText = styled(Typography.Text)`
-    font-size: 12px;
-    line-height: 20px;
-    color: ${ANTD_GRAY[7]};
-`;
-
-const GlossaryNodeIcon = styled(FolderOutlined)`
-    color: ${ANTD_GRAY[7]};
-
-    &&& {
-        font-size: 12px;
-        margin-right: 4px;
-    }
 `;
 
 export function getParentContainerNames(containers?: Maybe<Container>[] | null) {
@@ -181,13 +146,7 @@ function PlatformContentView(props: Props) {
                 </ParentContainersWrapper>
                 {directParentContainer && <ContainerLink container={directParentContainer} />}
             </StyledTooltip>
-            {[...(parentNodes || [])]?.reverse()?.map((parentNode, idx) => (
-                <>
-                    <GlossaryNodeIcon />
-                    <GlossaryNodeText>{parentNode?.properties?.name}</GlossaryNodeText>
-                    {idx + 1 !== parentNodes?.length && <StyledRightOutlined data-testid="right-arrow" />}
-                </>
-            ))}
+            <ParentNodesView parentNodes={parentNodes} />
         </PlatformContentWrapper>
     );
 }

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionsList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionsList.tsx
@@ -95,6 +95,7 @@ export const DatasetAssertionsList = ({ assertions, onDelete }: Props) => {
                 const resultColor = (record.lastExecResult && getResultColor(record.lastExecResult)) || 'default';
                 const resultText = (record.lastExecResult && getResultText(record.lastExecResult)) || 'No Evaluations';
                 const resultIcon = (record.lastExecResult && getResultIcon(record.lastExecResult)) || <StopOutlined />;
+                console.log('record', record);
                 return (
                     <ResultContainer>
                         <div>

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -23,7 +23,7 @@ import NoMarkdownViewer from '../entity/shared/components/styled/StripMarkdownTe
 import { getNumberWithOrdinal } from '../entity/shared/utils';
 import { useEntityData } from '../entity/shared/EntityContext';
 import PlatformContentView from '../entity/shared/containers/profile/header/PlatformContent/PlatformContentView';
-import { useParentContainersTruncation } from '../entity/shared/containers/profile/header/PlatformContent/PlatformContentContainer';
+import useContentTruncation from '../shared/useContentTruncation';
 import EntityCount from '../entity/shared/containers/profile/header/EntityCount';
 import { ExpandedActorGroup } from '../entity/shared/components/styled/ExpandedActorGroup';
 import { DeprecationPill } from '../entity/shared/components/styled/DeprecationPill';
@@ -242,7 +242,7 @@ export default function DefaultPreviewCard({
     }
     const [descriptionExpanded, setDescriptionExpanded] = useState(false);
 
-    const { parentContainersRef, areContainersTruncated } = useParentContainersTruncation(container);
+    const { contentRef, isContentTruncated } = useContentTruncation(container);
 
     const onPreventMouseDown = (event) => {
         event.preventDefault();
@@ -266,8 +266,8 @@ export default function DefaultPreviewCard({
                         entityType={type}
                         parentContainers={parentContainers?.containers}
                         parentNodes={parentNodes?.nodes}
-                        parentContainersRef={parentContainersRef}
-                        areContainersTruncated={areContainersTruncated}
+                        parentContainersRef={contentRef}
+                        areContainersTruncated={isContentTruncated}
                     />
                     <EntityTitleContainer>
                         <Link to={url}>

--- a/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
@@ -24,7 +24,7 @@ export const HoverEntityTooltip = ({ entity, canOpen = true, children }: Props) 
             visible={canOpen ? undefined : false}
             color="white"
             placement="topRight"
-            overlayStyle={{ minWidth: 300, maxWidth: 500, width: 'fit-content' }}
+            overlayStyle={{ minWidth: 300, maxWidth: 600, width: 'fit-content' }}
             overlayInnerStyle={{ padding: 12 }}
             title={<a href={url}>{entityRegistry.renderPreview(entity.type, PreviewType.HOVER_CARD, entity)}</a>}
         >

--- a/datahub-web-react/src/app/shared/useContentTruncation.ts
+++ b/datahub-web-react/src/app/shared/useContentTruncation.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useParentContainersTruncation(dataDependency: any) {
+    const contentRef = useRef<HTMLDivElement>(null);
+    const [isContentTruncated, setAreContainersTruncated] = useState(false);
+
+    useEffect(() => {
+        if (contentRef && contentRef.current && contentRef.current.scrollWidth > contentRef.current.clientWidth) {
+            setAreContainersTruncated(true);
+        }
+    }, [dataDependency]);
+
+    return { contentRef, isContentTruncated };
+}


### PR DESCRIPTION
Fixes a bad UX situation in the HoverEntityTooltip where a glossary term has lots of parents and it would cause them to get squished and bleed over to the side with owners by truncating them when they get too long just like we do with parent containers. If you hover over the ellipses we show you the whole path (like containers).

This also increases the maxWidth of this tooltip to allow for some more room when there's lots of content to show. We also still increase the width of the left side content when there's no Owners, so that situation will look good too.

Here's what it was before:
![image](https://user-images.githubusercontent.com/28656603/201435444-8df68063-9b8d-4f56-be1f-cd5fc2b6de2b.png)


and what it looks like now:
<img width="856" alt="image" src="https://user-images.githubusercontent.com/28656603/201435413-97995428-e64f-4026-a605-fcc2b82b5766.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
