### PR TITLE
fix(ingest/powerbi-report-server): deprecate unused graphql config

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -6,6 +6,8 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Breaking Changes
 
+- `graphql_url` option of `powerbi-report-server` source deprecated as the options is not used.
+
 ### Potential Downtime
 
 ### Deprecations

--- a/metadata-ingestion/docs/sources/powerbi/powerbi-report-server_recipe.yml
+++ b/metadata-ingestion/docs/sources/powerbi/powerbi-report-server_recipe.yml
@@ -13,8 +13,6 @@ source:
     server_alias: server_alias
     # Workspace's dataset environments, example: (PROD, DEV, QA, STAGE)
     env: DEV
-    # Workspace's dataset environments, example: (PROD, DEV, QA, STAGE)
-    graphql_url: http://localhost:8080/api/graphql
     # Your Power BI Report Server base virtual directory name for reports
     report_virtual_directory_name: Reports
     #  Your Power BI Report Server base virtual directory name for report server

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi_report_server/report_server.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi_report_server/report_server.py
@@ -5,7 +5,7 @@
 #########################################################
 import logging
 from dataclasses import dataclass, field as dataclass_field
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Optional
 
 import pydantic
 import requests
@@ -68,7 +68,9 @@ class PowerBiReportServerAPIConfig(EnvBasedSourceConfigBase):
     server_alias: str = pydantic.Field(
         default="", description="Alias for Power BI Report Server host URL"
     )
-    graphql_url: str = pydantic.Field(description="GraphQL API URL")
+    graphql_url: Optional[str] = pydantic.Field(
+        default=None, description="[deprecated] Not used"
+    )
     report_virtual_directory_name: str = pydantic.Field(
         description="Report Virtual Directory URL name"
     )

--- a/metadata-ingestion/tests/integration/powerbi_report_server/test_powerbi_report_server.py
+++ b/metadata-ingestion/tests/integration/powerbi_report_server/test_powerbi_report_server.py
@@ -167,7 +167,7 @@ def default_source_config():
         "workstation_name": "workstation",
         "host_port": "host_port",
         "server_alias": "server_alias",
-        "graphql_url": "http://localhost:8080/api/graphql",
+        "graphql_url": None,
         "report_virtual_directory_name": "Reports",
         "report_server_virtual_directory_name": "ReportServer",
         "env": "DEV",


### PR DESCRIPTION
The source use graph from ctx so graphql_url is not needed.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
