### PR TITLE
feat(backend): Supporting Embeddable Previews for Dashboards, Charts, Datasets 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -111,6 +111,7 @@ import com.linkedin.datahub.graphql.resolvers.domain.DomainEntitiesResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.ListDomainsResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.SetDomainResolver;
 import com.linkedin.datahub.graphql.resolvers.domain.UnsetDomainResolver;
+import com.linkedin.datahub.graphql.resolvers.embed.UpdateEmbedResolver;
 import com.linkedin.datahub.graphql.resolvers.entity.EntityExistsResolver;
 import com.linkedin.datahub.graphql.resolvers.entity.EntityPrivilegesResolver;
 import com.linkedin.datahub.graphql.resolvers.glossary.AddRelatedTermsResolver;
@@ -852,6 +853,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("updateGlobalViewsSettings", new UpdateGlobalViewsSettingsResolver(this.settingsService))
             .dataFetcher("updateCorpUserViewsSettings", new UpdateCorpUserViewsSettingsResolver(this.settingsService))
             .dataFetcher("updateLineage", new UpdateLineageResolver(this.entityService, this.lineageService))
+            .dataFetcher("updateEmbed", new UpdateEmbedResolver(this.entityService))
         );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolver.java
@@ -43,7 +43,7 @@ public class UpdateEmbedResolver implements DataFetcher<CompletableFuture<Boolea
 
     return CompletableFuture.supplyAsync(() -> {
 
-      if (!EmbedUtils.isAuthorizedToUpdateEmbedForEntity(environment.getContext(), entityUrn)) {
+      if (!EmbedUtils.isAuthorizedToUpdateEmbedForEntity(entityUrn, environment.getContext())) {
         throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
       }
       validateUpdateEmbedInput(
@@ -59,7 +59,6 @@ public class UpdateEmbedResolver implements DataFetcher<CompletableFuture<Boolea
 
         updateEmbed(embed, input);
 
-        // Create the Domains aspects
         final MetadataChangeProposal proposal = new MetadataChangeProposal();
         proposal.setEntityUrn(entityUrn);
         proposal.setEntityType(entityUrn.getEntityType());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolver.java
@@ -1,0 +1,105 @@
+package com.linkedin.datahub.graphql.resolvers.embed;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Embed;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.UpdateEmbedInput;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.EmbedUtils;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
+
+
+/**
+ * Resolver used for updating the embed render URL for an asset.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class UpdateEmbedResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityService _entityService;
+
+  @Override
+  public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
+
+    final QueryContext context = environment.getContext();
+    final UpdateEmbedInput input = bindArgument(environment.getArgument("input"), UpdateEmbedInput.class);
+    final Urn entityUrn = UrnUtils.getUrn(input.getUrn());
+
+    return CompletableFuture.supplyAsync(() -> {
+
+      if (!EmbedUtils.isAuthorizedToUpdateEmbedForEntity(environment.getContext(), entityUrn)) {
+        throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+      validateUpdateEmbedInput(
+          input,
+          _entityService
+      );
+      try {
+        final Embed embed = (Embed) getAspectFromEntity(
+            entityUrn.toString(),
+            Constants.EMBED_ASPECT_NAME,
+            _entityService,
+            new Embed());
+
+        updateEmbed(embed, input);
+
+        // Create the Domains aspects
+        final MetadataChangeProposal proposal = new MetadataChangeProposal();
+        proposal.setEntityUrn(entityUrn);
+        proposal.setEntityType(entityUrn.getEntityType());
+        proposal.setAspectName(Constants.EMBED_ASPECT_NAME);
+        proposal.setAspect(GenericRecordUtils.serializeAspect(embed));
+        proposal.setChangeType(ChangeType.UPSERT);
+        _entityService.ingestProposal(
+            proposal,
+            new AuditStamp().setActor(UrnUtils.getUrn(context.getActorUrn())).setTime(System.currentTimeMillis()),
+            false
+        );
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException(String.format("Failed to update Embed for to resource with entity urn %s", entityUrn), e);
+      }
+    });
+  }
+
+  /**
+   * Validates an instance of {@link UpdateEmbedInput}, and throws an {@link IllegalArgumentException} if the input
+   * is not valid.
+   *
+   * For an input to be valid, the target URN must exist.
+   *
+   * @param input the input to validate
+   * @param entityService an instance of {@link EntityService} used to validate the input.
+   */
+  private static void validateUpdateEmbedInput(@Nonnull final UpdateEmbedInput input, @Nonnull final EntityService entityService) {
+    if (!entityService.exists(UrnUtils.getUrn(input.getUrn()))) {
+      throw new IllegalArgumentException(
+          String.format("Failed to update embed for entity with urn %s. Entity does not exist!", input.getUrn()));
+    }
+  }
+
+  /**
+   * Applies an instance of {@link UpdateEmbedInput} to a base instance of {@link Embed}.
+   * @param embed an embed to update
+   * @param input the updates to apply
+   */
+  private static void updateEmbed(@Nonnull final Embed embed, @Nonnull final UpdateEmbedInput input) {
+    embed.setRenderUrl(input.getRenderUrl(), SetMode.IGNORE_NULL);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -107,21 +107,41 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
         orPrivilegesGroup);
   }
 
+  private boolean canEditEmbed(Urn urn, QueryContext context) {
+    final ConjunctivePrivilegeGroup allPrivilegesGroup = new ConjunctivePrivilegeGroup(ImmutableList.of(
+        PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()
+    ));
+    DisjunctivePrivilegeGroup orPrivilegesGroup = new DisjunctivePrivilegeGroup(ImmutableList.of(
+        allPrivilegesGroup,
+        new ConjunctivePrivilegeGroup(Collections.singletonList(PoliciesConfig.EDIT_ENTITY_EMBED_PRIVILEGE.getType()))
+    ));
+    return AuthorizationUtils.isAuthorized(
+        context.getAuthorizer(),
+        context.getActorUrn(),
+        urn.getEntityType(),
+        urn.toString(),
+        orPrivilegesGroup);
+  }
+
+
   private EntityPrivileges getDatasetPrivileges(Urn urn, QueryContext context) {
     final EntityPrivileges result = new EntityPrivileges();
     result.setCanEditLineage(canEditEntityLineage(urn, context));
+    result.setCanEditEmbed(canEditEmbed(urn, context));
     return result;
   }
 
   private EntityPrivileges getChartPrivileges(Urn urn, QueryContext context) {
     final EntityPrivileges result = new EntityPrivileges();
     result.setCanEditLineage(canEditEntityLineage(urn, context));
+    result.setCanEditEmbed(canEditEmbed(urn, context));
     return result;
   }
 
   private EntityPrivileges getDashboardPrivileges(Urn urn, QueryContext context) {
     final EntityPrivileges result = new EntityPrivileges();
     result.setCanEditLineage(canEditEntityLineage(urn, context));
+    result.setCanEditEmbed(canEditEmbed(urn, context));
     return result;
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityPrivilegesResolver.java
@@ -10,6 +10,7 @@ import com.linkedin.datahub.graphql.authorization.DisjunctivePrivilegeGroup;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityPrivileges;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.EmbedUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
@@ -107,41 +108,24 @@ public class EntityPrivilegesResolver implements DataFetcher<CompletableFuture<E
         orPrivilegesGroup);
   }
 
-  private boolean canEditEmbed(Urn urn, QueryContext context) {
-    final ConjunctivePrivilegeGroup allPrivilegesGroup = new ConjunctivePrivilegeGroup(ImmutableList.of(
-        PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()
-    ));
-    DisjunctivePrivilegeGroup orPrivilegesGroup = new DisjunctivePrivilegeGroup(ImmutableList.of(
-        allPrivilegesGroup,
-        new ConjunctivePrivilegeGroup(Collections.singletonList(PoliciesConfig.EDIT_ENTITY_EMBED_PRIVILEGE.getType()))
-    ));
-    return AuthorizationUtils.isAuthorized(
-        context.getAuthorizer(),
-        context.getActorUrn(),
-        urn.getEntityType(),
-        urn.toString(),
-        orPrivilegesGroup);
-  }
-
-
   private EntityPrivileges getDatasetPrivileges(Urn urn, QueryContext context) {
     final EntityPrivileges result = new EntityPrivileges();
     result.setCanEditLineage(canEditEntityLineage(urn, context));
-    result.setCanEditEmbed(canEditEmbed(urn, context));
+    result.setCanEditEmbed(EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context));
     return result;
   }
 
   private EntityPrivileges getChartPrivileges(Urn urn, QueryContext context) {
     final EntityPrivileges result = new EntityPrivileges();
     result.setCanEditLineage(canEditEntityLineage(urn, context));
-    result.setCanEditEmbed(canEditEmbed(urn, context));
+    result.setCanEditEmbed(EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context));
     return result;
   }
 
   private EntityPrivileges getDashboardPrivileges(Urn urn, QueryContext context) {
     final EntityPrivileges result = new EntityPrivileges();
     result.setCanEditLineage(canEditEntityLineage(urn, context));
-    result.setCanEditEmbed(canEditEmbed(urn, context));
+    result.setCanEditEmbed(EmbedUtils.isAuthorizedToUpdateEmbedForEntity(urn, context));
     return result;
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/EmbedUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/EmbedUtils.java
@@ -20,7 +20,7 @@ public class EmbedUtils {
 
   private EmbedUtils() { }
 
-  public static boolean isAuthorizedToUpdateEmbedForEntity(@Nonnull QueryContext context, Urn entityUrn) {
+  public static boolean isAuthorizedToUpdateEmbedForEntity(@Nonnull final Urn entityUrn, @Nonnull final QueryContext context) {
     final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
         ALL_PRIVILEGES_GROUP,
         new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.EDIT_ENTITY_EMBED_PRIVILEGE.getType()))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/EmbedUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/EmbedUtils.java
@@ -1,0 +1,36 @@
+package com.linkedin.datahub.graphql.resolvers.mutate.util;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.authorization.ConjunctivePrivilegeGroup;
+import com.linkedin.datahub.graphql.authorization.DisjunctivePrivilegeGroup;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class EmbedUtils {
+  private static final ConjunctivePrivilegeGroup ALL_PRIVILEGES_GROUP = new ConjunctivePrivilegeGroup(ImmutableList.of(
+      PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()
+  ));
+
+  private EmbedUtils() { }
+
+  public static boolean isAuthorizedToUpdateEmbedForEntity(@Nonnull QueryContext context, Urn entityUrn) {
+    final DisjunctivePrivilegeGroup orPrivilegeGroups = new DisjunctivePrivilegeGroup(ImmutableList.of(
+        ALL_PRIVILEGES_GROUP,
+        new ConjunctivePrivilegeGroup(ImmutableList.of(PoliciesConfig.EDIT_ENTITY_EMBED_PRIVILEGE.getType()))
+    ));
+
+    return AuthorizationUtils.isAuthorized(
+        context.getAuthorizer(),
+        context.getActorUrn(),
+        entityUrn.getEntityType(),
+        entityUrn.toString(),
+        orPrivilegeGroups);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -72,7 +72,8 @@ public class ChartType implements SearchableEntityType<Chart, String>, Browsable
         DOMAINS_ASPECT_NAME,
         DEPRECATION_ASPECT_NAME,
         DATA_PLATFORM_INSTANCE_ASPECT_NAME,
-        INPUT_FIELDS_ASPECT_NAME
+        INPUT_FIELDS_ASPECT_NAME,
+        EMBED_ASPECT_NAME
     );
     private static final Set<String> FACET_FIELDS = ImmutableSet.of("access", "queryType", "tool", "type");
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java
@@ -91,8 +91,8 @@ public class ChartMapper implements ModelMapper<EntityResponse, Chart> {
             dataset.setDataPlatformInstance(DataPlatformInstanceAspectMapper.map(new DataPlatformInstance(dataMap))));
         mappingHelper.mapToResult(INPUT_FIELDS_ASPECT_NAME, (chart, dataMap) ->
             chart.setInputFields(InputFieldsMapper.map(new InputFields(dataMap), entityUrn)));
-        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (dataset, dataMap) ->
-            dataset.setEmbed(EmbedMapper.map(new Embed(dataMap))));
+        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (chart, dataMap) ->
+            chart.setEmbed(EmbedMapper.map(new Embed(dataMap))));
         return mappingHelper.getResult();
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartMapper.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.graphql.types.chart.mappers;
 import com.linkedin.chart.EditableChartProperties;
 import com.linkedin.common.DataPlatformInstance;
 import com.linkedin.common.Deprecation;
+import com.linkedin.common.Embed;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.InputFields;
@@ -26,6 +27,7 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.types.common.mappers.AuditStampMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.EmbedMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
@@ -89,7 +91,8 @@ public class ChartMapper implements ModelMapper<EntityResponse, Chart> {
             dataset.setDataPlatformInstance(DataPlatformInstanceAspectMapper.map(new DataPlatformInstance(dataMap))));
         mappingHelper.mapToResult(INPUT_FIELDS_ASPECT_NAME, (chart, dataMap) ->
             chart.setInputFields(InputFieldsMapper.map(new InputFields(dataMap), entityUrn)));
-
+        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (dataset, dataMap) ->
+            dataset.setEmbed(EmbedMapper.map(new Embed(dataMap))));
         return mappingHelper.getResult();
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/EmbedMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/EmbedMapper.java
@@ -1,0 +1,22 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import com.linkedin.datahub.graphql.generated.Embed;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+
+import javax.annotation.Nonnull;
+
+public class EmbedMapper implements ModelMapper<com.linkedin.common.Embed, Embed> {
+
+  public static final EmbedMapper INSTANCE = new EmbedMapper();
+
+  public static Embed map(@Nonnull final com.linkedin.common.Embed metadata) {
+    return INSTANCE.apply(metadata);
+  }
+
+  @Override
+  public Embed apply(@Nonnull final com.linkedin.common.Embed input) {
+    final Embed result = new Embed();
+    result.setRenderUrl(input.getRenderUrl());
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -74,7 +74,8 @@ public class DashboardType implements SearchableEntityType<Dashboard, String>, B
         DEPRECATION_ASPECT_NAME,
         DATA_PLATFORM_INSTANCE_ASPECT_NAME,
         INPUT_FIELDS_ASPECT_NAME,
-        SUB_TYPES_ASPECT_NAME
+        SUB_TYPES_ASPECT_NAME,
+        EMBED_ASPECT_NAME
     );
     private static final Set<String> FACET_FIELDS = ImmutableSet.of("access", "tool");
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java
@@ -90,8 +90,8 @@ public class DashboardMapper implements ModelMapper<EntityResponse, Dashboard> {
         mappingHelper.mapToResult(INPUT_FIELDS_ASPECT_NAME, (dashboard, dataMap) ->
             dashboard.setInputFields(InputFieldsMapper.map(new InputFields(dataMap), entityUrn)));
         mappingHelper.mapToResult(SUB_TYPES_ASPECT_NAME, this::mapSubTypes);
-        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (dataset, dataMap) ->
-            dataset.setEmbed(EmbedMapper.map(new Embed(dataMap))));
+        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (dashboard, dataMap) ->
+            dashboard.setEmbed(EmbedMapper.map(new Embed(dataMap))));
         return mappingHelper.getResult();
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/mappers/DashboardMapper.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.types.dashboard.mappers;
 
 import com.linkedin.common.DataPlatformInstance;
 import com.linkedin.common.Deprecation;
