### PR TITLE
fix(docs): Updating Tag, Glossary Term docs to point to correct GraphQL methods

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1541,7 +1541,7 @@ type GlossaryTerm implements Entity {
     type: EntityType!
 
     """
-    A unique identifier for the Glossary Term. Deprecated - Use properties.name field instead instead.
+    A unique identifier for the Glossary Term. Deprecated - Use properties.name field instead.
     """
     name: String! @deprecated
 
@@ -3571,7 +3571,7 @@ type Tag implements Entity {
     type: EntityType!
 
     """
-    A unique identifier for the Tag. Deprecated - Use properties.name field instead instead.
+    A unique identifier for the Tag. Deprecated - Use properties.name field instead.
     """
     name: String! @deprecated
 

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1541,7 +1541,7 @@ type GlossaryTerm implements Entity {
     type: EntityType!
 
     """
-    Name / id of the glossary term
+    A unique identifier for the Glossary Term. Deprecated - Use properties.name field instead instead.
     """
     name: String! @deprecated
 
@@ -3571,7 +3571,7 @@ type Tag implements Entity {
     type: EntityType!
 
     """
-    The name / id of the tag. Use properties.name instead.
+    A unique identifier for the Tag. Deprecated - Use properties.name field instead instead.
     """
     name: String! @deprecated
 

--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -86,6 +86,15 @@ In the modal that pops up you can select the Term you care about in one of two w
 
 ![](../imgs/glossary/add-term-modal.png)
 
+## Managing Glossary with Git 
+
+In many cases, it may be preferable to manage the Business Glossary in a version-control system like git. This can make
+managing changes across teams easier, by funneling all changes through a change management and review process.
+
+To manage your glossary using Git, you can define it within a file and then use the DataHub CLI to ingest
+it into DataHub whenever a change is made (e.g. on a `git commit` hook). For detailed information about the format of
+the glossary file, and how to ingest it into DataHub, check out the [Business Glossary](../generated/ingestion/sources/business-glossary.md) source guide.
+
 ## Demo
 
 Check out [our demo site](https://demo.datahubproject.io/glossary) to see an example Glossary and how it works!
@@ -100,7 +109,7 @@ Check out [our demo site](https://demo.datahubproject.io/glossary) to see an exa
 * [createGlossaryTerm](../../graphql/mutations.md#createglossaryterm)
 * [createGlossaryNode](../../graphql/mutations.md#createglossarynode) (Term Group)
 
-You can easily fetch the Glossary Terms for an entity with a given its URN using the "glossaryTerms" property. Check out [Working with Metadata Entities](../api/graphql/querying-entities.md#querying-for-glossary-terms-of-an-asset) for an example.
+You can easily fetch the Glossary Terms for an entity with a given its URN using the **glossaryTerms** property. Check out [Working with Metadata Entities](../api/graphql/querying-entities.md#querying-for-glossary-terms-of-an-asset) for an example.
 
 ## Resources
 - [Creating a Business Glossary and Putting it to use in DataHub](https://blog.datahubproject.io/creating-a-business-glossary-and-putting-it-to-use-in-datahub-43a088323c12)

--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -100,7 +100,7 @@ Check out [our demo site](https://demo.datahubproject.io/glossary) to see an exa
 * [createGlossaryTerm](../../graphql/mutations.md#createglossaryterm)
 * [createGlossaryNode](../../graphql/mutations.md#createglossarynode) (Term Group)
 
-You can easily fetch the Glossary Terms for an entity with a given its URN using the "glossaryTerms" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md#querying-for-glossary-terms-of-an-asset) for an example.
+You can easily fetch the Glossary Terms for an entity with a given its URN using the "glossaryTerms" property. Check out [Working with Metadata Entities](../api/graphql/querying-entities.md#querying-for-glossary-terms-of-an-asset) for an example.
 
 ## Resources
 - [Creating a Business Glossary and Putting it to use in DataHub](https://blog.datahubproject.io/creating-a-business-glossary-and-putting-it-to-use-in-datahub-43a088323c12)

--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -90,6 +90,18 @@ In the modal that pops up you can select the Term you care about in one of two w
 
 Check out [our demo site](https://demo.datahubproject.io/glossary) to see an example Glossary and how it works!
 
+### GraphQL
+
+* [addTerm](../graphql/mutations.md#addterm)
+* [addTerms](../graphql/mutations.md#addterms)
+* [batchAddTerms](../graphql/mutations.md#batchaddterms)
+* [removeTerm](../graphql/mutations.md#removeterm)
+* [batchRemoveTerms](../graphql/mutations.md#batchremoveterms)
+* [createGlossaryTerm](../graphql/mutations.md#createglossaryterm)
+* [createGlossaryNode](../graphql/mutations.md#createglossarynode) (Term Group)
+
+You can easily fetch the Glossary Terms for an entity with a given its URN using the "glossaryTerms" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md#querying-for-glossary-terms-of-an-asset) for an example.
+
 ## Resources
 - [Creating a Business Glossary and Putting it to use in DataHub](https://blog.datahubproject.io/creating-a-business-glossary-and-putting-it-to-use-in-datahub-43a088323c12)
 - [Tags and Terms: Two Powerful DataHub Features, Used in Two Different Scenarios](https://medium.com/datahub-project/tags-and-terms-two-powerful-datahub-features-used-in-two-different-scenarios-b5b4791e892e)

--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -92,13 +92,13 @@ Check out [our demo site](https://demo.datahubproject.io/glossary) to see an exa
 
 ### GraphQL
 
-* [addTerm](../graphql/mutations.md#addterm)
-* [addTerms](../graphql/mutations.md#addterms)
-* [batchAddTerms](../graphql/mutations.md#batchaddterms)
-* [removeTerm](../graphql/mutations.md#removeterm)
-* [batchRemoveTerms](../graphql/mutations.md#batchremoveterms)
-* [createGlossaryTerm](../graphql/mutations.md#createglossaryterm)
-* [createGlossaryNode](../graphql/mutations.md#createglossarynode) (Term Group)
+* [addTerm](../../graphql/mutations.md#addterm)
+* [addTerms](../../graphql/mutations.md#addterms)
+* [batchAddTerms](../../graphql/mutations.md#batchaddterms)
+* [removeTerm](../../graphql/mutations.md#removeterm)
+* [batchRemoveTerms](../../graphql/mutations.md#batchremoveterms)
+* [createGlossaryTerm](../../graphql/mutations.md#createglossaryterm)
+* [createGlossaryNode](../../graphql/mutations.md#createglossarynode) (Term Group)
 
 You can easily fetch the Glossary Terms for an entity with a given its URN using the "glossaryTerms" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md#querying-for-glossary-terms-of-an-asset) for an example.
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -81,7 +81,7 @@ You can search for a tag in the search bar, and even filter entities by the pres
 * [updateTag](../graphql/mutations.md#updatetag)
 * [deleteTag](../graphql/mutations.md#deletetag)
 
-You can easily fetch the Tags for an entity with a given its URN using the "tags" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md#querying-for-tags-of-an-asset) for an example. 
+You can easily fetch the Tags for an entity with a given its URN using the **tags** property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md#querying-for-tags-of-an-asset) for an example. 
 
 ### DataHub Blog
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -81,7 +81,7 @@ You can search for a tag in the search bar, and even filter entities by the pres
 * [updateTag](../graphql/mutations.md#updatetag)
 * [deleteTag](../graphql/mutations.md#deletetag)
 
-You can easily fetch the Tags for an entity with a given its URN using the "tags" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md) for an example. 
+You can easily fetch the Tags for an entity with a given its URN using the "tags" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md#querying-for-tags-of-an-asset) for an example. 
 
 ### DataHub Blog
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -72,10 +72,16 @@ You can search for a tag in the search bar, and even filter entities by the pres
 
 ### GraphQL
 
-* [Tag](../graphql/queries.md#tag)
-* [AddTagsInput](../graphql/inputObjects.md#addtagsinput)
-* [BatchAddTagsInput](../graphql/inputObjects.md#batchaddtagsinput)
-* [BatchRemoveTagsInput](../graphql/inputObjects.md#batchremovetagsinput)
+* [addTag](../graphql/mutations.md#addtag)
+* [addTags](../graphql/mutations.md#addtags)
+* [batchAddTags](../graphql/mutations.md#batchaddtags)
+* [removeTag](../graphql/mutations.md#removetag)
+* [batchRemoveTags](../graphql/mutations.md#batchremovetags)
+* [createTag](../graphql/mutations.md#createtag)
+* [updateTag](../graphql/mutations.md#updatetag)
+* [deleteTag](../graphql/mutations.md#deletetag)
+
+You can easily fetch the Tags for an entity with a given its URN using the "tags" property. Check out [Working with Metadata Entities](./api/graphql/querying-entities.md) for an example. 
 
 ### DataHub Blog
 


### PR DESCRIPTION
- Clarifying deprecated field docs. 
- Updating tag docs to point to correct GraphQL methods.
- Adding glossary docs to point to correct GraphQL methods. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
