### PR TITLE
fix(ingest): prevent NullPointerException when non-jdbc SaveIntoDataS…

### DIFF
--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
@@ -143,7 +143,7 @@ public class DatasetExtractor {
       SaveIntoDataSourceCommand cmd = (SaveIntoDataSourceCommand) p;
 
       Map<String, String> options = JavaConversions.mapAsJavaMap(cmd.options());
-      String url = options.get("url"); // e.g. jdbc:postgresql://localhost:5432/sparktestdb
+      String url = options.getOrDefault("url", ""); // e.g. jdbc:postgresql://localhost:5432/sparktestdb
       if (!url.contains("jdbc")) {
         return Optional.empty();
       }


### PR DESCRIPTION
For SaveIntoDataSource commands that are not using JDBC, there is a NullPointerException. Set a default to prevent NullPointerException.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
