### PR TITLE
fix(lineage) Fix lineage viz with multiple siblings

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.graph.SiblingGraphService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.net.URISyntaxException;
+import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -57,7 +58,8 @@ public class EntityLineageResultResolver implements DataFetcher<CompletableFutur
                 start != null ? start : 0,
                 count != null ? count : 100,
                 1,
-                separateSiblings != null ? input.getSeparateSiblings() : false
+                separateSiblings != null ? input.getSeparateSiblings() : false,
+                new HashSet<>()
             ));
       } catch (URISyntaxException e) {
         log.error("Failed to fetch lineage for {}", urn);

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
@@ -8,6 +8,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.entity.EntityService;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,7 @@ public class SiblingGraphService {
   @Nonnull
   public EntityLineageResult getLineage(@Nonnull Urn entityUrn, @Nonnull LineageDirection direction, int offset,
       int count, int maxHops) {
-    return getLineage(entityUrn, direction, offset, count, maxHops, false);
+    return getLineage(entityUrn, direction, offset, count, maxHops, false, new HashSet<>());
   }
 
   /**
@@ -45,7 +46,7 @@ public class SiblingGraphService {
    */
   @Nonnull
   public EntityLineageResult getLineage(@Nonnull Urn entityUrn, @Nonnull LineageDirection direction,
-     int offset, int count, int maxHops, boolean separateSiblings) {
+     int offset, int count, int maxHops, boolean separateSiblings, @Nonnull Set<Urn> visitedUrns) {
     if (separateSiblings) {
       return _graphService.getLineage(entityUrn, direction, offset, count, maxHops);
     }
@@ -73,10 +74,15 @@ public class SiblingGraphService {
       offset = Math.max(0, offset - entityLineage.getTotal());
       count = Math.max(0, count - entityLineage.getRelationships().size());
 
+      visitedUrns.add(entityUrn);
       // iterate through each sibling and include their lineage in the bunch
       for (Urn siblingUrn : siblingUrns) {
+        if (visitedUrns.contains(siblingUrn)) {
+          continue;
+        }
+        // need to call siblingGraphService to get sibling results for this sibling entity in case there is more than one sibling
         EntityLineageResult nextEntityLineage = filterLineageResultFromSiblings(siblingUrn, allSiblingsInGroup,
-            _graphService.getLineage(siblingUrn, direction, offset, count, maxHops), entityLineage);
+            getLineage(siblingUrn, direction, offset, count, maxHops, false, visitedUrns), entityLineage);
 
         // Update offset and count to fetch the correct number of edges from the next sibling node
         offset = Math.max(0, offset - nextEntityLineage.getTotal());

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
@@ -8,7 +8,6 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.entity.EntityService;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
@@ -466,6 +466,94 @@ public class SiblingGraphServiceTest {
     assertEquals(upstreamLineage, expectedResult);
   }
 
+  // we should be combining lineage of siblings of siblings
+  // ie. dataset1 has sibling dataset2. dataset 2 has siblings dataset1 and dataset3. dataset3 has sibling dataset2. dataset3 has upstream dataset4.
+  // requesting upstream for dataset1 should give us dataset4
+  @Test
+  public void testUpstreamOfSiblingSiblings() throws Exception {
+    EntityLineageResult mockResult = new EntityLineageResult();
+    EntityLineageResult expectedResult = new EntityLineageResult();
+
+    LineageRelationshipArray relationships = new LineageRelationshipArray();
+    LineageRelationshipArray expectedRelationships = new LineageRelationshipArray();
+
+    LineageRelationship relationship = new LineageRelationship();
+    relationship.setDegree(0);
+    relationship.setType(downstreamOf);
+    relationship.setEntity(datasetFourUrn);
+
+    relationships.add(relationship);
+
+    expectedRelationships.add(relationship);
+
+    expectedResult.setCount(1);
+    expectedResult.setStart(0);
+    expectedResult.setTotal(1);
+    expectedResult.setRelationships(expectedRelationships);
+
+    mockResult.setStart(0);
+    mockResult.setTotal(1);
+    mockResult.setCount(1);
+    mockResult.setRelationships(relationships);
+
+    EntityLineageResult emptyLineageResult = new EntityLineageResult();
+    emptyLineageResult.setRelationships(new LineageRelationshipArray());
+    emptyLineageResult.setStart(0);
+    emptyLineageResult.setTotal(0);
+    emptyLineageResult.setCount(0);
+
+    Mockito.when(_graphService.getLineage(
+        Mockito.eq(datasetOneUrn),  Mockito.eq(LineageDirection.UPSTREAM), Mockito.anyInt(), Mockito.anyInt(), Mockito.eq(1)
+    )).thenReturn(emptyLineageResult);
+
+    Mockito.when(_graphService.getLineage(
+        Mockito.eq(datasetTwoUrn),  Mockito.eq(LineageDirection.UPSTREAM), Mockito.anyInt(), Mockito.anyInt(), Mockito.eq(1)
+    )).thenReturn(emptyLineageResult);
+
+    Mockito.when(_graphService.getLineage(
+        Mockito.eq(datasetThreeUrn),  Mockito.eq(LineageDirection.UPSTREAM), Mockito.anyInt(), Mockito.anyInt(), Mockito.eq(1)
+    )).thenReturn(mockResult);
+
+    Siblings dataset1Siblings = new Siblings();
+    dataset1Siblings.setPrimary(true);
+    dataset1Siblings.setSiblings(new UrnArray(ImmutableList.of(datasetTwoUrn)));
+
+    Mockito.when(_mockEntityService.getLatestAspect(datasetOneUrn, SIBLINGS_ASPECT_NAME)).thenReturn(dataset1Siblings);
+
+    Siblings dataset2Siblings = new Siblings();
+    dataset2Siblings.setPrimary(true);
+    dataset2Siblings.setSiblings(new UrnArray(ImmutableList.of(datasetOneUrn, datasetThreeUrn)));
+
+    Mockito.when(_mockEntityService.getLatestAspect(datasetTwoUrn, SIBLINGS_ASPECT_NAME)).thenReturn(dataset2Siblings);
+
+    Siblings dataset3Siblings = new Siblings();
+    dataset3Siblings.setPrimary(true);
+    dataset3Siblings.setSiblings(new UrnArray(ImmutableList.of(datasetTwoUrn)));
+
+    Mockito.when(_mockEntityService.getLatestAspect(datasetThreeUrn, SIBLINGS_ASPECT_NAME)).thenReturn(dataset3Siblings);
+
+    Siblings dataset4Siblings = new Siblings();
+    dataset4Siblings.setPrimary(true);
+    dataset4Siblings.setSiblings(new UrnArray());
+
+    Mockito.when(_mockEntityService.getLatestAspect(datasetFourUrn, SIBLINGS_ASPECT_NAME)).thenReturn(dataset4Siblings);
+
+    Map<Urn, List<RecordTemplate>> siblingsMap = ImmutableMap.of(
+        datasetOneUrn, ImmutableList.of(dataset1Siblings),
+        datasetTwoUrn, ImmutableList.of(dataset2Siblings),
+        datasetThreeUrn, ImmutableList.of(dataset3Siblings),
+        datasetFourUrn, ImmutableList.of(dataset4Siblings)
+    );
+
+    Mockito.when(_mockEntityService.getLatestAspects(Mockito.any(), Mockito.any())).thenReturn(siblingsMap);
+
+    SiblingGraphService service = _client;
+
+    EntityLineageResult upstreamLineage = service.getLineage(datasetOneUrn, LineageDirection.UPSTREAM, 0, 100, 1);
+
+    assertEquals(upstreamLineage, expectedResult);
+  }
+
   static Urn createFromString(@Nonnull String rawUrn) {
     try {
       return Urn.createFromString(rawUrn);


### PR DESCRIPTION
Fixes a bug we were seeing in the lineage visualization where there were multiple sibling nodes. The bug was that we weren't getting all of the sibling lineages for non-central nodes so if the node with multiple siblings wasn't the sibling node, we would only get their lineage from the urn we have, and not any of the lineages of their siblings. So it wouldn't show non-central node siblings lineage at all, and things would look like the explicit lineage described by individual aspects, not the combined siblings lineage. If we the center node is the one with multiple siblings it worked just fine.

This fixes it by calling the sibling graph service `getLineage` method for all siblings as well as the center, original request node (as opposed to the regular graph service that just gets lineage from the graph based on the singular urn provided). The siblings graph service aggregates all sibling lineage for a given node to get all of its siblings lineage as well. I need to keep track of the visited urns so that we don't get stuck in an infinite loop of siblings and fetching.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
