### PR TITLE
feat(models): Adding 'created', 'lastModified' timestamp to Dataset, Container, Dashboard, Chart

### DIFF
--- a/li-utils/src/main/pegasus/com/linkedin/common/TimeStamp.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/TimeStamp.pdl
@@ -1,0 +1,16 @@
+namespace com.linkedin.common
+
+/**
+ * A standard event timestamp
+ */
+record TimeStamp {
+  /**
+   * When did the event occur
+   */
+  time: Time
+
+  /**
+   * Optional: The actor urn involved in the event.
+   */
+  actor: optional Urn
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
@@ -2,7 +2,7 @@ namespace com.linkedin.container
 
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
-import com.linkedin.common.AuditStamp
+import com.linkedin.common.Time
 
 /**
  * Information about a Asset Container as received from a 3rd party source system
@@ -44,5 +44,8 @@ record ContainerProperties includes CustomProperties, ExternalReference {
    * Audit stamp describing the time and actor
    * that created the Container in the source Data Platform (not on DataHub)
    */
-  created: optional AuditStamp
+  @Searchable = {
+    "fieldType": "DATETIME"
+  }
+  createdAt: optional Time
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.container
 
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
+import com.linkedin.common.AuditStamp
 
 /**
  * Information about a Asset Container as received from a 3rd party source system
@@ -38,4 +39,10 @@ record ContainerProperties includes CustomProperties, ExternalReference {
     "hasValuesFieldName": "hasDescription"
   }
   description: optional string
+
+  /**
+   * Audit stamp describing the time and actor
+   * that created the Container in the source Data Platform (not on DataHub)
+   */
+  created: optional AuditStamp
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
@@ -2,7 +2,7 @@ namespace com.linkedin.container
 
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
-import com.linkedin.common.Time
+import com.linkedin.common.TimeStamp
 
 /**
  * Information about a Asset Container as received from a 3rd party source system
@@ -41,11 +41,24 @@ record ContainerProperties includes CustomProperties, ExternalReference {
   description: optional string
 
   /**
-   * Audit stamp describing the time and actor
-   * that created the Container in the source Data Platform (not on DataHub)
+   * A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)
    */
   @Searchable = {
-    "fieldType": "DATETIME"
+    "/time": {
+      "fieldName": "createdAt",
+      "fieldType": "DATETIME"
+    }
   }
-  createdAt: optional Time
+  created: optional TimeStamp
+
+  /**
+   * A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)
+   */
+  @Searchable = {
+    "/time": {
+      "fieldName": "lastModifiedAt",
+      "fieldType": "DATETIME"
+    }
+  }
+  lastModified: optional TimeStamp
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.datajob
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.Urn
-import com.linkedin.common.Time
+import com.linkedin.common.TimeStamp
 
 /**
  * Information about a Data processing flow
@@ -42,11 +42,24 @@ record DataFlowInfo includes CustomProperties, ExternalReference {
   project: optional string
 
   /**
-   * Audit stamp describing the time and actor
-   * that created the Data Flow in the source Data Platform (not on DataHub)
+   * A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)
    */
   @Searchable = {
-    "fieldType": "DATETIME"
+    "/time": {
+      "fieldName": "createdAt",
+      "fieldType": "DATETIME"
+    }
   }
-  createdAt: optional Time
+  created: optional TimeStamp
+
+  /**
+   * A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)
+   */
+  @Searchable = {
+    "/time": {
+      "fieldName": "lastModifiedAt",
+      "fieldType": "DATETIME"
+    }
+  }
+  lastModified: optional TimeStamp
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.datajob
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.Urn
-import com.linkedin.common.AuditStamp
+import com.linkedin.common.Time
 
 /**
  * Information about a Data processing flow
@@ -45,5 +45,8 @@ record DataFlowInfo includes CustomProperties, ExternalReference {
    * Audit stamp describing the time and actor
    * that created the Data Flow in the source Data Platform (not on DataHub)
    */
-  created: optional AuditStamp
+  @Searchable = {
+    "fieldType": "DATETIME"
+  }
+  createdAt: optional Time
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
@@ -3,6 +3,7 @@ namespace com.linkedin.datajob
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.Urn
+import com.linkedin.common.AuditStamp
 
 /**
  * Information about a Data processing flow
@@ -39,4 +40,10 @@ record DataFlowInfo includes CustomProperties, ExternalReference {
     "queryByDefault": false
   }
   project: optional string
+
+  /**
+   * Audit stamp describing the time and actor
+   * that created the Data Flow in the source Data Platform (not on DataHub)
+   */
+  created: optional AuditStamp
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
@@ -4,7 +4,7 @@ import com.linkedin.datajob.azkaban.AzkabanJobType
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.DataFlowUrn
-import com.linkedin.common.AuditStamp
+import com.linkedin.common.Time
 
 /**
  * Information about a Data processing job
@@ -48,11 +48,14 @@ record DataJobInfo includes CustomProperties, ExternalReference {
    * Audit stamp describing the time and actor
    * that created the Data Job in the source Data Platform (not on DataHub)
    */
-  created: optional AuditStamp
+  @Searchable = {
+    "fieldType": "DATETIME"
+  }
+  createdAt: optional Time
 
   /**
    * Status of the job - Deprecated for Data Process Instance model.
    */
-  @deprecated("Use Data Process Instance model, instead")
+  @deprecated = "Use Data Process Instance model, instead"
   status: optional JobStatus
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
@@ -4,7 +4,7 @@ import com.linkedin.datajob.azkaban.AzkabanJobType
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.DataFlowUrn
-import com.linkedin.common.Time
+import com.linkedin.common.TimeStamp
 
 /**
  * Information about a Data processing job
@@ -45,13 +45,26 @@ record DataJobInfo includes CustomProperties, ExternalReference {
   flowUrn: optional DataFlowUrn
 
   /**
-   * Audit stamp describing the time and actor
-   * that created the Data Job in the source Data Platform (not on DataHub)
+   * A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)
    */
   @Searchable = {
-    "fieldType": "DATETIME"
+    "/time": {
+      "fieldName": "createdAt",
+      "fieldType": "DATETIME"
+    }
   }
-  createdAt: optional Time
+  created: optional TimeStamp
+
+  /**
+   * A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)
+   */
+  @Searchable = {
+    "/time": {
+      "fieldName": "lastModifiedAt",
+      "fieldType": "DATETIME"
+    }
+  }
+  lastModified: optional TimeStamp
 
   /**
    * Status of the job - Deprecated for Data Process Instance model.

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
@@ -4,6 +4,7 @@ import com.linkedin.datajob.azkaban.AzkabanJobType
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.DataFlowUrn
+import com.linkedin.common.AuditStamp
 
 /**
  * Information about a Data processing job
@@ -44,7 +45,14 @@ record DataJobInfo includes CustomProperties, ExternalReference {
   flowUrn: optional DataFlowUrn
 
   /**
-   * Status of the job
+   * Audit stamp describing the time and actor
+   * that created the Data Job in the source Data Platform (not on DataHub)
    */
+  created: optional AuditStamp
+
+  /**
+   * Status of the job - Deprecated for Data Process Instance model.
+   */
+  @deprecated("Use Data Process Instance model, instead")
   status: optional JobStatus
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.dataset
 import com.linkedin.common.Uri
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
-import com.linkedin.common.Time
+import com.linkedin.common.AuditStamp
 
 /**
  * Properties associated with a Dataset
@@ -49,10 +49,10 @@ record DatasetProperties includes CustomProperties, ExternalReference {
   uri: optional Uri
 
   /**
-   * The time in milliseconds when the Dataset was
-   * originally created in the source Data Platform (not on DataHub)
+   * Audit stamp describing the time and actor
+   * that created the Dataset in the source Data Platform (not on DataHub)
    */
-  createdAt: optional Time
+  created: optional AuditStamp
 
   /**
    * [Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.dataset
 import com.linkedin.common.Uri
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
-import com.linkedin.common.Time
+import com.linkedin.common.TimeStamp
 
 /**
  * Properties associated with a Dataset
@@ -49,13 +49,26 @@ record DatasetProperties includes CustomProperties, ExternalReference {
   uri: optional Uri
 
   /**
-   * Audit stamp describing the time and actor
-   * that created the Dataset in the source Data Platform (not on DataHub)
+   * A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)
    */
   @Searchable = {
-    "fieldType": "DATETIME"
+    "/time": {
+      "fieldName": "createdAt",
+      "fieldType": "DATETIME"
+    }
   }
-  createdAt: optional Time
+  created: optional TimeStamp
+
+  /**
+   * A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)
+   */
+  @Searchable = {
+    "/time": {
+      "fieldName": "lastModifiedAt",
+      "fieldType": "DATETIME"
+    }
+  }
+  lastModified: optional TimeStamp
 
   /**
    * [Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
@@ -3,6 +3,7 @@ namespace com.linkedin.dataset
 import com.linkedin.common.Uri
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
+import com.linkedin.common.Time
 
 /**
  * Properties associated with a Dataset
@@ -48,7 +49,15 @@ record DatasetProperties includes CustomProperties, ExternalReference {
   uri: optional Uri
 
   /**
-   * [Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.
+   * The time in milliseconds when the Dataset was
+   * originally created in the source Data Platform (not on DataHub)
    */
+  createdAt: optional Time
+
+  /**
+   * [Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.
+   * This is now deprecated.
+   */
+  @deprecated = "Use GlobalTags aspect instead."
   tags: array[string] = [ ]
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.dataset
 import com.linkedin.common.Uri
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
-import com.linkedin.common.AuditStamp
+import com.linkedin.common.Time
 
 /**
  * Properties associated with a Dataset
@@ -52,7 +52,10 @@ record DatasetProperties includes CustomProperties, ExternalReference {
    * Audit stamp describing the time and actor
    * that created the Dataset in the source Data Platform (not on DataHub)
    */
-  created: optional AuditStamp
+  @Searchable = {
+    "fieldType": "DATETIME"
+  }
+  createdAt: optional Time
 
   /**
    * [Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1156,6 +1156,21 @@
       "name" : "status"
     }
   }, "com.linkedin.common.TagAssociation", "com.linkedin.common.TagUrn", "com.linkedin.common.Time", {
+    "type" : "record",
+    "name" : "TimeStamp",
+    "namespace" : "com.linkedin.common",
+    "doc" : "A standard event timestamp",
+    "fields" : [ {
+      "name" : "time",
+      "type" : "Time",
+      "doc" : "When did the event occur"
+    }, {
+      "name" : "actor",
+      "type" : "Urn",
+      "doc" : "Optional: The actor urn involved in the event.",
+      "optional" : true
+    } ]
+  }, {
     "type" : "typeref",
     "name" : "Uri",
     "namespace" : "com.linkedin.common",
@@ -1287,6 +1302,28 @@
         "fieldType" : "TEXT_PARTIAL",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "dataFlowInfo"
@@ -1340,6 +1377,28 @@
       "doc" : "DataFlow urn that this job is part of",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "status",
       "type" : {
         "type" : "enum",
@@ -1357,8 +1416,9 @@
           "UNKNOWN" : "Jobs with unknown status (either unmappable or unavailable)"
         }
       },
-      "doc" : "Status of the job",
-      "optional" : true
+      "doc" : "Status of the job - Deprecated for Data Process Instance model.",
+      "optional" : true,
+      "deprecated" : "Use Data Process Instance model, instead"
     } ],
     "Aspect" : {
       "name" : "dataJobInfo"
@@ -1630,13 +1690,36 @@
       "doc" : "The abstracted URI such as hdfs:///data/tracking/PageViewEvent, file:///dir/file_name. Uri should not include any environment specific properties. Some datasets might not have a standardized uri, which makes this field optional (i.e. kafka topic).",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "tags",
       "type" : {
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.",
-      "default" : [ ]
+      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.\nThis is now deprecated.",
+      "default" : [ ],
+      "deprecated" : "Use GlobalTags aspect instead."
     } ],
     "Aspect" : {
       "name" : "datasetProperties"
@@ -1655,12 +1738,11 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+      "doc" : "Audit stamp containing who reported the lineage and when.",
       "default" : {
         "actor" : "urn:li:corpuser:unknown",
         "time" : 0
-      },
-      "deprecated" : "we no longer associate a timestamp per upstream edge"
+      }
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",
@@ -1765,7 +1847,6 @@
       "doc" : "Optional id for the GlossaryNode",
       "optional" : true,
       "Searchable" : {
-        "enableAutocomplete" : true,
         "fieldType" : "TEXT_PARTIAL"
       }
     } ],
@@ -1784,7 +1865,6 @@
       "doc" : "Optional id for the term",
       "optional" : true,
       "Searchable" : {
-        "enableAutocomplete" : true,
         "fieldType" : "TEXT_PARTIAL"
       }
     }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -1167,6 +1167,21 @@
       "name" : "status"
     }
   }, "com.linkedin.common.TagAssociation", "com.linkedin.common.TagUrn", "com.linkedin.common.Time", {
+    "type" : "record",
+    "name" : "TimeStamp",
+    "namespace" : "com.linkedin.common",
+    "doc" : "A standard event timestamp",
+    "fields" : [ {
+      "name" : "time",
+      "type" : "Time",
+      "doc" : "When did the event occur"
+    }, {
+      "name" : "actor",
+      "type" : "Urn",
+      "doc" : "Optional: The actor urn involved in the event.",
+      "optional" : true
+    } ]
+  }, {
     "type" : "typeref",
     "name" : "Uri",
     "namespace" : "com.linkedin.common",
@@ -1317,6 +1332,28 @@
         "fieldType" : "TEXT_PARTIAL",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "dataFlowInfo"
@@ -1370,6 +1407,28 @@
       "doc" : "DataFlow urn that this job is part of",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "status",
       "type" : {
         "type" : "enum",
@@ -1387,8 +1446,9 @@
           "UNKNOWN" : "Jobs with unknown status (either unmappable or unavailable)"
         }
       },
-      "doc" : "Status of the job",
-      "optional" : true
+      "doc" : "Status of the job - Deprecated for Data Process Instance model.",
+      "optional" : true,
+      "deprecated" : "Use Data Process Instance model, instead"
     } ],
     "Aspect" : {
       "name" : "dataJobInfo"
@@ -1840,13 +1900,36 @@
       "doc" : "The abstracted URI such as hdfs:///data/tracking/PageViewEvent, file:///dir/file_name. Uri should not include any environment specific properties. Some datasets might not have a standardized uri, which makes this field optional (i.e. kafka topic).",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "tags",
       "type" : {
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.",
-      "default" : [ ]
+      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.\nThis is now deprecated.",
+      "default" : [ ],
+      "deprecated" : "Use GlobalTags aspect instead."
     } ],
     "Aspect" : {
       "name" : "datasetProperties"
@@ -1901,12 +1984,11 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+      "doc" : "Audit stamp containing who reported the lineage and when.",
       "default" : {
         "actor" : "urn:li:corpuser:unknown",
         "time" : 0
-      },
-      "deprecated" : "we no longer associate a timestamp per upstream edge"
+      }
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",
@@ -4478,7 +4560,6 @@
                     "doc" : "Optional id for the term",
                     "optional" : true,
                     "Searchable" : {
-                      "enableAutocomplete" : true,
                       "fieldType" : "TEXT_PARTIAL"
                     }
                   }, {
@@ -4603,7 +4684,6 @@
                     },
                     "Searchable" : {
                       "/*" : {
-                        "boostScore" : 2.0,
                         "fieldName" : "values",
                         "fieldType" : "URN"
                       }
@@ -4619,12 +4699,11 @@
                     "Relationship" : {
                       "/*" : {
                         "entityTypes" : [ "glossaryTerm" ],
-                        "name" : "isRelatedTo"
+                        "name" : "IsRelatedTo"
                       }
                     },
                     "Searchable" : {
                       "/*" : {
-                        "boostScore" : 2.0,
                         "fieldName" : "relatedTerms",
                         "fieldType" : "URN"
                       }
@@ -4716,7 +4795,6 @@
                     "doc" : "Optional id for the GlossaryNode",
                     "optional" : true,
                     "Searchable" : {
-                      "enableAutocomplete" : true,
                       "fieldType" : "TEXT_PARTIAL"
                     }
                   } ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -910,6 +910,21 @@
       "name" : "status"
     }
   }, "com.linkedin.common.TagAssociation", "com.linkedin.common.TagUrn", "com.linkedin.common.Time", {
+    "type" : "record",
+    "name" : "TimeStamp",
+    "namespace" : "com.linkedin.common",
+    "doc" : "A standard event timestamp",
+    "fields" : [ {
+      "name" : "time",
+      "type" : "Time",
+      "doc" : "When did the event occur"
+    }, {
+      "name" : "actor",
+      "type" : "Urn",
+      "doc" : "Optional: The actor urn involved in the event.",
+      "optional" : true
+    } ]
+  }, {
     "type" : "typeref",
     "name" : "Uri",
     "namespace" : "com.linkedin.common",
@@ -1041,6 +1056,28 @@
         "fieldType" : "TEXT_PARTIAL",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "dataFlowInfo"
@@ -1094,6 +1131,28 @@
       "doc" : "DataFlow urn that this job is part of",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "status",
       "type" : {
         "type" : "enum",
@@ -1111,8 +1170,9 @@
           "UNKNOWN" : "Jobs with unknown status (either unmappable or unavailable)"
         }
       },
-      "doc" : "Status of the job",
-      "optional" : true
+      "doc" : "Status of the job - Deprecated for Data Process Instance model.",
+      "optional" : true,
+      "deprecated" : "Use Data Process Instance model, instead"
     } ],
     "Aspect" : {
       "name" : "dataJobInfo"
@@ -1384,13 +1444,36 @@
       "doc" : "The abstracted URI such as hdfs:///data/tracking/PageViewEvent, file:///dir/file_name. Uri should not include any environment specific properties. Some datasets might not have a standardized uri, which makes this field optional (i.e. kafka topic).",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "tags",
       "type" : {
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.",
-      "default" : [ ]
+      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.\nThis is now deprecated.",
+      "default" : [ ],
+      "deprecated" : "Use GlobalTags aspect instead."
     } ],
     "Aspect" : {
       "name" : "datasetProperties"
@@ -1409,12 +1492,11 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+      "doc" : "Audit stamp containing who reported the lineage and when.",
       "default" : {
         "actor" : "urn:li:corpuser:unknown",
         "time" : 0
-      },
-      "deprecated" : "we no longer associate a timestamp per upstream edge"
+      }
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",
@@ -1511,7 +1593,6 @@
       "doc" : "Optional id for the GlossaryNode",
       "optional" : true,
       "Searchable" : {
-        "enableAutocomplete" : true,
         "fieldType" : "TEXT_PARTIAL"
       }
     } ],
@@ -1530,7 +1611,6 @@
       "doc" : "Optional id for the term",
       "optional" : true,
       "Searchable" : {
-        "enableAutocomplete" : true,
         "fieldType" : "TEXT_PARTIAL"
       }
     }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -1167,6 +1167,21 @@
       "name" : "status"
     }
   }, "com.linkedin.common.TagAssociation", "com.linkedin.common.TagUrn", "com.linkedin.common.Time", {
+    "type" : "record",
+    "name" : "TimeStamp",
+    "namespace" : "com.linkedin.common",
+    "doc" : "A standard event timestamp",
+    "fields" : [ {
+      "name" : "time",
+      "type" : "Time",
+      "doc" : "When did the event occur"
+    }, {
+      "name" : "actor",
+      "type" : "Urn",
+      "doc" : "Optional: The actor urn involved in the event.",
+      "optional" : true
+    } ]
+  }, {
     "type" : "typeref",
     "name" : "Uri",
     "namespace" : "com.linkedin.common",
@@ -1317,6 +1332,28 @@
         "fieldType" : "TEXT_PARTIAL",
         "queryByDefault" : false
       }
+    }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "dataFlowInfo"
@@ -1370,6 +1407,28 @@
       "doc" : "DataFlow urn that this job is part of",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "status",
       "type" : {
         "type" : "enum",
@@ -1387,8 +1446,9 @@
           "UNKNOWN" : "Jobs with unknown status (either unmappable or unavailable)"
         }
       },
-      "doc" : "Status of the job",
-      "optional" : true
+      "doc" : "Status of the job - Deprecated for Data Process Instance model.",
+      "optional" : true,
+      "deprecated" : "Use Data Process Instance model, instead"
     } ],
     "Aspect" : {
       "name" : "dataJobInfo"
@@ -1840,13 +1900,36 @@
       "doc" : "The abstracted URI such as hdfs:///data/tracking/PageViewEvent, file:///dir/file_name. Uri should not include any environment specific properties. Some datasets might not have a standardized uri, which makes this field optional (i.e. kafka topic).",
       "optional" : true
     }, {
+      "name" : "created",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was created in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "createdAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
+      "name" : "lastModified",
+      "type" : "com.linkedin.common.TimeStamp",
+      "doc" : "A timestamp documenting when the asset was last modified in the source Data Platform (not on DataHub)",
+      "optional" : true,
+      "Searchable" : {
+        "/time" : {
+          "fieldName" : "lastModifiedAt",
+          "fieldType" : "DATETIME"
+        }
+      }
+    }, {
       "name" : "tags",
       "type" : {
         "type" : "array",
         "items" : "string"
       },
-      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.",
-      "default" : [ ]
+      "doc" : "[Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect.\nThis is now deprecated.",
+      "default" : [ ],
+      "deprecated" : "Use GlobalTags aspect instead."
     } ],
     "Aspect" : {
       "name" : "datasetProperties"
@@ -1901,12 +1984,11 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+      "doc" : "Audit stamp containing who reported the lineage and when.",
       "default" : {
         "actor" : "urn:li:corpuser:unknown",
         "time" : 0
-      },
-      "deprecated" : "we no longer associate a timestamp per upstream edge"
+      }
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",
@@ -4472,7 +4554,6 @@
                     "doc" : "Optional id for the term",
                     "optional" : true,
                     "Searchable" : {
-                      "enableAutocomplete" : true,
                       "fieldType" : "TEXT_PARTIAL"
                     }
                   }, {
@@ -4597,7 +4678,6 @@
                     },
                     "Searchable" : {
                       "/*" : {
-                        "boostScore" : 2.0,
                         "fieldName" : "values",
                         "fieldType" : "URN"
                       }
@@ -4613,12 +4693,11 @@
                     "Relationship" : {
                       "/*" : {
                         "entityTypes" : [ "glossaryTerm" ],
-                        "name" : "isRelatedTo"
+                        "name" : "IsRelatedTo"
                       }
                     },
                     "Searchable" : {
                       "/*" : {
-                        "boostScore" : 2.0,
                         "fieldName" : "relatedTerms",
                         "fieldType" : "URN"
                       }
@@ -4710,7 +4789,6 @@
                     "doc" : "Optional id for the GlossaryNode",
                     "optional" : true,
                     "Searchable" : {
-                      "enableAutocomplete" : true,
                       "fieldType" : "TEXT_PARTIAL"
                     }
                   } ],


### PR DESCRIPTION
## Summary

Adding a 'createdAt' timestamp to Datasets, Containers, DataJobs, DataFlows. This is useful for reporting the native platform created time for data assets when ingesting into DataHub. 

We are not using an AuditStamp here because the Actor field inside is _required_. We do not always know that the actor will be resolvable to an URN for created actions, so we are choosing to omit for now. 

## Status

Ready for review. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
