### PR TITLE
feat(ingest): allow extracting snowflake tags

### DIFF
--- a/metadata-ingestion/docs/sources/snowflake/snowflake_pre.md
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_pre.md
@@ -16,7 +16,7 @@ grant usage on DATABASE "<your-database>" to role datahub_role;
 grant usage on all schemas in database "<your-database>" to role datahub_role;
 grant usage on future schemas in database "<your-database>" to role datahub_role;
 
-// If you are NOT using Snowflake Profiling or Classification feature: Grant references privileges to your tables and views 
+// If you are NOT using Snowflake Profiling or Classification feature: Grant references privileges to your tables and views
 grant references on all tables in database "<your-database>" to role datahub_role;
 grant references on future tables in database "<your-database>" to role datahub_role;
 grant references on all external tables in database "<your-database>" to role datahub_role;
@@ -30,10 +30,10 @@ grant select on future tables in database "<your-database>" to role datahub_role
 grant select on all external tables in database "<your-database>" to role datahub_role;
 grant select on future external tables in database "<your-database>" to role datahub_role;
 
-// Create a new DataHub user and assign the DataHub role to it 
+// Create a new DataHub user and assign the DataHub role to it
 create user datahub_user display_name = 'DataHub' password='' default_role = datahub_role default_warehouse = '<your-warehouse>';
 
-// Grant the datahub_role to the new DataHub user. 
+// Grant the datahub_role to the new DataHub user.
 grant role datahub_role to user datahub_user;
 ```
 
@@ -50,7 +50,7 @@ grant usage on schema "<your-database>"."<your-schema>" to role datahub_role;
 
 This represents the bare minimum privileges required to extract databases, schemas, views, tables from Snowflake.
 
-If you plan to enable extraction of table lineage, via the `include_table_lineage` config flag or extraction of usage statistics, via the `include_usage_stats` config, you'll also need to grant access to the [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage.html) system tables, using which the DataHub source extracts information. This can be done by granting access to the `snowflake` database.
+If you plan to enable extraction of table lineage, via the `include_table_lineage` config flag, extraction of usage statistics, via the `include_usage_stats` config, or extraction of tags (without lineage), via the `extract_tags` config, you'll also need to grant access to the [Account Usage](https://docs.snowflake.com/en/sql-reference/account-usage.html) system tables, using which the DataHub source extracts information. This can be done by granting access to the `snowflake` database.
 
 ```sql
 grant imported privileges on database snowflake to role datahub_role;

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
@@ -36,6 +36,9 @@ class SnowflakeObjectDomain(str, Enum):
     EXTERNAL_TABLE = "external table"
     VIEW = "view"
     MATERIALIZED_VIEW = "materialized view"
