### PR TITLE
fix(lint): pin pydantic version

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -24,7 +24,7 @@ base_requirements = {
     "mypy_extensions>=0.4.3",
     # Actual dependencies.
     "typing-inspect",
-    "pydantic>=1.5.1",
+    "pydantic==1.10.2",
     "mixpanel>=4.9.0",
 }
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -24,7 +24,7 @@ base_requirements = {
     "mypy_extensions>=0.4.3",
     # Actual dependencies.
     "typing-inspect",
-    "pydantic==1.10.2",
+    "pydantic>=1.5.1,<1.10.3",
     "mixpanel>=4.9.0",
 }
 


### PR DESCRIPTION
A new version `1.10.3` was released 2 hours ago which broke all our builds. Pinning this version so builds do not break randomly.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
