### PR TITLE
DRAFT fix(graphql): sort domains in alphabetical order

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/ListDomainsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/ListDomainsResolver.java
@@ -59,7 +59,7 @@ public class ListDomainsResolver implements DataFetcher<CompletableFuture<ListDo
                   Constants.DOMAIN_ENTITY_NAME,
                   query,
                   null,
-                  new SortCriterion().setField(DOMAIN_CREATED_TIME_INDEX_FIELD_NAME).setOrder(SortOrder.DESCENDING),
+                  new SortCriterion().setField(DOMAIN_NAME_INDEX_FIELD_NAME).setOrder(SortOrder.ASCENDING),
                   start,
                   count,
                   context.getAuthentication());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/ListDomainsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/ListDomainsResolverTest.java
@@ -40,7 +40,7 @@ public class ListDomainsResolverTest {
         Mockito.eq(Constants.DOMAIN_ENTITY_NAME),
         Mockito.eq(""),
         Mockito.eq(null),
-        Mockito.eq(new SortCriterion().setField(DOMAIN_CREATED_TIME_INDEX_FIELD_NAME).setOrder(SortOrder.DESCENDING)),
+        Mockito.eq(new SortCriterion().setField(DOMAIN_NAME_INDEX_FIELD_NAME).setOrder(SortOrder.ASCENDING)),
         Mockito.eq(0),
         Mockito.eq(20),
         Mockito.any(Authentication.class)

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -199,7 +199,7 @@ public class Constants {
   public static final String DOMAIN_KEY_ASPECT_NAME = "domainKey";
   public static final String DOMAIN_PROPERTIES_ASPECT_NAME = "domainProperties";
   public static final String DOMAINS_ASPECT_NAME = "domains";
-  public static final String DOMAIN_CREATED_TIME_INDEX_FIELD_NAME = "createdTime";
+  public static final String DOMAIN_NAME_INDEX_FIELD_NAME = "name";
 
   // Assertion
   public static final String ASSERTION_KEY_ASPECT_NAME = "assertionKey";


### PR DESCRIPTION
Is there a reason why Domains are sorted by create time? This makes it quite hard for human to find anything in the listings.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
