### PR TITLE
fix(ingest): fix codegen `from_obj` for empty dicts in unions with null

### DIFF
--- a/metadata-ingestion/scripts/install_editable_versions.sh
+++ b/metadata-ingestion/scripts/install_editable_versions.sh
@@ -2,6 +2,6 @@
 
 set -euxo pipefail
 
-pip install -e 'git+https://github.com/hsheth2/avro_gen#egg=avro-gen3'
-pip install -e 'git+https://github.com/hsheth2/PyHive#egg=acryl-pyhive[hive]'
+pip install -e 'git+https://github.com/acryldata/avro_gen#egg=avro-gen3'
+pip install -e 'git+https://github.com/acryldata/PyHive#egg=acryl-pyhive[hive]'
 pip install -e '.[dev]'

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -36,7 +36,7 @@ framework_common = {
     "entrypoints",
     "docker",
     "expandvars>=0.6.5",
-    "avro-gen3==0.7.7",
+    "avro-gen3==0.7.8",
     # "avro-gen3 @ git+https://github.com/acryldata/avro_gen@master#egg=avro-gen3",
     "avro>=1.10.2,<1.11",
     "python-dateutil>=2.8.0",

--- a/metadata-ingestion/tests/unit/serde/test_serde.py
+++ b/metadata-ingestion/tests/unit/serde/test_serde.py
@@ -309,3 +309,23 @@ def test_reserved_keywords() -> None:
 
     filter3 = models.FilterClass.from_obj(filter2.to_obj())
     assert filter2 == filter3
+
+
+def test_read_empty_dict() -> None:
+    original = '{"type": "SUCCESS", "nativeResults": {}}'
+
+    model = models.AssertionResultClass.from_obj(json.loads(original))
+    assert model.nativeResults == {}
+    assert model == models.AssertionResultClass(
+        type=models.AssertionResultTypeClass.SUCCESS, nativeResults={}
+    )
+
+
+def test_write_optional_empty_dict() -> None:
+    model = models.AssertionResultClass(
+        type=models.AssertionResultTypeClass.SUCCESS, nativeResults={}
+    )
+    assert model.nativeResults == {}
+
+    out = json.dumps(model.to_obj())
+    assert out == '{"type": "SUCCESS", "nativeResults": {}}'


### PR DESCRIPTION
The code changes in https://github.com/acryldata/avro_gen/pull/16, but tests are written here. Prior to this change, the test_read_empty_dict test would give `nativeResults = None` instead of `{}`.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
