### PR TITLE
feat(ingest/postgres): emit lineage for postgres views

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/postgres.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/postgres.py
@@ -1,4 +1,6 @@
 # This import verifies that the dependencies are available.
+from typing import Dict, Iterable, List, Union
+
 import psycopg2  # noqa: F401
 import sqlalchemy.dialects.postgresql as custom_types
 
@@ -8,9 +10,15 @@ import sqlalchemy.dialects.postgresql as custom_types
 # effects of the import. For more details, see here:
 # https://geoalchemy-2.readthedocs.io/en/latest/core_tutorial.html#reflecting-tables.
 from geoalchemy2 import Geometry  # noqa: F401
+from pydantic import BaseModel
 from pydantic.fields import Field
+from sqlalchemy import create_engine
+from sqlalchemy.engine.cursor import CursorResult
 
 from datahub.configuration.common import AllowDenyPattern
+from datahub.emitter import mce_builder
+from datahub.emitter.mcp_builder import mcps_from_mce
+from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SourceCapability,
     SupportStatus,
@@ -19,9 +27,11 @@ from datahub.ingestion.api.decorators import (
     platform_name,
     support_status,
 )
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.sql_common import (
     BasicSQLAlchemyConfig,
     SQLAlchemySource,
+    SqlWorkUnit,
     register_custom_type,
 )
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
@@ -36,10 +46,58 @@ register_custom_type(custom_types.JSONB, BytesTypeClass)
 register_custom_type(custom_types.HSTORE, MapTypeClass)
 
 
+VIEW_LINEAGE_QUERY = """
+WITH RECURSIVE view_deps AS (
+SELECT DISTINCT dependent_ns.nspname as dependent_schema
+, dependent_view.relname as dependent_view
+, source_ns.nspname as source_schema
+, source_table.relname as source_table
+FROM pg_depend
+JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid
+JOIN pg_class as dependent_view ON pg_rewrite.ev_class = dependent_view.oid
+JOIN pg_class as source_table ON pg_depend.refobjid = source_table.oid
+JOIN pg_namespace dependent_ns ON dependent_ns.oid = dependent_view.relnamespace
+JOIN pg_namespace source_ns ON source_ns.oid = source_table.relnamespace
+WHERE NOT (dependent_ns.nspname = source_ns.nspname AND dependent_view.relname = source_table.relname)
+UNION
+SELECT DISTINCT dependent_ns.nspname as dependent_schema
+, dependent_view.relname as dependent_view
+, source_ns.nspname as source_schema
+, source_table.relname as source_table
+FROM pg_depend
+JOIN pg_rewrite ON pg_depend.objid = pg_rewrite.oid
+JOIN pg_class as dependent_view ON pg_rewrite.ev_class = dependent_view.oid
+JOIN pg_class as source_table ON pg_depend.refobjid = source_table.oid
+JOIN pg_namespace dependent_ns ON dependent_ns.oid = dependent_view.relnamespace
+JOIN pg_namespace source_ns ON source_ns.oid = source_table.relnamespace
+INNER JOIN view_deps vd
+    ON vd.dependent_schema = source_ns.nspname
+    AND vd.dependent_view = source_table.relname
+    AND NOT (dependent_ns.nspname = vd.dependent_schema AND dependent_view.relname = vd.dependent_view)
+)
+
+
+SELECT source_table, source_schema, dependent_view, dependent_schema
+FROM view_deps
+WHERE NOT (source_schema = 'information_schema' OR source_schema = 'pg_catalog')
+ORDER BY source_schema, source_table;
+"""
+
+
+class ViewLineageEntry(BaseModel):
+    # note that the order matches our query above
+    # so pydantic is able to parse the tuple using parse_obj
+    source_table: str
+    source_schema: str
+    dependent_view: str
+    dependent_schema: str
+
+
 class PostgresConfig(BasicSQLAlchemyConfig):
     # defaults
     scheme = Field(default="postgresql+psycopg2", description="database scheme")
     schema_pattern = Field(default=AllowDenyPattern(deny=["information_schema"]))
