### PR TITLE
feat(ui): Adding Explore all button on home page search

### DIFF
--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -22,6 +22,7 @@ export enum EventType {
     RecommendationImpressionEvent,
     RecommendationClickEvent,
     HomePageRecommendationClickEvent,
+    HomePageExploreAllClickEvent,
     SearchAcrossLineageEvent,
     SearchAcrossLineageResultsViewEvent,
     DownloadAsCsvEvent,
@@ -338,6 +339,10 @@ export interface ShowStandardHomepageEvent extends BaseEvent {
     type: EventType.ShowStandardHomepageEvent;
 }
 
+export interface HomePageExploreAllClickEvent extends BaseEvent {
+    type: EventType.HomePageExploreAllClickEvent;
+}
+
 // Business glossary events
 
 export interface CreateGlossaryEntityEvent extends BaseEvent {
@@ -389,6 +394,7 @@ export type Event =
     | ResetCredentialsEvent
     | SearchEvent
     | HomePageSearchEvent
+    | HomePageExploreAllClickEvent
     | SearchResultsViewEvent
     | SearchResultClickEvent
     | BrowseResultClickEvent

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router';
 import { Typography, Image, Row, Button, Tag } from 'antd';
 import styled, { useTheme } from 'styled-components';
-
+import { RightOutlined } from '@ant-design/icons';
 import { ManageAccount } from '../shared/ManageAccount';
 import { useGetAuthenticatedUser } from '../useGetAuthenticatedUser';
 import { useEntityRegistry } from '../useEntityRegistry';
@@ -68,6 +68,12 @@ const SuggestionsContainer = styled.div`
     align-items: start;
 `;
 
+const SuggestionsHeader = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+`;
+
 const SuggestionTagContainer = styled.div`
     display: flex;
     justify-content: left;
@@ -100,6 +106,27 @@ const SuggestedQueriesText = styled(Typography.Text)`
 
 const SearchBarContainer = styled.div`
     text-align: center;
+`;
+
+const ExploreAllButtonContainer = styled.div`
+    display: flex;
+    justify-content: right;
+`;
+
+const ExploreAllButton = styled(Button)`
+    && {
+        padding: 0px;
+        margin: 0px;
+        height: 16px;
+    }
+`;
+
+const StyledRightOutlined = styled(RightOutlined)`
+    &&& {
+        font-size: 7px;
+        margin-left: 4px;
+        padding: 0px;
+    }
 `;
 
 function truncate(input, length) {
@@ -155,6 +182,16 @@ export const HomePageHeader = () => {
                 },
             });
         }
+    };
+
+    const onClickExploreAll = () => {
+        analytics.event({
+            type: EventType.HomePageExploreAllClickEvent,
+        });
+        navigateToSearchUrl({
+            query: '*',
+            history,
+        });
     };
 
     // Fetch results
@@ -228,7 +265,14 @@ export const HomePageHeader = () => {
                     />
                     {searchResultsToShow && searchResultsToShow.length > 0 && (
                         <SuggestionsContainer>
-                            <SuggestedQueriesText strong>Try searching for</SuggestedQueriesText>
+                            <SuggestionsHeader>
+                                <SuggestedQueriesText strong>Try searching for</SuggestedQueriesText>
+                                <ExploreAllButtonContainer>
+                                    <ExploreAllButton type="link" onClick={onClickExploreAll}>
+                                        Explore all <StyledRightOutlined />
+                                    </ExploreAllButton>
+                                </ExploreAllButtonContainer>
+                            </SuggestionsHeader>
                             <SuggestionTagContainer>
                                 {searchResultsToShow.slice(0, 3).map((suggestion) => (
                                     <SuggestionButton

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -108,11 +108,6 @@ const SearchBarContainer = styled.div`
     text-align: center;
 `;
 
-const ExploreAllButtonContainer = styled.div`
-    display: flex;
-    justify-content: right;
-`;
-
 const ExploreAllButton = styled(Button)`
     && {
         padding: 0px;
@@ -267,11 +262,9 @@ export const HomePageHeader = () => {
                         <SuggestionsContainer>
                             <SuggestionsHeader>
                                 <SuggestedQueriesText strong>Try searching for</SuggestedQueriesText>
-                                <ExploreAllButtonContainer>
-                                    <ExploreAllButton type="link" onClick={onClickExploreAll}>
-                                        Explore all <StyledRightOutlined />
-                                    </ExploreAllButton>
-                                </ExploreAllButtonContainer>
+                                <ExploreAllButton type="link" onClick={onClickExploreAll}>
+                                    Explore all <StyledRightOutlined />
+                                </ExploreAllButton>
                             </SuggestionsHeader>
                             <SuggestionTagContainer>
                                 {searchResultsToShow.slice(0, 3).map((suggestion) => (

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -292,55 +292,57 @@ export const SearchBar = ({
     }
 
     return (
-        <AutoCompleteContainer style={style} ref={searchBarWrapperRef}>
-            <StyledAutoComplete
-                defaultActiveFirstOption={false}
-                style={autoCompleteStyle}
-                options={options}
-                filterOption={false}
-                onSelect={(value: string, option) => {
-                    // If the autocomplete option type is NOT an entity, then render as a normal search query.
-                    if (
-                        option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
-                        option.type === RECOMMENDED_QUERY_OPTION_TYPE
-                    ) {
-                        onSearch(
-                            `${filterSearchQuery(value)}`,
-                            searchEntityTypes.indexOf(option.type) >= 0 ? option.type : undefined,
-                        );
-                    } else {
-                        // Navigate directly to the entity profile.
-                        history.push(getEntityPath(option.type, value, entityRegistry, false, false));
-                        setSelected('');
-                    }
-                }}
-                onSearch={(value: string) => onQueryChange(value)}
-                defaultValue={initialQuery || undefined}
-                value={selected}
-                onChange={(v) => setSelected(filterSearchQuery(v))}
-                dropdownStyle={{
-                    maxHeight: 1000,
-                    overflowY: 'visible',
-                    position: (fixAutoComplete && 'fixed') || 'relative',
-                }}
-            >
-                <StyledSearchBar
-                    placeholder={placeholderText}
-                    onPressEnter={() => {
-                        // e.stopPropagation();
-                        onSearch(filterSearchQuery(searchQuery || ''));
+        <>
+            <AutoCompleteContainer style={style} ref={searchBarWrapperRef}>
+                <StyledAutoComplete
+                    defaultActiveFirstOption={false}
+                    style={autoCompleteStyle}
+                    options={options}
+                    filterOption={false}
+                    onSelect={(value: string, option) => {
+                        // If the autocomplete option type is NOT an entity, then render as a normal search query.
+                        if (
+                            option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
+                            option.type === RECOMMENDED_QUERY_OPTION_TYPE
+                        ) {
+                            onSearch(
+                                `${filterSearchQuery(value)}`,
+                                searchEntityTypes.indexOf(option.type) >= 0 ? option.type : undefined,
+                            );
+                        } else {
+                            // Navigate directly to the entity profile.
+                            history.push(getEntityPath(option.type, value, entityRegistry, false, false));
+                            setSelected('');
+                        }
                     }}
-                    style={inputStyle}
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                    data-testid="search-input"
-                    onFocus={handleFocus}
-                    onBlur={handleBlur}
-                    allowClear
-                    prefix={<SearchOutlined onClick={() => onSearch(filterSearchQuery(searchQuery || ''))} />}
-                />
-            </StyledAutoComplete>
-        </AutoCompleteContainer>
+                    onSearch={(value: string) => onQueryChange(value)}
+                    defaultValue={initialQuery || undefined}
+                    value={selected}
+                    onChange={(v) => setSelected(filterSearchQuery(v))}
+                    dropdownStyle={{
+                        maxHeight: 1000,
+                        overflowY: 'visible',
+                        position: (fixAutoComplete && 'fixed') || 'relative',
+                    }}
+                >
+                    <StyledSearchBar
+                        placeholder={placeholderText}
+                        onPressEnter={() => {
+                            // e.stopPropagation();
+                            onSearch(filterSearchQuery(searchQuery || ''));
+                        }}
+                        style={inputStyle}
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        data-testid="search-input"
+                        onFocus={handleFocus}
+                        onBlur={handleBlur}
+                        allowClear
+                        prefix={<SearchOutlined onClick={() => onSearch(filterSearchQuery(searchQuery || ''))} />}
+                    />
+                </StyledAutoComplete>
+            </AutoCompleteContainer>
+        </>
     );
 };
 

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -292,57 +292,55 @@ export const SearchBar = ({
     }
 
     return (
-        <>
-            <AutoCompleteContainer style={style} ref={searchBarWrapperRef}>
-                <StyledAutoComplete
-                    defaultActiveFirstOption={false}
-                    style={autoCompleteStyle}
-                    options={options}
-                    filterOption={false}
-                    onSelect={(value: string, option) => {
-                        // If the autocomplete option type is NOT an entity, then render as a normal search query.
-                        if (
-                            option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
-                            option.type === RECOMMENDED_QUERY_OPTION_TYPE
-                        ) {
-                            onSearch(
-                                `${filterSearchQuery(value)}`,
-                                searchEntityTypes.indexOf(option.type) >= 0 ? option.type : undefined,
-                            );
-                        } else {
-                            // Navigate directly to the entity profile.
-                            history.push(getEntityPath(option.type, value, entityRegistry, false, false));
-                            setSelected('');
-                        }
+        <AutoCompleteContainer style={style} ref={searchBarWrapperRef}>
+            <StyledAutoComplete
+                defaultActiveFirstOption={false}
+                style={autoCompleteStyle}
+                options={options}
+                filterOption={false}
+                onSelect={(value: string, option) => {
+                    // If the autocomplete option type is NOT an entity, then render as a normal search query.
+                    if (
+                        option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
+                        option.type === RECOMMENDED_QUERY_OPTION_TYPE
+                    ) {
+                        onSearch(
+                            `${filterSearchQuery(value)}`,
+                            searchEntityTypes.indexOf(option.type) >= 0 ? option.type : undefined,
+                        );
+                    } else {
+                        // Navigate directly to the entity profile.
+                        history.push(getEntityPath(option.type, value, entityRegistry, false, false));
+                        setSelected('');
+                    }
+                }}
+                onSearch={(value: string) => onQueryChange(value)}
+                defaultValue={initialQuery || undefined}
+                value={selected}
+                onChange={(v) => setSelected(filterSearchQuery(v))}
+                dropdownStyle={{
+                    maxHeight: 1000,
+                    overflowY: 'visible',
+                    position: (fixAutoComplete && 'fixed') || 'relative',
+                }}
+            >
+                <StyledSearchBar
+                    placeholder={placeholderText}
+                    onPressEnter={() => {
+                        // e.stopPropagation();
+                        onSearch(filterSearchQuery(searchQuery || ''));
                     }}
-                    onSearch={(value: string) => onQueryChange(value)}
-                    defaultValue={initialQuery || undefined}
-                    value={selected}
-                    onChange={(v) => setSelected(filterSearchQuery(v))}
-                    dropdownStyle={{
-                        maxHeight: 1000,
-                        overflowY: 'visible',
-                        position: (fixAutoComplete && 'fixed') || 'relative',
-                    }}
-                >
-                    <StyledSearchBar
-                        placeholder={placeholderText}
-                        onPressEnter={() => {
-                            // e.stopPropagation();
-                            onSearch(filterSearchQuery(searchQuery || ''));
-                        }}
-                        style={inputStyle}
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        data-testid="search-input"
-                        onFocus={handleFocus}
-                        onBlur={handleBlur}
-                        allowClear
-                        prefix={<SearchOutlined onClick={() => onSearch(filterSearchQuery(searchQuery || ''))} />}
-                    />
-                </StyledAutoComplete>
-            </AutoCompleteContainer>
-        </>
+                    style={inputStyle}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    data-testid="search-input"
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                    allowClear
+                    prefix={<SearchOutlined onClick={() => onSearch(filterSearchQuery(searchQuery || ''))} />}
+                />
+            </StyledAutoComplete>
+        </AutoCompleteContainer>
     );
 };
 


### PR DESCRIPTION
## Summary

Adding a button for browsing all entities from the Home page. This allows users to start exploring before they know exactly what exists inside of DataHub. 

## Demo

https://user-images.githubusercontent.com/17549204/202368305-1082a09f-cccf-472c-b0bb-9b847798bd6e.mov


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
