### PR TITLE
feat(ingest): pass timeout config in kafka admin client api calls

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -417,7 +417,8 @@ class KafkaSource(StatefulIngestionSourceBase):
         configs: Dict[
             ConfigResource, concurrent.futures.Future
         ] = self.admin_client.describe_configs(
-            resources=[ConfigResource(ResourceType.TOPIC, t) for t in topics]
+            resources=[ConfigResource(ResourceType.TOPIC, t) for t in topics],
+            request_timeout=self.source_config.connection.client_timeout_seconds,
         )
         logger.debug("Waiting for config details futures to complete")
         concurrent.futures.wait(configs.values())


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
