### PR TITLE
feat(ingest): mark database_alias and env as deprecated

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -158,6 +158,10 @@ class IgnorableError(MetaError):
     """An error that can be ignored."""
 
 
+class ConfigurationWarning(Warning):
+    """A configuration warning."""
+
+
 class ConfigurationMechanism(ABC):
     @abstractmethod
     def load_config(self, config_fp: IO) -> dict:

--- a/metadata-ingestion/src/datahub/configuration/pydantic_field_deprecation.py
+++ b/metadata-ingestion/src/datahub/configuration/pydantic_field_deprecation.py
@@ -1,0 +1,20 @@
+import warnings
+from typing import Optional, Type
+
+import pydantic
+
+from datahub.configuration.common import ConfigurationWarning
+
+
+def pydantic_field_deprecated(field: str, message: Optional[str] = None) -> classmethod:
+    if message:
+        output = message
+    else:
+        output = f"{field} is deprecated and will be removed in a future release. Please remove it from your config."
+
+    def _validate_deprecated(cls: Type, values: dict) -> dict:
+        if field in values:
+            warnings.warn(output, ConfigurationWarning, stacklevel=2)
+        return values
+
+    return pydantic.root_validator(pre=True, allow_reuse=True)(_validate_deprecated)

--- a/metadata-ingestion/src/datahub/configuration/source_common.py
+++ b/metadata-ingestion/src/datahub/configuration/source_common.py
@@ -4,6 +4,7 @@ from pydantic import validator
 from pydantic.fields import Field
 
 from datahub.configuration.common import ConfigModel, ConfigurationError
+from datahub.configuration.pydantic_field_deprecation import pydantic_field_deprecated
 from datahub.metadata.schema_classes import FabricTypeClass
 
 DEFAULT_ENV = FabricTypeClass.PROD
@@ -37,6 +38,11 @@ class EnvBasedSourceConfigBase(ConfigModel):
     env: str = Field(
         default=DEFAULT_ENV,
         description="The environment that all assets produced by this connector belong to",
+    )
+
+    _env_deprecation = pydantic_field_deprecated(
+        "env",
+        "env is deprecated and will be removed in a future release. Please use platform_instance instead.",
     )
 
     @validator("env")

--- a/metadata-ingestion/src/datahub/configuration/validate_field_removal.py
+++ b/metadata-ingestion/src/datahub/configuration/validate_field_removal.py
@@ -3,6 +3,8 @@ from typing import Type
 
 import pydantic
 
