### PR TITLE
fix(ui) Fix roles not always displaying on page load

### DIFF
--- a/datahub-web-react/src/app/identity/user/SelectRole.tsx
+++ b/datahub-web-react/src/app/identity/user/SelectRole.tsx
@@ -5,19 +5,21 @@ import styled from 'styled-components';
 import { CorpUser, DataHubRole } from '../../../types.generated';
 import AssignRoleConfirmation from './AssignRoleConfirmation';
 import { mapRoleIcon } from './UserUtils';
+import { ANTD_GRAY } from '../../entity/shared/constants';
 
 const NO_ROLE_TEXT = 'No Role';
 const NO_ROLE_URN = 'urn:li:dataHubRole:NoRole';
 
 type Props = {
     user: CorpUser;
-    userRoleUrn?: string;
+    userRoleUrn: string;
     selectRoleOptions: Array<DataHubRole>;
     refetch?: () => void;
 };
 
-const RoleSelect = styled(Select)`
+const RoleSelect = styled(Select)<{ color?: string }>`
     min-width: 105px;
+    ${(props) => (props.color ? ` color: ${props.color};` : '')}
 `;
 
 const RoleIcon = styled.span`
@@ -40,16 +42,17 @@ export default function SelectRole({ user, userRoleUrn, selectRoleOptions, refet
         );
     });
 
-    const [currentRole, setCurrentRole] = useState<string | undefined>(userRoleUrn || undefined);
+    const defaultRoleUrn = userRoleUrn || NO_ROLE_URN;
+    const [currentRole, setCurrentRole] = useState<string>(defaultRoleUrn);
     const [isViewingAssignRole, setIsViewingAssignRole] = useState(false);
 
     const onSelectRole = (roleUrn: string) => {
-        setCurrentRole(roleUrn === NO_ROLE_URN ? undefined : roleUrn);
+        setCurrentRole(roleUrn);
         setIsViewingAssignRole(true);
     };
 
     const onCancel = () => {
-        setCurrentRole(userRoleUrn || undefined);
+        setCurrentRole(defaultRoleUrn);
         setIsViewingAssignRole(false);
     };
 
@@ -74,12 +77,13 @@ export default function SelectRole({ user, userRoleUrn, selectRoleOptions, refet
                 }
                 value={currentRole}
                 onChange={(e) => onSelectRole(e as string)}
+                color={currentRole === NO_ROLE_URN ? ANTD_GRAY[6] : undefined}
             >
                 {selectOptions}
             </RoleSelect>
             <AssignRoleConfirmation
                 visible={isViewingAssignRole}
-                roleToAssign={rolesMap.get(currentRole || '')}
+                roleToAssign={rolesMap.get(currentRole)}
                 userUrn={user.urn}
                 username={user.username}
                 onClose={onCancel}


### PR DESCRIPTION
Sometimes roles would not always be displayed properly on the users page because we have to load the list of available roles from the backend and then set initial role state for a user based on that list. However, there was a race condition where we had the user's role urn but not the list of roles available loaded yet, so our initial state would be `undefined` and that wouldn't get updated until you selected something.

This fixes that by changing what we store in state to be an urn string (which is a bit more expected than a role object if you ask me) and then we dynamically render the role based on the urn in state for their role. This also fixes another weird situation where if you have no role and select no role we ask you to confirm if you want to remove the role. In order to fix that I'm being more controlled about what's in state instead of relying on falsy javascript values to control what's being displayed.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
