### PR TITLE
refactor(ui): Simplify base glossary page toolbar  

### DIFF
--- a/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
+++ b/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
@@ -2,10 +2,8 @@ import React, { useState } from 'react';
 import { Button, Typography } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import styled from 'styled-components/macro';
-
 import { useGetRootGlossaryNodesQuery, useGetRootGlossaryTermsQuery } from '../../graphql/glossary.generated';
 import TabToolbar from '../entity/shared/components/styled/TabToolbar';
-import GlossaryEntitiesPath from './GlossaryEntitiesPath';
 import GlossaryEntitiesList from './GlossaryEntitiesList';
 import GlossaryBrowser from './GlossaryBrowser/GlossaryBrowser';
 import GlossarySearch from './GlossarySearch';
@@ -93,9 +91,8 @@ function BusinessGlossaryPage() {
                     isSidebarOnLeft
                 />
                 <MainContentWrapper>
-                    <GlossaryEntitiesPath />
                     <HeaderWrapper>
-                        <Typography.Title level={3}>Glossary</Typography.Title>
+                        <Typography.Title level={3}>Business Glossary</Typography.Title>
                         <div>
                             <Button type="text" onClick={() => setIsCreateTermModalVisible(true)}>
                                 <PlusOutlined /> Add Term


### PR DESCRIPTION
## Summary

Removing the duplicative "browse" bar in the Glossary page.

Before:
<img width="1205" alt="Screen Shot 2022-11-16 at 10 14 19 PM" src="https://user-images.githubusercontent.com/17549204/202370743-6f1d072a-e5ab-42f4-857a-df4320a29387.png">

After:
<img width="1309" alt="Screen Shot 2022-11-16 at 10 13 25 PM" src="https://user-images.githubusercontent.com/17549204/202370762-af409923-7352-457e-b762-34676e04f6f5.png">



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
