### PR TITLE
revert: mssql - lowercase db name in mssql ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql.py
@@ -122,7 +122,7 @@ class SQLServerSource(SQLAlchemySource):
         super().__init__(config, ctx, "mssql")
         # Cache the table and column descriptions
         self.config: SQLServerConfig = config
-        self.current_database: Optional[str] = None
+        self.current_database = None
         self.table_descriptions: Dict[str, str] = {}
         self.column_descriptions: Dict[str, str] = {}
         for inspector in self.get_inspectors():
@@ -262,5 +262,5 @@ class SQLServerSource(SQLAlchemySource):
                 return f"{self.config.database_alias}.{regular}"
             return f"{self.config.database}.{regular}"
         if self.current_database:
-            return f"{self.current_database.lower()}.{regular}"
+            return f"{self.current_database}.{regular}"
         return regular


### PR DESCRIPTION
This reverts commit cf6fb91f8dbf180b5a54ee9af701a26e608f2737.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
