### PR TITLE
Revert "fix(ci): remove warnings due to deprecated action"

### DIFF
--- a/.github/actions/docker-custom-build-and-push/action.yml
+++ b/.github/actions/docker-custom-build-and-push/action.yml
@@ -39,13 +39,14 @@ runs:
   steps:
     - name: Docker meta
       id: docker_meta
-      uses: docker/metadata-action@v4
+      uses: crazy-max/ghaction-docker-meta@v1
       with:
         # list of Docker images to use as base name for tags
         images: ${{ inputs.images }}
         # add git short SHA as Docker tag
-        tags: |
-          type=raw,value=${{ inputs.tags }}
+        tag-custom: ${{ inputs.tags }}
+        tag-custom-only: true
+    
     # Code for testing the build when not pushing to Docker Hub.
     - name: Build and Load image for testing (if not publishing)
       uses: docker/build-push-action@v3

--- a/.github/workflows/docker-ingestion.yml
+++ b/.github/workflows/docker-ingestion.yml
@@ -63,14 +63,14 @@ jobs:
           fetch-depth: 0
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-ingestion
           # add git short SHA as Docker tag
-          tags: |
-            type=raw,value=${{ needs.setup.outputs.tag }}
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-postgres-setup.yml
+++ b/.github/workflows/docker-postgres-setup.yml
@@ -54,14 +54,14 @@ jobs:
           fetch-depth: 0
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
           # list of Docker images to use as base name for tags
           images: |
             acryldata/datahub-postgres-setup
           # add git short SHA as Docker tag
-          tags: |
-            type=raw,value=${{ needs.setup.outputs.tag }}
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
       - name: Login to DockerHub
         if: ${{ needs.setup.outputs.publish == 'true' }}
         uses: docker/login-action@v2


### PR DESCRIPTION
Reverts datahub-project/datahub#6735 as that is causing problem of `head` tag not being published