### PR TITLE
fix(docs): add missing docs for 0.9.1

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -254,6 +254,7 @@ module.exports = {
       "docs/deploy/gcp",
       "docker/README",
       "docs/deploy/kubernetes",
+      "docs/how/updating-datahub",
       {
         Authentication: [
           "docs/authentication/README",
@@ -286,7 +287,6 @@ module.exports = {
       {
         "Advanced Guides": [
           "docs/how/delete-metadata",
-          "docs/how/updating-datahub",
           "datahub-ranger-plugin/README",
           "docs/how/backup-datahub",
           "docs/how/restore-indices",

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -28,6 +28,17 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Other notable Changes
 
+## 0.9.1
+
+### Breaking Changes
+- we have promoted `bigqery-beta` to `bigquery`. If you are using `bigquery-beta` then change your recipes to use the type `bigquery`
+
+### Potential Downtime
+
+### Deprecations
+
+### Other notable Changes
+
 ## 0.9.0
 
 ### Breaking Changes


### PR DESCRIPTION
Moving the doc to top-level as updating is part of managing a deployment and not an advanced operation.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
