### PR TITLE
fix(ingestion) Inject pipeline_name into recipes at runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ project.ext.externalDependency = [
     'jsonSchemaAvro': 'com.github.fge:json-schema-avro:0.1.4',
     'jsonSimple': 'com.googlecode.json-simple:json-simple:1.1.1',
     'jsonSmart': 'net.minidev:json-smart:2.4.6',
+    'json': 'org.json:json:20090211',
     'junitJupiterApi': "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion",
     'junitJupiterParams': "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion",
     'junitJupiterEngine': "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.metadata.key.ExecutionRequestKey;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.IngestionUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -105,7 +106,10 @@ public class CreateIngestionExecutionRequestResolver implements DataFetcher<Comp
           execInput.setRequestedAt(System.currentTimeMillis());
 
           Map<String, String> arguments = new HashMap<>();
-          arguments.put(RECIPE_ARG_NAME, injectRunId(ingestionSourceInfo.getConfig().getRecipe(), executionRequestUrn.toString()));
+          String recipe = ingestionSourceInfo.getConfig().getRecipe();
+          recipe = injectRunId(recipe, executionRequestUrn.toString());
+          recipe = IngestionUtils.injectPipelineName(recipe, executionRequestUrn.toString());
+          arguments.put(RECIPE_ARG_NAME, recipe);
           arguments.put(VERSION_ARG_NAME, ingestionSourceInfo.getConfig().hasVersion()
               ? ingestionSourceInfo.getConfig().getVersion()
               : _ingestionConfiguration.getDefaultCliVersion()

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
@@ -73,7 +73,6 @@ public class CreateTestConnectionRequestResolver implements DataFetcher<Completa
         execInput.setRequestedAt(System.currentTimeMillis());
 
         Map<String, String> arguments = new HashMap<>();
-        // might have to inject pipeline name in here as well? it might not be necessary with test connection but it's something I should test
         arguments.put(RECIPE_ARG_NAME, input.getRecipe());
         if (input.getVersion() != null) {
           arguments.put(VERSION_ARG_NAME, input.getVersion());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
@@ -73,6 +73,7 @@ public class CreateTestConnectionRequestResolver implements DataFetcher<Completa
         execInput.setRequestedAt(System.currentTimeMillis());
 
         Map<String, String> arguments = new HashMap<>();
+        // might have to inject pipeline name in here as well? it might not be necessary with test connection but it's something I should test
         arguments.put(RECIPE_ARG_NAME, input.getRecipe());
         if (input.getVersion() != null) {
           arguments.put(VERSION_ARG_NAME, input.getVersion());

--- a/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
+++ b/ingestion-scheduler/src/main/java/com/datahub/metadata/ingestion/IngestionScheduler.java
@@ -21,6 +21,7 @@ import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.metadata.key.ExecutionRequestKey;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.IngestionUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
 import java.util.ArrayList;
@@ -347,7 +348,8 @@ public class IngestionScheduler {
         input.setRequestedAt(System.currentTimeMillis());
 
         Map<String, String> arguments = new HashMap<>();
-        arguments.put(RECIPE_ARGUMENT_NAME, _ingestionSourceInfo.getConfig().getRecipe());
+        String recipe = IngestionUtils.injectPipelineName(_ingestionSourceInfo.getConfig().getRecipe(), _ingestionSourceUrn.toString());
+        arguments.put(RECIPE_ARGUMENT_NAME, recipe);
         arguments.put(VERSION_ARGUMENT_NAME, _ingestionSourceInfo.getConfig().hasVersion()
             ? _ingestionSourceInfo.getConfig().getVersion()
             : _ingestionConfiguration.getDefaultCliVersion());

--- a/metadata-utils/build.gradle
+++ b/metadata-utils/build.gradle
@@ -8,6 +8,7 @@ dependencies {
   compile externalDependency.elasticSearchRest
   compile externalDependency.httpClient
   compile externalDependency.neo4jJavaDriver
+  compile externalDependency.json
 
   compile spec.product.pegasus.restliClient
   compile spec.product.pegasus.restliCommon

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/IngestionUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/IngestionUtils.java
@@ -3,6 +3,8 @@ package com.linkedin.metadata.utils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.annotation.Nonnull;
+
 
 public class IngestionUtils {
 
@@ -18,9 +20,9 @@ public class IngestionUtils {
    * @param pipelineName the new pipeline name in the recipe.
    * @return a modified recipe JSON string
    */
-  public static String injectPipelineName(final String originalJson, final String pipelineName) {
+  public static String injectPipelineName(@Nonnull String originalJson, @Nonnull final String pipelineName) {
     try {
-      JSONObject jsonRecipe = new JSONObject(originalJson);
+      final JSONObject jsonRecipe = new JSONObject(originalJson);
       boolean hasPipelineName = jsonRecipe.has(PIPELINE_NAME) && jsonRecipe.get(PIPELINE_NAME) != null && !jsonRecipe.get(PIPELINE_NAME).equals("");
 
       if (!hasPipelineName) {
@@ -28,7 +30,7 @@ public class IngestionUtils {
         return jsonRecipe.toString();
       }
     } catch (JSONException e) {
-      throw new IllegalArgumentException("Failed to create execution request: Invalid recipe json provided.");
+      throw new IllegalArgumentException("Failed to create execution request: Invalid recipe json provided.", e);
     }
     return originalJson;
   }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/IngestionUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/IngestionUtils.java
@@ -1,0 +1,35 @@
+package com.linkedin.metadata.utils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+
+public class IngestionUtils {
+
+  private static final String PIPELINE_NAME = "pipeline_name";
+
+  private IngestionUtils() {
+  }
+
+  /**
+   * Injects a pipeline_name into a recipe if there isn't a pipeline_name already there.
+   * The pipeline_name will be the urn of the ingestion source.
+   *
+   * @param pipelineName the new pipeline name in the recipe.
+   * @return a modified recipe JSON string
+   */
+  public static String injectPipelineName(final String originalJson, final String pipelineName) {
+    try {
+      JSONObject jsonRecipe = new JSONObject(originalJson);
+      boolean hasPipelineName = jsonRecipe.has(PIPELINE_NAME) && jsonRecipe.get(PIPELINE_NAME) != null && !jsonRecipe.get(PIPELINE_NAME).equals("");
+
+      if (!hasPipelineName) {
+        jsonRecipe.put(PIPELINE_NAME, pipelineName);
+        return jsonRecipe.toString();
+      }
+    } catch (JSONException e) {
+      throw new IllegalArgumentException("Failed to create execution request: Invalid recipe json provided.");
+    }
+    return originalJson;
+  }
+}

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/IngestionUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/IngestionUtilsTest.java
@@ -21,6 +21,9 @@ public class IngestionUtilsTest {
     String recipe = "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}}}";
     recipe = IngestionUtils.injectPipelineName(recipe, ingestionSourceUrn);
 
-    assertEquals(recipe, "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}},\"pipeline_name\":\"urn:li:ingestionSource:12345\"}");
+    assertEquals(
+        recipe,
+        "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}},\"pipeline_name\":\"urn:li:ingestionSource:12345\"}"
+    );
   }
 }

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/IngestionUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/IngestionUtilsTest.java
@@ -1,0 +1,26 @@
+package com.linkedin.metadata.utils;
+
+import org.testng.annotations.Test;
+
+
+import static org.testng.Assert.assertEquals;
+
+public class IngestionUtilsTest {
+
+  private final String ingestionSourceUrn = "urn:li:ingestionSource:12345";
+
+  @Test
+  public void injectPipelineNameWhenThere() {
+    String recipe = "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}},\"pipeline_name\":\"test\"}";
+
+    assertEquals(recipe, IngestionUtils.injectPipelineName(recipe, ingestionSourceUrn));
+  }
+
+  @Test
+  public void injectPipelineNameWhenNotThere() {
+    String recipe = "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}}}";
+    recipe = IngestionUtils.injectPipelineName(recipe, ingestionSourceUrn);
+
+    assertEquals(recipe, "{\"source\":{\"type\":\"snowflake\",\"config\":{\"stateful_ingestion\":{\"enabled\":true}}},\"pipeline_name\":\"urn:li:ingestionSource:12345\"}");
+  }
+}


### PR DESCRIPTION
Now inject a pipeline_name into recipes that is the urn of the ingestion source at execution time instead of setting it on the recipe that we save and display in the UI. So I also am now removing the logic that was added to put this pipeline_name into the recipe when creating an ingestion source since we don't want that anymore.

Also note that we only inject this pipeline name in if there is not a pipeline_name already set. I don't want to overwrite it if the user is technically savvy enough to control that themselves.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
