### PR TITLE
feat(cli): support delete by container, optional delete references

### DIFF
--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -73,12 +73,18 @@ curl "http://localhost:8080/entities?action=delete" -X POST --data '{"urn": "urn
 
 ## Delete using Broader Filters
 
-_Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`). Additionally, as of v0.8.29 there is a new option: `--include-removed` that deletes softly deleted entities that match the provided filter.
+_Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`). Starting v0.8.29 there is a new option: `--include-removed` that deletes softly deleted entities that match the provided filter. Starting v0.9.4, these commands also delete references of deleted entities by default. You can use `--keep-references` to change default behavior._
 
 
 ### Delete all datasets in the DEV environment
 ```
 datahub delete --env DEV --entity_type dataset
+```
+
+### Delete all datasets in a particular container
+_Note that this command is not recursive and will only delete datasets directly inside the container._
+```
+datahub delete --container <container-urn>
 ```
 
 ### Delete all containers for a particular platform
@@ -148,6 +154,6 @@ In some cases, entities that were initially ingested by a run might have had fur
 1. Leave these aspects untouched in the database, and soft-delete the entity. A re-ingestion of these entities will result in this additional metadata becoming visible again in the UI, so you don't lose any of your work. 
 2. The datahub cli will save information about these unsafe entities as a CSV for operators to later review and decide on next steps (keep or remove).
 
-The rollback command will report how many entities have such aspects and save as a CSV the urns of these entities under a rollback reports directory, which defaults to `rollback_reports` under the current directory where the cli is run, and can be configured further using the `--reports-dir` command line arg.
+The rollback command will report how many entities have such aspects and save as a CSV the urns of these entities under a rollback reports directory, which defaults to `rollback_reports` under the current directory where the cli is run, and can be configured further using the `--report-dir` command line arg.
 
 The operator can use `datahub get --urn <>` to inspect the aspects that were left behind and either keep them (do nothing) or delete the entity (and its aspects) completely using `datahub delete --urn <urn> --hard`. If the operator wishes to remove all the metadata associated with these unsafe entities, they can re-issue the rollback command with the `--nuke` flag.

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -73,7 +73,7 @@ curl "http://localhost:8080/entities?action=delete" -X POST --data '{"urn": "urn
 
 ## Delete using Broader Filters
 
-_Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`). Starting v0.8.29 there is a new option: `--include-removed` that deletes softly deleted entities that match the provided filter. Starting v0.9.4, these commands also delete references of deleted entities by default. You can use `--keep-references` to change default behavior._
+_Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`). Starting v0.8.29 there is a new option: `--include-removed` that deletes softly deleted entities that match the provided filter. Starting v0.9.4, these commands also support deleting references of entities being deleted via `--delete-references`. This is important to use if you don't want to have ghost references in your metadata model and want to save space in the graph database._
 
 
 ### Delete all datasets in the DEV environment

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -19,7 +19,6 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - #6611 - Snowflake `schema_pattern` now accepts pattern for fully qualified schema name in format `<catalog_name>.<schema_name>` by setting config `match_fully_qualified_names : True`. Current default `match_fully_qualified_names: False` is only to maintain backward compatibility. The config option `match_fully_qualified_names` will be deprecated in future and the default behavior will assume `match_fully_qualified_names: True`."
 - #6636 - Sources `snowflake-legacy` and `snowflake-usage-legacy` have been removed.
-- Delete cli functionality now deletes references of deleted entities by default. Use `--keep-references` to change the default behavior.
 
 ## 0.9.3
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -19,6 +19,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - #6611 - Snowflake `schema_pattern` now accepts pattern for fully qualified schema name in format `<catalog_name>.<schema_name>` by setting config `match_fully_qualified_names : True`. Current default `match_fully_qualified_names: False` is only to maintain backward compatibility. The config option `match_fully_qualified_names` will be deprecated in future and the default behavior will assume `match_fully_qualified_names: True`."
 - #6636 - Sources `snowflake-legacy` and `snowflake-usage-legacy` have been removed.
+- Delete cli functionality now deletes references of deleted entities by default. Use `--keep-references` to change the default behavior.
 
 ## 0.9.3
 