+    include_view_lineage = Field(default=False, description="Include table lineage for views")
 
     def get_identifier(self: BasicSQLAlchemyConfig, schema: str, table: str) -> str:
         regular = f"{schema}.{table}"
@@ -56,6 +114,7 @@ class PostgresConfig(BasicSQLAlchemyConfig):
 @capability(SourceCapability.DOMAINS, "Enabled by default")
 @capability(SourceCapability.PLATFORM_INSTANCE, "Enabled by default")
 @capability(SourceCapability.DATA_PROFILING, "Optionally enabled via configuration")
+@capability(SourceCapability.LINEAGE_COARSE, "Optionally enabled via configuration")
 class PostgresSource(SQLAlchemySource):
     """
     This plugin extracts the following:
@@ -67,10 +126,93 @@ class PostgresSource(SQLAlchemySource):
     - Table, row, and column statistics via optional SQL profiling
     """
 
-    def __init__(self, config, ctx):
+    def __init__(self, config: PostgresConfig, ctx: PipelineContext):
         super().__init__(config, ctx, "postgres")
 
     @classmethod
     def create(cls, config_dict, ctx):
         config = PostgresConfig.parse_obj(config_dict)
         return cls(config, ctx)
+
+    def get_workunits(self) -> Iterable[Union[MetadataWorkUnit, SqlWorkUnit]]:
+        yield from super().get_workunits()
+
+        if self.config.include_view_lineage:  # type: ignore
+            yield from self._get_view_lineage_workunits()
+
+    def _get_view_lineage_workunits(self) -> Iterable[MetadataWorkUnit]:
+        url = self.config.get_sql_alchemy_url()
+        engine = create_engine(url, **self.config.options)
+
+        data: List[ViewLineageEntry] = []
+
+        with engine.connect() as conn:
+            results: CursorResult = conn.execute(VIEW_LINEAGE_QUERY)
+            if results.returns_rows is False:
+                return None
+
+            for row in results:
+                data.append(ViewLineageEntry.parse_obj(row))
+
+        if len(data) == 0:
+            return None
+
+        lineage_elements: Dict[str, List[str]] = {}
+        # Loop over the lineages in the JSON data.
+        for lineage in data:
+            if not self.config.view_pattern.allowed(lineage.dependent_view):
+                self.report.report_dropped(
+                    f"{lineage.dependent_schema}.{lineage.dependent_view}"
+                )
+                continue
+
+            if not self.config.schema_pattern.allowed(lineage.dependent_schema):
+                self.report.report_dropped(
+                    f"{lineage.dependent_schema}.{lineage.dependent_view}"
+                )
+                continue
+
+            # Check if the dependent view + source schema already exists in the dictionary, if not create a new entry.
+            # Use ':::::' to join as it is unlikely to be part of a schema or view name.
+            key = ":::::".join([lineage.dependent_view, lineage.dependent_schema])
+            if key not in lineage_elements:
+                lineage_elements[key] = []
+
+            # Append the source table to the list.
+            lineage_elements[key].append(
+                mce_builder.make_dataset_urn(
+                    "postgres",
+                    self.config.get_identifier(  # type: ignore
+                        lineage.source_schema,
+                        lineage.source_table,
+                    ),
+                    self.config.env,
+                )
+            )
+
+        # Loop over the lineage elements dictionary.
+        for key, source_tables in lineage_elements.items():
+            # Split the key into dependent view and dependent schema
+            dependent_view, dependent_schema = key.split(":::::")
+
+            # Construct a lineage object.
+            urn = mce_builder.make_dataset_urn(
+                "postgres",
+                self.config.get_identifier(  # type: ignore
+                    dependent_schema,
+                    dependent_view,
+                ),
+                self.config.env,
+            )
+
+            # use the mce_builder to ensure that the change proposal inherits
+            # the correct defaults for auditHeader and systemMetadata
+            lineage_mce = mce_builder.make_lineage_mce(
+                source_tables,
+                urn,
+            )
+
+            for item in mcps_from_mce(lineage_mce):
+                wu = item.as_workunit()
+                self.report.report_workunit(wu)
+                yield wu


