### PR TITLE
docs(ingest/airflow): clarify Airflow 1.x docs for airflow plugin

### DIFF
--- a/docs/lineage/airflow.md
+++ b/docs/lineage/airflow.md
@@ -14,7 +14,7 @@ You can use either the DataHub Airflow lineage plugin (recommended) or the Airfl
 
 The Airflow lineage plugin is only supported with Airflow version >= 2.0.2 or on MWAA with an Airflow version >= 2.0.2.
 
-If you're using Airflow 1.x, we recommend using the Airflow lineage backend with acryl-datahub <= 0.9.1.0.
+If you're using Airflow 1.x, use the Airflow lineage plugin with acryl-datahub-airflow-plugin <= 0.9.1.0.
 
 :::
 


### PR DESCRIPTION
Specifically, this makes it more clear on Airflow 1.x, the old Airflow plugin works and you don't have to use the lineage backend.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
