### PR TITLE
fix(ingest): profiling - Profiling failed if column cardinality threw an error

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -300,6 +300,7 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 "Profiling - Unable to get column cardinality",
                 f"{self.dataset_name}.{column}",
             )
+            return
 
         unique_count = None
         pct_unique = None


### PR DESCRIPTION

Fix for `UnboundLocalError: local variable 'nonnull_count' referenced before assignment` error


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
