### PR TITLE
fix(ui) Fix glossary side browser width fluctuating

### DIFF
--- a/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
+++ b/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
@@ -37,6 +37,7 @@ const MainContentWrapper = styled.div`
 
 export const BrowserWrapper = styled.div<{ width: number }>`
     max-height: 100%;
+    width: ${(props) => props.width}px;
     min-width: ${(props) => props.width}px;
 `;
 


### PR DESCRIPTION
When a user has a long glossary term / term group name and you switch tabs on a term/node page, the width of the sidebar browser flickers and that looks bad. This fixes it by setting the `width` as well as the `min-width` of the sidebar. It's still dynamic based on page size when you load the page.

**Here's what it looked like before:**

https://user-images.githubusercontent.com/28656603/202214666-2049fe85-05f8-475d-947c-8dfb3927735e.mov

**Here's what it looks like with this change:**

https://user-images.githubusercontent.com/28656603/202214860-078d80b4-8597-4ec0-a6e9-1913b9869b85.mov




## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
