### PR TITLE
feat(ingest/stateful): remove platform_instance_id from state urn

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/ingestion_job_checkpointing_provider_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/ingestion_job_checkpointing_provider_base.py
@@ -48,11 +48,19 @@ class IngestionCheckpointingProviderBase(StatefulCommittable[CheckpointJobStates
         orchestrator: str,
         pipeline_name: str,
         job_name: JobId,
-        platform_instance_id: str,
     ) -> str:
         """
         Standardizes datajob urn minting for all ingestion job state providers.
         """
-        return builder.make_data_job_urn(
+        return builder.make_data_job_urn(orchestrator, pipeline_name, job_name)
+
+    @staticmethod
+    def get_data_job_legacy_urn(
+        orchestrator: str,
+        pipeline_name: str,
+        job_name: JobId,
+        platform_instance_id: str,
+    ) -> str:
+        return IngestionCheckpointingProviderBase.get_data_job_urn(
             orchestrator, f"{pipeline_name}_{platform_instance_id}", job_name
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/state/checkpoint.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/checkpoint.py
@@ -97,7 +97,6 @@ class Checkpoint(Generic[StateType]):
 
     job_name: str
     pipeline_name: str
-    platform_instance_id: str
     run_id: str
     state: StateType
 
@@ -140,12 +139,12 @@ class Checkpoint(Generic[StateType]):
                 checkpoint = cls(
                     job_name=job_name,
                     pipeline_name=checkpoint_aspect.pipelineName,
-                    platform_instance_id=checkpoint_aspect.platformInstanceId,
                     run_id=checkpoint_aspect.runId,
                     state=state_obj,
                 )
                 logger.info(
-                    f"Successfully constructed last checkpoint state for job {job_name}"
+                    f"Successfully constructed last checkpoint state for job {job_name} "
+                    f"with timestamp {datetime.utcfromtimestamp(checkpoint_aspect.timestampMillis/1000)}"
                 )
                 return checkpoint
         return None
@@ -216,7 +215,7 @@ class Checkpoint(Generic[StateType]):
             checkpoint_aspect = DatahubIngestionCheckpointClass(
                 timestampMillis=int(datetime.utcnow().timestamp() * 1000),
                 pipelineName=self.pipeline_name,
-                platformInstanceId=self.platform_instance_id,
+                platformInstanceId="",
                 runId=self.run_id,
                 config="",
                 state=checkpoint_state,

--- a/metadata-ingestion/src/datahub/ingestion/source/state/redundant_run_skip_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/redundant_run_skip_handler.py
@@ -100,7 +100,6 @@ class RedundantRunSkipHandler(
         return Checkpoint(
             job_name=self.job_id,
             pipeline_name=self.pipeline_name,
-            platform_instance_id=self.source.get_platform_instance_id(),
             run_id=self.run_id,
             state=BaseUsageCheckpointState(
                 begin_timestamp_millis=self.INVALID_TIMESTAMP_VALUE,

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -215,7 +215,6 @@ class StaleEntityRemovalHandler(
             return Checkpoint(
                 job_name=self.job_id,
                 pipeline_name=self.pipeline_name,
-                platform_instance_id=self.source.get_platform_instance_id(),
                 run_id=self.run_id,
                 state=self.state_type_class(),
             )

--- a/metadata-ingestion/tests/unit/stateful_ingestion/provider/test_datahub_ingestion_checkpointing_provider.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/provider/test_datahub_ingestion_checkpointing_provider.py
@@ -25,7 +25,6 @@ from tests.test_helpers.type_helpers import assert_not_null
 class TestDatahubIngestionCheckpointProvider(unittest.TestCase):
     # Static members for the tests
     pipeline_name: str = "test_pipeline"
-    platform_instance_id: str = "test_platform_instance_1"
     job_names: List[JobId] = [JobId("job1"), JobId("job2")]
     run_id: str = "test_run"
 
@@ -95,7 +94,6 @@ class TestDatahubIngestionCheckpointProvider(unittest.TestCase):
             filter_criteria_map,
             {
                 "pipelineName": self.pipeline_name,
-                "platformInstanceId": self.platform_instance_id,
             },
         )
         # Retrieve the cached mcpw and return its aspect value.
@@ -111,7 +109,6 @@ class TestDatahubIngestionCheckpointProvider(unittest.TestCase):
         job1_checkpoint = Checkpoint(
             job_name=self.job_names[0],
             pipeline_name=self.pipeline_name,
-            platform_instance_id=self.platform_instance_id,
             run_id=self.run_id,
             state=job1_state_obj,
         )
@@ -122,7 +119,6 @@ class TestDatahubIngestionCheckpointProvider(unittest.TestCase):
         job2_checkpoint = Checkpoint(
             job_name=self.job_names[1],
             pipeline_name=self.pipeline_name,
-            platform_instance_id=self.platform_instance_id,
             run_id=self.run_id,
             state=job2_state_obj,
         )
@@ -146,10 +142,10 @@ class TestDatahubIngestionCheckpointProvider(unittest.TestCase):
         # 4. Get last committed state. This must match what has been committed earlier.
         # NOTE: This will retrieve from in-memory self.mcps_emitted because of the monkey-patching.
         job1_last_state = self.provider.get_latest_checkpoint(
-            self.pipeline_name, self.platform_instance_id, self.job_names[0]
+            self.pipeline_name, self.job_names[0]
         )
         job2_last_state = self.provider.get_latest_checkpoint(
-            self.pipeline_name, self.platform_instance_id, self.job_names[1]
+            self.pipeline_name, self.job_names[1]
         )
 
         # 5. Validate individual job checkpoint state values that have been committed and retrieved

--- a/metadata-ingestion/tests/unit/stateful_ingestion/state/test_checkpoint.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/state/test_checkpoint.py
@@ -17,7 +17,6 @@ from datahub.metadata.schema_classes import (
 
 # 1. Setup common test param values.
 test_pipeline_name: str = "test_pipeline"
-test_platform_instance_id: str = "test_platform_instance_1"
 test_job_name: str = "test_job_1"
 test_run_id: str = "test_run_1"
 
@@ -30,8 +29,8 @@ def _assert_checkpoint_deserialization(
     checkpoint_aspect = DatahubIngestionCheckpointClass(
         timestampMillis=int(datetime.utcnow().timestamp() * 1000),
         pipelineName=test_pipeline_name,
-        platformInstanceId=test_platform_instance_id,
-        config="",
+        platformInstanceId="this-can-be-anything-and-will-be-ignored",
+        config="this-is-also-ignored",
         state=serialized_checkpoint_state,
         runId=test_run_id,
     )
@@ -46,7 +45,6 @@ def _assert_checkpoint_deserialization(
     expected_checkpoint_obj = Checkpoint(
         job_name=test_job_name,
         pipeline_name=test_pipeline_name,
-        platform_instance_id=test_platform_instance_id,
         run_id=test_run_id,
         state=expected_checkpoint_state,
     )
@@ -120,7 +118,6 @@ def test_serde_idempotence(state_obj):
     orig_checkpoint_obj = Checkpoint(
         job_name=test_job_name,
         pipeline_name=test_pipeline_name,
-        platform_instance_id=test_platform_instance_id,
         run_id=test_run_id,
         state=state_obj,
     )


### PR DESCRIPTION
This PR resolves a long-standing issue with our stateful ingestion implementation.

Previously, the URNs under which we stored state were generated like this:

```
urn:li:dataJob:(urn:li:dataFlow:(datahub,<pipeline_name>_<platform>_<platform_instance_id>,prod),<platform>_stale_entity_removal)
```

While this seems reasonable at first glance, it turns out that most of our `get_platform_instance_id()` implementations did not actually produce a stable identifier. For example, Tableau and Looker's were implemented as `self.config.platform_instance or self.platform` and SQL common implemented it like this:

https://github.com/datahub-project/datahub/blob/44cfd21a653e23f869526a3c1a83e11d51b42a86/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py#L521-L529

As an example of why this is problematic, changing the hostname of a db in your DNS config would change platform_instance_id, which would prevent stateful ingestion from restoring the previous state correctly. Similarly, if you add a `platform_instance` config field, you'd expect that the old stuff would disappear rather than lingering.

We ultimately decided that `pipeline_name` should serve as the main identifier of an ingestion recipe because of its existing stability guarantees. While theoretically this means that we should've also removed `platform` from the URNs in addition to `platform_instance_id`, doing so would require a much larger change and hence was not done. My judgement was that `platform` is stable enough that it won't cause issues by being part of the URN.

As such, the new URN format is this:

```
urn:li:dataJob:(urn:li:dataFlow:(datahub,<pipeline_name>_<platform>,prod),<platform>_stale_entity_removal)
```

In order to maintain backwards compatibility, we do a lookup against the previous URN format if we fail to find any state under the new URN. This means that existing stateful ingestion users will be upgraded automatically.

This PR also updates the `datahub state inspect` command with the new format. I tested these changes manually.

These changes are stacked on top of https://github.com/datahub-project/datahub/pull/6794.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
