### PR TITLE
fix(ingest): support airflow mapped operators

### DIFF
--- a/metadata-ingestion/src/datahub_provider/_plugin.py
+++ b/metadata-ingestion/src/datahub_provider/_plugin.py
@@ -18,6 +18,9 @@ from datahub_provider.lineage.datahub import DatahubLineageConfig
 
 logger = logging.getLogger(__name__)
 
+TASK_ON_FAILURE_CALLBACK = "on_failure_callback"
+TASK_ON_SUCCESS_CALLBACK = "on_success_callback"
+
 
 def get_lineage_config() -> DatahubLineageConfig:
     """Load the lineage config from airflow.cfg."""
@@ -299,19 +302,19 @@ def task_policy(task: Union[BaseOperator, MappedOperator]) -> None:
     # We can bypass this by going through partial_kwargs for now
     if MappedOperator and isinstance(task, MappedOperator):  # type: ignore
         on_failure_callback_prop: property = getattr(
-            MappedOperator, "on_failure_callback"
+            MappedOperator, TASK_ON_FAILURE_CALLBACK
         )
         on_success_callback_prop: property = getattr(
-            MappedOperator, "on_success_callback"
+            MappedOperator, TASK_ON_SUCCESS_CALLBACK
         )
         if not on_failure_callback_prop.fset or not on_success_callback_prop.fset:
             task.log.debug(
                 "Using MappedOperator's partial_kwargs instead of callback properties"
             )
-            task.partial_kwargs["on_failure_callback"] = _wrap_on_failure_callback(
+            task.partial_kwargs[TASK_ON_FAILURE_CALLBACK] = _wrap_on_failure_callback(
                 task.on_failure_callback
             )
-            task.partial_kwargs["on_success_callback"] = _wrap_on_success_callback(
+            task.partial_kwargs[TASK_ON_SUCCESS_CALLBACK] = _wrap_on_success_callback(
                 task.on_success_callback
             )
             return

--- a/metadata-ingestion/src/datahub_provider/_plugin.py
+++ b/metadata-ingestion/src/datahub_provider/_plugin.py
@@ -314,6 +314,7 @@ def task_policy(task: Union[BaseOperator, MappedOperator]) -> None:
             task.partial_kwargs["on_success_callback"] = _wrap_on_success_callback(
                 task.on_success_callback
             )
+            return
 
     task.on_failure_callback = _wrap_on_failure_callback(task.on_failure_callback)  # type: ignore
     task.on_success_callback = _wrap_on_success_callback(task.on_success_callback)  # type: ignore

--- a/metadata-ingestion/src/datahub_provider/_plugin.py
+++ b/metadata-ingestion/src/datahub_provider/_plugin.py
@@ -1,13 +1,12 @@
-from datahub_provider._airflow_compat import Operator
+from datahub_provider._airflow_compat import BaseOperator, MappedOperator, Operator
 
 import contextlib
 import logging
 import traceback
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional, Union
 
 from airflow.configuration import conf
 from airflow.lineage import PIPELINE_OUTLETS
-from airflow.models.baseoperator import BaseOperator
 from airflow.plugins_manager import AirflowPlugin
 from airflow.utils.module_loading import import_string
 from cattr import structure
@@ -290,12 +289,34 @@ def _wrap_on_success_callback(on_success_callback):
     return custom_on_success_callback
 
 
-def task_policy(task: BaseOperator) -> None:
+def task_policy(task: Union[BaseOperator, MappedOperator]) -> None:
     task.log.debug(f"Setting task policy for Dag: {task.dag_id} Task: {task.task_id}")
     # task.add_inlets(["auto"])
     # task.pre_execute = _wrap_pre_execution(task.pre_execute)
-    task.on_failure_callback = _wrap_on_failure_callback(task.on_failure_callback)
-    task.on_success_callback = _wrap_on_success_callback(task.on_success_callback)
+
+    # MappedOperator's callbacks don't have setters until Airflow 2.X.X
+    # https://github.com/apache/airflow/issues/24547
+    # We can bypass this by going through partial_kwargs for now
+    if MappedOperator and isinstance(task, MappedOperator):  # type: ignore
+        on_failure_callback_prop: property = getattr(
+            MappedOperator, "on_failure_callback"
+        )
+        on_success_callback_prop: property = getattr(
+            MappedOperator, "on_success_callback"
+        )
+        if not on_failure_callback_prop.fset or not on_success_callback_prop.fset:
+            task.log.debug(
+                "Using MappedOperator's partial_kwargs instead of callback properties"
+            )
+            task.partial_kwargs["on_failure_callback"] = _wrap_on_failure_callback(
+                task.on_failure_callback
+            )
+            task.partial_kwargs["on_success_callback"] = _wrap_on_success_callback(
+                task.on_success_callback
+            )
+
+    task.on_failure_callback = _wrap_on_failure_callback(task.on_failure_callback)  # type: ignore
+    task.on_success_callback = _wrap_on_success_callback(task.on_success_callback)  # type: ignore
     # task.pre_execute = _wrap_pre_execution(task.pre_execute)
 
 


### PR DESCRIPTION
Airflow plugin was crashing when trying to apply task policies to dynamically generated tasks (i.e., MappedOperators). This fix will support current versions of Airflow and future versions when the following issue is addressed: https://github.com/apache/airflow/issues/24547.

Related Datahub issue: https://github.com/datahub-project/datahub/issues/6606


## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
