### PR TITLE
refactor(smoke): use env variables

### DIFF
--- a/smoke-test/tests/cypress/cypress/integration/login/login.js
+++ b/smoke-test/tests/cypress/cypress/integration/login/login.js
@@ -1,8 +1,8 @@
 describe('login', () => {
   it('logs in', () => {
     cy.visit('/');
-    cy.get('input[data-testid=username]').type('datahub');
-    cy.get('input[data-testid=password]').type('datahub');
+    cy.get('input[data-testid=username]').type(Cypress.env('ADMIN_USERNAME'));
+    cy.get('input[data-testid=password]').type(Cypress.env('ADMIN_PASSWORD'));
     cy.contains('Sign In').click();
     cy.contains('Welcome back, DataHub');
   });

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -27,7 +27,7 @@ def get_frontend_session():
 
 
 def get_admin_username() -> str:
-    return os.getenv("ADMIN_USERNAME", "datahub")
+    return get_admin_credentials()[0]
 
 
 def get_admin_credentials():


### PR DESCRIPTION
minor cleanup to use env variables consistenly

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
