### PR TITLE
fix(ui): only use visible and enabled tabs for selected tab and routing in entity profiles

### DIFF
--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -95,6 +95,14 @@ export class DashboardEntity implements Entity<Dashboard> {
                     },
                 },
                 {
+                    name: 'Datasets',
+                    component: DashboardDatasetsTab,
+                    display: {
+                        visible: (_, dashboard: GetDashboardQuery) => (dashboard?.dashboard?.datasets?.total || 0) > 0,
+                        enabled: (_, dashboard: GetDashboardQuery) => (dashboard?.dashboard?.datasets?.total || 0) > 0,
+                    },
+                },
+                {
                     name: 'Documentation',
                     component: DocumentationTab,
                 },
@@ -116,14 +124,6 @@ export class DashboardEntity implements Entity<Dashboard> {
                 {
                     name: 'Properties',
                     component: PropertiesTab,
-                },
-                {
-                    name: 'Datasets',
-                    component: DashboardDatasetsTab,
-                    display: {
-                        visible: (_, dashboard: GetDashboardQuery) => (dashboard?.dashboard?.datasets?.total || 0) > 0,
-                        enabled: (_, dashboard: GetDashboardQuery) => (dashboard?.dashboard?.datasets?.total || 0) > 0,
-                    },
                 },
             ]}
             sidebarSections={[

--- a/datahub-web-react/src/app/entity/shared/EntityContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityContext.tsx
@@ -7,6 +7,7 @@ const EntityContext = React.createContext<EntityContextType>({
     urn: '',
     entityType: EntityType.Dataset,
     entityData: null,
+    loading: true,
     baseEntity: null,
     updateEntity: () => Promise.resolve({}),
     routeToTab: () => {},
@@ -33,8 +34,8 @@ export const useEntityUpdate = <U,>(): UpdateEntityType<U> | null | undefined =>
 };
 
 export const useEntityData = () => {
-    const { urn, entityType, entityData } = useContext(EntityContext);
-    return { urn, entityType, entityData };
+    const { urn, entityType, entityData, loading } = useContext(EntityContext);
+    return { urn, entityType, entityData, loading };
 };
 
 export const useRouteToTab = () => {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -249,10 +249,6 @@ export const EntityProfile = <T, U>({
         tab.display?.visible(entityData, dataPossiblyCombinedWithSiblings),
     );
 
-    const enabledAndVisibleTabs = visibleTabs.filter((tab) =>
-        tab.display?.enabled(entityData, dataPossiblyCombinedWithSiblings),
-    );
-
     const routedTab = useRoutedTab(enabledAndVisibleTabs);
 
     if (isCompact) {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -249,7 +249,7 @@ export const EntityProfile = <T, U>({
         tab.display?.visible(entityData, dataPossiblyCombinedWithSiblings),
     );
 
-    const routedTab = useRoutedTab(enabledAndVisibleTabs);
+    const routedTab = useRoutedTab(visibleTabs);
 
     if (isCompact) {
         return (

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -245,7 +245,15 @@ export const EntityProfile = <T, U>({
             },
         })) || [];
 
-    const routedTab = useRoutedTab([...tabsWithDefaults, ...autoRenderTabs]);
+    const visibleTabs = [...tabsWithDefaults, ...autoRenderTabs].filter((tab) =>
+        tab.display?.visible(entityData, dataPossiblyCombinedWithSiblings),
+    );
+
+    const enabledAndVisibleTabs = visibleTabs.filter((tab) =>
+        tab.display?.enabled(entityData, dataPossiblyCombinedWithSiblings),
+    );
+
+    const routedTab = useRoutedTab(enabledAndVisibleTabs);
 
     if (isCompact) {
         return (
@@ -254,6 +262,7 @@ export const EntityProfile = <T, U>({
                     urn,
                     entityType,
                     entityData,
+                    loading,
                     baseEntity: dataPossiblyCombinedWithSiblings,
                     dataNotCombinedWithSiblings,
                     updateEntity,
@@ -291,6 +300,7 @@ export const EntityProfile = <T, U>({
                 urn,
                 entityType,
                 entityData,
+                loading,
                 baseEntity: dataPossiblyCombinedWithSiblings,
                 dataNotCombinedWithSiblings,
                 updateEntity,
@@ -344,10 +354,7 @@ export const EntityProfile = <T, U>({
                                                 subHeader={subHeader}
                                                 refreshBrowser={refreshBrowser}
                                             />
-                                            <EntityTabs
-                                                tabs={[...tabsWithDefaults, ...autoRenderTabs]}
-                                                selectedTab={routedTab}
-                                            />
+                                            <EntityTabs tabs={visibleTabs} selectedTab={routedTab} />
                                         </Header>
                                         <TabContent>
                                             {routedTab && <routedTab.component properties={routedTab.properties} />}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -249,7 +249,11 @@ export const EntityProfile = <T, U>({
         tab.display?.visible(entityData, dataPossiblyCombinedWithSiblings),
     );
 
-    const routedTab = useRoutedTab(visibleTabs);
+    const enabledAndVisibleTabs = visibleTabs.filter((tab) =>
+        tab.display?.enabled(entityData, dataPossiblyCombinedWithSiblings),
+    );
+
+    const routedTab = useRoutedTab(enabledAndVisibleTabs);
 
     if (isCompact) {
         return (

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityTabs.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityTabs.tsx
@@ -25,27 +25,25 @@ const Tab = styled(Tabs.TabPane)`
 `;
 
 export const EntityTabs = <T,>({ tabs, selectedTab }: Props) => {
-    const { entityData } = useEntityData();
+    const { entityData, loading } = useEntityData();
     const routeToTab = useRouteToTab();
     const baseEntity = useBaseEntity<T>();
 
-    useEffect(() => {
-        if (!selectedTab) {
-            if (tabs[0]) {
-                routeToTab({ tabName: tabs[0].name, method: 'replace' });
-            }
-        }
-    }, [tabs, selectedTab, routeToTab]);
+    const enabledTabs = tabs.filter((tab) => tab.display?.enabled(entityData, baseEntity));
 
-    const visibleTabs = tabs.filter((tab) => tab.display?.visible(entityData, baseEntity));
+    useEffect(() => {
+        if (!loading && !selectedTab && enabledTabs[0]) {
+            routeToTab({ tabName: enabledTabs[0].name, method: 'replace' });
+        }
+    }, [loading, enabledTabs, selectedTab, routeToTab]);
 
     return (
         <UnborderedTabs
-            activeKey={selectedTab?.name}
+            activeKey={selectedTab?.name || ''}
             size="large"
             onTabClick={(tab: string) => routeToTab({ tabName: tab })}
         >
-            {visibleTabs.map((tab) => {
+            {tabs.map((tab) => {
                 if (!tab.display?.enabled(entityData, baseEntity)) {
                     return <Tab tab={tab.name} key={tab.name} disabled />;
                 }

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -131,6 +131,7 @@ export type EntityContextType = {
     entityType: EntityType;
     dataNotCombinedWithSiblings: any;
     entityData: GenericEntityProperties | null;
+    loading: boolean;
     baseEntity: any;
     updateEntity?: UpdateEntityType<any> | null;
     routeToTab: (params: { tabName: string; tabParams?: Record<string, any>; method?: 'push' | 'replace' }) => void;


### PR DESCRIPTION
This PR fixes a bug when the first tab in an entity profile is not visible and/or is not enabled, but is selected by default when the url does not specify a tab. It also prevents an invisible and/or disabled tab from being manually selected by modifing the url (e.g. [here](https://demo.datahubproject.io/dataset/urn:li:dataset:(urn:li:dataPlatform:looker,long_tail_companions.view.ability,PROD)/Queries) the Queries tab is disabled, but is selected by adding "/Queries" to the url).

As I have noticed this bug after PR #5864, I have also moved the Datasets tabs after the Charts tab (the Charts and Datasets tab are conditionally visible or not, therefore the Datasets tab should be the first tab, when the Charts tab is not visible).

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
