### PR TITLE
fix(ingest): correctly handle transformer patch semantics

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_browse_path.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_browse_path.py
@@ -36,7 +36,7 @@ class AddDatasetBrowsePathTransformer(DatasetBrowsePathsTransformer):
         return cls(config, ctx)
 
     @staticmethod
-    def get_browse_paths_to_set(
+    def _merge_with_server_browse_paths(
         graph: DataHubGraph, urn: str, mce_browse_paths: Optional[BrowsePathsClass]
     ) -> Optional[BrowsePathsClass]:
         if not mce_browse_paths or not mce_browse_paths.paths:
@@ -82,12 +82,11 @@ class AddDatasetBrowsePathTransformer(DatasetBrowsePathsTransformer):
 
         if self.config.semantics == TransformerSemantics.PATCH:
             assert self.ctx.graph
-            patch_browse_paths: Optional[
-                BrowsePathsClass
-            ] = AddDatasetBrowsePathTransformer.get_browse_paths_to_set(
-                self.ctx.graph, entity_urn, browse_paths
+            return cast(
+                Optional[Aspect],
+                AddDatasetBrowsePathTransformer._merge_with_server_browse_paths(
+                    self.ctx.graph, entity_urn, browse_paths
+                ),
             )
-            if patch_browse_paths is not None:
-                browse_paths = patch_browse_paths
-
-        return cast(Optional[Aspect], browse_paths)
+        else:
+            return cast(Aspect, browse_paths)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_properties.py
@@ -54,7 +54,7 @@ class AddDatasetProperties(DatasetPropertiesTransformer):
         return cls(config, ctx)
 
     @staticmethod
-    def get_patch_dataset_properties_aspect(
+    def _merge_with_server_properties(
         graph: DataHubGraph,
         entity_urn: str,
         dataset_properties_aspect: Optional[DatasetPropertiesClass],
@@ -108,15 +108,11 @@ class AddDatasetProperties(DatasetPropertiesTransformer):
         if self.config.semantics == TransformerSemantics.PATCH:
             assert self.ctx.graph
             patch_dataset_properties_aspect = (
-                AddDatasetProperties.get_patch_dataset_properties_aspect(
+                AddDatasetProperties._merge_with_server_properties(
                     self.ctx.graph, entity_urn, out_dataset_properties_aspect
                 )
             )
-            out_dataset_properties_aspect = (
-                patch_dataset_properties_aspect
-                if patch_dataset_properties_aspect is not None
-                else out_dataset_properties_aspect
-            )
+            return cast(Optional[Aspect], patch_dataset_properties_aspect)
 
         return cast(Aspect, out_dataset_properties_aspect)
 

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_tags.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_tags.py
@@ -36,34 +36,25 @@ class AddDatasetTags(DatasetTagsTransformer):
         return cls(config, ctx)
 
     @staticmethod
-    def get_patch_global_tags_aspect(
+    def _merge_with_server_global_tags(
         graph: DataHubGraph, urn: str, global_tags_aspect: Optional[GlobalTagsClass]
     ) -> Optional[GlobalTagsClass]:
         if not global_tags_aspect or not global_tags_aspect.tags:
             # nothing to add, no need to consult server
-            return global_tags_aspect
+            return None
 
+        # Merge the transformed tags with existing server tags.
+        # The transformed tags takes precedence, which may change the tag context.
         server_global_tags_aspect = graph.get_tags(entity_urn=urn)
-        # No server aspect to patch
-        if server_global_tags_aspect is None:
-            return global_tags_aspect
+        if server_global_tags_aspect:
+            global_tags_aspect.tags = list(
+                {
+                    **{tag.tag: tag for tag in server_global_tags_aspect.tags},
+                    **{tag.tag: tag for tag in global_tags_aspect.tags},
+                }.values()
+            )
 
-        # Compute patch
-        # We only include tags which are not present in the server tag list
-        server_tag_urns: List[str] = [
-            tag_association.tag for tag_association in server_global_tags_aspect.tags
-        ]
-        tags_to_add: List[TagAssociationClass] = [
-            tag_association
-            for tag_association in global_tags_aspect.tags
-            if tag_association.tag not in server_tag_urns
-        ]
-        # Lets patch
-        patch_global_tags_aspect: GlobalTagsClass = GlobalTagsClass(tags=[])
-        patch_global_tags_aspect.tags.extend(server_global_tags_aspect.tags)
-        patch_global_tags_aspect.tags.extend(tags_to_add)
-
-        return patch_global_tags_aspect
+        return global_tags_aspect
 
     def transform_aspect(
         self, entity_urn: str, aspect_name: str, aspect: Optional[Aspect]
@@ -78,18 +69,16 @@ class AddDatasetTags(DatasetTagsTransformer):
         if tags_to_add is not None:
             out_global_tags_aspect.tags.extend(tags_to_add)
 
-        patch_global_tags_aspect: Optional[GlobalTagsClass] = None
         if self.config.semantics == TransformerSemantics.PATCH:
             assert self.ctx.graph
-            patch_global_tags_aspect = AddDatasetTags.get_patch_global_tags_aspect(
-                self.ctx.graph, entity_urn, out_global_tags_aspect
+            return cast(
+                Optional[Aspect],
+                AddDatasetTags._merge_with_server_global_tags(
+                    self.ctx.graph, entity_urn, out_global_tags_aspect
+                ),
             )
 
-        return (
-            cast(Optional[Aspect], patch_global_tags_aspect)
-            if patch_global_tags_aspect is not None
-            else cast(Optional[Aspect], out_global_tags_aspect)
-        )
+        return cast(Aspect, out_global_tags_aspect)
 
 
 class SimpleDatasetTagConfig(TransformerSemanticsConfigModel):

--- a/metadata-ingestion/src/datahub/ingestion/transformer/dataset_domain.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/dataset_domain.py
@@ -68,7 +68,7 @@ class AddDatasetDomain(DatasetDomainTransformer):
         return domain_class
 
     @staticmethod
-    def get_domains_to_set(
+    def _merge_with_server_domains(
         graph: DataHubGraph, urn: str, mce_domain: Optional[DomainsClass]
     ) -> Optional[DomainsClass]:
         if not mce_domain or not mce_domain.domains:
@@ -108,15 +108,10 @@ class AddDatasetDomain(DatasetDomainTransformer):
             assert self.ctx.graph
             patch_domain_aspect: Optional[
                 DomainsClass
-            ] = AddDatasetDomain.get_domains_to_set(
+            ] = AddDatasetDomain._merge_with_server_domains(
                 self.ctx.graph, entity_urn, domain_aspect
             )
-            # This will pass the mypy lint
-            domain_aspect = (
-                patch_domain_aspect
-                if patch_domain_aspect is not None
-                else domain_aspect
-            )
+            return cast(Optional[Aspect], patch_domain_aspect)
 
         return cast(Optional[Aspect], domain_aspect)
 

--- a/metadata-ingestion/src/datahub/ingestion/transformer/remove_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/remove_dataset_ownership.py
@@ -31,8 +31,7 @@ class SimpleRemoveDatasetOwnership(DatasetOwnershipTransformer):
     ) -> Optional[Aspect]:
         in_ownership_aspect = cast(OwnershipClass, aspect)
         if in_ownership_aspect is None:
-            return cast(Aspect, in_ownership_aspect)
+            return None
 
         in_ownership_aspect.owners = []
-
         return cast(Aspect, in_ownership_aspect)

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -845,7 +845,7 @@ def test_ownership_patching_intersect(mock_time):
     mce_ownership = gen_owners(["baz", "foo"])
     mock_graph.get_ownership.return_value = server_ownership
 
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", mce_ownership
     )
     assert test_ownership and test_ownership.owners
@@ -858,7 +858,7 @@ def test_ownership_patching_with_nones(mock_time):
     mock_graph = mock.MagicMock()
     mce_ownership = gen_owners(["baz", "foo"])
     mock_graph.get_ownership.return_value = None
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", mce_ownership
     )
     assert test_ownership and test_ownership.owners
@@ -867,7 +867,7 @@ def test_ownership_patching_with_nones(mock_time):
 
     server_ownership = gen_owners(["baz", "foo"])
     mock_graph.get_ownership.return_value = server_ownership
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", None
     )
     assert not test_ownership
@@ -877,7 +877,7 @@ def test_ownership_patching_with_empty_mce_none_server(mock_time):
     mock_graph = mock.MagicMock()
     mce_ownership = gen_owners([])
     mock_graph.get_ownership.return_value = None
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", mce_ownership
     )
     # nothing to add, so we omit writing
@@ -889,7 +889,7 @@ def test_ownership_patching_with_empty_mce_nonempty_server(mock_time):
     server_ownership = gen_owners(["baz", "foo"])
     mce_ownership = gen_owners([])
     mock_graph.get_ownership.return_value = server_ownership
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", mce_ownership
     )
     # nothing to add, so we omit writing
@@ -901,7 +901,7 @@ def test_ownership_patching_with_different_types_1(mock_time):
     server_ownership = gen_owners(["baz", "foo"], models.OwnershipTypeClass.PRODUCER)
     mce_ownership = gen_owners(["foo"], models.OwnershipTypeClass.DATAOWNER)
     mock_graph.get_ownership.return_value = server_ownership
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", mce_ownership
     )
     assert test_ownership and test_ownership.owners
@@ -919,7 +919,7 @@ def test_ownership_patching_with_different_types_2(mock_time):
     server_ownership = gen_owners(["baz", "foo"], models.OwnershipTypeClass.PRODUCER)
     mce_ownership = gen_owners(["foo", "baz"], models.OwnershipTypeClass.DATAOWNER)
     mock_graph.get_ownership.return_value = server_ownership
-    test_ownership = AddDatasetOwnership.get_patch_ownership_aspect(
+    test_ownership = AddDatasetOwnership._merge_with_server_ownership(
         mock_graph, "test_urn", mce_ownership
     )
     assert test_ownership and test_ownership.owners


### PR DESCRIPTION
The ownership transformer contains a clever optimization, where if it is set to PATCH and does not need to make any changes, no aspect is generated. The surrounding code did not handle this logic correctly, and would issue an upsert with the original ownership object, hence overwriting anything that lived on the server. This bug would only be triggered if the server already contained a superset of what the transformer was trying to add.

Many other dataset transformers also had a similar, subtle bug. For example, if using the `pattern_add_dataset_tags` transformer and a no new tags applied to a given dataset, the server's tags would get overwritten even if PATCH was specified. This PR should also resolve that class of bugs.

Tested manually with the ownership, props, and tags transformers.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