### PR DESCRIPTION
This PR will extend the Postgres source so that it emits table lineage for Views. 

The lineage is generated from Postgres' own internal metadata about view and table dependencies. The primary information this exposes is which other Views or Tables a View references. In the simplest case, these are the tables referenced in the `FROM` or a `JOIN`. 

This feature is optional and controlled by a new config value for the Postgres source, so it will not impact any installations of Datahub and is completely opt-in for users. I also tried to respect any name or schema filters that might already be configured.

I was not able to find any prior issues or PRs for this.

The implementation is based on a package we just published, so you can also see how it behaves using just this package https://pypi.org/project/datahub-postgres-lineage/

We originally implemented this at Contiamo because a client had a very old and, let's call it, well established Postgres DB with many many layers of Views and this enabled us to actually help them understand and then unravel the mess.

## Testing
After following the dev setup instructions for the metadata-ingestion component, you can test that it will generate the expected lineage using the following commands

```yaml
# docker-compose.yaml
services:
  sample-db:
    image: postgres:14-alpine
    environment:
      POSTGRES_PASSWORD: password
      POSTGRES_USER: normal_user
      POSTGRES_DB: cool_db
      POSTGRES_HOST_AUTH_METHOD: md5
    ports:
      - "6432:5432"
    volumes:
      - pg-lineage:/var/lib/postgresql/data

volumes:
  pg-lineage:
```

Start the database using 

```shell
docker-compose up -d
```

Create a table and some views

```shell
export PGHOST=localhost 
export PGPORT=6432 
export PGDATABASE=cool_db 
export PGUSER=normal_user 
export PGPASSWORD=password
psql -c 'create table if not exists users ( id uuid primary key, name text, email text, age int);'
psql -c 'create or replace view names as select distinct(name) from users;'
psql -c 'create or replace view emails as select distinct(email) from users;'
```

Now run datahub


```yaml
# recipe.yaml
source:
  type: postgres
  config:
    host_port: ${PGHOST}:${PGPORT}
    database: ${PGDATABASE}
    username: ${PGUSER}
    password: ${PGPASSWORD}

    include_view_lineage: true

    # view_pattern:
    #   deny:
    #     - "names"

sink:
  type: file
  config:
    filename: lineage.json
```


```shell
python -m datahub ingest -c recipe.yaml
```

Once it is done running, you can verify that it created two lineage UPSERTs using 

```shell
$ jq '.[] | select(.aspectName == "upstreamLineage")' lineage.json
{
  "entityType": "dataset",
  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cool_db.public.names,PROD)",
  "changeType": "UPSERT",
  "aspectName": "upstreamLineage",
  "aspect": {
    "json": {
      "upstreams": [
        {
          "auditStamp": {
            "time": 0,
            "actor": "urn:li:corpuser:unknown"
          },
          "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,cool_db.public.users,PROD)",
          "type": "TRANSFORMED"
        }
      ]
    }
  },
  "systemMetadata": {
    "lastObserved": 1672841718877,
    "runId": "postgres-2023_01_04-15_15_18"
  }
}
{
  "entityType": "dataset",
  "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:postgres,cool_db.public.emails,PROD)",
  "changeType": "UPSERT",
  "aspectName": "upstreamLineage",
  "aspect": {
    "json": {
      "upstreams": [
        {
          "auditStamp": {
            "time": 0,
            "actor": "urn:li:corpuser:unknown"
          },
          "dataset": "urn:li:dataset:(urn:li:dataPlatform:postgres,cool_db.public.users,PROD)",
          "type": "TRANSFORMED"
        }
      ]
    }
  },
  "systemMetadata": {
    "lastObserved": 1672841718878,
    "runId": "postgres-2023_01_04-15_15_18"
  }
}
``` 


When you are down, stop the db with 

```shell
docker-compose down -v
```

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
