### PR TITLE
fix(ingest): fall back to default table comment method for all Trino query errors

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/trino.py
@@ -13,7 +13,7 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.types import TypeEngine
 from trino.exceptions import TrinoQueryError
-from trino.sqlalchemy import datatype, error
+from trino.sqlalchemy import datatype
 from trino.sqlalchemy.dialect import TrinoDialect
 
 from datahub.ingestion.api.common import PipelineContext
@@ -82,13 +82,8 @@ def get_table_comment(self, connection, table_name: str, schema: str = None, **k
 
         return {"text": properties.get("comment", None), "properties": properties}
     # Fallback to default trino-sqlalchemy behaviour if `$properties` table doesn't exist
-    except TrinoQueryError as e:
-        if e.error_name in (
-            error.TABLE_NOT_FOUND,
-            error.COLUMN_NOT_FOUND,
-            error.NOT_FOUND,
-        ):
-            return self.get_table_comment_default(connection, table_name, schema)
+    except TrinoQueryError:
+        return self.get_table_comment_default(connection, table_name, schema)
     # Exception raised when using Starburst Delta Connector that falls back to a Hive Catalog
     except exc.ProgrammingError as e:
         if isinstance(e.orig, TrinoQueryError):


### PR DESCRIPTION
This fixes #6759. We can simply ignore the specific type of error that Trino returned, since falling back to the default method provided by the SQLAlchemy dialect is better than nothing.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
