### PR TITLE
fix(ui) Wrap schema field descriptions to allow read more/less always

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -160,6 +160,7 @@ export default function DescriptionField({ description, onUpdate, isEdited = fal
                             </>
                         }
                         suffix={EditButton}
+                        shouldWrap
                     >
                         {description}
                     </StripMarkdownText>


### PR DESCRIPTION
Schema field descriptions that were sufficiently long were getting cut off so that we couldn't see the "Read More" option to expand the description. All it takes is passing in a simple `shouldWrap` prop to the component and then "Read More" wraps when the description is too long to always show it.

**How it looked before:**
<img width="1129" alt="image" src="https://user-images.githubusercontent.com/28656603/203654687-88662aac-e2c5-4d92-8106-6343d019f49b.png">

**How it looks now**
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/28656603/203654758-d1994d8a-3593-4eb1-9c72-4ba1e498a6f9.png">



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