--- a/metadata-ingestion/examples/recipes/file_to_datahub.dhub.yaml
+++ b/metadata-ingestion/examples/recipes/file_to_datahub.dhub.yaml
@@ -3,7 +3,7 @@
 source:
   type: "file"
   config:
-    filename: ./examples/mce_files/nih_demo.json
+    filename: ./examples/mce_files/bootstrap_mce.json
 
 # see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
 sink:

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -344,6 +344,7 @@ def get_urns_by_filter(
     search_query: str = "*",
     include_removed: bool = False,
     only_soft_deleted: Optional[bool] = None,
+    container: Optional[str] = None,
 ) -> Iterable[str]:
     session, gms_host = get_session_and_host()
     endpoint: str = "/entities?action=search"
@@ -352,13 +353,12 @@ def get_urns_by_filter(
     entity_type_lower = entity_type.lower()
     if env and entity_type_lower != "container":
         filter_criteria.append({"field": "origin", "value": env, "condition": "EQUAL"})
-    if (
-        platform is not None
-        and entity_type_lower == "dataset"
-        or entity_type_lower == "dataflow"
-        or entity_type_lower == "datajob"
-        or entity_type_lower == "container"
-    ):
+    if platform is not None and entity_type_lower in {
+        "dataset",
+        "dataflow",
+        "datajob",
+        "container",
+    }:
         filter_criteria.append(
             {
                 "field": "platform",
@@ -388,6 +388,20 @@ def get_urns_by_filter(
             {
                 "field": "removed",
                 "value": "",  # accept anything regarding removed property (true, false, non-existent)
+                "condition": "EQUAL",
+            }
+        )
+
+    if container is not None and entity_type_lower in {
+        "dataset",
+        "chart",
+        "dashboard",
+        "container",
+    }:
+        filter_criteria.append(
+            {
+                "field": "container",
+                "value": container,
                 "condition": "EQUAL",
             }
         )

--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -143,7 +143,7 @@ def delete_for_registry(
     "remove_references",
     required=False,
     is_flag=True,
-    default=True,
+    default=False,
     help="specifies whether to delete references",
 )
 @upgrade.check_upgrade

--- a/smoke-test/tests/delete/cli_test_data.json
+++ b/smoke-test/tests/delete/cli_test_data.json
@@ -12,7 +12,8 @@
                   "owner": "urn:li:corpuser:datahub",
                   "type": "DATAOWNER",
                   "source": null
-                }],
+                }
+              ],
               "lastModified": {
                 "time": 0,
                 "actor": "urn:li:corpuser:unknown",
@@ -25,7 +26,8 @@
               "name": "Needs Documentation",
               "description": "A tag that is applied to all fields that require some documentation."
             }
-          }]
+          }
+        ]
       }
     },
     "proposedDelta": null
@@ -122,7 +124,11 @@
                   },
                   "nativeDataType": "varchar(100)",
                   "globalTags": {
-                    "tags": [{ "tag": "urn:li:tag:NeedsDocs" }]
+                    "tags": [
+                      {
+                        "tag": "urn:li:tag:NeedsDocs"
+                      }
+                    ]
                   },
                   "recursive": false
                 },
@@ -165,5 +171,72 @@
       }
     },
     "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "proposedSnapshot": {