+    DATABASE = "database"
+    SCHEMA = "schema"
+    COLUMN = "column"
 
 
 GENERIC_PERMISSION_ERROR_KEY = "permission-error"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -62,7 +62,7 @@ class SnowflakeV2Config(
 
     extract_tags: TagOption = Field(
         default=TagOption.skip,
-        description="""Optionally. Allowed values are `without_lineage`, `with_lineage`, and `skip` (default).
+        description="""Optional. Allowed values are `without_lineage`, `with_lineage`, and `skip` (default).
         `without_lineage` only extracts tags that have been applied directly to the given entity.
         `with_lineage` extracts both directly applied and propagated tags, but will be significantly slower.
         See the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/object-tagging.html#tag-lineage) for information about tag lineage/propagation. """,
@@ -93,7 +93,7 @@ class SnowflakeV2Config(
 
     tag_pattern: AllowDenyPattern = Field(
         default=AllowDenyPattern.allow_all(),
-        description="List of regex patterns for tags to include in ingestion.",
+        description="List of regex patterns for tags to include in ingestion. Only used if `extract_tags` is enabled.",
     )
 
     @root_validator(pre=False)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -91,6 +91,11 @@ class SnowflakeV2Config(
             )
         return v
 
+    tag_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="List of regex patterns for tags to include in ingestion.",
+    )
+
     @root_validator(pre=False)
     def validate_unsupported_configs(cls, values: Dict) -> Dict:
         value = values.get("provision_role")

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -1,4 +1,5 @@
 import logging
+from enum import Enum
 from typing import Dict, Optional, cast
 
 from pydantic import Field, SecretStr, root_validator, validator
@@ -17,6 +18,12 @@ from datahub.ingestion.source_config.sql.snowflake import (
 from datahub.ingestion.source_config.usage.snowflake_usage import SnowflakeUsageConfig
 
 logger = logging.Logger(__name__)
+
+
+class TagOption(str, Enum):
+    with_lineage = "with_lineage"
+    without_lineage = "without_lineage"
+    skip = "skip"
 
 
 class SnowflakeV2Config(
@@ -51,6 +58,14 @@ class SnowflakeV2Config(
 
     provision_role: Optional[SnowflakeProvisionRoleConfig] = Field(
         default=None, description="Not supported"
+    )
+
+    extract_tags: TagOption = Field(
+        default=TagOption.skip,
+        description="""Optionally. Allowed values are `without_lineage`, `with_lineage`, and `skip` (default).
+        `without_lineage` only extracts tags that have been applied directly to the given entity.
+        `with_lineage` extracts both directly applied and propagated tags, but will be significantly slower.
+        See the [Snowflake documentation](https://docs.snowflake.com/en/user-guide/object-tagging.html#tag-lineage) for information about tag lineage/propagation. """,
     )
 
     classification: Optional[ClassificationConfig] = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -138,7 +138,9 @@ class SnowflakeQuery:
         """
 
     @staticmethod
-    def get_tags_on_columns(db_name: str, quoted_table_identifier: str) -> str:
+    def get_tags_on_columns_with_propagation(
+        db_name: str, quoted_table_identifier: str
+    ) -> str:
         # https://docs.snowflake.com/en/sql-reference/functions/tag_references_all_columns.html
         return f"""
         SELECT tag_database as "TAG_DATABASE",

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -115,7 +115,7 @@ class SnowflakeQuery:
         tag_schema AS "TAG_SCHEMA",
         tag_name AS "TAG_NAME",
         tag_value AS "TAG_VALUE"
-        FROM table("{db_name}".information_schema.tag_references({quoted_identifier}, '{domain}'));
+        FROM table("{db_name}".information_schema.tag_references('{quoted_identifier}', '{domain}'));
         """
 
     @staticmethod
@@ -146,7 +146,7 @@ class SnowflakeQuery:
         tag_name AS "TAG_NAME",
         tag_value AS "TAG_VALUE",
         column_name AS "COLUMN_NAME"
-        FROM table("{db_name}".information_schema.tag_references_all_columns({quoted_table_identifier}, 'table'));
+        FROM table("{db_name}".information_schema.tag_references_all_columns('{quoted_table_identifier}', 'table'));
         """
 
     # View definition is retrived in information_schema query only if role is owner of view. Hence this query is not used.

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -106,7 +106,7 @@ class SnowflakeQuery:
         order by table_schema, table_name"""
 
     @staticmethod
-    def get_all_tags_on_object_with_lineage(
+    def get_all_tags_on_object_with_propagation(
         db_name: str, quoted_identifier: str, domain: str
     ) -> str:
         # https://docs.snowflake.com/en/sql-reference/functions/tag_references.html

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -106,14 +106,16 @@ class SnowflakeQuery:
         order by table_schema, table_name"""
 
     @staticmethod
-    def get_all_tags_on_object(db_name: str, identifier: str, domain: str) -> str:
+    def get_all_tags_on_object(
+        db_name: str, quoted_identifier: str, domain: str
+    ) -> str:
         # https://docs.snowflake.com/en/sql-reference/functions/tag_references.html
         return f"""
         SELECT tag_database as "TAG_DATABASE",
         tag_schema AS "TAG_SCHEMA",
         tag_name AS "TAG_NAME",
         tag_value AS "TAG_VALUE"
-        FROM table({db_name}.information_schema.tag_references('{identifier}', '{domain}'));
+        FROM table("{db_name}".information_schema.tag_references({quoted_identifier}, '{domain}'));
         """
 
     @staticmethod
@@ -136,7 +138,7 @@ class SnowflakeQuery:
         """
 
     @staticmethod
-    def get_tags_on_column(db_name: str, table_identifier: str) -> str:
+    def get_tags_on_column(db_name: str, quoted_table_identifier: str) -> str:
         # https://docs.snowflake.com/en/sql-reference/functions/tag_references_all_columns.html
         return f"""
         SELECT tag_database as "TAG_DATABASE",
@@ -144,7 +146,7 @@ class SnowflakeQuery:
         tag_name AS "TAG_NAME",
         tag_value AS "TAG_VALUE",
         column_name AS "COLUMN_NAME"
-        FROM table({db_name}.information_schema.tag_references_all_columns('{table_identifier}', 'table'));
+        FROM table("{db_name}".information_schema.tag_references_all_columns({quoted_table_identifier}, 'table'));
         """
 
     # View definition is retrived in information_schema query only if role is owner of view. Hence this query is not used.

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -105,6 +105,48 @@ class SnowflakeQuery:
         and table_type in ('BASE TABLE', 'EXTERNAL TABLE')
         order by table_schema, table_name"""
 
+    @staticmethod
+    def get_all_tags_on_object(db_name: str, identifier: str, domain: str) -> str:
+        # https://docs.snowflake.com/en/sql-reference/functions/tag_references.html
+        return f"""
+        SELECT tag_database as "TAG_DATABASE",
+        tag_schema AS "TAG_SCHEMA",
+        tag_name AS "TAG_NAME",
+        tag_value AS "TAG_VALUE"
+        FROM table({db_name}.information_schema.tag_references('{identifier}', '{domain}'));
+        """
+
+    @staticmethod
+    def get_all_tags_in_database_without_propagation(db_name: str) -> str:
+        # https://docs.snowflake.com/en/sql-reference/account-usage/tag_references.html
+        return f"""
+        SELECT tag_database as "TAG_DATABASE",
+        tag_schema AS "TAG_SCHEMA",
+        tag_name AS "TAG_NAME",
+        tag_value AS "TAG_VALUE",
+        object_database as "OBJECT_DATABASE",
+        object_schema AS "OBJECT_SCHEMA",
+        object_name AS "OBJECT_NAME",
+        column_name AS "COLUMN_NAME",
+        domain as "DOMAIN"
+        FROM snowflake.account_usage.tag_references
+        WHERE (object_database = '{db_name}' OR object_name = '{db_name}')
+        AND domain in ('DATABASE', 'SCHEMA', 'TABLE', 'COLUMN')
+        AND object_deleted IS NULL;
+        """
+
+    @staticmethod
+    def get_tags_on_column(db_name: str, table_identifier: str) -> str:
+        # https://docs.snowflake.com/en/sql-reference/functions/tag_references_all_columns.html
+        return f"""
+        SELECT tag_database as "TAG_DATABASE",
+        tag_schema AS "TAG_SCHEMA",
+        tag_name AS "TAG_NAME",
+        tag_value AS "TAG_VALUE",
+        column_name AS "COLUMN_NAME"
+        FROM table({db_name}.information_schema.tag_references_all_columns('{table_identifier}', 'table'));
+        """
+
     # View definition is retrived in information_schema query only if role is owner of view. Hence this query is not used.
     # https://community.snowflake.com/s/article/Is-it-possible-to-see-the-view-definition-in-information-schema-views-from-a-non-owner-role
     @staticmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -106,7 +106,7 @@ class SnowflakeQuery:
         order by table_schema, table_name"""
 
     @staticmethod
-    def get_all_tags_on_object(
+    def get_all_tags_on_object_with_lineage(
         db_name: str, quoted_identifier: str, domain: str
     ) -> str:
         # https://docs.snowflake.com/en/sql-reference/functions/tag_references.html
@@ -138,7 +138,7 @@ class SnowflakeQuery:
         """
 
     @staticmethod
-    def get_tags_on_column(db_name: str, quoted_table_identifier: str) -> str:
+    def get_tags_on_columns(db_name: str, quoted_table_identifier: str) -> str:
         # https://docs.snowflake.com/en/sql-reference/functions/tag_references_all_columns.html
         return f"""
         SELECT tag_database as "TAG_DATABASE",

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
@@ -1,4 +1,4 @@
-from typing import Optional, MutableSet
+from typing import MutableSet, Optional
 
 from datahub.ingestion.source.snowflake.constants import SnowflakeEdition
 from datahub.ingestion.source.sql.sql_generic_profiler import ProfilingSqlReport

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, MutableSet
 
 from datahub.ingestion.source.snowflake.constants import SnowflakeEdition
 from datahub.ingestion.source.sql.sql_generic_profiler import ProfilingSqlReport
@@ -12,6 +12,7 @@ class SnowflakeV2Report(SnowflakeReport, SnowflakeUsageReport, ProfilingSqlRepor
 
     schemas_scanned: int = 0
     databases_scanned: int = 0
+    tags_scanned: int = 0
 
     include_usage_stats: bool = False
     include_operational_stats: bool = False
@@ -31,7 +32,15 @@ class SnowflakeV2Report(SnowflakeReport, SnowflakeUsageReport, ProfilingSqlRepor
     num_get_views_for_schema_queries: int = 0
     num_get_columns_for_table_queries: int = 0
 
+    # these will be non-zero if the user choses to enable the extract_tags = "with_lineage" option, which requires
+    # individual queries per object (database, schema, table) and an extra query per table to get the tags on the columns.
+    num_get_tags_for_object_queries: int = 0
+    num_get_tags_on_columns_for_table_queries: int = 0
+
     rows_zero_objects_modified: int = 0
+
+    _processed_tags: MutableSet[str] = set()
+    _scanned_tags: MutableSet[str] = set()
 
     edition: Optional[SnowflakeEdition] = None
 
@@ -47,5 +56,21 @@ class SnowflakeV2Report(SnowflakeReport, SnowflakeUsageReport, ProfilingSqlRepor
             self.schemas_scanned += 1
         elif ent_type == "database":
             self.databases_scanned += 1
+        elif ent_type == "tag":
+            # the same tag can be assigned to multiple objects, so we need
+            # some extra logic account for each tag only once.
+            if self._is_tag_scanned(name):
+                return
+            self._scanned_tags.add(name)
+            self.tags_scanned += 1
         else:
             raise KeyError(f"Unknown entity {ent_type}.")
+
+    def is_tag_processed(self, tag_name: str) -> bool:
+        return tag_name in self._processed_tags
+
+    def _is_tag_scanned(self, tag_name: str) -> bool:
+        return tag_name in self._scanned_tags
+
+    def report_tag_processed(self, tag_name: str) -> None:
+        self._processed_tags.add(tag_name)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -37,10 +37,10 @@ class SnowflakeTag:
     name: str
     value: str
 
-    def __str__(self):
-        return f"{self.id_as_str()}:{self.value}"
+    def identifier(self)->str:
+        return f"{self._id_prefix_as_str()}:{self.value}"
 
-    def id_as_str(self):
+    def _id_prefix_as_str(self)->str:
         return f"{self.database}.{self.schema}.{self.name}"
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Optional
@@ -29,11 +30,23 @@ class SnowflakeFK:
     referred_column_names: List[str]
 
 
+@dataclass
+class SnowflakeTag:
+    database: str
+    schema: str
+    name: str
+    value: str
+
+    def __str__(self):
+        return f"{self.database}.{self.schema}.{self.name}={self.value}".lower()
+
+
 @dataclass(frozen=True, eq=True)
 class SnowflakeColumn(BaseColumn):
     character_maximum_length: Optional[int]
     numeric_precision: Optional[int]
     numeric_scale: Optional[int]
+    tags: Optional[List[SnowflakeTag]] = None
 
     def get_precise_native_type(self):
         precise_native_type = self.data_type
@@ -61,12 +74,14 @@ class SnowflakeTable(BaseTable):
     pk: Optional[SnowflakePK] = None
     columns: List[SnowflakeColumn] = field(default_factory=list)
     foreign_keys: List[SnowflakeFK] = field(default_factory=list)
+    tags: Optional[List[SnowflakeTag]] = None
     sample_data: Optional[pd.DataFrame] = None
 
 
 @dataclass
 class SnowflakeView(BaseView):
     columns: List[SnowflakeColumn] = field(default_factory=list)
+    tags: Optional[List[SnowflakeTag]] = None
 
 
 @dataclass
@@ -77,6 +92,7 @@ class SnowflakeSchema:
     comment: Optional[str]
     tables: List[SnowflakeTable] = field(default_factory=list)
     views: List[SnowflakeView] = field(default_factory=list)
+    tags: Optional[List[SnowflakeTag]] = None
 
 
 @dataclass
@@ -86,6 +102,64 @@ class SnowflakeDatabase:
     comment: Optional[str]
     last_altered: Optional[datetime] = None
     schemas: List[SnowflakeSchema] = field(default_factory=list)
+    tags: Optional[List[SnowflakeTag]] = None
+
+
+class _SnowflakeTagCache:
+    def __init__(self) -> None:
+        self._database_tags: Dict[str, List[SnowflakeTag]] = defaultdict(list)
+        self._schema_tags: Dict[str, Dict[str, List[SnowflakeTag]]] = defaultdict(
+            lambda: defaultdict(list)
+        )
+        self._table_tags: Dict[
+            str, Dict[str, Dict[str, List[SnowflakeTag]]]
+        ] = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        self._column_tags: Dict[
+            str, Dict[str, Dict[str, Dict[str, List[SnowflakeTag]]]]
+        ] = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+        )
+
+    def add_database_tag(self, db_name: str, tag: SnowflakeTag) -> None:
+        self._database_tags[db_name].append(tag)
+
+    def get_database_tags(self, db_name: str) -> List[SnowflakeTag]:
+        return self._database_tags.get(db_name, [])
+
+    def add_schema_tag(self, schema_name: str, db_name: str, tag: SnowflakeTag) -> None:
+        self._schema_tags[db_name][schema_name].append(tag)
+
+    def get_schema_tags(self, schema_name: str, db_name: str) -> List[SnowflakeTag]:
+        return self._schema_tags.get(db_name, {}).get(schema_name, [])
+
+    def add_table_tag(
+        self, table_name: str, schema_name: str, db_name: str, tag: SnowflakeTag
+    ) -> None:
+        self._table_tags[db_name][schema_name][table_name].append(tag)
+
+    def get_table_tags(
+        self, table_name: str, schema_name: str, db_name: str
+    ) -> List[SnowflakeTag]:
+        return (
+            self._table_tags.get(db_name, {}).get(schema_name, {}).get(table_name, [])
+        )
+
+    def add_column_tag(
+        self,
+        column_name: str,
+        table_name: str,
+        schema_name: str,
+        db_name: str,
+        tag: SnowflakeTag,
+    ) -> None:
+        self._column_tags[db_name][schema_name][table_name][column_name].append(tag)
+
+    def get_column_tags_for_table(
+        self, table_name: str, schema_name: str, db_name: str
+    ) -> Dict[str, List[SnowflakeTag]]:
+        return (
+            self._column_tags.get(db_name, {}).get(schema_name, {}).get(table_name, {})
+        )
 
 
 class SnowflakeDataDictionary(SnowflakeQueryMixin):
@@ -142,6 +216,8 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         cur = self.query(
             SnowflakeQuery.schemas_for_database(db_name),
         )
+
+        # get tags as strings
 
         for schema in cur:
             snowflake_schema = SnowflakeSchema(
@@ -358,3 +434,109 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
             constraints[row["fk_table_name"]].append(fk_constraints_map[row["fk_name"]])
 
         return constraints
+
+    def get_tags_for_database_without_propagation(
+        self,
+        conn: SnowflakeConnection,
+        db_name: str,
+    ) -> _SnowflakeTagCache:
+        cur = self.query(
+            SnowflakeQuery.get_all_tags_in_database_without_propagation(db_name)
+        )
+
+        tags = _SnowflakeTagCache()
+
+        for tag in cur:
+            snowflake_tag = SnowflakeTag(
+                database=tag["TAG_DATABASE"],
+                schema=tag["TAG_SCHEMA"],
+                name=tag["TAG_NAME"],
+                value=tag["TAG_VALUE"],
+            )
+
+            # This is the name of the object, unless the object is a column, in which
+            # case the name is in the `COLUMN_NAME` field.
+            object_name = tag["OBJECT_NAME"]
+            # This will be null if the object is a database or schema
+            object_schema = tag["OBJECT_SCHEMA"]
+            # This will be null if the object is a database
+            object_database = tag["OBJECT_DATABASE"]
+
+            domain = tag["DOMAIN"]
+            if domain == "DATABASE":
+                tags.add_database_tag(object_name, snowflake_tag)
+            elif domain == "SCHEMA":
+                tags.add_schema_tag(object_name, object_database, snowflake_tag)
+            elif domain == "TABLE":  # including views
+                tags.add_table_tag(
+                    object_name, object_schema, object_database, snowflake_tag
+                )
+            elif domain == "COLUMN":
+                column_name = tag["COLUMN_NAME"]
+                tags.add_column_tag(
+                    column_name,
+                    object_name,
+                    object_schema,
+                    object_database,
+                    snowflake_tag,
+                )
+            else:
+                # This should never happen.
+                continue
+
+        return tags
+
+    def get_tags_for_object(
+        self,
+        conn: SnowflakeConnection,
+        table_name: Optional[str],
+        schema_name: Optional[str],
+        db_name: str,
+    ) -> List[SnowflakeTag]:
+        domain = "database"
+        identifier = db_name
+        if schema_name is not None:
+            domain = "schema"
+            identifier = f"{identifier}.{schema_name}"
+            if table_name is not None:
+                domain = "table"
+                identifier = f"{identifier}.{table_name}"
+
+        tags: list[SnowflakeTag] = []
+
+        cur = self.query(
+            SnowflakeQuery.get_all_tags_on_object(db_name, identifier, domain),
+        )
+
+        for tag in cur:
+            tags.append(
+                SnowflakeTag(
+                    database=tag["TAG_DATABASE"],
+                    schema=tag["TAG_SCHEMA"],
+                    name=tag["TAG_NAME"],
+                    value=tag["TAG_VALUE"],
+                )
+            )
+        return tags
+
+    def get_tags_on_columns_for_table(
+        self, conn: SnowflakeConnection, table_name: str, schema_name: str, db_name: str
+    ) -> Dict[str, List[SnowflakeTag]]:
+        tags: Dict[str, List[SnowflakeTag]] = defaultdict(list)
+        cur = self.query(
+            SnowflakeQuery.get_tags_on_column(
+                db_name, f"{db_name}.{schema_name}.{table_name}"
+            ),
+        )
+
+        for tag in cur:
+            column_name = tag["COLUMN_NAME"]
+            snowflake_tag = SnowflakeTag(
+                database=tag["TAG_DATABASE"],
+                schema=tag["TAG_SCHEMA"],
+                name=tag["TAG_NAME"],
+                value=tag["TAG_VALUE"],
+            )
+            tags[column_name].append(snowflake_tag)
+
+        return tags

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -495,7 +495,7 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
 
         return tags
 
-    def get_tags_for_object_with_lineage(
+    def get_tags_for_object_with_propagation(
         self,
         domain: str,
         quoted_identifier: str,
@@ -504,7 +504,7 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         tags: List[SnowflakeTag] = []
 
         cur = self.query(
-            SnowflakeQuery.get_all_tags_on_object_with_lineage(
+            SnowflakeQuery.get_all_tags_on_object_with_propagation(
                 db_name, quoted_identifier, domain
             ),
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -49,7 +49,6 @@ class SnowflakeColumn(BaseColumn):
     character_maximum_length: Optional[int]
     numeric_precision: Optional[int]
     numeric_scale: Optional[int]
-    tags: Optional[List[SnowflakeTag]] = None
 
     def get_precise_native_type(self):
         precise_native_type = self.data_type
@@ -78,6 +77,7 @@ class SnowflakeTable(BaseTable):
     columns: List[SnowflakeColumn] = field(default_factory=list)
     foreign_keys: List[SnowflakeFK] = field(default_factory=list)
     tags: Optional[List[SnowflakeTag]] = None
+    column_tags: Dict[str, List[SnowflakeTag]] = field(default_factory=dict)
     sample_data: Optional[pd.DataFrame] = None
 
 
@@ -85,6 +85,7 @@ class SnowflakeTable(BaseTable):
 class SnowflakeView(BaseView):
     columns: List[SnowflakeColumn] = field(default_factory=list)
     tags: Optional[List[SnowflakeTag]] = None
+    column_tags: Dict[str, List[SnowflakeTag]] = field(default_factory=dict)
 
 
 @dataclass
@@ -440,7 +441,6 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
 
     def get_tags_for_database_without_propagation(
         self,
-        conn: SnowflakeConnection,
         db_name: str,
     ) -> _SnowflakeTagCache:
         cur = self.query(
@@ -492,7 +492,6 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
 
     def get_tags_for_object(
         self,
-        conn: SnowflakeConnection,
         domain: str,
         quoted_identifier: str,
         db_name: str,
@@ -515,7 +514,7 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         return tags
 
     def get_tags_on_columns_for_table(
-        self, conn: SnowflakeConnection, quoted_table_name: str, db_name: str
+        self, quoted_table_name: str, db_name: str
     ) -> Dict[str, List[SnowflakeTag]]:
         tags: Dict[str, List[SnowflakeTag]] = defaultdict(list)
         cur = self.query(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -502,7 +502,7 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
                 domain = "table"
                 identifier = f"{identifier}.{table_name}"
 
-        tags: list[SnowflakeTag] = []
+        tags: List[SnowflakeTag] = []
 
         cur = self.query(
             SnowflakeQuery.get_all_tags_on_object(db_name, identifier, domain),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -38,7 +38,10 @@ class SnowflakeTag:
     value: str
 
     def __str__(self):
-        return f"{self.database}.{self.schema}.{self.name}={self.value}".lower()
+        return f"{self.id_as_str()}={self.value}".lower()
+
+    def id_as_str(self):
+        return f"{self.database}.{self.schema}.{self.name}".lower()
 
 
 @dataclass(frozen=True, eq=True)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -38,10 +38,10 @@ class SnowflakeTag:
     value: str
 
     def __str__(self):
-        return f"{self.id_as_str()}={self.value}".lower()
+        return f"{self.id_as_str()}:{self.value}"
 
     def id_as_str(self):
-        return f"{self.database}.{self.schema}.{self.name}".lower()
+        return f"{self.database}.{self.schema}.{self.name}"
 
 
 @dataclass(frozen=True, eq=True)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -482,6 +482,7 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
                 )
             else:
                 # This should never happen.
+                self.logger.error(f"Encountered an unexpected domain: {domain}")
                 continue
 
         return tags

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -490,23 +490,14 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
     def get_tags_for_object(
         self,
         conn: SnowflakeConnection,
-        table_name: Optional[str],
-        schema_name: Optional[str],
+        domain: str,
+        quoted_identifier: str,
         db_name: str,
     ) -> List[SnowflakeTag]:
-        domain = "database"
-        identifier = db_name
-        if schema_name is not None:
-            domain = "schema"
-            identifier = f"{identifier}.{schema_name}"
-            if table_name is not None:
-                domain = "table"
-                identifier = f"{identifier}.{table_name}"
-
         tags: List[SnowflakeTag] = []
 
         cur = self.query(
-            SnowflakeQuery.get_all_tags_on_object(db_name, identifier, domain),
+            SnowflakeQuery.get_all_tags_on_object(db_name, quoted_identifier, domain),
         )
 
         for tag in cur:
@@ -521,13 +512,11 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         return tags
 
     def get_tags_on_columns_for_table(
-        self, conn: SnowflakeConnection, table_name: str, schema_name: str, db_name: str
+        self, conn: SnowflakeConnection, quoted_table_name: str, db_name: str
     ) -> Dict[str, List[SnowflakeTag]]:
         tags: Dict[str, List[SnowflakeTag]] = defaultdict(list)
         cur = self.query(
-            SnowflakeQuery.get_tags_on_column(
-                db_name, f"{db_name}.{schema_name}.{table_name}"
-            ),
+            SnowflakeQuery.get_tags_on_column(db_name, quoted_table_name),
         )
 
         for tag in cur:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
@@ -30,9 +30,6 @@ class SnowflakeTagExtractor(SnowflakeCommonMixin):
 
         self.tag_cache: Optional[_SnowflakeTagCache] = None
 
-    def invalidate_cache(self):
-        self.tag_cache = None
-
     def get_tags_on_object(
         self,
         domain: str,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
@@ -77,7 +77,7 @@ class SnowflakeTagExtractor(SnowflakeCommonMixin):
             assert identifier
 
             self.report.num_get_tags_for_object_queries += 1
-            tags = self.data_dictionary.get_tags_for_object(
+            tags = self.data_dictionary.get_tags_for_object_with_lineage(
                 domain=domain, quoted_identifier=identifier, db_name=db_name
             )
         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
@@ -1,0 +1,139 @@
+import logging
+from typing import Dict, List, Optional
+
+from datahub.ingestion.source.snowflake.snowflake_config import (
+    SnowflakeV2Config,
+    TagOption,
+)
+from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
+from datahub.ingestion.source.snowflake.snowflake_schema import (
+    SnowflakeDataDictionary,
+    SnowflakeTag,
+    _SnowflakeTagCache,
+)
+from datahub.ingestion.source.snowflake.snowflake_utils import SnowflakeCommonMixin
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class SnowflakeTagExtractor(SnowflakeCommonMixin):
+    def __init__(
+        self,
+        config: SnowflakeV2Config,
+        data_dictionary: SnowflakeDataDictionary,
+        report: SnowflakeV2Report,
+    ) -> None:
+        self.config = config
+        self.data_dictionary = data_dictionary
+        self.report = report
+        self.logger = logger
+
+        self.tag_cache: Optional[_SnowflakeTagCache] = None
+
+    def invalidate_cache(self):
+        self.tag_cache = None
+
+    def get_tags_on_object(
+        self,
+        domain: str,
+        db_name: str,
+        schema_name: Optional[str] = None,
+        table_name: Optional[str] = None,
+    ) -> List[SnowflakeTag]:
+        if self.config.extract_tags == TagOption.without_lineage:
+            if self.tag_cache is None:
+                self.tag_cache = (
+                    self.data_dictionary.get_tags_for_database_without_propagation(
+                        db_name
+                    )
+                )
+
+            if domain == "database":
+                return self.tag_cache.get_database_tags(db_name)
+            elif domain == "schema":
+                assert schema_name is not None
+                tags = self.tag_cache.get_schema_tags(schema_name, db_name)
+            elif domain == "table":  # Views belong to this domain as well.
+                assert schema_name is not None
+                assert table_name is not None
+                tags = self.tag_cache.get_table_tags(table_name, schema_name, db_name)
+            else:
+                raise ValueError(f"Unknown domain {domain}")
+        elif self.config.extract_tags == TagOption.with_lineage:
+            identifier = ""
+            if domain == "database":
+                identifier = self.get_quoted_identifier_for_database(db_name)
+            elif domain == "schema":
+                assert schema_name is not None
+                identifier = self.get_quoted_identifier_for_schema(db_name, schema_name)
+            elif domain == "table":  # Views belong to this domain as well.
+                assert schema_name is not None
+                assert table_name is not None
+                identifier = self.get_quoted_identifier_for_table(
+                    db_name, schema_name, table_name
+                )
+            else:
+                raise ValueError(f"Unknown domain {domain}")
+            assert identifier
+
+            self.report.num_get_tags_for_object_queries += 1
+            tags = self.data_dictionary.get_tags_for_object(
+                domain=domain, quoted_identifier=identifier, db_name=db_name
+            )
+        else:
+            tags = []
+
+        allowed_tags = self._filter_tags(tags)
+
+        return allowed_tags if allowed_tags else []
+
+    def get_column_tags_for_table(
+        self,
+        table_name: str,
+        schema_name: str,
+        db_name: str,
+    ) -> Dict[str, List[SnowflakeTag]]:
+        temp_column_tags: Dict[str, List[SnowflakeTag]] = {}
+        if self.config.extract_tags == TagOption.without_lineage:
+            if self.tag_cache is None:
+                self.tag_cache = (
+                    self.data_dictionary.get_tags_for_database_without_propagation(
+                        db_name
+                    )
+                )
+            temp_column_tags = self.tag_cache.get_column_tags_for_table(
+                table_name, schema_name, db_name
+            )
+        elif self.config.extract_tags == TagOption.with_lineage:
+            self.report.num_get_tags_on_columns_for_table_queries += 1
+            temp_column_tags = self.data_dictionary.get_tags_on_columns_for_table(
+                quoted_table_name=self.get_quoted_identifier_for_table(
+                    db_name, schema_name, table_name
+                ),
+                db_name=db_name,
+            )
+
+        column_tags: Dict[str, List[SnowflakeTag]] = {}
+
+        for column_name in temp_column_tags:
+            tags = temp_column_tags[column_name]
+            allowed_tags = self._filter_tags(tags)
+            if allowed_tags:
+                column_tags[column_name] = allowed_tags
+
+        return column_tags
+
+    def _filter_tags(
+        self, tags: Optional[List[SnowflakeTag]]
+    ) -> Optional[List[SnowflakeTag]]:
+        if tags is None:
+            return tags
+
+        allowed_tags = []
+        for tag in tags:
+            tag_identifier = str(tag)
+            self.report.report_entity_scanned(tag_identifier, "tag")
+            if not self.config.tag_pattern.allowed(tag_identifier):
+                self.report.report_dropped(tag_identifier)
+            allowed_tags.append(tag)
+        return allowed_tags

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
@@ -76,7 +76,7 @@ class SnowflakeTagExtractor(SnowflakeCommonMixin):
             assert identifier
 
             self.report.num_get_tags_for_object_queries += 1
-            tags = self.data_dictionary.get_tags_for_object_with_lineage(
+            tags = self.data_dictionary.get_tags_for_object_with_propagation(
                 domain=domain, quoted_identifier=identifier, db_name=db_name
             )
         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_tag.py
@@ -131,7 +131,7 @@ class SnowflakeTagExtractor(SnowflakeCommonMixin):
 
         allowed_tags = []
         for tag in tags:
-            tag_identifier = str(tag)
+            tag_identifier = tag.identifier()
             self.report.report_entity_scanned(tag_identifier, "tag")
             if not self.config.tag_pattern.allowed(tag_identifier):
                 self.report.report_dropped(tag_identifier)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -158,6 +158,18 @@ class SnowflakeCommonMixin:
             return identifier.lower()
         return identifier
 
+    @staticmethod
+    def get_quoted_identifier_for_database(db_name):
+        return f'"{db_name}"'
+
+    @staticmethod
+    def get_quoted_identifier_for_schema(db_name, schema_name):
+        return f'"{db_name}"."{schema_name}"'
+
+    @staticmethod
+    def get_quoted_identifier_for_table(db_name, schema_name, table_name):
+        return f'"{db_name}"."{schema_name}"."{table_name}"'
+
     def get_dataset_identifier(
         self: SnowflakeCommonProtocol, table_name: str, schema_name: str, db_name: str
     ) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -652,7 +652,7 @@ class SnowflakeV2Source(
                 )
             return
 
-        if self.config.extract_tags is not TagOption.skip:
+        if self.config.extract_tags != TagOption.skip:
             snowflake_db.tags = self.tag_extractor.get_tags_on_object(
                 domain="database", db_name=db_name
             )
@@ -710,7 +710,7 @@ class SnowflakeV2Source(
 
         schema_name = snowflake_schema.name
 
-        if self.config.extract_tags is not TagOption.skip:
+        if self.config.extract_tags != TagOption.skip:
             snowflake_schema.tags = self.tag_extractor.get_tags_on_object(
                 schema_name=schema_name, db_name=db_name, domain="schema"
             )
@@ -806,7 +806,7 @@ class SnowflakeV2Source(
             table, schema_name, db_name, dataset_name
         )
 
-        if self.config.extract_tags is not TagOption.skip:
+        if self.config.extract_tags != TagOption.skip:
             table.tags = self.tag_extractor.get_tags_on_object(
                 table_name=table.name,
                 schema_name=schema_name,
@@ -877,7 +877,7 @@ class SnowflakeV2Source(
     def fetch_columns_for_table(self, table, schema_name, db_name, table_identifier):
         try:
             table.columns = self.get_columns_for_table(table.name, schema_name, db_name)
-            if self.config.extract_tags is not TagOption.skip:
+            if self.config.extract_tags != TagOption.skip:
                 table.column_tags = self.tag_extractor.get_column_tags_for_table(
                     table.name, schema_name, db_name
                 )
@@ -904,7 +904,7 @@ class SnowflakeV2Source(
 
         try:
             view.columns = self.get_columns_for_table(view.name, schema_name, db_name)
-            if self.config.extract_tags is not TagOption.skip:
+            if self.config.extract_tags != TagOption.skip:
                 view.column_tags = self.tag_extractor.get_column_tags_for_table(
                     view.name, schema_name, db_name
                 )
@@ -915,8 +915,7 @@ class SnowflakeV2Source(
             )
             self.report_warning("Failed to get columns for view", view_name)
 
-        if self.config.extract_tags is not TagOption.skip:
-            # TODO: make sure this works for views
+        if self.config.extract_tags != TagOption.skip:
             view.tags = self.tag_extractor.get_tags_on_object(
                 table_name=view.name,
                 schema_name=schema_name,
@@ -935,7 +934,7 @@ class SnowflakeV2Source(
         yield from self.gen_dataset_workunits(view, schema_name, db_name)
 
     def _process_tag(self, tag: SnowflakeTag) -> Iterable[MetadataWorkUnit]:
-        tag_identifier = str(tag)
+        tag_identifier = tag.identifier()
 
         if self.report.is_tag_processed(tag_identifier):
             return
@@ -1061,7 +1060,7 @@ class SnowflakeV2Source(
 
         tag_properties_aspect = TagProperties(
             name=tag_key,
-            description=f"Represents the Snowflake tag `{tag.id_as_str()}` with value `{tag.value}`.",
+            description=f"Represents the Snowflake tag `{tag._id_prefix_as_str()}` with value `{tag.value}`.",
         )
 
         self.stale_entity_removal_handler.add_entity_to_state("tag", tag_urn)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1047,7 +1047,7 @@ class SnowflakeV2Source(
         )
 
     def gen_tag_workunits(self, tag: SnowflakeTag) -> Iterable[MetadataWorkUnit]:
-        tag_key = str(tag)
+        tag_key = self.snowflake_identifier(str(tag))
         tag_urn = make_tag_urn(tag_key)
 
         tag_properties_aspect = TagProperties(
@@ -1091,7 +1091,12 @@ class SnowflakeV2Source(
                     if isinstance(table, SnowflakeTable) and table.pk is not None
                     else None,
                     globalTags=GlobalTags(
-                        [TagAssociation(make_tag_urn(str(tag))) for tag in col.tags]
+                        [
+                            TagAssociation(
+                                make_tag_urn(self.snowflake_identifier(str(tag)))
+                            )
+                            for tag in col.tags
+                        ]
                     )
                     if col.tags
                     else None,
@@ -1283,7 +1288,9 @@ class SnowflakeV2Source(
             else int(database.created.timestamp() * 1000)
             if database.created is not None
             else None,
-            tags=[str(tag) for tag in database.tags] if database.tags else None,
+            tags=[self.snowflake_identifier(str(tag)) for tag in database.tags]
+            if database.tags
+            else None,
         )
 
         self.stale_entity_removal_handler.add_entity_to_state(
@@ -1331,7 +1338,9 @@ class SnowflakeV2Source(
             else int(schema.created.timestamp() * 1000)
             if schema.created is not None
             else None,
-            tags=[str(tag) for tag in schema.tags] if schema.tags else None,
+            tags=[self.snowflake_identifier(str(tag)) for tag in schema.tags]
+            if schema.tags
+            else None,
         )
 
         for wu in container_workunits:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1410,9 +1410,7 @@ class SnowflakeV2Source(
             )
 
         # Access to table but none of its columns - is this possible ?
-        table_columns = columns.get(table_name, [])
-
-        return table_columns
+        return columns.get(table_name, [])
 
     def get_pk_constraints_for_table(
         self, table_name: str, schema_name: str, db_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -374,6 +374,7 @@ class SnowflakeV2Source(
                     _report[SourceCapability.CONTAINERS] = CapabilityReport(
                         capable=True
                     )
+                    _report[SourceCapability.TAGS] = CapabilityReport(capable=True)
                 elif privilege.object_type in (
                     "TABLE",
                     "VIEW",
@@ -407,6 +408,8 @@ class SnowflakeV2Source(
                         _report[SourceCapability.USAGE_STATS] = CapabilityReport(
                             capable=True
                         )
+                        _report[SourceCapability.TAGS] = CapabilityReport(capable=True)
+
                 # If all capabilities supported, no need to continue
                 if set(capabilities) == set(_report.keys()):
                     break
@@ -430,7 +433,7 @@ class SnowflakeV2Source(
             SourceCapability.LINEAGE_COARSE: "Current role does not have permissions to snowflake account usage views",
             SourceCapability.LINEAGE_FINE: "Current role does not have permissions to snowflake account usage views",
             SourceCapability.USAGE_STATS: "Current role does not have permissions to snowflake account usage views",
-            SourceCapability.TAGS: "Either no tags have been applied to objects or the current role does not have permission to access the objects",
+            SourceCapability.TAGS: "Either no tags have been applied to objects, or the current role does not have permission to access the objects or to snowflake account usage views ",
         }
 
         for c in capabilities:  # type:ignore

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -660,6 +660,10 @@ class SnowflakeV2Source(
 
         self.fetch_schemas_for_database(snowflake_db, db_name)
 
+        if self.config.include_technical_schema and snowflake_db.tags:
+            for tag in snowflake_db.tags:
+                yield from self._process_tag(tag)
+
         for snowflake_schema in snowflake_db.schemas:
             yield from self._process_schema(snowflake_schema, db_name)
 
@@ -688,10 +692,6 @@ class SnowflakeV2Source(
                 "No schemas found in database. If schemas exist, please grant USAGE permissions on them.",
                 db_name,
             )
-
-        if self.config.include_technical_schema and snowflake_db.tags:
-            for tag in snowflake_db.tags:
-                yield from self._process_tag(tag)
 
     def _process_schema(
         self, snowflake_schema: SnowflakeSchema, db_name: str
@@ -729,6 +729,10 @@ class SnowflakeV2Source(
             if self.config.include_technical_schema:
                 for view in snowflake_schema.views:
                     yield from self._process_view(view, schema_name, db_name)
+
+        if self.config.include_technical_schema and snowflake_schema.tags:
+            for tag in snowflake_schema.tags:
+                yield from self._process_tag(tag)
 
         if not snowflake_schema.views and not snowflake_schema.tables:
             self.report_warning(
@@ -773,10 +777,6 @@ class SnowflakeV2Source(
                     "Failed to get tables for schema",
                     f"{db_name}.{schema_name}",
                 )
-
-        if self.config.include_technical_schema and snowflake_schema.tags:
-            for tag in snowflake_schema.tags:
-                yield from self._process_tag(tag)
 
     def _process_table(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -430,6 +430,7 @@ class SnowflakeV2Source(
             SourceCapability.LINEAGE_COARSE: "Current role does not have permissions to snowflake account usage views",
             SourceCapability.LINEAGE_FINE: "Current role does not have permissions to snowflake account usage views",
             SourceCapability.USAGE_STATS: "Current role does not have permissions to snowflake account usage views",
+            SourceCapability.TAGS: "Either no tags have been applied to objects or the current role does not have permission to access the objects",
         }
 
         for c in capabilities:  # type:ignore
@@ -441,6 +442,7 @@ class SnowflakeV2Source(
                 SourceCapability.LINEAGE_COARSE,
                 SourceCapability.LINEAGE_FINE,
                 SourceCapability.USAGE_STATS,
+                SourceCapability.TAGS,
             ):
                 failure_message = (
                     f"Current role {current_role} does not have permissions to use warehouse {connection_conf.warehouse}. Please check the grants associated with this role."

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1050,8 +1050,8 @@ class SnowflakeV2Source(
         )
 
     def gen_tag_workunits(self, tag: SnowflakeTag) -> Iterable[MetadataWorkUnit]:
-        tag_key = self.snowflake_identifier(str(tag))
-        tag_urn = make_tag_urn(tag_key)
+        tag_key = str(tag)
+        tag_urn = make_tag_urn(self.snowflake_identifier(tag_key))
 
         tag_properties_aspect = TagProperties(
             name=tag_key,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1052,7 +1052,7 @@ class SnowflakeV2Source(
 
         tag_properties_aspect = TagProperties(
             name=tag_key,
-            description=f"Represents the Snowflake tag `{tag_key.split('=')[0]}` with value `{tag.value}`.",
+            description=f"Represents the Snowflake tag `{tag.id_as_str()}` with value `{tag.value}`.",
         )
 
         self.stale_entity_removal_handler.add_entity_to_state("tag", tag_urn)

--- a/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
@@ -13,10 +13,6 @@ class SnowflakeUsageConfig(BaseUsageConfig):
         default=None,
         description="Email domain of your organisation so users can be displayed on UI appropriately.",
     )
-    tag_pattern: AllowDenyPattern = pydantic.Field(
-        default=AllowDenyPattern.allow_all(),
-        description="List of regex patterns for tags to include in ingestion.",
-    )
     apply_view_usage_to_tables: bool = pydantic.Field(
         default=False,
         description="Allow/deny patterns for views in snowflake dataset names.",

--- a/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/usage/snowflake_usage.py
@@ -13,6 +13,10 @@ class SnowflakeUsageConfig(BaseUsageConfig):
         default=None,
         description="Email domain of your organisation so users can be displayed on UI appropriately.",
     )
+    tag_pattern: AllowDenyPattern = pydantic.Field(
+        default=AllowDenyPattern.allow_all(),
+        description="List of regex patterns for tags to include in ingestion.",
+    )
     apply_view_usage_to_tables: bool = pydantic.Field(
         default=False,
         description="Allow/deny patterns for views in snowflake dataset names.",

--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -286,7 +286,6 @@ def default_query_results(query):  # noqa: C901
             }
             for op_idx in range(1, NUM_OPS + 1)
         ]
-
     elif query == snowflake_query.SnowflakeQuery.external_table_lineage_history(
         1654499820000,
         1654586220000,
@@ -368,7 +367,7 @@ def default_query_results(query):  # noqa: C901
                     "TAG_VALUE": f"my_value_{ix}",
                     "OBJECT_DATABASE": "TEST_DB",
                     "OBJECT_SCHEMA": "TEST_SCHEMA",
-                    "OBJECT_NAME": "TABLE_2",
+                    "OBJECT_NAME": "VIEW_2",
                     "COLUMN_NAME": None,
                     "DOMAIN": "TABLE",
                 }
@@ -381,7 +380,7 @@ def default_query_results(query):  # noqa: C901
                 "TAG_VALUE": "pii",
                 "OBJECT_DATABASE": "TEST_DB",
                 "OBJECT_SCHEMA": "TEST_SCHEMA",
-                "OBJECT_NAME": "TABLE_1",
+                "OBJECT_NAME": "VIEW_1",
                 "COLUMN_NAME": "COL_1",
                 "DOMAIN": "COLUMN",
             },

--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -286,6 +286,7 @@ def default_query_results(query):  # noqa: C901
             }
             for op_idx in range(1, NUM_OPS + 1)
         ]
+
     elif query == snowflake_query.SnowflakeQuery.external_table_lineage_history(
         1654499820000,
         1654586220000,
@@ -352,5 +353,60 @@ def default_query_results(query):  # noqa: C901
     ]:
         return []
 
+    elif (
+        query
+        == snowflake_query.SnowflakeQuery.get_all_tags_in_database_without_propagation(
+            "TEST_DB"
+        )
+    ):
+        return [
+            *[
+                {
+                    "TAG_DATABASE": "TEST_DB",
+                    "TAG_SCHEMA": "TEST_SCHEMA",
+                    "TAG_NAME": f"my_tag_{ix}",
+                    "TAG_VALUE": f"my_value_{ix}",
+                    "OBJECT_DATABASE": "TEST_DB",
+                    "OBJECT_SCHEMA": "TEST_SCHEMA",
+                    "OBJECT_NAME": "TABLE_2",
+                    "COLUMN_NAME": None,
+                    "DOMAIN": "TABLE",
+                }
+                for ix in range(3)
+            ],
+            {
+                "TAG_DATABASE": "TEST_DB",
+                "TAG_SCHEMA": "TEST_SCHEMA",
+                "TAG_NAME": "security",
+                "TAG_VALUE": "pii",
+                "OBJECT_DATABASE": "TEST_DB",
+                "OBJECT_SCHEMA": "TEST_SCHEMA",
+                "OBJECT_NAME": "TABLE_1",
+                "COLUMN_NAME": "COL_1",
+                "DOMAIN": "COLUMN",
+            },
+            {
+                "TAG_DATABASE": "OTHER_DB",
+                "TAG_SCHEMA": "OTHER_SCHEMA",
+                "TAG_NAME": "my_other_tag",
+                "TAG_VALUE": "other",
+                "OBJECT_DATABASE": "TEST_DB",
+                "OBJECT_SCHEMA": None,
+                "OBJECT_NAME": "TEST_SCHEMA",
+                "COLUMN_NAME": None,
+                "DOMAIN": "SCHEMA",
+            },
+            {
+                "TAG_DATABASE": "OTHER_DB",
+                "TAG_SCHEMA": "OTHER_SCHEMA",
+                "TAG_NAME": "my_other_tag",
+                "TAG_VALUE": "other",
+                "OBJECT_DATABASE": None,
+                "OBJECT_SCHEMA": None,
+                "OBJECT_NAME": "TEST_DB",
+                "COLUMN_NAME": None,
+                "DOMAIN": "DATABASE",
+            },
+        ]
     # Unreachable code
     raise Exception(f"Unknown query {query}")

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -57,6 +57,20 @@
   },
   {
     "entityType": "container",
+    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -115,6 +129,20 @@
     "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+    "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
       "value": "{\"container\": \"urn:li:container:5e359958be02ce647cd9ac196dbd4585\"}",
@@ -123,6 +151,20 @@
     "systemMetadata": {
       "lastObserved": 1654621200000,
       "runId": "snowflake-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.security=pii",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.security=pii\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.security` with value `pii`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
     }
   },
   {
@@ -145,7 +187,7 @@
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.security=pii\"}]}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.security=pii\"}]}, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -193,6 +235,48 @@
     "systemMetadata": {
       "lastObserved": 1654621200000,
       "runId": "snowflake-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0=my_value_0",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.my_tag_0=my_value_0\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_0` with value `my_value_0`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1=my_value_1",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.my_tag_1=my_value_1\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_1` with value `my_value_1`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2=my_value_2",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.my_tag_2=my_value_2\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_2` with value `my_value_2`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
     }
   },
   {
@@ -263,6 +347,20 @@
     "systemMetadata": {
       "lastObserved": 1654621200000,
       "runId": "snowflake-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_0=my_value_0\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_1=my_value_1\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_2=my_value_2\"}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
     }
   },
   {
@@ -1246,6 +1344,20 @@
     }
   },
   {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag=other",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"other_db.other_schema.my_other_tag=other\", \"description\": \"Represents the Snowflake tag `other_db.other_schema.my_other_tag` with value `other`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
@@ -1383,118 +1495,6 @@
     "systemMetadata": {
       "lastObserved": 1654621200000,
       "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_0=my_value_0\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_1=my_value_1\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_2=my_value_2\"}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0=my_value_0",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_0=my_value_0\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_0` with value `my_value_0`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1=my_value_1",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_1=my_value_1\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_1` with value `my_value_1`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2=my_value_2",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_2=my_value_2\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_2` with value `my_value_2`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag=other",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"other_db.other_schema.my_other_tag=other\", \"description\": \"Represents the Snowflake tag `other_db.other_schema.my_other_tag` with value `other`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.security=pii",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.security=pii\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.security` with value `pii`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
     }
   }
 ]

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -159,7 +159,7 @@
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.security:pii\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.security` with value `pii`.\"}",
+      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.security:pii\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.security` with value `pii`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -243,7 +243,7 @@
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_0:my_value_0\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_0` with value `my_value_0`.\"}",
+      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.my_tag_0:my_value_0\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_0` with value `my_value_0`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -257,7 +257,7 @@
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_1:my_value_1\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_1` with value `my_value_1`.\"}",
+      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_1` with value `my_value_1`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -271,7 +271,7 @@
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_2:my_value_2\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_2` with value `my_value_2`.\"}",
+      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_2` with value `my_value_2`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -1349,7 +1349,7 @@
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"other_db.other_schema.my_other_tag:other\", \"description\": \"Represents the Snowflake tag `OTHER_DB.OTHER_SCHEMA.my_other_tag` with value `other`.\"}",
+      "value": "{\"name\": \"OTHER_DB.OTHER_SCHEMA.my_other_tag:other\", \"description\": \"Represents the Snowflake tag `OTHER_DB.OTHER_SCHEMA.my_other_tag` with value `other`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -180,6 +180,1886 @@
   }
 },
 {
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_1",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_1/",
+      "name": "TABLE_1",
+      "qualifiedName": "test_db.test_schema.table_1",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_2",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_2/",
+      "name": "TABLE_2",
+      "qualifiedName": "test_db.test_schema.table_2",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_3",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_3/",
+      "name": "TABLE_3",
+      "qualifiedName": "test_db.test_schema.table_3",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_4",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_4/",
+      "name": "TABLE_4",
+      "qualifiedName": "test_db.test_schema.table_4",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_5",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_5/",
+      "name": "TABLE_5",
+      "qualifiedName": "test_db.test_schema.table_5",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_6",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_6/",
+      "name": "TABLE_6",
+      "qualifiedName": "test_db.test_schema.table_6",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_7",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_7/",
+      "name": "TABLE_7",
+      "qualifiedName": "test_db.test_schema.table_7",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_8",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_8/",
+      "name": "TABLE_8",
+      "qualifiedName": "test_db.test_schema.table_8",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_9",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_9/",
+      "name": "TABLE_9",
+      "qualifiedName": "test_db.test_schema.table_9",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.table_10",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Age" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "glossaryTerms": {
+            "terms": [{ "urn": "urn:li:glossaryTerm:Email_Address" }],
+            "auditStamp": {
+              "time": 1654621200000,
+              "actor": "urn:li:corpuser:datahub"
+            }
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_10/",
+      "name": "TABLE_10",
+      "qualifiedName": "test_db.test_schema.table_10",
+      "description": "Comment for Table",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["table"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
   "entityType": "tag",
   "entityUrn": "urn:li:tag:test_db.test_schema.security:pii",
   "changeType": "UPSERT",
@@ -606,6 +2486,1786 @@
         { "tag": "urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1" },
         { "tag": "urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2" }
       ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProfile",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "rowCount": 10000,
+      "columnCount": 10,
+      "sizeInBytes": 1024
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        },
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        },
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "upstreamLineage",
+  "aspect": {
+    "json": {
+      "upstreams": [
+        {
+          "auditStamp": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+          "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+          "type": "TRANSFORMED"
+        }
+      ],
+      "fineGrainedLineages": [
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_1)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_10)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_2)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_3)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_4)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_5)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_6)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_7)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_8)"
+          ],
+          "confidenceScore": 1.0
+        },
+        {
+          "upstreamType": "FIELD_SET",
+          "upstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)"
+          ],
+          "downstreamType": "FIELD",
+          "downstreams": [
+            "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_9)"
+          ],
+          "confidenceScore": 1.0
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "operation",
+  "aspect": {
+    "json": {
+      "timestampMillis": 1654621200000,
+      "partitionSpec": {
+        "type": "FULL_TABLE",
+        "partition": "FULL_TABLE_SNAPSHOT"
+      },
+      "actor": "urn:li:corpuser:abc",
+      "operationType": "CREATE",
+      "lastUpdatedTimestamp": 1654144861367
     }
   },
   "systemMetadata": {

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -1,1500 +1,616 @@
 [
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {\"platform\": \"snowflake\", \"instance\": \"PROD\", \"database\": \"test_db\"}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/\", \"name\": \"TEST_DB\", \"description\": \"Comment for TEST_DB\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-      "value": "{\"platform\": \"urn:li:dataPlatform:snowflake\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"Database\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag:other\"}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {\"platform\": \"snowflake\", \"instance\": \"PROD\", \"database\": \"test_db\", \"schema\": \"test_schema\"}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/\", \"name\": \"TEST_SCHEMA\", \"description\": \"comment for TEST_DB.TEST_SCHEMA\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-      "value": "{\"platform\": \"urn:li:dataPlatform:snowflake\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"Schema\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag:other\"}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "container",
-    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:5e359958be02ce647cd9ac196dbd4585\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.security:pii",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.security:pii\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.security` with value `pii`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.security:pii\"}]}, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_1/\", \"name\": \"TABLE_1\", \"qualifiedName\": \"test_db.test_schema.table_1\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0:my_value_0",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.my_tag_0:my_value_0\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_0` with value `my_value_0`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1:my_value_1",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_1` with value `my_value_1`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2:my_value_2",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_2` with value `my_value_2`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_2\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_2/\", \"name\": \"TABLE_2\", \"qualifiedName\": \"test_db.test_schema.table_2\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_0:my_value_0\"}, {\"tag\": \"urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1\"}, {\"tag\": \"urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2\"}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_3\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_3/\", \"name\": \"TABLE_3\", \"qualifiedName\": \"test_db.test_schema.table_3\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_4\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_4/\", \"name\": \"TABLE_4\", \"qualifiedName\": \"test_db.test_schema.table_4\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_5\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_5/\", \"name\": \"TABLE_5\", \"qualifiedName\": \"test_db.test_schema.table_5\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_6\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_6/\", \"name\": \"TABLE_6\", \"qualifiedName\": \"test_db.test_schema.table_6\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_7\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_7/\", \"name\": \"TABLE_7\", \"qualifiedName\": \"test_db.test_schema.table_7\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_8\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_8/\", \"name\": \"TABLE_8\", \"qualifiedName\": \"test_db.test_schema.table_8\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_9\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_9/\", \"name\": \"TABLE_9\", \"qualifiedName\": \"test_db.test_schema.table_9\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_10\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_10/\", \"name\": \"TABLE_10\", \"qualifiedName\": \"test_db.test_schema.table_10\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"table\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.view_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_1/\", \"name\": \"VIEW_1\", \"qualifiedName\": \"test_db.test_schema.view_1\", \"description\": \"Comment for View\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"view\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-      "value": "{\"removed\": false}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.view_2\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_2/\", \"name\": \"VIEW_2\", \"qualifiedName\": \"test_db.test_schema.view_2\", \"description\": \"Comment for View\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-      "value": "{\"typeNames\": [\"view\"]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProfile",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}, {\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}, {\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "upstreamLineage",
-    "aspect": {
-      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag:other",
-    "changeType": "UPSERT",
-    "aspectName": "tagProperties",
-    "aspect": {
-      "value": "{\"name\": \"OTHER_DB.OTHER_SCHEMA.my_other_tag:other\", \"description\": \"Represents the Snowflake tag `OTHER_DB.OTHER_SCHEMA.my_other_tag` with value `other`.\"}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-beta-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
-  },
-  {
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "operation",
-    "aspect": {
-      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-      "contentType": "application/json"
-    },
-    "systemMetadata": {
-      "lastObserved": 1654621200000,
-      "runId": "snowflake-2022_06_07-17_00_00"
-    }
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+  "changeType": "UPSERT",
+  "aspectName": "containerProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {
+        "platform": "snowflake",
+        "instance": "PROD",
+        "database": "test_db"
+      },
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/",
+      "name": "TEST_DB",
+      "description": "Comment for TEST_DB",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 }
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
   }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+  "changeType": "UPSERT",
+  "aspectName": "dataPlatformInstance",
+  "aspect": { "json": { "platform": "urn:li:dataPlatform:snowflake" } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["Database"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+  "changeType": "UPSERT",
+  "aspectName": "globalTags",
+  "aspect": {
+    "json": {
+      "tags": [
+        { "tag": "urn:li:tag:other_db.other_schema.my_other_tag:other" }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "tag",
+  "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag:other",
+  "changeType": "UPSERT",
+  "aspectName": "tagProperties",
+  "aspect": {
+    "json": {
+      "name": "OTHER_DB.OTHER_SCHEMA.my_other_tag:other",
+      "description": "Represents the Snowflake tag `OTHER_DB.OTHER_SCHEMA.my_other_tag` with value `other`."
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+  "changeType": "UPSERT",
+  "aspectName": "containerProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {
+        "platform": "snowflake",
+        "instance": "PROD",
+        "database": "test_db",
+        "schema": "test_schema"
+      },
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/",
+      "name": "TEST_SCHEMA",
+      "description": "comment for TEST_DB.TEST_SCHEMA",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 }
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+  "changeType": "UPSERT",
+  "aspectName": "dataPlatformInstance",
+  "aspect": { "json": { "platform": "urn:li:dataPlatform:snowflake" } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["Schema"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+  "changeType": "UPSERT",
+  "aspectName": "globalTags",
+  "aspect": {
+    "json": {
+      "tags": [
+        { "tag": "urn:li:tag:other_db.other_schema.my_other_tag:other" }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "container",
+  "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:5e359958be02ce647cd9ac196dbd4585"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "tag",
+  "entityUrn": "urn:li:tag:test_db.test_schema.security:pii",
+  "changeType": "UPSERT",
+  "aspectName": "tagProperties",
+  "aspect": {
+    "json": {
+      "name": "TEST_DB.TEST_SCHEMA.security:pii",
+      "description": "Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.security` with value `pii`."
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.view_1",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "globalTags": {
+            "tags": [{ "tag": "urn:li:tag:test_db.test_schema.security:pii" }]
+          },
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_1/",
+      "name": "VIEW_1",
+      "qualifiedName": "test_db.test_schema.view_1",
+      "description": "Comment for View",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["view"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "tag",
+  "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0:my_value_0",
+  "changeType": "UPSERT",
+  "aspectName": "tagProperties",
+  "aspect": {
+    "json": {
+      "name": "TEST_DB.TEST_SCHEMA.my_tag_0:my_value_0",
+      "description": "Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_0` with value `my_value_0`."
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "tag",
+  "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1:my_value_1",
+  "changeType": "UPSERT",
+  "aspectName": "tagProperties",
+  "aspect": {
+    "json": {
+      "name": "TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1",
+      "description": "Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_1` with value `my_value_1`."
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "tag",
+  "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2:my_value_2",
+  "changeType": "UPSERT",
+  "aspectName": "tagProperties",
+  "aspect": {
+    "json": {
+      "name": "TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2",
+      "description": "Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_2` with value `my_value_2`."
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "status",
+  "aspect": { "json": { "removed": false } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "schemaMetadata",
+  "aspect": {
+    "json": {
+      "schemaName": "test_db.test_schema.view_2",
+      "platform": "urn:li:dataPlatform:snowflake",
+      "version": 0,
+      "created": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "lastModified": { "time": 0, "actor": "urn:li:corpuser:unknown" },
+      "hash": "",
+      "platformSchema": {
+        "com.linkedin.schema.MySqlDDL": { "tableSchema": "" }
+      },
+      "fields": [
+        {
+          "fieldPath": "col_1",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.NumberType": {} } },
+          "nativeDataType": "NUMBER(38,0)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_2",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_3",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_4",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_5",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_6",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_7",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_8",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_9",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        },
+        {
+          "fieldPath": "col_10",
+          "nullable": false,
+          "description": "Comment for column",
+          "type": { "type": { "com.linkedin.schema.StringType": {} } },
+          "nativeDataType": "VARCHAR(255)",
+          "recursive": false,
+          "isPartOfKey": false
+        }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "datasetProperties",
+  "aspect": {
+    "json": {
+      "customProperties": {},
+      "externalUrl": "https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_2/",
+      "name": "VIEW_2",
+      "qualifiedName": "test_db.test_schema.view_2",
+      "description": "Comment for View",
+      "created": { "time": 1623110400000 },
+      "lastModified": { "time": 1623110400000 },
+      "tags": []
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "container",
+  "aspect": {
+    "json": {
+      "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "subTypes",
+  "aspect": { "json": { "typeNames": ["view"] } },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+},
+{
+  "entityType": "dataset",
+  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+  "changeType": "UPSERT",
+  "aspectName": "globalTags",
+  "aspect": {
+    "json": {
+      "tags": [
+        { "tag": "urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_0:my_value_0" },
+        { "tag": "urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1" },
+        { "tag": "urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2" }
+      ]
+    }
+  },
+  "systemMetadata": {
+    "lastObserved": 1654621200000,
+    "runId": "snowflake-2022_06_07-17_00_00"
+  }
+}
 ]

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -1,1388 +1,1500 @@
 [
-{
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
-        "value": "{\"customProperties\": {\"platform\": \"snowflake\", \"instance\": \"PROD\", \"database\": \"test_db\"}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/\", \"name\": \"TEST_DB\", \"description\": \"Comment for TEST_DB\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {\"platform\": \"snowflake\", \"instance\": \"PROD\", \"database\": \"test_db\"}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/\", \"name\": \"TEST_DB\", \"description\": \"Comment for TEST_DB\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
-        "value": "{\"platform\": \"urn:li:dataPlatform:snowflake\"}",
-        "contentType": "application/json"
+      "value": "{\"platform\": \"urn:li:dataPlatform:snowflake\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"Database\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"Database\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
     "aspect": {
-        "value": "{\"customProperties\": {\"platform\": \"snowflake\", \"instance\": \"PROD\", \"database\": \"test_db\", \"schema\": \"test_schema\"}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/\", \"name\": \"TEST_SCHEMA\", \"description\": \"comment for TEST_DB.TEST_SCHEMA\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {\"platform\": \"snowflake\", \"instance\": \"PROD\", \"database\": \"test_db\", \"schema\": \"test_schema\"}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/\", \"name\": \"TEST_SCHEMA\", \"description\": \"comment for TEST_DB.TEST_SCHEMA\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
-        "value": "{\"platform\": \"urn:li:dataPlatform:snowflake\"}",
-        "contentType": "application/json"
+      "value": "{\"platform\": \"urn:li:dataPlatform:snowflake\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"Schema\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"Schema\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "container",
     "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:5e359958be02ce647cd9ac196dbd4585\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:5e359958be02ce647cd9ac196dbd4585\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.security=pii\"}]}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_1/\", \"name\": \"TABLE_1\", \"qualifiedName\": \"test_db.test_schema.table_1\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_1/\", \"name\": \"TABLE_1\", \"qualifiedName\": \"test_db.test_schema.table_1\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_2\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_2\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_2/\", \"name\": \"TABLE_2\", \"qualifiedName\": \"test_db.test_schema.table_2\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_2/\", \"name\": \"TABLE_2\", \"qualifiedName\": \"test_db.test_schema.table_2\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_3\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_3\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_3/\", \"name\": \"TABLE_3\", \"qualifiedName\": \"test_db.test_schema.table_3\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_3/\", \"name\": \"TABLE_3\", \"qualifiedName\": \"test_db.test_schema.table_3\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_4\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_4\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_4/\", \"name\": \"TABLE_4\", \"qualifiedName\": \"test_db.test_schema.table_4\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_4/\", \"name\": \"TABLE_4\", \"qualifiedName\": \"test_db.test_schema.table_4\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_5\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_5\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_5/\", \"name\": \"TABLE_5\", \"qualifiedName\": \"test_db.test_schema.table_5\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_5/\", \"name\": \"TABLE_5\", \"qualifiedName\": \"test_db.test_schema.table_5\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_6\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_6\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_6/\", \"name\": \"TABLE_6\", \"qualifiedName\": \"test_db.test_schema.table_6\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_6/\", \"name\": \"TABLE_6\", \"qualifiedName\": \"test_db.test_schema.table_6\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_7\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_7\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_7/\", \"name\": \"TABLE_7\", \"qualifiedName\": \"test_db.test_schema.table_7\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_7/\", \"name\": \"TABLE_7\", \"qualifiedName\": \"test_db.test_schema.table_7\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_8\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_8\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_8/\", \"name\": \"TABLE_8\", \"qualifiedName\": \"test_db.test_schema.table_8\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_8/\", \"name\": \"TABLE_8\", \"qualifiedName\": \"test_db.test_schema.table_8\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_9\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_9\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_9/\", \"name\": \"TABLE_9\", \"qualifiedName\": \"test_db.test_schema.table_9\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_9/\", \"name\": \"TABLE_9\", \"qualifiedName\": \"test_db.test_schema.table_9\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.table_10\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.table_10\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_10/\", \"name\": \"TABLE_10\", \"qualifiedName\": \"test_db.test_schema.table_10\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/table/TABLE_10/\", \"name\": \"TABLE_10\", \"qualifiedName\": \"test_db.test_schema.table_10\", \"description\": \"Comment for Table\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"table\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"table\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.view_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.view_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_1/\", \"name\": \"VIEW_1\", \"qualifiedName\": \"test_db.test_schema.view_1\", \"description\": \"Comment for View\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_1/\", \"name\": \"VIEW_1\", \"qualifiedName\": \"test_db.test_schema.view_1\", \"description\": \"Comment for View\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"view\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"view\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+      "value": "{\"removed\": false}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-        "value": "{\"schemaName\": \"test_db.test_schema.view_2\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
-        "contentType": "application/json"
+      "value": "{\"schemaName\": \"test_db.test_schema.view_2\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_2/\", \"name\": \"VIEW_2\", \"qualifiedName\": \"test_db.test_schema.view_2\", \"description\": \"Comment for View\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
-        "contentType": "application/json"
+      "value": "{\"customProperties\": {}, \"externalUrl\": \"https://app.snowflake.com/ap-south-1/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/VIEW_2/\", \"name\": \"VIEW_2\", \"qualifiedName\": \"test_db.test_schema.view_2\", \"description\": \"Comment for View\", \"created\": {\"time\": 1623110400000}, \"lastModified\": {\"time\": 1623110400000}, \"tags\": []}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
-        "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
-        "contentType": "application/json"
+      "value": "{\"container\": \"urn:li:container:94c696a054bab40b73e640a7f82e3b1c\"}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"view\"]}",
-        "contentType": "application/json"
+      "value": "{\"typeNames\": [\"view\"]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProfile",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"rowCount\": 10000, \"columnCount\": 10, \"sizeInBytes\": 1024}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}, {\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}, {\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}, {\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}, {\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "upstreamLineage",
     "aspect": {
-        "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
-        "contentType": "application/json"
+      "value": "{\"upstreams\": [{\"auditStamp\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"dataset\": \"urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)\", \"type\": \"TRANSFORMED\"}], \"fineGrainedLineages\": [{\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_1)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_1)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_10)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_10)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_2)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_2)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_3)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_3)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_4)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_4)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_5)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_5)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_6)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_6)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_7)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_7)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_8)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_8)\"], \"confidenceScore\": 1.0}, {\"upstreamType\": \"FIELD_SET\", \"upstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD),col_9)\"], \"downstreamType\": \"FIELD\", \"downstreams\": [\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD),col_9)\"], \"confidenceScore\": 1.0}]}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-},
-{
+  },
+  {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
-        "contentType": "application/json"
+      "value": "{\"timestampMillis\": 1654621200000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:abc\", \"operationType\": \"CREATE\", \"lastUpdatedTimestamp\": 1654144861367}",
+      "contentType": "application/json"
     },
     "systemMetadata": {
-        "lastObserved": 1654621200000,
-        "runId": "snowflake-2022_06_07-17_00_00"
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-2022_06_07-17_00_00"
     }
-}
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_0=my_value_0\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_1=my_value_1\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_2=my_value_2\"}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0=my_value_0",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.my_tag_0=my_value_0\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_0` with value `my_value_0`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1=my_value_1",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.my_tag_1=my_value_1\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_1` with value `my_value_1`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2=my_value_2",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.my_tag_2=my_value_2\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_2` with value `my_value_2`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag=other",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"other_db.other_schema.my_other_tag=other\", \"description\": \"Represents the Snowflake tag `other_db.other_schema.my_other_tag` with value `other`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:test_db.test_schema.security=pii",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"test_db.test_schema.security=pii\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.security` with value `pii`.\"}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  },
+  {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
+      "contentType": "application/json"
+    },
+    "systemMetadata": {
+      "lastObserved": 1654621200000,
+      "runId": "snowflake-beta-2022_06_07-17_00_00"
+    }
+  }
 ]

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -61,7 +61,7 @@
     "changeType": "UPSERT",
     "aspectName": "globalTags",
     "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag:other\"}]}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -131,7 +131,7 @@
     "changeType": "UPSERT",
     "aspectName": "globalTags",
     "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag=other\"}]}",
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:other_db.other_schema.my_other_tag:other\"}]}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -155,11 +155,11 @@
   },
   {
     "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.security=pii",
+    "entityUrn": "urn:li:tag:test_db.test_schema.security:pii",
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.security=pii\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.security` with value `pii`.\"}",
+      "value": "{\"name\": \"test_db.test_schema.security:pii\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.security` with value `pii`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -187,7 +187,7 @@
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
-      "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.security=pii\"}]}, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
+      "value": "{\"schemaName\": \"test_db.test_schema.table_1\", \"platform\": \"urn:li:dataPlatform:snowflake\", \"version\": 0, \"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"hash\": \"\", \"platformSchema\": {\"com.linkedin.schema.MySqlDDL\": {\"tableSchema\": \"\"}}, \"fields\": [{\"fieldPath\": \"col_1\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.NumberType\": {}}}, \"nativeDataType\": \"NUMBER(38,0)\", \"recursive\": false, \"globalTags\": {\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.security:pii\"}]}, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Age\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_2\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"glossaryTerms\": {\"terms\": [{\"urn\": \"urn:li:glossaryTerm:Email_Address\"}], \"auditStamp\": {\"time\": 1654621200000, \"actor\": \"urn:li:corpuser:datahub\"}}, \"isPartOfKey\": false}, {\"fieldPath\": \"col_3\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_4\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_5\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_6\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_7\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_8\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_9\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}, {\"fieldPath\": \"col_10\", \"nullable\": false, \"description\": \"Comment for column\", \"type\": {\"type\": {\"com.linkedin.schema.StringType\": {}}}, \"nativeDataType\": \"VARCHAR(255)\", \"recursive\": false, \"isPartOfKey\": false}]}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -239,11 +239,11 @@
   },
   {
     "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0=my_value_0",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_0:my_value_0",
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_0=my_value_0\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_0` with value `my_value_0`.\"}",
+      "value": "{\"name\": \"test_db.test_schema.my_tag_0:my_value_0\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_0` with value `my_value_0`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -253,11 +253,11 @@
   },
   {
     "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1=my_value_1",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_1:my_value_1",
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_1=my_value_1\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_1` with value `my_value_1`.\"}",
+      "value": "{\"name\": \"test_db.test_schema.my_tag_1:my_value_1\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_1` with value `my_value_1`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -267,11 +267,11 @@
   },
   {
     "entityType": "tag",
-    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2=my_value_2",
+    "entityUrn": "urn:li:tag:test_db.test_schema.my_tag_2:my_value_2",
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"test_db.test_schema.my_tag_2=my_value_2\", \"description\": \"Represents the Snowflake tag `test_db.test_schema.my_tag_2` with value `my_value_2`.\"}",
+      "value": "{\"name\": \"test_db.test_schema.my_tag_2:my_value_2\", \"description\": \"Represents the Snowflake tag `TEST_DB.TEST_SCHEMA.my_tag_2` with value `my_value_2`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -355,7 +355,7 @@
     "changeType": "UPSERT",
     "aspectName": "globalTags",
     "aspect": {
-      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_0=my_value_0\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_1=my_value_1\"}, {\"tag\": \"urn:li:tag:test_db.test_schema.my_tag_2=my_value_2\"}]}",
+      "value": "{\"tags\": [{\"tag\": \"urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_0:my_value_0\"}, {\"tag\": \"urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_1:my_value_1\"}, {\"tag\": \"urn:li:tag:TEST_DB.TEST_SCHEMA.my_tag_2:my_value_2\"}]}",
       "contentType": "application/json"
     },
     "systemMetadata": {
@@ -1345,11 +1345,11 @@
   },
   {
     "entityType": "tag",
-    "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag=other",
+    "entityUrn": "urn:li:tag:other_db.other_schema.my_other_tag:other",
     "changeType": "UPSERT",
     "aspectName": "tagProperties",
     "aspect": {
-      "value": "{\"name\": \"other_db.other_schema.my_other_tag=other\", \"description\": \"Represents the Snowflake tag `other_db.other_schema.my_other_tag` with value `other`.\"}",
+      "value": "{\"name\": \"other_db.other_schema.my_other_tag:other\", \"description\": \"Represents the Snowflake tag `OTHER_DB.OTHER_SCHEMA.my_other_tag` with value `other`.\"}",
       "contentType": "application/json"
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake.py
@@ -19,7 +19,10 @@ from datahub.ingestion.glossary.datahub_classifier import (
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.run.pipeline_config import PipelineConfig, SourceConfig
 from datahub.ingestion.source.ge_profiling_config import GEProfilingConfig
-from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
+from datahub.ingestion.source.snowflake.snowflake_config import (
+    SnowflakeV2Config,
+    TagOption,
+)
 from tests.integration.snowflake.common import FROZEN_TIME, default_query_results
 from tests.test_helpers import mce_helpers
 
@@ -109,6 +112,7 @@ def test_snowflake_basic(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
                             profile_table_size_limit=None,
                             profile_table_level_only=True,
                         ),
+                        extract_tags=TagOption.without_lineage,
                     ),
                 ),
                 sink=DynamicTypedConfig(


### PR DESCRIPTION
Adding support to extracts tags object tags from Snowflake. The scope is limited to database, schema, table/view, and column tags. It also (optionally) creates the extracted tags. Only the tags that are applied to objects are created; it does not pull all existing tags in Snowflake. Caters to https://feature-requests.datahubproject.io/p/ingest-snowflake-object-tags

There are some peculiarities about Snowflake tags that should be considered.

### 1. Snowflake tags are key-values, not simple strings (as in Datahub).

This is handled in this PR by converting the key-value tag into a simple string with the following formatting: `<db_name>.<schema_name>.<tag_name>=<tag_value>`, where `db_name` and `schema_name` are the DB and schema in which the tag is defined, respectively. While not the prettiest, this format should allow users to quite easily define a formatter to customize the look of the tag, if they chose to. Implementing this formatter is outside the scope of this PR.  

### 2. Snowflake allows tagging objects directly, but also through propagation (or lineage as they call it). 

This means that a tag applied to a database propagates down to the schemas, tables, and columns as well. Applying the same, propagated tag directly on the object, but with a different value, takes precedence over the propagated value. There are different methodologies to get the tags that are directly applied and the ones that are also propagated. 

As the propagated tags are "effective" (for example tag_based masking policies applied to tables evaluated when querying columns), a Datahub user might want extract them in addition to the directly applied tags. To accommodate both uses cases, a configuration field `extract_tags` is introduced that allows selecting which type of tags extraction is wanted.

It should be noted that extracting the propagated tags is done on an object basis (except for columns) and will therefore require more queries to be made. Extracting only the directly applied tags can be done in a single query per DB (+ cached).  




## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
