### PR TITLE
Make changes to tests for virtual table feature

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/Schema.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/Schema.test.tsx
@@ -5,6 +5,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import TestPageContainer from '../../../../../utils/test-utils/TestPageContainer';
 import {
     sampleSchema,
+    sampleSchemaWithFk,
     sampleSchemaWithKeyValueFields,
     sampleSchemaWithoutFields,
     sampleSchemaWithPkFk,
@@ -39,10 +40,8 @@ describe('Schema', () => {
                 </TestPageContainer>
             </MockedProvider>,
         );
-        expect(getByText('name')).toBeInTheDocument();
-        expect(getByText('the name of the order')).toBeInTheDocument();
-        expect(getByText('shipping_address')).toBeInTheDocument();
-        expect(getByText('the address the order ships to')).toBeInTheDocument();
+        expect(getByText('id')).toBeInTheDocument();
+        expect(getByText('order id')).toBeInTheDocument();
     });
 
     it('renders raw', () => {
@@ -158,7 +157,7 @@ describe('Schema', () => {
                 </TestPageContainer>
             </MockedProvider>,
         );
-        expect(getByText('shipping_address')).toBeInTheDocument();
+        expect(getByText('id')).toBeInTheDocument();
     });
 
     it('renders primary keys', () => {
@@ -197,7 +196,7 @@ describe('Schema', () => {
                             entityType: EntityType.Dataset,
                             entityData: {
                                 description: 'This is a description',
-                                schemaMetadata: sampleSchemaWithPkFk as SchemaMetadata,
+                                schemaMetadata: sampleSchemaWithFk as SchemaMetadata,
                             },
                             baseEntity: {},
                             updateEntity: jest.fn(),
@@ -245,7 +244,6 @@ describe('Schema', () => {
         expect(getByText('Key')).toBeInTheDocument();
         expect(getByText('Value')).toBeInTheDocument();
         expect(getByText('count')).toBeInTheDocument();
-        expect(getByText('cost')).toBeInTheDocument();
         expect(queryByText('id')).not.toBeInTheDocument();
 
         const keyButton = getByText('Key');
@@ -255,7 +253,6 @@ describe('Schema', () => {
         expect(getByText('Value')).toBeInTheDocument();
         expect(getByText('id')).toBeInTheDocument();
         expect(queryByText('count')).not.toBeInTheDocument();
-        expect(queryByText('cost')).not.toBeInTheDocument();
     });
 
     it('does not renders key/value toggle when no schema', () => {

--- a/datahub-web-react/src/app/entity/dataset/profile/stories/sampleSchema.ts
+++ b/datahub-web-react/src/app/entity/dataset/profile/stories/sampleSchema.ts
@@ -197,7 +197,7 @@ export const sampleSchemaWithTags: Schema = {
 };
 
 export const sampleSchemaWithPkFk: SchemaMetadata = {
-    primaryKeys: ['name'],
+    primaryKeys: ['id'],
     foreignKeys: [
         {
             name: 'constraint',
@@ -319,6 +319,45 @@ export const sampleSchemaWithPkFk: SchemaMetadata = {
             description: 'struct representing the payment information',
             type: SchemaFieldDataType.Struct,
             nativeDataType: 'struct',
+            recursive: false,
+        } as SchemaField,
+    ],
+};
+
+export const sampleSchemaWithFk: SchemaMetadata = {
+    foreignKeys: [
+        {
+            name: 'constraint',
+            sourceFields: [
+                {
+                    urn: 'datasetUrn',
+                    type: EntityType.Dataset,
+                    parent: { urn: 'test', type: EntityType.Dataset },
+                    fieldPath: 'shipping_address',
+                },
+            ],
+            foreignFields: [
+                {
+                    urn: dataset3.urn,
+                    type: EntityType.Dataset,
+                    parent: { urn: dataset3.name, type: EntityType.Dataset },
+                    fieldPath: 'address',
+                },
+            ],
+            foreignDataset: dataset3,
+        },
+    ],
+    name: 'MockSchema',
+    platformUrn: 'mock:urn',
+    version: 1,
+    hash: '',
+    fields: [
+        {
+            fieldPath: 'shipping_address',
+            nullable: true,
+            description: 'the address the order ships to',
+            type: SchemaFieldDataType.String,
+            nativeDataType: 'string',
             recursive: false,
         } as SchemaField,
     ],


### PR DESCRIPTION
**Do not merge - this is a branch to help with another feature by showing the diff needed to fix tests**

Here are some fixes for this PR to get tests passing. Basically, the addition of the virtual table only renders the first row in a table in tests, so these changes allow us to test everything that we were testing in our unit tests but with the rows that get rendered by react-testing-library. There may be another solution as well, but this works just fine in my opinion.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