+      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:kafka,dataset-with-tags,PROD)",
+        "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "Dataset with tags"
+            }
+          },
+          {
+            "com.linkedin.pegasus2avro.common.GlobalTags": {
+              "tags": [
+                {
+                  "tag": "urn:li:tag:NeedsOwners"
+                },
+                {
+                  "tag": "urn:li:tag:NeedsReview"
+                },
+                {
+                  "tag": "urn:li:tag:KeepTag"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "proposedDelta": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:NeedsOwners",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"Needs Owners\" }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:KeepTag",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"Dummy tag\" }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:NeedsReview",
+    "changeType": "UPSERT",
+    "aspectName": "tagProperties",
+    "aspect": {
+      "value": "{\"name\": \"Needs Review\" }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
   }
 ]

--- a/smoke-test/tests/delete/delete_test.py
+++ b/smoke-test/tests/delete/delete_test.py
@@ -135,6 +135,7 @@ def test_delete_tags_remove_references(test_setup, depends=["test_healthchecks"]
 
     sleep(3)
 
+    # Validate that references no longer exist for soft deleted tags
     references_count, _ = delete_references(
         tag_to_delete, dry_run=True, cached_session_host=(session, gms_host)
     )
@@ -167,7 +168,7 @@ def test_delete_tags_keep_references(test_setup, depends=["test_healthchecks"]):
 
     sleep(3)
 
-    # Validate that references no longer exist for soft deleted tags
+    # Validate that references still exist for soft deleted tags
     references_count, _ = delete_references(
         tag_to_delete, dry_run=True, cached_session_host=(session, gms_host)
     )

--- a/smoke-test/tests/delete/delete_test.py
+++ b/smoke-test/tests/delete/delete_test.py
@@ -1,11 +1,14 @@
 import os
-import json
 import pytest
 from time import sleep
 from datahub.cli.cli_utils import get_aspects_for_entity
 from datahub.cli.ingest_cli import get_session_and_host
-from datahub.cli.delete_cli import delete_references
-from tests.utils import ingest_file_via_rest, wait_for_healthcheck_util
+from datahub.cli.delete_cli import delete_references, delete_with_filters
+from tests.utils import (
+    delete_urns_from_file,
+    ingest_file_via_rest,
+    wait_for_healthcheck_util,
+)
 
 # Disable telemetry
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
@@ -23,7 +26,7 @@ def test_healthchecks(wait_for_healthchecks):
     pass
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(scope="module", autouse=False)
 def test_setup():
     """Fixture to execute asserts before and after a test is run"""
 
@@ -33,23 +36,33 @@ def test_setup():
     env = "PROD"
     dataset_urn = f"urn:li:dataset:({platform},{dataset_name},{env})"
 
-    session, gms_host = get_session_and_host()
+    assert "browsePaths" not in get_aspects_for_entity(
+        entity_urn=dataset_urn, aspects=["browsePaths"], typed=False
+    )
+    assert "editableDatasetProperties" not in get_aspects_for_entity(
+        entity_urn=dataset_urn, aspects=["editableDatasetProperties"], typed=False
+    )
 
-    assert "browsePaths" not in get_aspects_for_entity(entity_urn=dataset_urn, aspects=["browsePaths"], typed=False)
-    assert "editableDatasetProperties" not in get_aspects_for_entity(entity_urn=dataset_urn, aspects=["editableDatasetProperties"], typed=False)
+    ingest_file_via_rest("tests/delete/cli_test_data.json")
+    ingest_file_via_rest("tests/containers/data.json")
 
-    ingested_dataset_run_id = ingest_file_via_rest("tests/delete/cli_test_data.json").config.run_id
-
-    assert "browsePaths" in get_aspects_for_entity(entity_urn=dataset_urn, aspects=["browsePaths"], typed=False)
+    assert "browsePaths" in get_aspects_for_entity(
+        entity_urn=dataset_urn, aspects=["browsePaths"], typed=False
+    )
 
     yield
-    rollback_url = f"{gms_host}/runs?action=rollback"
-    session.post(rollback_url, data=json.dumps({"runId": ingested_dataset_run_id, "dryRun": False, "hardDelete": True, "safe": False}))
+    print("removing delete test data")
+    delete_urns_from_file("tests/delete/cli_test_data.json")
+    delete_urns_from_file("tests/containers/data.json")
 
     sleep(3)
 
-    assert "browsePaths" not in get_aspects_for_entity(entity_urn=dataset_urn, aspects=["browsePaths"], typed=False)
-    assert "editableDatasetProperties" not in get_aspects_for_entity(entity_urn=dataset_urn, aspects=["editableDatasetProperties"], typed=False)
+    assert "browsePaths" not in get_aspects_for_entity(
+        entity_urn=dataset_urn, aspects=["browsePaths"], typed=False
+    )
+    assert "editableDatasetProperties" not in get_aspects_for_entity(
+        entity_urn=dataset_urn, aspects=["editableDatasetProperties"], typed=False
+    )
 
 
 @pytest.mark.dependency()
@@ -64,11 +77,13 @@ def test_delete_reference(test_setup, depends=["test_healthchecks"]):
     session, gms_host = get_session_and_host()
 
     # Validate that the ingested tag is being referenced by the dataset
-    references_count, related_aspects = delete_references(tag_urn, dry_run=True, cached_session_host=(session, gms_host))
+    references_count, related_aspects = delete_references(
+        tag_urn, dry_run=True, cached_session_host=(session, gms_host)
+    )
     print("reference count: " + str(references_count))
     print(related_aspects)
     assert references_count == 1
-    assert related_aspects[0]['entity'] == dataset_urn
+    assert related_aspects[0]["entity"] == dataset_urn
 
     # Delete references to the tag
     delete_references(tag_urn, dry_run=False, cached_session_host=(session, gms_host))
@@ -76,5 +91,84 @@ def test_delete_reference(test_setup, depends=["test_healthchecks"]):
     sleep(3)
 
     # Validate that references no longer exist
-    references_count, related_aspects = delete_references(tag_urn, dry_run=True, cached_session_host=(session, gms_host))
+    references_count, related_aspects = delete_references(
+        tag_urn, dry_run=True, cached_session_host=(session, gms_host)
+    )
     assert references_count == 0
+
+
+@pytest.mark.dependency()
+def test_delete_by_container(test_setup, depends=["test_healthchecks"]):
+    container = "urn:li:container:SCHEMA"
+
+    result = delete_with_filters(
+        dry_run=True,
+        soft=True,
+        force=False,
+        include_removed=False,
+        container=container,
+    )
+    assert result.num_entities == 1
+
+
+@pytest.mark.dependency()
+def test_delete_tags_remove_references(test_setup, depends=["test_healthchecks"]):
+    tag_to_delete = "urn:li:tag:NeedsOwners"
+    session, gms_host = get_session_and_host()
+
+    references_count, _ = delete_references(
+        tag_to_delete, dry_run=True, cached_session_host=(session, gms_host)
+    )
+    assert references_count == 1
+
+    # Hard delete tag and delete references to the tag
+    result = delete_with_filters(
+        dry_run=False,
+        soft=True,
+        force=True,
+        include_removed=False,
+        search_query="Owners",
+        entity_type="tag",
+        remove_references=True,
+    )
+    assert result.num_entities == 1
+
+    sleep(3)
+
+    references_count, _ = delete_references(
+        tag_to_delete, dry_run=True, cached_session_host=(session, gms_host)
+    )
+    assert references_count == 0
+
+
+@pytest.mark.dependency()
+def test_delete_tags_keep_references(test_setup, depends=["test_healthchecks"]):
+
+    tag_to_delete = "urn:li:tag:NeedsReview"
+
+    session, gms_host = get_session_and_host()
+
+    references_count, _ = delete_references(
+        tag_to_delete, dry_run=True, cached_session_host=(session, gms_host)
+    )
+    assert references_count == 1
+
+    # Soft delete tag but keep references to the tag
+    result = delete_with_filters(
+        dry_run=False,
+        soft=True,
+        force=True,
+        include_removed=False,
+        entity_type="tag",
+        search_query="Review",
+        remove_references=False,
+    )
+    assert result.num_entities == 1
+
+    sleep(3)
+
+    # Validate that references no longer exist for soft deleted tags
+    references_count, _ = delete_references(
+        tag_to_delete, dry_run=True, cached_session_host=(session, gms_host)
+    )
+    assert references_count == 1


### PR DESCRIPTION
- Supports deleting datasets inside a container using `datahub delete --container container_urn`
Earlier this could be done wither using a `query` filter OR listing all datasets in a container and deleting dataset one by one using urn. `query` is not an ideal filter as it may lead to incorrect results if database/schema names are similar. Also deleting datasets from a container one by one is not efficient.

- This PR also adds support for deleting references when using above query or any other [delete cli using broad filters](https://datahubproject.io/docs/how/delete-metadata/#delete-using-broader-filters). This will help get rid of unnecessary references. If using `--dry-run`, referenced entities are also shown in preview. Deleting References is disabled by default and can be enabled using `--delete-references`
`




## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
