### PR TITLE
fix(ingest): support patches in `auto_status_aspect`

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/source_helpers.py
+++ b/metadata-ingestion/src/datahub/utilities/source_helpers.py
@@ -5,7 +5,11 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalHandler,
 )
-from datahub.metadata.schema_classes import MetadataChangeEventClass, StatusClass
+from datahub.metadata.schema_classes import (
+    MetadataChangeEventClass,
+    MetadataChangeProposalClass,
+    StatusClass,
+)
 from datahub.utilities.urns.urn import guess_entity_type
 
 
@@ -39,6 +43,9 @@ def auto_status_aspect(
                 status_urns.add(urn)
         elif isinstance(wu.metadata, MetadataChangeProposalWrapper):
             if isinstance(wu.metadata.aspect, StatusClass):
+                status_urns.add(urn)
+        elif isinstance(wu.metadata, MetadataChangeProposalClass):
+            if wu.metadata.aspectName == StatusClass.ASPECT_NAME:
                 status_urns.add(urn)
         else:
             raise ValueError(f"Unexpected type {type(wu.metadata)}")


### PR DESCRIPTION
Patches generate a raw MCP because MCPW doesn't support patches right now, so we need to handle that correctly downstream.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
