### PR TITLE
docs: Incorrect import statement fixed in example

### DIFF
--- a/docs/actions/guides/developing-an-action.md
+++ b/docs/actions/guides/developing-an-action.md
@@ -24,7 +24,7 @@ print the configuration that is provided when it is created, and print any Event
 ```python
 # custom_action.py
 from datahub_actions.action.action import Action
-from datahub_actions.event.event import EventEnvelope
+from datahub_actions.event.event_envelope import EventEnvelope
 from datahub_actions.pipeline.pipeline_context import PipelineContext
 
 class CustomAction(Action):


### PR DESCRIPTION
## Summary

Import statement for `EventEnvelope` was incorrect in the example, so I updated the documentation.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
