### PR TITLE
fix(config): unify the handling of boolean environment variables

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -53,6 +53,16 @@ class DatahubConfig(BaseModel):
     gms: GmsConfig
 
 
+def get_boolean_env_variable(key: str, default: bool = False) -> bool:
+    value = os.environ.get(key)
+    if value is None:
+        return default
+    elif value.lower() in ("true", "1"):
+        return True
+    else:
+        return False
+
+
 def set_env_variables_override_config(url: str, token: Optional[str]) -> None:
     """Should be used to override the config when using rest emitter"""
     config_override[ENV_METADATA_HOST_URL] = url
@@ -73,7 +83,7 @@ def write_datahub_config(host: str, token: Optional[str]) -> None:
 
 
 def should_skip_config() -> bool:
-    return os.getenv(ENV_SKIP_CONFIG, False) == "True"
+    return get_boolean_env_variable(ENV_SKIP_CONFIG, False)
 
 
 def ensure_datahub_config() -> None:

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -9,7 +9,11 @@ from pydantic import ValidationError
 
 import datahub as datahub_package
 from datahub.cli.check_cli import check
-from datahub.cli.cli_utils import DATAHUB_CONFIG_PATH, write_datahub_config
+from datahub.cli.cli_utils import (
+    DATAHUB_CONFIG_PATH,
+    get_boolean_env_variable,
+    write_datahub_config,
+)
 from datahub.cli.delete_cli import delete
 from datahub.cli.docker_cli import docker
 from datahub.cli.get_cli import get
@@ -95,7 +99,7 @@ def datahub(
     # 3. Turn off propagation to the root handler.
     datahub_logger.propagate = False
     # 4. Adjust log-levels.
-    if debug or os.getenv("DATAHUB_DEBUG", False):
+    if debug or get_boolean_env_variable("DATAHUB_DEBUG", False):
         logging.getLogger().setLevel(logging.INFO)
         datahub_logger.setLevel(logging.DEBUG)
         logging.getLogger("datahub_classify").setLevel(logging.DEBUG)

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, Iterable, List, Optional, Type, Union
 
@@ -10,6 +9,7 @@ from deprecated import deprecated
 from requests.adapters import Response
 from requests.models import HTTPError
 
+from datahub.cli.cli_utils import get_boolean_env_variable
 from datahub.configuration.common import ConfigModel, OperationalError
 from datahub.emitter.mce_builder import Aspect
 from datahub.emitter.rest_emitter import DatahubRestEmitter
@@ -31,9 +31,7 @@ from datahub.utilities.urns.urn import Urn, guess_entity_type
 logger = logging.getLogger(__name__)
 
 
-telemetry_enabled = (
-    os.environ.get("DATAHUB_TELEMETRY_ENABLED", "true").lower() == "true"
-)
+telemetry_enabled = get_boolean_env_variable("DATAHUB_TELEMETRY_ENABLED", True)
 
 
 class DatahubClientConfig(ConfigModel):

--- a/metadata-ingestion/src/datahub/integrations/great_expectations/action.py
+++ b/metadata-ingestion/src/datahub/integrations/great_expectations/action.py
@@ -2,7 +2,6 @@ from datahub.utilities._markupsafe_compat import MARKUPSAFE_PATCHED
 
 import json
 import logging
-import os
 import sys
 import time
 from dataclasses import dataclass
@@ -33,6 +32,7 @@ from sqlalchemy.engine.base import Connection, Engine
 from sqlalchemy.engine.url import make_url
 
 import datahub.emitter.mce_builder as builder
+from datahub.cli.cli_utils import get_boolean_env_variable
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.rest_emitter import DatahubRestEmitter
 from datahub.ingestion.source.sql.sql_common import get_platform_from_sqlalchemy_uri
@@ -64,7 +64,7 @@ if TYPE_CHECKING:
 
 assert MARKUPSAFE_PATCHED
 logger = logging.getLogger(__name__)
-if os.getenv("DATAHUB_DEBUG", False):
+if get_boolean_env_variable("DATAHUB_DEBUG", False):
     handler = logging.StreamHandler(stream=sys.stdout)
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)

--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar
 from mixpanel import Consumer, Mixpanel
 
 import datahub as datahub_package
-from datahub.cli.cli_utils import DATAHUB_ROOT_FOLDER
+from datahub.cli.cli_utils import DATAHUB_ROOT_FOLDER, get_boolean_env_variable
 from datahub.ingestion.graph.client import DataHubGraph
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ DATAHUB_FOLDER = Path(DATAHUB_ROOT_FOLDER)
 CONFIG_FILE = DATAHUB_FOLDER / "telemetry-config.json"
 
 # also fall back to environment variable if config file is not found
-ENV_ENABLED = os.environ.get("DATAHUB_TELEMETRY_ENABLED", "true").lower() == "true"
+ENV_ENABLED = get_boolean_env_variable("DATAHUB_TELEMETRY_ENABLED", True)
 
 # see
 # https://adamj.eu/tech/2020/03/09/detect-if-your-tests-are-running-on-ci/


### PR DESCRIPTION
When I have tried to set the environment variable DATAHUB_SKIP_CONFIG, I have noticed that the handling of the boolean environment variables (DATAHUB_SKIP_CONFIG, DATAHUB_DEBUG and DATAHUB_TELEMETRY_ENABLED) are quite different: For example the DATAHUB_SKIP_CONFIG variable had to be set to "True" to be true, while the DATAHUB_DEBUG would also be treated as true with the value "false" (the string "false" is a truthy value in Python).

This PR changes/fixes this behaviour by converting all boolean environment variables to lowercase first and comparing them to the strings "true" and "1" (e.g., [here](https://github.com/datahub-project/datahub/blob/3758bcbe348082ea511d8605e3e01e18742283dd/metadata-ingestion/tests/conftest.py#L9) the value "1" is assigned to DATAHUB_DEBUG, therefore the value "1" should also be handled as true).

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)