### PR TITLE
fix(ingest): correct external url for account identifier with account name

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -3,6 +3,14 @@ from typing import Optional
 
 class SnowflakeQuery:
     @staticmethod
+    def current_account() -> str:
+        return "select CURRENT_ACCOUNT()"
+
+    @staticmethod
+    def current_region() -> str:
+        return "select CURRENT_REGION()"
+
+    @staticmethod
     def current_version() -> str:
         return "select CURRENT_VERSION()"
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
@@ -1,9 +1,14 @@
+from typing import Optional
+
 from datahub.ingestion.source.sql.sql_generic_profiler import ProfilingSqlReport
 from datahub.ingestion.source_report.sql.snowflake import SnowflakeReport
 from datahub.ingestion.source_report.usage.snowflake_usage import SnowflakeUsageReport
 
 
 class SnowflakeV2Report(SnowflakeReport, SnowflakeUsageReport, ProfilingSqlReport):
+
+    account_locator: Optional[str] = None
+    region: Optional[str] = None
 
     schemas_scanned: int = 0
     databases_scanned: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -84,6 +84,18 @@ class SnowflakeCommonMixin:
             url = f"https://app.snowflake.com/{cloud_region_id}.{cloud}/{account_locator}/"
         return url
 
+    @staticmethod
+    def get_cloud_region_from_snowflake_region_id(region):
+        if region in SNOWFLAKE_REGION_CLOUD_REGION_MAPPING.keys():
+            cloud, cloud_region_id = SNOWFLAKE_REGION_CLOUD_REGION_MAPPING[region]
+        elif region.startswith(("aws_", "gcp_", "azure_")):
+            # e.g. aws_us_west_2, gcp_us_central1, azure_northeurope
+            cloud, cloud_region_id = region.split("_", 1)
+            cloud_region_id = cloud_region_id.replace("_", "-")
+        else:
+            raise Exception(f"Unknown snowflake region {region}")
+        return cloud, cloud_region_id
+
     def _is_dataset_pattern_allowed(
         self: SnowflakeCommonProtocol,
         dataset_name: Optional[str],

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -24,45 +24,11 @@ class SnowflakeCloudProvider(str, Enum):
 
 
 # See https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#region-ids
-# This needs an update if and when snowflake supports new region
+# Includes only exceptions to format <provider>_<cloud region with hyphen replaced by _>
 SNOWFLAKE_REGION_CLOUD_REGION_MAPPING = {
-    "aws_us_west_2": (SnowflakeCloudProvider.AWS, "us-west-2"),
-    "aws_us_gov_west_1": (SnowflakeCloudProvider.AWS, "us-gov-west-1"),
-    "aws_us_east_2": (SnowflakeCloudProvider.AWS, "us-east-2"),
-    "aws_us_east_1": (SnowflakeCloudProvider.AWS, "us-east-1"),
     "aws_us_east_1_gov": (SnowflakeCloudProvider.AWS, "us-east-1"),
-    "aws_ca_central_1": (SnowflakeCloudProvider.AWS, "ca-central-1"),
-    "aws_sa_east_1": (SnowflakeCloudProvider.AWS, "sa-east-1"),
-    "aws_eu_west_1": (SnowflakeCloudProvider.AWS, "eu-west-1"),
-    "aws_eu_west_2": (SnowflakeCloudProvider.AWS, "eu-west-2"),
-    "aws_eu_west_3": (SnowflakeCloudProvider.AWS, "eu-west-3"),
-    "aws_eu_central_1": (SnowflakeCloudProvider.AWS, "eu-central-1"),
-    "aws_eu_north_1": (SnowflakeCloudProvider.AWS, "eu-north-1"),
-    "aws_ap_northeast_1": (SnowflakeCloudProvider.AWS, "ap-northeast-1"),
-    "aws_ap_northeast_3": (SnowflakeCloudProvider.AWS, "ap-northeast-3"),
-    "aws_ap_northeast_2": (SnowflakeCloudProvider.AWS, "ap-northeast-2"),
-    "aws_ap_south_1": (SnowflakeCloudProvider.AWS, "ap-south-1"),
-    "aws_ap_southeast_1": (SnowflakeCloudProvider.AWS, "ap-southeast-1"),
-    "aws_ap_southeast_2": (SnowflakeCloudProvider.AWS, "ap-southeast-2"),
-    "gcp_us_central1": (SnowflakeCloudProvider.GCP, "us-central1"),
-    "gcp_us_east4": (SnowflakeCloudProvider.GCP, "us-east4"),
-    "gcp_europe_west2": (SnowflakeCloudProvider.GCP, "europe-west2"),
-    "gcp_europe_west4": (SnowflakeCloudProvider.GCP, "europe-west4"),
-    "azure_westus2": (SnowflakeCloudProvider.AZURE, "westus2"),
-    "azure_centralus": (SnowflakeCloudProvider.AZURE, "centralus"),
-    "azure_southcentralus": (SnowflakeCloudProvider.AZURE, "southcentralus"),
-    "azure_eastus2": (SnowflakeCloudProvider.AZURE, "eastus2"),
-    "azure_usgovvirginia": (SnowflakeCloudProvider.AZURE, "usgovvirginia"),
-    "azure_canadacentral": (SnowflakeCloudProvider.AZURE, "canadacentral"),
     "azure_uksouth": (SnowflakeCloudProvider.AZURE, "uk-south"),
-    "azure_northeurope": (SnowflakeCloudProvider.AZURE, "northeurope"),
-    "azure_westeurope": (SnowflakeCloudProvider.AZURE, "westeurope"),
-    "azure_switzerlandnorth": (SnowflakeCloudProvider.AZURE, "switzerlandnorth"),
-    "azure_uaenorth": (SnowflakeCloudProvider.AZURE, "uaenorth"),
     "azure_centralindia": (SnowflakeCloudProvider.AZURE, "central-india.azure"),
-    "azure_japaneast": (SnowflakeCloudProvider.AZURE, "japaneast"),
-    "azure_southeastasia": (SnowflakeCloudProvider.AZURE, "southeastasia"),
-    "azure_australiaeast": (SnowflakeCloudProvider.AZURE, "australiaeast"),
 }
 
 SNOWFLAKE_DEFAULT_CLOUD = SnowflakeCloudProvider.AWS

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -26,47 +26,45 @@ class SnowflakeCloudProvider(str, Enum):
 # See https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#region-ids
 # This needs an update if and wuhen snowflake supports new region
 SNOWFLAKE_REGION_CLOUD_REGION_MAPPING = {
-    "aws_us_west_2": ("aws", "us-west-2"),
-    "aws_us_gov_west_1": ("aws", "us-gov-west-1"),
-    "aws_us_east_2": ("aws", "us-east-2"),
-    "aws_us_east_1": ("aws", "us-east-1"),
-    "aws_us_east_1_gov": ("aws", "us-east-1"),
-    "aws_ca_central_1": ("aws", "ca-central-1"),
-    "aws_sa_east_1": ("aws", "sa-east-1"),
-    "aws_eu_west_1": ("aws", "eu-west-1"),
-    "aws_eu_west_2": ("aws", "eu-west-2"),
-    "aws_eu_west_3": ("aws", "eu-west-3"),
-    "aws_eu_central_1": ("aws", "eu-central-1"),
-    "aws_eu_north_1": ("aws", "eu-north-1"),
-    "aws_ap_northeast_1": ("aws", "ap-northeast-1"),
-    "aws_ap_northeast_3": ("aws", "ap-northeast-3"),
-    "aws_ap_northeast_2": ("aws", "ap-northeast-2"),
-    "aws_ap_south_1": ("aws", "ap-south-1"),
-    "aws_ap_southeast_1": ("aws", "ap-southeast-1"),
-    "aws_ap_southeast_2": ("aws", "ap-southeast-2"),
-    "gcp_us_central1": ("gcp", "us-central1"),
-    "gcp_us_east4": ("gcp", "us-east4"),
-    "gcp_europe_west2": ("gcp", "europe-west2"),
-    "gcp_europe_west4": ("gcp", "europe-west4"),
-    "azure_westus2": ("azure", "westus2"),
-    "azure_centralus": ("azure", "centralus"),
-    "azure_southcentralus": ("azure", "southcentralus"),
-    "azure_eastus2": ("azure", "eastus2"),
-    "azure_usgovvirginia": ("azure", "usgovvirginia"),
-    "azure_canadacentral": ("azure", "canadacentral"),
-    "azure_uksouth": ("azure", "uk-south"),
-    "azure_northeurope": ("azure", "northeurope"),
-    "azure_westeurope": ("azure", "westeurope"),
-    "azure_switzerlandnorth": ("azure", "switzerlandnorth"),
-    "azure_uaenorth": ("azure", "uaenorth"),
-    "azure_centralindia": ("azure", "central-india.azure"),
-    "azure_japaneast": ("azure", "japaneast"),
-    "azure_southeastasia": ("azure", "southeastasia"),
-    "azure_australiaeast": ("azure", "australiaeast"),
+    "aws_us_west_2": (SnowflakeCloudProvider.AWS, "us-west-2"),
+    "aws_us_gov_west_1": (SnowflakeCloudProvider.AWS, "us-gov-west-1"),
+    "aws_us_east_2": (SnowflakeCloudProvider.AWS, "us-east-2"),
+    "aws_us_east_1": (SnowflakeCloudProvider.AWS, "us-east-1"),
+    "aws_us_east_1_gov": (SnowflakeCloudProvider.AWS, "us-east-1"),
+    "aws_ca_central_1": (SnowflakeCloudProvider.AWS, "ca-central-1"),
+    "aws_sa_east_1": (SnowflakeCloudProvider.AWS, "sa-east-1"),
+    "aws_eu_west_1": (SnowflakeCloudProvider.AWS, "eu-west-1"),
+    "aws_eu_west_2": (SnowflakeCloudProvider.AWS, "eu-west-2"),
+    "aws_eu_west_3": (SnowflakeCloudProvider.AWS, "eu-west-3"),
+    "aws_eu_central_1": (SnowflakeCloudProvider.AWS, "eu-central-1"),
+    "aws_eu_north_1": (SnowflakeCloudProvider.AWS, "eu-north-1"),
+    "aws_ap_northeast_1": (SnowflakeCloudProvider.AWS, "ap-northeast-1"),
+    "aws_ap_northeast_3": (SnowflakeCloudProvider.AWS, "ap-northeast-3"),
+    "aws_ap_northeast_2": (SnowflakeCloudProvider.AWS, "ap-northeast-2"),
+    "aws_ap_south_1": (SnowflakeCloudProvider.AWS, "ap-south-1"),
+    "aws_ap_southeast_1": (SnowflakeCloudProvider.AWS, "ap-southeast-1"),
+    "aws_ap_southeast_2": (SnowflakeCloudProvider.AWS, "ap-southeast-2"),
+    "gcp_us_central1": (SnowflakeCloudProvider.GCP, "us-central1"),
+    "gcp_us_east4": (SnowflakeCloudProvider.GCP, "us-east4"),
+    "gcp_europe_west2": (SnowflakeCloudProvider.GCP, "europe-west2"),
+    "gcp_europe_west4": (SnowflakeCloudProvider.GCP, "europe-west4"),
+    "azure_westus2": (SnowflakeCloudProvider.AZURE, "westus2"),
+    "azure_centralus": (SnowflakeCloudProvider.AZURE, "centralus"),
+    "azure_southcentralus": (SnowflakeCloudProvider.AZURE, "southcentralus"),
+    "azure_eastus2": (SnowflakeCloudProvider.AZURE, "eastus2"),
+    "azure_usgovvirginia": (SnowflakeCloudProvider.AZURE, "usgovvirginia"),
+    "azure_canadacentral": (SnowflakeCloudProvider.AZURE, "canadacentral"),
+    "azure_uksouth": (SnowflakeCloudProvider.AZURE, "uk-south"),
+    "azure_northeurope": (SnowflakeCloudProvider.AZURE, "northeurope"),
+    "azure_westeurope": (SnowflakeCloudProvider.AZURE, "westeurope"),
+    "azure_switzerlandnorth": (SnowflakeCloudProvider.AZURE, "switzerlandnorth"),
+    "azure_uaenorth": (SnowflakeCloudProvider.AZURE, "uaenorth"),
+    "azure_centralindia": (SnowflakeCloudProvider.AZURE, "central-india.azure"),
+    "azure_japaneast": (SnowflakeCloudProvider.AZURE, "japaneast"),
+    "azure_southeastasia": (SnowflakeCloudProvider.AZURE, "southeastasia"),
+    "azure_australiaeast": (SnowflakeCloudProvider.AZURE, "australiaeast"),
 }
 
-
-SNOWFLAKE_DEFAULT_CLOUD_REGION_ID = "us-west-2"
 SNOWFLAKE_DEFAULT_CLOUD = SnowflakeCloudProvider.AWS
 
 
@@ -119,45 +117,6 @@ class SnowflakeCommonMixin:
         else:
             url = f"https://app.snowflake.com/{cloud_region_id}.{cloud}/{account_locator}/"
         return url
-
-    def get_snowsight_base_url_from_legacy_account_id(
-        self: SnowflakeCommonProtocol, conn: SnowflakeConnection
-    ) -> Optional[str]:
-        account_id = self.config.get_account()
-        if "." not in account_id:  # e.g. xy12345
-            account_locator = account_id.lower()
-            cloud_region_id = SNOWFLAKE_DEFAULT_CLOUD_REGION_ID
-            privatelink = False
-        else:
-            parts = account_id.split(".")
-            if len(parts) == 2:  # e.g. xy12345.us-east-1
-                account_locator = parts[0].lower()
-                cloud_region_id = parts[1].lower()
-                cloud = SNOWFLAKE_DEFAULT_CLOUD.value
-                privatelink = False
-            elif len(parts) == 3 and parts[2] in (
-                SnowflakeCloudProvider.AWS,
-                SnowflakeCloudProvider.GCP,
-                SnowflakeCloudProvider.AZURE,
-            ):
-                # e.g. xy12345.ap-south-1.aws or xy12345.us-central1.gcp or xy12345.west-us-2.azure
-                # NOT xy12345.us-west-2.privatelink or xy12345.eu-central-1.privatelink
-                account_locator = parts[0].lower()
-                cloud_region_id = parts[1].lower()
-                cloud = parts[2].lower()
-                privatelink = False
-            elif len(parts) == 3 and parts[2] == "privatelink":
-                account_locator = parts[0].lower()
-                cloud_region_id = parts[1].lower()
-                privatelink = True
-            else:
-                logger.warning(
-                    f"Could not find account locator and cloud region id for account {account_id}."
-                )
-                return None
-        return SnowflakeCommonMixin.create_snowsight_base_url(
-            account_locator, cloud_region_id, cloud, privatelink
-        )
 
     def _is_dataset_pattern_allowed(
         self: SnowflakeCommonProtocol,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -24,7 +24,7 @@ class SnowflakeCloudProvider(str, Enum):
 
 
 # See https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#region-ids
-# This needs an update if and wuhen snowflake supports new region
+# This needs an update if and when snowflake supports new region
 SNOWFLAKE_REGION_CLOUD_REGION_MAPPING = {
     "aws_us_west_2": (SnowflakeCloudProvider.AWS, "us-west-2"),
     "aws_us_gov_west_1": (SnowflakeCloudProvider.AWS, "us-gov-west-1"),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -1,6 +1,5 @@
 import logging
 from enum import Enum
-from functools import lru_cache
 from typing import Any, Optional
 
 from snowflake.connector import SnowflakeConnection
@@ -22,6 +21,49 @@ class SnowflakeCloudProvider(str, Enum):
     AWS = "aws"
     GCP = "gcp"
     AZURE = "azure"
+
+
+# See https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#region-ids
+# This needs an update if and wuhen snowflake supports new region
+SNOWFLAKE_REGION_CLOUD_REGION_MAPPING = {
+    "aws_us_west_2": ("aws", "us-west-2"),
+    "aws_us_gov_west_1": ("aws", "us-gov-west-1"),
+    "aws_us_east_2": ("aws", "us-east-2"),
+    "aws_us_east_1": ("aws", "us-east-1"),
+    "aws_us_east_1_gov": ("aws", "us-east-1"),
+    "aws_ca_central_1": ("aws", "ca-central-1"),
+    "aws_sa_east_1": ("aws", "sa-east-1"),
+    "aws_eu_west_1": ("aws", "eu-west-1"),
+    "aws_eu_west_2": ("aws", "eu-west-2"),
+    "aws_eu_west_3": ("aws", "eu-west-3"),
+    "aws_eu_central_1": ("aws", "eu-central-1"),
+    "aws_eu_north_1": ("aws", "eu-north-1"),
+    "aws_ap_northeast_1": ("aws", "ap-northeast-1"),
+    "aws_ap_northeast_3": ("aws", "ap-northeast-3"),
+    "aws_ap_northeast_2": ("aws", "ap-northeast-2"),
+    "aws_ap_south_1": ("aws", "ap-south-1"),
+    "aws_ap_southeast_1": ("aws", "ap-southeast-1"),
+    "aws_ap_southeast_2": ("aws", "ap-southeast-2"),
+    "gcp_us_central1": ("gcp", "us-central1"),
+    "gcp_us_east4": ("gcp", "us-east4"),
+    "gcp_europe_west2": ("gcp", "europe-west2"),
+    "gcp_europe_west4": ("gcp", "europe-west4"),
+    "azure_westus2": ("azure", "westus2"),
+    "azure_centralus": ("azure", "centralus"),
+    "azure_southcentralus": ("azure", "southcentralus"),
+    "azure_eastus2": ("azure", "eastus2"),
+    "azure_usgovvirginia": ("azure", "usgovvirginia"),
+    "azure_canadacentral": ("azure", "canadacentral"),
+    "azure_uksouth": ("azure", "uk-south"),
+    "azure_northeurope": ("azure", "northeurope"),
+    "azure_westeurope": ("azure", "westeurope"),
+    "azure_switzerlandnorth": ("azure", "switzerlandnorth"),
+    "azure_uaenorth": ("azure", "uaenorth"),
+    "azure_centralindia": ("azure", "central-india.azure"),
+    "azure_japaneast": ("azure", "japaneast"),
+    "azure_southeastasia": ("azure", "southeastasia"),
+    "azure_australiaeast": ("azure", "australiaeast"),
+}
 
 
 SNOWFLAKE_DEFAULT_CLOUD_REGION_ID = "us-west-2"
@@ -64,21 +106,35 @@ class SnowflakeCommonMixin:
     platform = "snowflake"
 
     @staticmethod
-    @lru_cache(maxsize=128)
-    def create_snowsight_base_url(account_id: str) -> Optional[str]:
-        cloud: Optional[str] = None
-        account_locator: Optional[str] = None
-        cloud_region_id: Optional[str] = None
-        privatelink: bool = False
+    def create_snowsight_base_url(
+        account_locator: str,
+        cloud_region_id: str,
+        cloud: str,
+        privatelink: bool = False,
+    ) -> Optional[str]:
+        if privatelink:
+            url = f"https://app.{account_locator}.{cloud_region_id}.privatelink.snowflakecomputing.com/"
+        elif cloud == SNOWFLAKE_DEFAULT_CLOUD:
+            url = f"https://app.snowflake.com/{cloud_region_id}/{account_locator}/"
+        else:
+            url = f"https://app.snowflake.com/{cloud_region_id}.{cloud}/{account_locator}/"
+        return url
 
+    def get_snowsight_base_url_from_legacy_account_id(
+        self: SnowflakeCommonProtocol, conn: SnowflakeConnection
+    ) -> Optional[str]:
+        account_id = self.config.get_account()
         if "." not in account_id:  # e.g. xy12345
             account_locator = account_id.lower()
             cloud_region_id = SNOWFLAKE_DEFAULT_CLOUD_REGION_ID
+            privatelink = False
         else:
             parts = account_id.split(".")
             if len(parts) == 2:  # e.g. xy12345.us-east-1
                 account_locator = parts[0].lower()
                 cloud_region_id = parts[1].lower()
+                cloud = SNOWFLAKE_DEFAULT_CLOUD.value
+                privatelink = False
             elif len(parts) == 3 and parts[2] in (
                 SnowflakeCloudProvider.AWS,
                 SnowflakeCloudProvider.GCP,
@@ -89,24 +145,19 @@ class SnowflakeCommonMixin:
                 account_locator = parts[0].lower()
                 cloud_region_id = parts[1].lower()
                 cloud = parts[2].lower()
+                privatelink = False
             elif len(parts) == 3 and parts[2] == "privatelink":
                 account_locator = parts[0].lower()
                 cloud_region_id = parts[1].lower()
                 privatelink = True
             else:
                 logger.warning(
-                    f"Could not create Snowsight base url for account {account_id}."
+                    f"Could not find account locator and cloud region id for account {account_id}."
                 )
                 return None
-
-        if not privatelink and (cloud is None or cloud == SNOWFLAKE_DEFAULT_CLOUD):
-            return f"https://app.snowflake.com/{cloud_region_id}/{account_locator}/"
-        elif privatelink:
-            return f"https://app.{account_locator}.{cloud_region_id}.privatelink.snowflakecomputing.com/"
-        return f"https://app.snowflake.com/{cloud_region_id}.{cloud}/{account_locator}/"
-
-    def get_snowsight_base_url(self: SnowflakeCommonProtocol) -> Optional[str]:
-        return SnowflakeCommonMixin.create_snowsight_base_url(self.config.get_account())
+        return SnowflakeCommonMixin.create_snowsight_base_url(
+            account_locator, cloud_region_id, cloud, privatelink
+        )
 
     def _is_dataset_pattern_allowed(
         self: SnowflakeCommonProtocol,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1191,7 +1191,8 @@ class SnowflakeV2Source(
 
             cloud, cloud_region_id = SNOWFLAKE_REGION_CLOUD_REGION_MAPPING[region]
 
-            # How to find whether this is privatelink ?
+            # For privatelink, account identifier ends with .privatelink
+            # See https://docs.snowflake.com/en/user-guide/organizations-connect.html#private-connectivity-urls
             return self.create_snowsight_base_url(
                 account_locator,
                 cloud_region_id,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1190,7 +1190,18 @@ class SnowflakeV2Source(
             region = region.split(".")[-1].lower()
             account_locator = account_locator.lower()
 
-            cloud, cloud_region_id = SNOWFLAKE_REGION_CLOUD_REGION_MAPPING[region]
+            if region in SNOWFLAKE_REGION_CLOUD_REGION_MAPPING.keys():
+                cloud, cloud_region_id = SNOWFLAKE_REGION_CLOUD_REGION_MAPPING[region]
+            elif region.startswith(("aws_", "gcp_", "azure_")):
+                # e.g. aws_us_west_2, gcp_us_central1, azure_northeurope
+                cloud, cloud_region_id = region.split("_", 1)
+                cloud_region_id = cloud_region_id.replace("_", "-")
+            else:
+                self.warn(
+                    self.logger,
+                    "snowsight url",
+                    f"unable to get snowsight base url, unknown region {region}",
+                )
 
             # For privatelink, account identifier ends with .privatelink
             # See https://docs.snowflake.com/en/user-guide/organizations-connect.html#private-connectivity-urls

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -64,7 +64,6 @@ from datahub.ingestion.source.snowflake.snowflake_usage_v2 import (
     SnowflakeUsageExtractor,
 )
 from datahub.ingestion.source.snowflake.snowflake_utils import (
-    SNOWFLAKE_REGION_CLOUD_REGION_MAPPING,
     SnowflakeCommonMixin,
     SnowflakeQueryMixin,
 )
@@ -1190,18 +1189,9 @@ class SnowflakeV2Source(
             region = region.split(".")[-1].lower()
             account_locator = account_locator.lower()
 
-            if region in SNOWFLAKE_REGION_CLOUD_REGION_MAPPING.keys():
-                cloud, cloud_region_id = SNOWFLAKE_REGION_CLOUD_REGION_MAPPING[region]
-            elif region.startswith(("aws_", "gcp_", "azure_")):
-                # e.g. aws_us_west_2, gcp_us_central1, azure_northeurope
-                cloud, cloud_region_id = region.split("_", 1)
-                cloud_region_id = cloud_region_id.replace("_", "-")
-            else:
-                self.warn(
-                    self.logger,
-                    "snowsight url",
-                    f"unable to get snowsight base url, unknown region {region}",
-                )
+            cloud, cloud_region_id = self.get_cloud_region_from_snowflake_region_id(
+                region
+            )
 
             # For privatelink, account identifier ends with .privatelink
             # See https://docs.snowflake.com/en/user-guide/organizations-connect.html#private-connectivity-urls

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1176,6 +1176,7 @@ class SnowflakeV2Source(
 
     def get_snowsight_base_url(self, conn):
         try:
+            # See https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#finding-the-region-and-locator-for-an-account
             for db_row in self.query(conn, SnowflakeQuery.current_account()):
                 account_locator = db_row["CURRENT_ACCOUNT()"]
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -64,6 +64,7 @@ from datahub.ingestion.source.snowflake.snowflake_usage_v2 import (
     SnowflakeUsageExtractor,
 )
 from datahub.ingestion.source.snowflake.snowflake_utils import (
+    SNOWFLAKE_REGION_CLOUD_REGION_MAPPING,
     SnowflakeCommonMixin,
     SnowflakeQueryMixin,
 )
@@ -192,6 +193,7 @@ class SnowflakeV2Source(
         self.config: SnowflakeV2Config = config
         self.report: SnowflakeV2Report = SnowflakeV2Report()
         self.logger = logger
+        self.snowsight_base_url = None
         # Create and register the stateful ingestion use-case handlers.
         self.stale_entity_removal_handler = StaleEntityRemovalHandler(
             source=self,
@@ -230,6 +232,7 @@ class SnowflakeV2Source(
 
         if self.is_classification_enabled():
             self.classifiers = self.get_classifiers()
+
         # Currently caching using instance variables
         # TODO - rewrite cache for readability or use out of the box solution
         self.db_tables: Dict[str, Optional[Dict[str, List[SnowflakeTable]]]] = {}
@@ -431,6 +434,8 @@ class SnowflakeV2Source(
         conn: SnowflakeConnection = self.config.get_connection()
         self.add_config_to_report()
         self.inspect_session_metadata(conn)
+        if self.config.include_external_url:
+            self.snowsight_base_url = self.get_snowsight_base_url(conn)
 
         self.report.include_technical_schema = self.config.include_technical_schema
         databases: List[SnowflakeDatabase] = []
@@ -1153,21 +1158,51 @@ class SnowflakeV2Source(
     def get_external_url_for_table(
         self, table_name: str, schema_name: str, db_name: str, domain: str
     ) -> Optional[str]:
-        base_url = self.get_snowsight_base_url()
-        if base_url is not None:
-            return f"{base_url}#/data/databases/{db_name}/schemas/{schema_name}/{domain}/{table_name}/"
+        if self.snowsight_base_url is not None:
+            return f"{self.snowsight_base_url}#/data/databases/{db_name}/schemas/{schema_name}/{domain}/{table_name}/"
         return None
 
     def get_external_url_for_schema(
         self, schema_name: str, db_name: str
     ) -> Optional[str]:
-        base_url = self.get_snowsight_base_url()
-        if base_url is not None:
-            return f"{base_url}#/data/databases/{db_name}/schemas/{schema_name}/"
+        if self.snowsight_base_url is not None:
+            return f"{self.snowsight_base_url}#/data/databases/{db_name}/schemas/{schema_name}/"
         return None
 
     def get_external_url_for_database(self, db_name: str) -> Optional[str]:
-        base_url = self.get_snowsight_base_url()
-        if base_url is not None:
-            return f"{base_url}#/data/databases/{db_name}/"
+        if self.snowsight_base_url is not None:
+            return f"{self.snowsight_base_url}#/data/databases/{db_name}/"
         return None
+
+    def get_snowsight_base_url(self, conn):
+        try:
+            for db_row in self.query(conn, SnowflakeQuery.current_account()):
+                account_locator = db_row["CURRENT_ACCOUNT()"]
+
+            for db_row in self.query(conn, SnowflakeQuery.current_region()):
+                region = db_row["CURRENT_REGION()"]
+
+            self.report.account_locator = account_locator
+            self.report.region = region
+
+            # Returned region may be in the form <region_group>.<region>, see https://docs.snowflake.com/en/sql-reference/functions/current_region.html
+            region = region.split(".")[-1].lower()
+            account_locator = account_locator.lower()
+
+            cloud, cloud_region_id = SNOWFLAKE_REGION_CLOUD_REGION_MAPPING[region]
+
+            # How to find whether this is privatelink ?
+            return self.create_snowsight_base_url(
+                account_locator,
+                cloud_region_id,
+                cloud,
+                self.config.account_id.endswith(".privatelink"),  # type:ignore
+            )
+
+        except Exception as e:
+            self.warn(
+                self.logger,
+                "snowsight url",
+                f"unable to get snowsight base url due to an error -> {e}",
+            )
+            return None

--- a/metadata-ingestion/tests/integration/snowflake-beta/test_snowflake_beta.py
+++ b/metadata-ingestion/tests/integration/snowflake-beta/test_snowflake_beta.py
@@ -30,6 +30,10 @@ NUM_OPS = 10
 
 
 def default_query_results(query):
+    if query == SnowflakeQuery.current_account():
+        return [{"CURRENT_ACCOUNT()": "ABC12345"}]
+    if query == SnowflakeQuery.current_region():
+        return [{"CURRENT_REGION()": "AWS_AP_SOUTH_1"}]
     if query == SnowflakeQuery.current_role():
         return [{"CURRENT_ROLE()": "TEST_ROLE"}]
     elif query == SnowflakeQuery.current_version():

--- a/metadata-ingestion/tests/unit/test_snowflake_beta_source.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_beta_source.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from datahub.configuration.common import ConfigurationError, OauthConfiguration
 from datahub.ingestion.api.source import SourceCapability
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
+from datahub.ingestion.source.snowflake.snowflake_utils import SnowflakeCloudProvider
 from datahub.ingestion.source.snowflake.snowflake_v2 import SnowflakeV2Source
 
 
@@ -447,3 +448,61 @@ def test_test_connection_capability_all_success(mock_connect):
     assert report.capability_report[SourceCapability.DATA_PROFILING].capable
     assert report.capability_report[SourceCapability.DESCRIPTIONS].capable
     assert report.capability_report[SourceCapability.LINEAGE_COARSE].capable
+
+
+def test_aws_cloud_region_from_snowflake_region_id():
+    (
+        cloud,
+        cloud_region_id,
+    ) = SnowflakeV2Source.get_cloud_region_from_snowflake_region_id("aws_ca_central_1")
+
+    assert cloud == SnowflakeCloudProvider.AWS
+    assert cloud_region_id == "ca-central-1"
+
+    (
+        cloud,
+        cloud_region_id,
+    ) = SnowflakeV2Source.get_cloud_region_from_snowflake_region_id("aws_us_east_1_gov")
+
+    assert cloud == SnowflakeCloudProvider.AWS
+    assert cloud_region_id == "us-east-1"
+
+
+def test_google_cloud_region_from_snowflake_region_id():
+    (
+        cloud,
+        cloud_region_id,
+    ) = SnowflakeV2Source.get_cloud_region_from_snowflake_region_id("gcp_europe_west2")
+
+    assert cloud == SnowflakeCloudProvider.GCP
+    assert cloud_region_id == "europe-west2"
+
+
+def test_azure_cloud_region_from_snowflake_region_id():
+    (
+        cloud,
+        cloud_region_id,
+    ) = SnowflakeV2Source.get_cloud_region_from_snowflake_region_id(
+        "azure_switzerlandnorth"
+    )
+
+    assert cloud == SnowflakeCloudProvider.AZURE
+    assert cloud_region_id == "switzerlandnorth"
+
+    (
+        cloud,
+        cloud_region_id,
+    ) = SnowflakeV2Source.get_cloud_region_from_snowflake_region_id(
+        "azure_centralindia"
+    )
+
+    assert cloud == SnowflakeCloudProvider.AZURE
+    assert cloud_region_id == "central-india.azure"
+
+
+def test_unknown_cloud_region_from_snowflake_region_id():
+    with pytest.raises(Exception) as e:
+        SnowflakeV2Source.get_cloud_region_from_snowflake_region_id(
+            "somecloud_someregion"
+        )
+    assert "Unknown snowflake region" in str(e)


### PR DESCRIPTION
Earlier approach did not work when using snowflake account identifiers of the form <org-name>-<account-name> in snowflake recipe. Also there is no clear way to identify whether input is in with account locator OR account and org name. The revised approach makes no assumptions and fetches account and region details by querying snowflake.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
