### PR TITLE
fix(cli): fix delete urn cli bug + stricter type annotations

### DIFF
--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -207,7 +207,6 @@ def delete(
             aspect_name=aspect_name,
             soft=soft,
             dry_run=dry_run,
-            entity_type=entity_type,
             start_time=start_time,
             end_time=end_time,
             cached_session_host=(session, host),

--- a/metadata-ingestion/src/datahub/telemetry/telemetry.py
+++ b/metadata-ingestion/src/datahub/telemetry/telemetry.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, TypeVar
 
 from mixpanel import Consumer, Mixpanel
+from typing_extensions import ParamSpec
 
 import datahub as datahub_package
 from datahub.cli.cli_utils import DATAHUB_ROOT_FOLDER, get_boolean_env_variable
@@ -222,19 +223,22 @@ class Telemetry:
     def ping(
         self,
         event_name: str,
-        properties: Dict[str, Any] = {},
+        properties: Optional[Dict[str, Any]] = None,
         server: Optional[DataHubGraph] = None,
     ) -> None:
         """
         Send a single telemetry event.
 
         Args:
-            event_name (str): name of the event to send.
-            properties (Optional[Dict[str, Any]]): metadata for the event
+            event_name: name of the event to send.
+            properties: metadata for the event
         """
 
         if not self.enabled or self.mp is None:
             return
+
+        if properties is None:
+            properties = {}
 
         # send event
         try:
@@ -266,10 +270,8 @@ class Telemetry:
 
 telemetry_instance = Telemetry()
 
-T = TypeVar("T")
 
-
-def suppress_telemetry() -> Any:
+def suppress_telemetry() -> None:
     """disables telemetry for this invocation, doesn't affect persistent client settings"""
     if telemetry_instance.enabled:
         logger.debug("Disabling telemetry locally due to server config")
@@ -283,9 +285,13 @@ def get_full_class_name(obj):
     return f"{module}.{obj.__class__.__name__}"
 
 
-def with_telemetry(func: Callable[..., T]) -> Callable[..., T]:
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
+def with_telemetry(func: Callable[_P, _T]) -> Callable[_P, _T]:
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         function = f"{func.__module__}.{func.__name__}"
 
         telemetry_instance.init_tracking()


### PR DESCRIPTION
Ran into an issue where `datahub delete --urn <urn> --soft` crashed. This fixes the bug and adds type annotations to `with_telemetry` so we catch similar issues in the future.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
