### PR TITLE
fix(ui) Fix double scroll in embedded list search sections

### DIFF
--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -13,7 +13,7 @@ const StyledCheckbox = styled(Checkbox)`
 `;
 
 const StyledList = styled(List)`
-    overflow-y: scroll;
+    overflow-y: auto;
     height: 100%;
     margin-top: -1px;
     box-shadow: ${(props) => props.theme.styles['box-shadow']};

--- a/datahub-web-react/src/app/search/AdvancedSearchFilters.tsx
+++ b/datahub-web-react/src/app/search/AdvancedSearchFilters.tsx
@@ -11,11 +11,9 @@ import { FIELDS_THAT_USE_CONTAINS_OPERATOR, UnionType } from './utils/constants'
 import { AdvancedSearchAddFilterSelect } from './AdvancedSearchAddFilterSelect';
 
 export const SearchFilterWrapper = styled.div`
-    min-height: 100%;
+    flex: 1;
+    padding: 6px 12px 10px 12px;
     overflow: auto;
-    margin-top: 6px;
-    margin-left: 12px;
-    margin-right: 12px;
 
     &::-webkit-scrollbar {
         height: 12px;

--- a/datahub-web-react/src/app/search/SearchFiltersSection.tsx
+++ b/datahub-web-react/src/app/search/SearchFiltersSection.tsx
@@ -17,7 +17,8 @@ type Props = {
 };
 
 const FiltersContainer = styled.div`
-    display: block;
+    display: flex;
+    flex-direction: column;
     max-width: 260px;
     min-width: 260px;
     overflow-wrap: break-word;
@@ -45,7 +46,8 @@ const FiltersHeader = styled.div`
 `;
 
 const SearchFilterContainer = styled.div`
-    padding-top: 10px;
+    flex: 1;
+    overflow: auto;
 `;
 
 // This component renders the entire filters section that allows toggling

--- a/datahub-web-react/src/app/search/SimpleSearchFilters.tsx
+++ b/datahub-web-react/src/app/search/SimpleSearchFilters.tsx
@@ -7,6 +7,7 @@ import { SimpleSearchFilter } from './SimpleSearchFilter';
 const TOP_FILTERS = ['degree', 'entity', 'tags', 'glossaryTerms', 'domains', 'owners'];
 
 export const SearchFilterWrapper = styled.div`
+    padding-top: 10px;
     max-height: 100%;
     overflow: auto;
 


### PR DESCRIPTION
Fixes a situation where filters were not scrolling by themselves and were causing a double scroll in embedded list search situations by adding correct scrolling behavior inside of filters (advanced and basic).

**Before:**


https://user-images.githubusercontent.com/28656603/205368635-4825f5ae-ce56-473d-b9c1-c0ab88824530.mov



**After:**

https://user-images.githubusercontent.com/28656603/205368416-4382167d-efbc-480e-8026-3e0de5ecf398.mov




## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