+import com.linkedin.common.Embed;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.InputFields;
@@ -25,6 +26,7 @@ import com.linkedin.datahub.graphql.types.chart.mappers.InputFieldsMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.AuditStampMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.EmbedMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
@@ -88,7 +90,8 @@ public class DashboardMapper implements ModelMapper<EntityResponse, Dashboard> {
         mappingHelper.mapToResult(INPUT_FIELDS_ASPECT_NAME, (dashboard, dataMap) ->
             dashboard.setInputFields(InputFieldsMapper.map(new InputFields(dataMap), entityUrn)));
         mappingHelper.mapToResult(SUB_TYPES_ASPECT_NAME, this::mapSubTypes);
-
+        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (dataset, dataMap) ->
+            dataset.setEmbed(EmbedMapper.map(new Embed(dataMap))));
         return mappingHelper.getResult();
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
@@ -80,7 +80,8 @@ public class DatasetType implements SearchableEntityType<Dataset, String>, Brows
         DOMAINS_ASPECT_NAME,
         SCHEMA_METADATA_ASPECT_NAME,
         DATA_PLATFORM_INSTANCE_ASPECT_NAME,
-        SIBLINGS_ASPECT_NAME
+        SIBLINGS_ASPECT_NAME,
+        EMBED_ASPECT_NAME
     );
 
     private static final Set<String> FACET_FIELDS = ImmutableSet.of("origin", "platform");

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.types.dataset.mappers;
 
 import com.linkedin.common.DataPlatformInstance;
 import com.linkedin.common.Deprecation;