+from datahub.configuration.common import ConfigurationWarning
+
 
 def pydantic_removed_field(
     field: str,
@@ -13,7 +15,7 @@ def pydantic_removed_field(
             if print_warning:
                 warnings.warn(
                     f"The {field} was removed, please remove it from your recipe.",
-                    UserWarning,
+                    ConfigurationWarning,
                     stacklevel=2,
                 )
             values.pop(field)

--- a/metadata-ingestion/src/datahub/configuration/validate_field_rename.py
+++ b/metadata-ingestion/src/datahub/configuration/validate_field_rename.py
@@ -3,6 +3,8 @@ from typing import Callable, Type, TypeVar
 
 import pydantic
 
+from datahub.configuration.common import ConfigurationWarning
+
 _T = TypeVar("_T")
 
 
@@ -25,8 +27,8 @@ def pydantic_renamed_field(
             else:
                 if print_warning:
                     warnings.warn(
-                        f"The {old_name} is deprecated, please use {new_name} instead.",
-                        UserWarning,
+                        f"{old_name} is deprecated, please use {new_name} instead.",
+                        ConfigurationWarning,
                         stacklevel=2,
                     )
                 values[new_name] = transform(values.pop(old_name))

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -20,7 +20,6 @@ from datahub.configuration.common import AllowDenyPattern, ConfigurationError
 from datahub.configuration.kafka import KafkaConsumerConnectionConfig
 from datahub.configuration.source_common import DatasetSourceConfigBase
 from datahub.emitter.mce_builder import (
-    DEFAULT_ENV,
     make_data_platform_urn,
     make_dataplatform_instance_urn,
     make_dataset_urn_with_platform_instance,
@@ -73,8 +72,6 @@ class KafkaTopicConfigKeys(str, Enum):
 
 
 class KafkaSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigBase):
-    env: str = DEFAULT_ENV
-    # TODO: inline the connection config
     connection: KafkaConsumerConnectionConfig = KafkaConsumerConnectionConfig()
 
     topic_patterns: AllowDenyPattern = AllowDenyPattern(allow=[".*"], deny=["^_.*"])

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -102,11 +102,6 @@ class OpenApiConfig(ConfigModel):
         return sw_dict
 
 
-# class ParserWarning(UserWarning):
-#     def __init__(self, message: str, key: str) -> None:
-#         self.message
-
-
 class ApiWorkUnit(MetadataWorkUnit):
     pass
 

--- a/metadata-ingestion/src/datahub/ingestion/source/source_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/source_registry.py
@@ -1,5 +1,6 @@
 import warnings
 
+from datahub.configuration.common import ConfigurationWarning
 from datahub.ingestion.api.registry import PluginRegistry
 from datahub.ingestion.api.source import Source
 
@@ -14,14 +15,16 @@ source_registry.register_alias(
     "snowflake-beta",
     "snowflake",
     lambda: warnings.warn(
-        UserWarning("source type snowflake-beta is deprecated, use snowflake instead")
+        "source type snowflake-beta is deprecated, use snowflake instead",
+        ConfigurationWarning,
     ),
 )
 source_registry.register_alias(
     "bigquery-beta",
     "bigquery",
     lambda: warnings.warn(
-        UserWarning("source type bigquery-beta is deprecated, use bigquery instead")
+        "source type bigquery-beta is deprecated, use bigquery instead",
+        ConfigurationWarning,
     ),
 )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql.py
@@ -57,11 +57,6 @@ class SQLServerConfig(BasicSQLAlchemyConfig):
         description="database (catalog). If set to Null, all databases will be considered for ingestion.",
     )
 
-    database_alias: Optional[str] = Field(
-        default=None,
-        description="Alias to apply to database when ingesting. Ignored when `database` is not set.",
-    )
-
     @pydantic.validator("uri_args")
     def passwords_match(cls, v, values, **kwargs):
         if values["use_odbc"] and "driver" not in v:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -30,6 +30,7 @@ from sqlalchemy.sql import sqltypes as types
 from sqlalchemy.types import TypeDecorator, TypeEngine
 
 from datahub.configuration.common import AllowDenyPattern
+from datahub.configuration.pydantic_field_deprecation import pydantic_field_deprecated
 from datahub.emitter.mce_builder import (
     make_container_urn,
     make_data_platform_urn,
@@ -303,15 +304,20 @@ class BasicSQLAlchemyConfig(SQLAlchemyConfig):
         description="URI of database to connect to. See https://docs.sqlalchemy.org/en/14/core/engines.html#database-urls. Takes precedence over other connection parameters.",
     )
 
+    _database_alias_deprecation = pydantic_field_deprecated(
+        "database_alias",
+        message="database_alias is deprecated. Use platform_instance instead.",
+    )
+
     def get_sql_alchemy_url(self, uri_opts: Optional[Dict[str, Any]] = None) -> str:
         if not ((self.host_port and self.scheme) or self.sqlalchemy_uri):
             raise ValueError("host_port and schema or connect_uri required.")
 
         return self.sqlalchemy_uri or make_sqlalchemy_uri(
-            self.scheme,  # type: ignore
+            self.scheme,
             self.username,
             self.password.get_secret_value() if self.password is not None else None,
-            self.host_port,  # type: ignore
+            self.host_port,
             self.database,
             uri_opts=uri_opts,
         )

--- a/metadata-ingestion/tests/unit/test_airflow.py
+++ b/metadata-ingestion/tests/unit/test_airflow.py
@@ -74,6 +74,9 @@ def test_airflow_provider_info():
     assert get_provider_info()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*is deprecated.*:airflow.exceptions.RemovedInAirflow3Warning"
+)
 def test_dags_load_with_no_errors(pytestconfig: pytest.Config) -> None:
     airflow_examples_folder = (
         pytestconfig.rootpath / "src/datahub_provider/example_dags"

--- a/metadata-ingestion/tests/unit/test_plugin_system.py
+++ b/metadata-ingestion/tests/unit/test_plugin_system.py
@@ -2,7 +2,7 @@ import warnings
 
 import pytest
 
-from datahub.configuration.common import ConfigurationError
+from datahub.configuration.common import ConfigurationError, ConfigurationWarning
 from datahub.ingestion.api.registry import PluginRegistry
 from datahub.ingestion.api.sink import Sink
 from datahub.ingestion.extractor.extractor_registry import extractor_registry
@@ -97,9 +97,9 @@ def test_registry():
         "console-alias",
         "console",
         lambda: warnings.warn(
-            UserWarning("console-alias is deprecated, use console instead")
+            ConfigurationWarning("console-alias is deprecated, use console instead")
         ),
     )
-    with pytest.warns(UserWarning):
+    with pytest.warns(ConfigurationWarning):
         assert fake_registry.get("console-alias") == ConsoleSink
     assert "console-alias" not in fake_registry.summary(verbose=False)


### PR DESCRIPTION
- Adds pydantic_field_deprecated helper
- Adds a custom ConfigurationWarning type
- Removes duplicate config options from a few places


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
