### PR TITLE
Ownership type is deprecated

### DIFF
--- a/metadata-ingestion/examples/library/dataset_add_owner.py
+++ b/metadata-ingestion/examples/library/dataset_add_owner.py
@@ -20,7 +20,7 @@ logging.basicConfig(level=logging.INFO)
 
 # Inputs -> owner, ownership_type, dataset
 owner_to_add = make_user_urn("jdoe")
-ownership_type = OwnershipTypeClass.DATAOWNER
+ownership_type = OwnershipTypeClass.TECHNICAL_OWNER
 dataset_urn = make_dataset_urn(platform="hive", name="realestate_db.sales", env="PROD")
 
 # Some objects to help with conditional pathways later


### PR DESCRIPTION
fix: ownership type is deprecated

the ownership type is deprecated (described in OwnershipTypeClass), thats why it should be changed from DATAOWNER to TECHNICAL_OWNER


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