+import com.linkedin.common.Embed;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.InstitutionalMemory;
@@ -18,6 +19,7 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FabricType;
 import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.EmbedMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.SiblingsMapper;
@@ -101,7 +103,8 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
             dataset.setSiblings(SiblingsMapper.map(new Siblings(dataMap))));
         mappingHelper.mapToResult(UPSTREAM_LINEAGE_ASPECT_NAME, (dataset, dataMap) ->
             dataset.setFineGrainedLineages(UpstreamLineagesMapper.map(new UpstreamLineage(dataMap))));
-
+        mappingHelper.mapToResult(EMBED_ASPECT_NAME, (dataset, dataMap) ->
+            dataset.setEmbed(EmbedMapper.map(new Embed(dataMap))));
         return mappingHelper.getResult();
     }
 

--- a/datahub-graphql-core/src/main/resources/auth.graphql
+++ b/datahub-graphql-core/src/main/resources/auth.graphql
@@ -258,4 +258,9 @@ type EntityPrivileges {
   Whether or not a user can create or delete lineage edges for an entity.
   """
   canEditLineage: Boolean
+
+  """
+  Whether or not a user update the embed information
+  """
+  canEditEmbed: Boolean
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -576,6 +576,11 @@ type Mutation {
     Update lineage for an entity
     """
     updateLineage(input: UpdateLineageInput!): Boolean
+
+    """
+    Update the Embed information for a Dataset, Dashboard, or Chart.
+    """
+    updateEmbed(input: UpdateEmbedInput!): Boolean
 }
 
 """
@@ -1085,6 +1090,11 @@ type Dataset implements EntityWithRelationships & Entity & BrowsableEntity {
     Status of the Dataset
     """
     status: Status
