### PR TITLE
fix(python-sdk): DataHubGraph get_aspect should accept empty responses

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -152,7 +152,7 @@ class DataHubGraph(DatahubRestEmitter):
 
         # Deserialize the aspect json into the aspect type.
         aspect_json = response_json.get("aspect", {}).get(aspect_type_name)
-        if aspect_json:
+        if aspect_json is not None:
             # need to apply a transform to the response to match rest.li and avro serialization
             post_json_obj = post_json_transform(aspect_json)
             return aspect_type.from_obj(post_json_obj)

--- a/metadata-ingestion/tests/unit/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/graph/test_client.py
@@ -15,6 +15,3 @@ def test_get_aspect(mock_test_connection):
         mock_get.return_value = mock_response
         editable = graph.get_aspect(user_urn, CorpUserEditableInfoClass)
         assert editable is not None
-
-if __name__ == "__main__":
-    test_get_aspect()

--- a/metadata-ingestion/tests/unit/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/graph/test_client.py
@@ -1,17 +1,23 @@
 from unittest.mock import Mock, patch
+
 from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
 from datahub.metadata.schema_classes import CorpUserEditableInfoClass
 
 
-@patch('datahub.ingestion.graph.client.telemetry_enabled', False)
+@patch("datahub.ingestion.graph.client.telemetry_enabled", False)
 @patch("datahub.emitter.rest_emitter.DataHubRestEmitter.test_connection")
 def test_get_aspect(mock_test_connection):
     mock_test_connection.return_value = {}
     graph = DataHubGraph(DataHubGraphConfig())
-    user_urn="urn:li:corpuser:foo"
+    user_urn = "urn:li:corpuser:foo"
     with patch("requests.Session.get") as mock_get:
         mock_response = Mock()
-        mock_response.json = Mock(return_value={'version': 0, 'aspect': {'com.linkedin.identity.CorpUserEditableInfo': {}}})
+        mock_response.json = Mock(
+            return_value={
+                "version": 0,
+                "aspect": {"com.linkedin.identity.CorpUserEditableInfo": {}},
+            }
+        )
         mock_get.return_value = mock_response
         editable = graph.get_aspect(user_urn, CorpUserEditableInfoClass)
         assert editable is not None

--- a/metadata-ingestion/tests/unit/graph/test_client.py
+++ b/metadata-ingestion/tests/unit/graph/test_client.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock, patch
+from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+from datahub.metadata.schema_classes import CorpUserEditableInfoClass
+
+
+@patch('datahub.ingestion.graph.client.telemetry_enabled', False)
+@patch("datahub.emitter.rest_emitter.DataHubRestEmitter.test_connection")
+def test_get_aspect(mock_test_connection):
+    mock_test_connection.return_value = {}
+    graph = DataHubGraph(DataHubGraphConfig())
+    user_urn="urn:li:corpuser:foo"
+    with patch("requests.Session.get") as mock_get:
+        mock_response = Mock()
+        mock_response.json = Mock(return_value={'version': 0, 'aspect': {'com.linkedin.identity.CorpUserEditableInfo': {}}})
+        mock_get.return_value = mock_response
+        editable = graph.get_aspect(user_urn, CorpUserEditableInfoClass)
+        assert editable is not None
+
+if __name__ == "__main__":
+    test_get_aspect()


### PR DESCRIPTION
Context: https://datahubspace.slack.com/archives/C029A3M079U/p1670257620431059

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
