### PR TITLE
fix(ui) Fix parentNodes overfetching everywhere it's used

### DIFF
--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -1,38 +1,3 @@
-fragment simplifiedGlossaryTerms on GlossaryTerms {
-    terms {
-        term {
-            urn
-            name
-            type
-            hierarchicalName
-            properties {
-                name
-                description
-                definition
-                termSource
-                customProperties {
-                    key
-                    value
-                }
-            }
-            ownership {
-                ...ownershipFields
-            }
-            parentNodes {
-                count
-                nodes {
-                    urn
-                    type
-                    properties {
-                        name
-                    }
-                }
-            }
-        }
-        associatedUrn
-    }
-}
-
 query getDataProfiles($urn: String!, $limit: Int, $startTime: Long, $endTime: Long) {
     dataset(urn: $urn) {
         urn
@@ -84,7 +49,7 @@ fragment nonSiblingDatasetFields on Dataset {
                 ...globalTagsFields
             }
             glossaryTerms {
-                ...simplifiedGlossaryTerms
+                ...glossaryTerms
             }
         }
     }
@@ -98,7 +63,7 @@ fragment nonSiblingDatasetFields on Dataset {
         ...globalTagsFields
     }
     glossaryTerms {
-        ...simplifiedGlossaryTerms
+        ...glossaryTerms
     }
     subTypes {
         typeNames

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -73,7 +73,11 @@ fragment parentContainersFields on ParentContainersResult {
 fragment parentNodesFields on ParentNodesResult {
     count
     nodes {
-        ...glossaryNode
+        urn
+        type
+        properties {
+            name
+        }
     }
 }
 


### PR DESCRIPTION
Builds off of what was done in [this PR](https://github.com/datahub-project/datahub/pull/6396) and makes it more generalized so everyone benefits from the lack of overfecthing.

Basically we don't need `children` from each of the parentNodes and this was causing many more trips to the graph index for no reason.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
