### PR TITLE
fix(ingest): rectify filter for BigQuery external tables

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -119,7 +119,7 @@ FROM
         table_name) as p on
     t.table_name = p.table_name
 WHERE
-  table_type in ('BASE TABLE', 'EXTERNAL TABLE')
+  table_type in ('BASE TABLE', 'EXTERNAL')
 {table_filter}
 order by
   table_schema ASC,
@@ -146,7 +146,7 @@ FROM
   and t.TABLE_NAME = tos.TABLE_NAME
   and tos.OPTION_NAME = "description"
 WHERE
-  table_type in ('BASE TABLE', 'EXTERNAL TABLE')
+  table_type in ('BASE TABLE', 'EXTERNAL')
 {table_filter}
 order by
   table_schema ASC,


### PR DESCRIPTION
In the SQL statement querying BigQuery table metadata, the `table_type` is incorrectly filtered for external tables:

According to the [official documentation](https://cloud.google.com/bigquery/docs/information-schema-tables#schema), the `table_type` will be `EXTERNAL` for external tables.
The query incorrectly expected it to be `EXTERNAL TABLE` instead.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
