### PR TITLE
feat(ingestion): support lineage for delta lake writes

### DIFF
--- a/metadata-integration/java/spark-lineage/README.md
+++ b/metadata-integration/java/spark-lineage/README.md
@@ -186,10 +186,11 @@ Below is a list of Spark commands that are parsed currently:
 
 - InsertIntoHadoopFsRelationCommand
 - SaveIntoDataSourceCommand (jdbc)
+- SaveIntoDataSourceCommand (Delta Lake)
 - CreateHiveTableAsSelectCommand
 - InsertIntoHiveTable
 
-Effectively, these support data sources/sinks corresponding to Hive, HDFS and JDBC.
+Effectively, these support data sources/sinks corresponding to Hive, HDFS, JDBC, and Delta Lake.
 
 DataFrame.persist command is supported for below LeafExecNodes:
 

--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/DatasetExtractor.java
@@ -144,13 +144,17 @@ public class DatasetExtractor {
 
       Map<String, String> options = JavaConversions.mapAsJavaMap(cmd.options());
       String url = options.getOrDefault("url", ""); // e.g. jdbc:postgresql://localhost:5432/sparktestdb
-      if (!url.contains("jdbc")) {
+      if (url.contains("jdbc")) {
+        String tbl = options.get("dbtable");
+        return Optional.of(Collections.singletonList(
+            new JdbcDataset(url, tbl, getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig))));
+      } else if (options.containsKey("path")) {
+        return Optional.of(Collections.singletonList(new HdfsPathDataset(new Path(options.get("path")),
+            getCommonPlatformInstance(datahubConfig), getIncludeScheme(datahubConfig),
+            getCommonFabricType(datahubConfig))));
+      } else {
         return Optional.empty();
       }
-
-      String tbl = options.get("dbtable");
-      return Optional.of(Collections.singletonList(
-          new JdbcDataset(url, tbl, getCommonPlatformInstance(datahubConfig), getCommonFabricType(datahubConfig))));
     });
 
     PLAN_TO_DATASET.put(CreateDataSourceTableAsSelectCommand.class, (p, ctx, datahubConfig) -> {


### PR DESCRIPTION
This PR adds support for Spark lineage with Delta Lake writes.
Here is an example of a Delta Lake write:
```
df.write.format("delta").mode("overwrite").save("s3://bucket/prefix")
```
This creates a `SaveIntoDataSourceCommand` that has the output path `path` included in the `options`.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
