### PR TITLE
refactor(ui): Make include_tables and include_views default to True. Improve Tableau default recipe. 

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/common.tsx
@@ -374,21 +374,41 @@ export const INGEST_OWNER: RecipeField = {
     rules: null,
 };
 
+const includeTablesPath = 'source.config.include_tables';
 export const INCLUDE_TABLES: RecipeField = {
     name: 'include_tables',
     label: 'Include Tables',
     tooltip: 'Extract Tables from source.',
     type: FieldType.BOOLEAN,
-    fieldPath: 'source.config.include_tables',
+    fieldPath: includeTablesPath,
+    // Always set include views indicator to true by default.
+    // This is in accordance with what the ingestion sources do.
+    getValueFromRecipeOverride: (recipe: any) => {
+        const includeTables = get(recipe, includeTablesPath);
+        if (includeTables !== undefined && includeTables !== null) {
+            return includeTables;
+        }
+        return true;
+    },
     rules: null,
 };
 
+const includeViewsPath = 'source.config.include_views';
 export const INCLUDE_VIEWS: RecipeField = {
     name: 'include_views',
     label: 'Include Views',
     tooltip: 'Extract Views from source.',
     type: FieldType.BOOLEAN,
-    fieldPath: 'source.config.include_views',
+    fieldPath: includeViewsPath,
+    // Always set include views indicator to true by default.
+    // This is in accordance with what the ingestion sources do.
+    getValueFromRecipeOverride: (recipe: any) => {
+        const includeViews = get(recipe, includeViewsPath);
+        if (includeViews !== undefined && includeViews !== null) {
+            return includeViews;
+        }
+        return true;
+    },
     rules: null,
 };
 

--- a/datahub-web-react/src/app/ingest/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingest/source/builder/sources.json
@@ -46,7 +46,7 @@
         "name": "tableau",
         "displayName": "Tableau",
         "docsUrl": "https://datahubproject.io/docs/generated/ingestion/sources/tableau/",
-        "recipe": "source:\n  type: tableau\n  config:\n    # Coordinates\n    connect_uri: null\n        stateful_ingestion:\n            enabled: true"
+        "recipe": "source:\n    type: tableau\n    config:\n        # Coordinates\n        connect_uri: null\n        stateful_ingestion:\n            enabled: true"
     },
     {
         "urn": "urn:li:dataPlatform:mysql",


### PR DESCRIPTION
## Summary

In this PR, we make include_tables and include_views selected (True) as default for the SQL sources. This fixes an issue where previously created recipes will appear with include views and include tables as false. This should reduce confusion going forward.

We also make small tweaks to the indentation on the Tableau base recipe. 

## Status

Ready for review.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