+
+    """
+    Embed information about the Dataset
+    """
+    embed: Embed
 
     """
     Tags used for searching dataset
@@ -4419,6 +4429,11 @@ type Dashboard implements EntityWithRelationships & Entity & BrowsableEntity {
     status: Status
 
     """
+    Embed information about the Dashboard
+    """
+    embed: Embed
+
+    """
     The deprecation status of the dashboard
     """
     deprecation: Deprecation
@@ -4720,6 +4735,11 @@ type Chart implements EntityWithRelationships & Entity & BrowsableEntity {
     The deprecation status of the chart
     """
     deprecation: Deprecation
+
+    """
+    Embed information about the Chart
+    """
+    embed: Embed
 
     """
     The tags associated with the chart
@@ -10017,4 +10037,29 @@ input UpdateCorpUserViewsSettingsInput {
   If not provided, any existing default view will be removed.
   """
   defaultView: String
+}
+
+"""
+Information required to render an embedded version of an asset
+"""
+type Embed {
+    """
+    A URL which can be rendered inside of an iframe.
+    """
+    renderUrl: String
+}
+
+"""
+Input required to set or clear information related to rendering a Data Asset inside of DataHub.
+"""
+input UpdateEmbedInput {
+  """
+  The URN associated with the Data Asset to update. Only dataset, dashboard, and chart urns are currently supported.
+  """
+  urn: String!
+
+  """
+  Set or clear a URL used to render an embedded asset.
+  """
+  renderUrl: String
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolverTest.java
@@ -1,0 +1,198 @@
+package com.linkedin.datahub.graphql.resolvers.embed;
+
+import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Embed;
+import com.linkedin.common.urn.CorpuserUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.UpdateEmbedInput;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.CompletionException;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+public class UpdateEmbedResolverTest {
+
+  private static final String TEST_ENTITY_URN = "urn:li:dashboard:(looker,1)";
+  private static final String TEST_RENDER_URL = "https://www.google.com";
+  private static final UpdateEmbedInput TEST_EMBED_INPUT = new UpdateEmbedInput(
+      TEST_ENTITY_URN,
+      TEST_RENDER_URL
+  );
+  private static final CorpuserUrn TEST_ACTOR_URN = new CorpuserUrn("test");
+
+  @Test
+  public void testGetSuccessNoExistingEmbed() throws Exception {
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)),
+        Mockito.eq(Constants.EMBED_ASPECT_NAME),
+        Mockito.eq(0L))).thenReturn(null);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+
+    UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_EMBED_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    resolver.get(mockEnv).get();
+
+    final Embed newEmbed = new Embed().setRenderUrl(TEST_RENDER_URL);
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN));
+    proposal.setEntityType(Constants.DASHBOARD_ENTITY_NAME);
+    proposal.setAspectName(Constants.EMBED_ASPECT_NAME);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(newEmbed));
+    proposal.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal),
+        Mockito.any(AuditStamp.class),
+        Mockito.eq(false)
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+        Mockito.eq(Urn.createFromString(TEST_ENTITY_URN))
+    );
+  }
+
+  @Test
+  public void testGetSuccessExistingEmbed() throws Exception {
+    Embed originalEmbed = new Embed().setRenderUrl("https://otherurl.com");
+
+    // Create resolver
+    EntityService mockService = Mockito.mock(EntityService.class);
+
+    Mockito.when(mockService.getAspect(
+        Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)),
+        Mockito.eq(Constants.EMBED_ASPECT_NAME),
+        Mockito.eq(0L))).thenReturn(originalEmbed);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+
+    UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_EMBED_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    resolver.get(mockEnv).get();
+
+    final Embed newEmbed = new Embed().setRenderUrl(TEST_RENDER_URL);
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(Urn.createFromString(TEST_ENTITY_URN));
+    proposal.setEntityType(Constants.DASHBOARD_ENTITY_NAME);
+    proposal.setAspectName(Constants.EMBED_ASPECT_NAME);
+    proposal.setAspect(GenericRecordUtils.serializeAspect(newEmbed));
+    proposal.setChangeType(ChangeType.UPSERT);
+
+    Mockito.verify(mockService, Mockito.times(1)).ingestProposal(
+        Mockito.eq(proposal),
+        Mockito.any(AuditStamp.class),
+        Mockito.eq(false)
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+        Mockito.eq(Urn.createFromString(TEST_ENTITY_URN))
+    );
+  }
+
+  @Test
+  public void testGetFailureEntityDoesNotExist() throws Exception {
+    // Create resolver
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    Mockito.when(mockClient.batchGetV2(
+        Mockito.eq(Constants.DASHBOARD_ENTITY_NAME),
+        Mockito.eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
+        Mockito.eq(ImmutableSet.of(Constants.EMBED_ASPECT_NAME)),
+        Mockito.any(Authentication.class)))
+        .thenReturn(ImmutableMap.of(Urn.createFromString(TEST_ENTITY_URN),
+            new EntityResponse()
+                .setEntityName(Constants.DASHBOARD_ENTITY_NAME)
+                .setUrn(Urn.createFromString(TEST_ENTITY_URN))
+                .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
+
+    EntityService mockService = Mockito.mock(EntityService.class);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
+
+    UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_EMBED_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class),
+        Mockito.eq(false)
+    );;
+  }
+
+  @Test
+  public void testGetUnauthorized() throws Exception {
+    // Create resolver
+    EntityService mockService = Mockito.mock(EntityService.class);
+    UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_EMBED_INPUT);
+    QueryContext mockContext = getMockDenyContext();
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+    Mockito.verify(mockService, Mockito.times(0)).ingestProposal(
+        Mockito.any(),
+        Mockito.any(AuditStamp.class),
+        Mockito.eq(false)
+    );
+  }
+
+  @Test
+  public void testGetEntityClientException() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    EntityService mockService = Mockito.mock(EntityService.class);
+    Mockito.doThrow(RemoteInvocationException.class).when(mockClient).ingestProposal(
+        Mockito.any(),
+        Mockito.any(Authentication.class));
+    UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
+
+    // Execute resolver
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_EMBED_INPUT);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/common/mappers/EmbedMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/common/mappers/EmbedMapperTest.java
@@ -1,0 +1,14 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import com.linkedin.datahub.graphql.generated.Embed;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class EmbedMapperTest {
+  @Test
+  public void testEmbedMapper() throws Exception {
+    final String renderUrl = "https://www.google.com";
+    final Embed result = EmbedMapper.map(new com.linkedin.common.Embed().setRenderUrl(renderUrl));
+    Assert.assertEquals(result.getRenderUrl(), renderUrl);
+  }
+}

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -155,6 +155,7 @@ export const dataset1 = {
     uri: 'www.google.com',
     privileges: {
         canEditLineage: false,
+        canEditEmbed: false,
     },
     properties: {
         name: 'The Great Test Dataset',
@@ -253,6 +254,7 @@ export const dataset2 = {
     },
     privileges: {
         canEditLineage: false,
+        canEditEmbed: false,
     },
     lastIngested: null,
     dataPlatformInstance: null,
@@ -344,6 +346,7 @@ export const dataset3 = {
     },
     privileges: {
         canEditLineage: false,
+        canEditEmbed: false,
     },
     lastIngested: null,
     dataPlatformInstance: null,
@@ -1223,6 +1226,7 @@ export const dataJob1 = {
     },
     privileges: {
         canEditLineage: false,
+        canEditEmbed: false,
     },
     properties: {
         name: 'DataJobInfoName',
@@ -1284,6 +1288,7 @@ export const dataJob2 = {
     jobId: 'jobId2',
     privileges: {
         canEditLineage: false,
+        canEditEmbed: false,
     },
     ownership: {
         __typename: 'Ownership',
@@ -1353,6 +1358,7 @@ export const dataJob3 = {
     lastIngested: null,
     privileges: {
         canEditLineage: false,
+        canEditEmbed: false,
     },
     ownership: {
         __typename: 'Ownership',

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -236,6 +236,7 @@ export const dataset1 = {
     deprecation: null,
     testResults: null,
     statsSummary: null,
+    embed: null,
 };
 
 export const dataset2 = {
@@ -327,6 +328,7 @@ export const dataset2 = {
     deprecation: null,
     testResults: null,
     statsSummary: null,
+    embed: null,
 };
 
 export const dataset3 = {
@@ -555,6 +557,7 @@ export const dataset3 = {
     testResults: null,
     siblings: null,
     statsSummary: null,
+    embed: null,
 } as Dataset;
 
 export const dataset4 = {

--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -20,6 +20,7 @@ import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
 import { ChartStatsSummarySubHeader } from './profile/stats/ChartStatsSummarySubHeader';
 import { InputFieldsTab } from '../shared/tabs/Entity/InputFieldsTab';
 import { ChartSnippet } from './ChartSnippet';
+import { EmbedTab } from '../shared/tabs/Embed/EmbedTab';
 
 /**
  * Definition of the DataHub Chart entity.
@@ -91,8 +92,12 @@ export class ChartEntity implements Entity<Chart> {
                     },
                 },
                 {
-                    name: 'Properties',
-                    component: PropertiesTab,
+                    name: 'Preview',
+                    component: EmbedTab,
+                    display: {
+                        visible: (_, chart: GetChartQuery) => !!chart?.chart?.embed?.renderUrl,
+                        enabled: (_, chart: GetChartQuery) => !!chart?.chart?.embed?.renderUrl,
+                    },
                 },
                 {
                     name: 'Lineage',
@@ -108,6 +113,10 @@ export class ChartEntity implements Entity<Chart> {
                         visible: (_, _1) => true,
                         enabled: (_, chart: GetChartQuery) => (chart?.chart?.dashboards?.total || 0) > 0,
                     },
+                },
+                {
+                    name: 'Properties',
+                    component: PropertiesTab,
                 },
             ]}
             sidebarSections={[

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -25,6 +25,7 @@ import { LineageTab } from '../shared/tabs/Lineage/LineageTab';
 import { capitalizeFirstLetterOnly } from '../../shared/textUtil';
 import { DashboardStatsSummarySubHeader } from './profile/DashboardStatsSummarySubHeader';
 import { ChartSnippet } from '../chart/ChartSnippet';
+import { EmbedTab } from '../shared/tabs/Embed/EmbedTab';
 
 /**
  * Definition of the DataHub Dashboard entity.
@@ -98,8 +99,12 @@ export class DashboardEntity implements Entity<Dashboard> {
                     component: DocumentationTab,
                 },
                 {
-                    name: 'Properties',
-                    component: PropertiesTab,
+                    name: 'Preview',
+                    component: EmbedTab,
+                    display: {
+                        visible: (_, dashboard: GetDashboardQuery) => !!dashboard?.dashboard?.embed?.renderUrl,
+                        enabled: (_, dashboard: GetDashboardQuery) => !!dashboard?.dashboard?.embed?.renderUrl,
+                    },
                 },
                 {
                     name: 'Lineage',
@@ -107,6 +112,10 @@ export class DashboardEntity implements Entity<Dashboard> {
                     properties: {
                         defaultDirection: LineageDirection.Upstream,
                     },
+                },
+                {
+                    name: 'Properties',
+                    component: PropertiesTab,
                 },
                 {
                     name: 'Datasets',

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -27,6 +27,7 @@ import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { SidebarSiblingsSection } from '../shared/containers/profile/sidebar/SidebarSiblingsSection';
 import { DatasetStatsSummarySubHeader } from './profile/stats/stats/DatasetStatsSummarySubHeader';
 import { DatasetSearchSnippet } from './DatasetSearchSnippet';
+import { EmbedTab } from '../shared/tabs/Embed/EmbedTab';
 
 const SUBTYPES = {
     VIEW: 'view',
@@ -108,12 +109,20 @@ export class DatasetEntity implements Entity<Dataset> {
                     component: DocumentationTab,
                 },
                 {
-                    name: 'Properties',
-                    component: PropertiesTab,
+                    name: 'Preview',
+                    component: EmbedTab,
+                    display: {
+                        visible: (_, dataset: GetDatasetQuery) => !!dataset?.dataset?.embed?.renderUrl,
+                        enabled: (_, dataset: GetDatasetQuery) => !!dataset?.dataset?.embed?.renderUrl,
+                    },
                 },
                 {
                     name: 'Lineage',
                     component: LineageTab,
+                },
+                {
+                    name: 'Properties',
+                    component: PropertiesTab,
                 },
                 {
                     name: 'Queries',

--- a/datahub-web-react/src/app/entity/shared/tabs/Embed/EmbedTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Embed/EmbedTab.tsx
@@ -23,7 +23,6 @@ const StyledEmpty = styled(Empty)`
 export const EmbedTab = () => {
     const { entityData } = useEntityData();
     const embedRenderUrl = entityData?.embed?.renderUrl;
-    // TODO: Deal with cases where render URL does not work properly.
     return (
         <EmbedContainer>
             {(embedRenderUrl && <StyledIframe src={embedRenderUrl} title={entityData?.urn} frameBorder={0} />) || (

--- a/datahub-web-react/src/app/entity/shared/tabs/Embed/EmbedTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Embed/EmbedTab.tsx
@@ -1,0 +1,34 @@
+import { Empty } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import { ANTD_GRAY } from '../../constants';
+import { useEntityData } from '../../EntityContext';
+
+const EmbedContainer = styled.div`
+    width: 100%;
+    height: 100%;
+`;
+
+const StyledIframe = styled.iframe`
+    width: 100%;
+    height: 100%;
+`;
+
+const StyledEmpty = styled(Empty)`
+    margin-top: 28px;
+    font-size: 16px;
+    color: ${ANTD_GRAY[8]};
+`;
+
+export const EmbedTab = () => {
+    const { entityData } = useEntityData();
+    const embedRenderUrl = entityData?.embed?.renderUrl;
+    // TODO: Deal with cases where render URL does not work properly.
+    return (
+        <EmbedContainer>
+            {(embedRenderUrl && <StyledIframe src={embedRenderUrl} title={entityData?.urn} frameBorder={0} />) || (
+                <StyledEmpty description="No preview was found." />
+            )}
+        </EmbedContainer>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -33,6 +33,7 @@ import {
     InputFields,
     FineGrainedLineage,
     EntityPrivileges,
+    Embed,
 } from '../../../types.generated';
 import { FetchedEntity } from '../../lineage/types';
 
@@ -101,6 +102,7 @@ export type GenericEntityProperties = {
     inputFields?: Maybe<InputFields>;
     fineGrainedLineages?: Maybe<FineGrainedLineage[]>;
     privileges?: Maybe<EntityPrivileges>;
+    embed?: Maybe<Embed>;
 };
 
 export type GenericEntityUpdate = {

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -51,6 +51,9 @@ query getChart($urn: String!) {
         deprecation {
             ...deprecationFields
         }
+        embed {
+            ...embedFields
+        }
         inputs: relationships(input: { types: ["Consumes"], direction: OUTGOING, start: 0, count: 100 }) {
             ...fullRelationshipResults
         }
@@ -96,6 +99,7 @@ query getChart($urn: String!) {
         }
         privileges {
             canEditLineage
+            canEditEmbed
         }
     }
 }

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -207,10 +207,11 @@ fragment nonSiblingDatasetFields on Dataset {
         }
     }
     siblings {
-      isPrimary
+        isPrimary
     }
     privileges {
         canEditLineage
+        canEditEmbed
     }
 }
 

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -172,6 +172,10 @@ fragment ownershipFields on Ownership {
     }
 }
 
+fragment embedFields on Embed {
+    renderUrl
+}
+
 fragment institutionalMemoryFields on InstitutionalMemory {
     elements {
         url
@@ -248,6 +252,9 @@ fragment nonRecursiveDatasetFields on Dataset {
     }
     deprecation {
         ...deprecationFields
+    }
+    embed {
+        ...embedFields
     }
 }
 
@@ -405,6 +412,9 @@ fragment dashboardFields on Dashboard {
     status {
         removed
     }
+    embed {
+        ...embedFields
+    }
     deprecation {
         ...deprecationFields
     }
@@ -438,6 +448,7 @@ fragment dashboardFields on Dashboard {
     }
     privileges {
         canEditLineage
+        canEditEmbed
     }
 }
 
@@ -768,7 +779,7 @@ fragment nonRecursiveMLModel on MLModel {
     }
     institutionalMemory {
         ...institutionalMemoryFields
-    }    
+    }
 }
 
 fragment nonRecursiveMLModelGroupFields on MLModelGroup {

--- a/datahub-web-react/src/graphql/mutations.graphql
+++ b/datahub-web-react/src/graphql/mutations.graphql
@@ -123,3 +123,7 @@ mutation createPost($input: CreatePostInput!) {
 mutation updateLineage($input: UpdateLineageInput!) {
     updateLineage(input: $input)
 }
+
+mutation updateEmbed($input: UpdateEmbedInput!) {
+    updateEmbed(input: $input)
+}

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -72,6 +72,7 @@ public class Constants {
   public static final String SIBLINGS_ASPECT_NAME = "siblings";
   public static final String ORIGIN_ASPECT_NAME = "origin";
   public static final String INPUT_FIELDS_ASPECT_NAME = "inputFields";
+  public static final String EMBED_ASPECT_NAME = "embed";
 
   // User
   public static final String CORP_USER_KEY_ASPECT_NAME = "corpUserKey";

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Embed.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Embed.pdl
@@ -1,0 +1,14 @@
+namespace com.linkedin.common
+
+/**
+ * Information regarding rendering an embed for an asset.
+ */
+@Aspect = {
+  "name": "embed"
+}
+record Embed {
+  /**
+   * An embed URL to be rendered inside of an iframe.
+   */
+  renderUrl: optional string
+}

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -21,6 +21,7 @@ entities:
       - deprecation
       - testResults
       - siblings
+      - embed
   - name: dataHubPolicy
     doc: DataHub Policies represent access policies granted to users or groups on metadata operations like edit, view etc.
     category: internal
@@ -59,6 +60,7 @@ entities:
       - deprecation
       - inputFields
       - chartUsageStatistics
+      - embed
   - name: dashboard
     keyAspect: dashboardKey
     aspects:
@@ -68,6 +70,7 @@ entities:
       - dashboardUsageStatistics
       - inputFields
       - subTypes
+      - embed
   - name: notebook
     doc: Notebook represents a combination of query, text, chart and etc. This is in BETA version
     keyAspect: notebookKey

--- a/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/authorization/PoliciesConfig.java
@@ -194,6 +194,11 @@ public class PoliciesConfig {
       "Edit Lineage",
       "The ability to add and remove lineage edges for this entity.");
 
+  public static final Privilege EDIT_ENTITY_EMBED_PRIVILEGE = Privilege.of(
+      "EDIT_ENTITY_EMBED",
+      "Edit Embedded Content",
+      "The ability to edit the embedded content for an entity.");
+
   public static final List<Privilege> COMMON_ENTITY_PRIVILEGES = ImmutableList.of(
       VIEW_ENTITY_PAGE_PRIVILEGE,
       EDIT_ENTITY_TAGS_PRIVILEGE,
@@ -279,7 +284,7 @@ public class PoliciesConfig {
               EDIT_DATASET_COL_TAGS_PRIVILEGE,
               EDIT_DATASET_COL_GLOSSARY_TERMS_PRIVILEGE,
               EDIT_ENTITY_ASSERTIONS_PRIVILEGE,
-              EDIT_LINEAGE_PRIVILEGE))
+              EDIT_LINEAGE_PRIVILEGE, EDIT_ENTITY_EMBED_PRIVILEGE))
           .flatMap(Collection::stream)
           .collect(Collectors.toList())
   );
@@ -291,7 +296,7 @@ public class PoliciesConfig {
       "Charts indexed by DataHub",
       Stream.concat(
           COMMON_ENTITY_PRIVILEGES.stream(),
-          ImmutableList.of(EDIT_LINEAGE_PRIVILEGE).stream())
+          ImmutableList.of(EDIT_LINEAGE_PRIVILEGE, EDIT_ENTITY_EMBED_PRIVILEGE).stream())
           .collect(Collectors.toList())
   );
 
@@ -302,7 +307,7 @@ public class PoliciesConfig {
       "Dashboards indexed by DataHub",
       Stream.concat(
               COMMON_ENTITY_PRIVILEGES.stream(),
-              ImmutableList.of(EDIT_LINEAGE_PRIVILEGE).stream())
+              ImmutableList.of(EDIT_LINEAGE_PRIVILEGE, EDIT_ENTITY_EMBED_PRIVILEGE).stream())
           .collect(Collectors.toList())
   );
 


### PR DESCRIPTION
## Summary

In this PR, we introduce support for attaching an "embed" render URL to a dataset, dashboard or chart. We also introduce logic for rendering these URLs inside of an iframe when they are present. This allows us to do things like directly embed Looker / Tableau / Mode / Redash Looks, Dashboards, Explores into the Dataset pages themselves. 

## Status

Ready for review

## Screenshots

<img width="1290" alt="Screen Shot 2022-12-27 at 12 44 00 PM" src="https://user-images.githubusercontent.com/17549204/209840671-fdce41b2-4ad9-4fab-bb98-7a1153ae5f05.png">
<img width="1084" alt="Screen Shot 2022-12-27 at 12 35 03 PM" src="https://user-images.githubusercontent.com/17549204/209840673-9c89bcb8-2908-43fb-91b3-368231aa8b2a.png">
<img width="1107" alt="Screen Shot 2022-12-27 at 12 19 25 PM" src="https://user-images.githubusercontent.com/17549204/209840674-8029bc3a-59d0-4ab7-ba5b-22d84194f718.png">

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
