### PR TITLE
feat(ui): Support defining the ID for Glossary Term and Glossary Term Group in UI

### DIFF
--- a/datahub-web-react/src/app/domain/CreateDomainModal.tsx
+++ b/datahub-web-react/src/app/domain/CreateDomainModal.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { message, Button, Input, Modal, Typography, Form, Collapse, Tag } from 'antd';
 import { useCreateDomainMutation } from '../../graphql/domain.generated';
 import { useEnterKeyListener } from '../shared/useEnterKeyListener';
-import { groupIdTextValidation } from '../shared/textUtil';
+import { validateCustomUrnId } from '../shared/textUtil';
 import analytics, { EventType } from '../analytics';
 
 const SuggestedNamesGroup = styled.div`
@@ -156,7 +156,7 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
                                 rules={[
                                     () => ({
                                         validator(_, value) {
-                                            if (value && groupIdTextValidation(value)) {
+                                            if (value && validateCustomUrnId(value)) {
                                                 return Promise.resolve();
                                             }
                                             return Promise.reject(new Error('Please enter a valid Domain id'));

--- a/datahub-web-react/src/app/identity/group/CreateGroupModal.tsx
+++ b/datahub-web-react/src/app/identity/group/CreateGroupModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { message, Button, Input, Modal, Typography, Form, Collapse } from 'antd';
 import { useCreateGroupMutation } from '../../../graphql/group.generated';
 import { useEnterKeyListener } from '../../shared/useEnterKeyListener';
-import { groupIdTextValidation } from '../../shared/textUtil';
+import { validateCustomUrnId } from '../../shared/textUtil';
 import analytics, { EventType } from '../../analytics';
 import { CorpGroup, EntityType } from '../../../types.generated';
 
@@ -134,7 +134,7 @@ export default function CreateGroupModal({ onClose, onCreate }: Props) {
                                 rules={[
                                     () => ({
                                         validator(_, value) {
-                                            if (value && groupIdTextValidation(value)) {
+                                            if (value && validateCustomUrnId(value)) {
                                                 return Promise.resolve();
                                             }
                                             return Promise.reject(new Error('Please enter correct Group name'));

--- a/datahub-web-react/src/app/shared/textUtil.ts
+++ b/datahub-web-react/src/app/shared/textUtil.ts
@@ -19,7 +19,7 @@ export function capitalizeFirstLetterOnly(str?: string | null) {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-export function groupIdTextValidation(str: string) {
+export function validateCustomUrnId(str: string) {
     if (str.indexOf(' ') > 0) return false;
     if (str.indexOf(',') > 0) return false;
     if (str.indexOf('(') > 0) return false;


### PR DESCRIPTION
## Summary

Support setting a custom UUID for Glossary Term and Glossary Term Group.

## Screenshots

<img width="842" alt="Screen Shot 2022-12-21 at 10 15 53 AM" src="https://user-images.githubusercontent.com/17549204/208975972-d418dc3b-d5c0-42dc-8595-339f111b930b.png">
<img width="832" alt="Screen Shot 2022-12-21 at 10 15 58 AM" src="https://user-images.githubusercontent.com/17549204/208975977-7021ab90-ea51-4f3b-9db6-0cd52a7f03cc.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
