### PR TITLE
Added the parent nodes view to all searched glossary term in search bar

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/ParentNodesView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/ParentNodesView.tsx
@@ -34,24 +34,24 @@ export const StyledTooltip = styled(Tooltip)`
     overflow: hidden;
 `;
 
-const GlossaryNodeText = styled(Typography.Text)<{ color: string; fontSize: number }>`
+const GlossaryNodeText = styled(Typography.Text)<{ color: string; fontSize?: number }>`
     line-height: 20px;
-    font-size: ${(props) => props.fontSize};
+    font-size: ${(props) => (props.fontSize ? props.fontSize : 12)}px;
     color: ${(props) => props.color};
 `;
 
-const GlossaryNodeIcon = styled(FolderOutlined)<{ color: string; fontSize: number }>`
+const GlossaryNodeIcon = styled(FolderOutlined)<{ color: string; fontSize?: number }>`
     color: ${(props) => props.color};
 
     &&& {
-        font-size: ${(props) => props.fontSize};
+        font-size: ${(props) => (props.fontSize ? props.fontSize : 12)}px;
         margin-right: 4px;
     }
 `;
 
 interface Props {
     parentNodes?: GlossaryNode[] | null;
-    customizeFontSize: number;
+    customizeFontSize?: number;
 }
 
 export default function ParentNodesView({ parentNodes, customizeFontSize }: Props) {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/ParentNodesView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/ParentNodesView.tsx
@@ -34,26 +34,27 @@ export const StyledTooltip = styled(Tooltip)`
     overflow: hidden;
 `;
 
-const GlossaryNodeText = styled(Typography.Text)<{ color: string }>`
-    font-size: 12px;
+const GlossaryNodeText = styled(Typography.Text)<{ color: string; fontSize: number }>`
     line-height: 20px;
+    font-size: ${(props) => props.fontSize};
     color: ${(props) => props.color};
 `;
 
-const GlossaryNodeIcon = styled(FolderOutlined)<{ color: string }>`
+const GlossaryNodeIcon = styled(FolderOutlined)<{ color: string; fontSize: number }>`
     color: ${(props) => props.color};
 
     &&& {
-        font-size: 12px;
+        font-size: ${(props) => props.fontSize};
         margin-right: 4px;
     }
 `;
 
 interface Props {
     parentNodes?: GlossaryNode[] | null;
+    customizeFontSize: number;
 }
 
-export default function ParentNodesView({ parentNodes }: Props) {
+export default function ParentNodesView({ parentNodes, customizeFontSize }: Props) {
     const entityRegistry = useEntityRegistry();
     const { contentRef, isContentTruncated } = useContentTruncation(parentNodes);
 
@@ -63,8 +64,8 @@ export default function ParentNodesView({ parentNodes }: Props) {
                 <>
                     {[...(parentNodes || [])]?.reverse()?.map((parentNode, idx) => (
                         <>
-                            <GlossaryNodeIcon color="white" />
-                            <GlossaryNodeText color="white">
+                            <GlossaryNodeIcon color="white" fontSize={customizeFontSize} />
+                            <GlossaryNodeText color="white" fontSize={customizeFontSize}>
                                 {entityRegistry.getDisplayName(EntityType.GlossaryNode, parentNode)}
                             </GlossaryNodeText>
                             {idx + 1 !== parentNodes?.length && <StyledRightOutlined data-testid="right-arrow" />}
@@ -78,10 +79,10 @@ export default function ParentNodesView({ parentNodes }: Props) {
             <ParentNodesWrapper ref={contentRef}>
                 {[...(parentNodes || [])]?.map((parentNode, idx) => (
                     <>
-                        <GlossaryNodeText color={ANTD_GRAY[7]}>
+                        <GlossaryNodeText color={ANTD_GRAY[7]} fontSize={customizeFontSize}>
                             {entityRegistry.getDisplayName(EntityType.GlossaryNode, parentNode)}
                         </GlossaryNodeText>
-                        <GlossaryNodeIcon color={ANTD_GRAY[7]} />
+                        <GlossaryNodeIcon color={ANTD_GRAY[7]} fontSize={customizeFontSize} />
                         {idx + 1 !== parentNodes?.length && <StyledRightOutlined data-testid="right-arrow" />}
                     </>
                 ))}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
@@ -146,7 +146,7 @@ function PlatformContentView(props: Props) {
                 </ParentContainersWrapper>
                 {directParentContainer && <ContainerLink container={directParentContainer} />}
             </StyledTooltip>
-            <ParentNodesView parentNodes={parentNodes} />
+            <ParentNodesView parentNodes={parentNodes} customizeFontSize={12} />
         </PlatformContentWrapper>
     );
 }

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
@@ -146,7 +146,7 @@ function PlatformContentView(props: Props) {
                 </ParentContainersWrapper>
                 {directParentContainer && <ContainerLink container={directParentContainer} />}
             </StyledTooltip>
-            <ParentNodesView parentNodes={parentNodes} customizeFontSize={12} />
+            <ParentNodesView parentNodes={parentNodes} />
         </PlatformContentWrapper>
     );
 }

--- a/datahub-web-react/src/app/glossary/GlossarySearch.tsx
+++ b/datahub-web-react/src/app/glossary/GlossarySearch.tsx
@@ -31,7 +31,6 @@ const ResultsWrapper = styled.div`
 
 const ParentViewWrapper = styled.div`
     margin-bottom: 5px;
-    font-size: 8px;
 `;
 
 const SearchResult = styled(Link)`

--- a/datahub-web-react/src/app/glossary/GlossarySearch.tsx
+++ b/datahub-web-react/src/app/glossary/GlossarySearch.tsx
@@ -5,6 +5,7 @@ import { useGetSearchResultsForMultipleQuery } from '../../graphql/search.genera
 import { EntityType } from '../../types.generated';
 import { IconStyleType } from '../entity/Entity';
 import { ANTD_GRAY } from '../entity/shared/constants';
+import ParentNodesView from '../entity/shared/containers/profile/header/PlatformContent/ParentNodesView';
 import { SearchBar } from '../search/SearchBar';
 import ClickOutside from '../shared/ClickOutside';
 import { useEntityRegistry } from '../useEntityRegistry';
@@ -86,17 +87,20 @@ function GlossarySearch() {
                 />
                 {isSearchBarFocused && searchResults && !!searchResults.length && (
                     <ResultsWrapper>
-                        {searchResults.map((result) => {
+                        {searchResults.map((result: any) => {
                             return (
-                                <SearchResult
-                                    to={`/${entityRegistry.getPathName(result.entity.type)}/${result.entity.urn}`}
-                                    onClick={() => setIsSearchBarFocused(false)}
-                                >
-                                    <IconWrapper>
-                                        {entityRegistry.getIcon(result.entity.type, 12, IconStyleType.ACCENT)}
-                                    </IconWrapper>
-                                    {entityRegistry.getDisplayName(result.entity.type, result.entity)}
-                                </SearchResult>
+                                <>
+                                    <ParentNodesView parentNodes={result.entity.parentNodes.nodes} />
+                                    <SearchResult
+                                        to={`/${entityRegistry.getPathName(result.entity.type)}/${result.entity.urn}`}
+                                        onClick={() => setIsSearchBarFocused(false)}
+                                    >
+                                        <IconWrapper>
+                                            {entityRegistry.getIcon(result.entity.type, 12, IconStyleType.ACCENT)}
+                                        </IconWrapper>
+                                        {entityRegistry.getDisplayName(result.entity.type, result.entity)}
+                                    </SearchResult>
+                                </>
                             );
                         })}
                     </ResultsWrapper>

--- a/datahub-web-react/src/app/glossary/GlossarySearch.tsx
+++ b/datahub-web-react/src/app/glossary/GlossarySearch.tsx
@@ -29,6 +29,11 @@ const ResultsWrapper = styled.div`
     top: 45px;
 `;
 
+const ParentViewWrapper = styled.div`
+    margin-bottom: 5px;
+    font-size: 8px;
+`;
+
 const SearchResult = styled(Link)`
     color: #262626;
     display: inline-block;
@@ -90,11 +95,16 @@ function GlossarySearch() {
                         {searchResults.map((result: any) => {
                             return (
                                 <>
-                                    <ParentNodesView parentNodes={result.entity.parentNodes.nodes} />
                                     <SearchResult
                                         to={`/${entityRegistry.getPathName(result.entity.type)}/${result.entity.urn}`}
                                         onClick={() => setIsSearchBarFocused(false)}
                                     >
+                                        <ParentViewWrapper>
+                                            <ParentNodesView
+                                                parentNodes={result.entity.parentNodes.nodes}
+                                                customizeFontSize={10}
+                                            />
+                                        </ParentViewWrapper>
                                         <IconWrapper>
                                             {entityRegistry.getIcon(result.entity.type, 12, IconStyleType.ACCENT)}
                                         </IconWrapper>


### PR DESCRIPTION
![parent_path_1](https://user-images.githubusercontent.com/86347578/202974991-f2f79c51-475a-4d2d-a77b-77823e3c4f96.png)

![parent_path_2](https://user-images.githubusercontent.com/86347578/202974846-86ffe46a-2c4b-476b-815e-128dfde6fbe6.png)
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
