### PR TITLE
fix(gms/startup): remove set -x from start.sh

### DIFF
--- a/docker/datahub-gms/start.sh
+++ b/docker/datahub-gms/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+
 # Add default URI (http) scheme if needed
 if ! echo $NEO4J_HOST | grep -q "://" ; then
     NEO4J_HOST="http://$NEO4J_HOST"


### PR DESCRIPTION
This PR resolves a security _risk_ (not vuln) where credentials are logged in plaintext during GMS docker start.sh execution.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
