### PR TITLE
fix(test): fix delete smoke test

### DIFF
--- a/smoke-test/tests/delete/delete_test.py
+++ b/smoke-test/tests/delete/delete_test.py
@@ -23,7 +23,7 @@ def test_healthchecks(wait_for_healthchecks):
     pass
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def test_setup():
     """Fixture to execute asserts before and after a test is run"""
 
@@ -53,7 +53,7 @@ def test_setup():
 
 
 @pytest.mark.dependency()
-def test_delete_reference(depends=["test_healthchecks"]):
+def test_delete_reference(test_setup, depends=["test_healthchecks"]):
     platform = "urn:li:dataPlatform:kafka"
     dataset_name = "test-delete"
 


### PR DESCRIPTION
This is required since a delete executed for the healthcheck prevents the actual test from working because elasticsearch recalls that the fixture was deleted for around 60s.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
