### PR TITLE
feat(auth) Update auth cookies to have same-site none for chrome extension

### DIFF
--- a/datahub-frontend/app/auth/AuthUtils.java
+++ b/datahub-frontend/app/auth/AuthUtils.java
@@ -98,9 +98,11 @@ public class AuthUtils {
      */
     public static Http.Cookie createActorCookie(final String actorUrn, final Integer ttlInHours) {
         return Http.Cookie.builder(ACTOR, actorUrn)
-                .withHttpOnly(false)
-                .withMaxAge(Duration.of(ttlInHours, ChronoUnit.HOURS))
-                .build();
+            .withHttpOnly(false)
+            .withMaxAge(Duration.of(ttlInHours, ChronoUnit.HOURS))
+            .withSameSite(Http.Cookie.SameSite.NONE)
+            .withSecure(true)
+            .build();
     }
 
     public static Map<String, String> createSessionMap(final String userUrnStr, final String accessToken) {

--- a/datahub-frontend/app/auth/AuthUtils.java
+++ b/datahub-frontend/app/auth/AuthUtils.java
@@ -84,19 +84,6 @@ public class AuthUtils {
      * as well as their agreement to determine authentication status.
      */
     public static boolean hasValidSessionCookie(final Http.Request req) {
-        System.out.println("~~~~~~~~~~~~~~~~~~NOW~~~~~~~~~~~~~~~~~");
-        System.out.println(req);
-        System.out.println(".............");
-        System.out.println(req.cookies().toString());
-        System.out.println(".............");
-        System.out.println(req.session().data());
-        System.out.println(".............");
-        System.out.println(req.session().data().containsKey(ACTOR));
-        System.out.println(".............");
-        System.out.println(req.getCookie("PLAY_SESSION").isPresent());
-        System.out.println(".............");
-        System.out.println(req.getCookie(ACTOR).isPresent());
-        System.out.println("~~~~~~~~~~~~~~~~~~NOW~~~~~~~~~~~~~~~~~");
         return req.session().data().containsKey(ACTOR)
                 && req.getCookie(ACTOR).isPresent()
                 && req.session().data().get(ACTOR).equals(req.getCookie(ACTOR).get().value());

--- a/datahub-frontend/app/auth/AuthUtils.java
+++ b/datahub-frontend/app/auth/AuthUtils.java
@@ -129,7 +129,7 @@ public class AuthUtils {
         try {
             return Http.Cookie.SameSite.valueOf(sameSiteValue);
         } catch (IllegalArgumentException e) {
-            log.warn(String.format("Invalid AUTH_COOKIE_SAME_SITE value: %s", sameSiteValue), e);
+            log.warn(String.format("Invalid AUTH_COOKIE_SAME_SITE value: %s. Using LAX instead.", sameSiteValue), e);
             return Http.Cookie.SameSite.LAX;
         }
     }

--- a/datahub-frontend/app/auth/sso/SsoConfigs.java
+++ b/datahub-frontend/app/auth/sso/SsoConfigs.java
@@ -28,6 +28,8 @@ public class SsoConfigs {
   private final String _authSuccessRedirectPath;
   private final Integer _sessionTtlInHours;
   private final Boolean _oidcEnabled;
+  private final String _authCookieSameSite;
+  private final Boolean _authCookieSecure;
 
   public SsoConfigs(final com.typesafe.config.Config configs) {
     _authBaseUrl = getRequired(configs, AUTH_BASE_URL_CONFIG_PATH);
@@ -46,6 +48,14 @@ public class SsoConfigs {
     _oidcEnabled =  configs.hasPath(OIDC_ENABLED_CONFIG_PATH)
         && Boolean.TRUE.equals(
         Boolean.parseBoolean(configs.getString(OIDC_ENABLED_CONFIG_PATH)));
+    _authCookieSameSite = getOptional(
+        configs,
+        AUTH_COOKIE_SAME_SITE,
+        DEFAULT_AUTH_COOKIE_SAME_SITE);
+    _authCookieSecure = Boolean.parseBoolean(getOptional(
+        configs,
+        AUTH_COOKIE_SECURE,
+        String.valueOf(DEFAULT_AUTH_COOKIE_SECURE)));
   }
 
   public String getAuthBaseUrl() {
@@ -62,6 +72,14 @@ public class SsoConfigs {
 
   public Integer getSessionTtlInHours() {
     return _sessionTtlInHours;
+  }
+
+  public String getAuthCookieSameSite() {
+    return _authCookieSameSite;
+  }
+
+  public boolean getAuthCookieSecure() {
+    return _authCookieSecure;
   }
 
   public Boolean isOidcEnabled() {

--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -154,7 +154,14 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
       final String accessToken = _authClient.generateSessionTokenForUser(corpUserUrn.getId());
       return result
               .withSession(createSessionMap(corpUserUrn.toString(), accessToken))
-              .withCookies(createActorCookie(corpUserUrn.toString(), oidcConfigs.getSessionTtlInHours()));
+              .withCookies(
+                  createActorCookie(
+                      corpUserUrn.toString(),
+                      oidcConfigs.getSessionTtlInHours(),
+                      oidcConfigs.getAuthCookieSameSite(),
+                      oidcConfigs.getAuthCookieSecure()
+                  )
+              );
     }
     return internalServerError(
         "Failed to authenticate current user. Cannot find valid identity provider profile in session.");

--- a/datahub-frontend/app/controllers/AuthenticationController.java
+++ b/datahub-frontend/app/controllers/AuthenticationController.java
@@ -30,7 +30,11 @@ import play.mvc.Result;
 import play.mvc.Results;
 import security.AuthenticationManager;
 
+import static auth.AuthUtils.AUTH_COOKIE_SAME_SITE;
+import static auth.AuthUtils.AUTH_COOKIE_SECURE;
 import static auth.AuthUtils.DEFAULT_ACTOR_URN;
+import static auth.AuthUtils.DEFAULT_AUTH_COOKIE_SAME_SITE;
+import static auth.AuthUtils.DEFAULT_AUTH_COOKIE_SECURE;
 import static auth.AuthUtils.DEFAULT_SESSION_TTL_HOURS;
 import static auth.AuthUtils.EMAIL;
 import static auth.AuthUtils.FULL_NAME;
@@ -113,10 +117,15 @@ public class AuthenticationController extends Controller {
         // 3. If no auth enabled, fallback to using default user account & redirect.
         // Generate GMS session token, TODO:
         final String accessToken = _authClient.generateSessionTokenForUser(DEFAULT_ACTOR_URN.getId());
+        int ttlInHours = _configs.hasPath(SESSION_TTL_CONFIG_PATH) ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
+            : DEFAULT_SESSION_TTL_HOURS;
+        String authCookieSameSite = _configs.hasPath(AUTH_COOKIE_SAME_SITE) ? _configs.getString(AUTH_COOKIE_SAME_SITE)
+            : DEFAULT_AUTH_COOKIE_SAME_SITE;
+        boolean authCookieSecure = _configs.hasPath(AUTH_COOKIE_SECURE) ? _configs.getBoolean(AUTH_COOKIE_SECURE)
+            : DEFAULT_AUTH_COOKIE_SECURE;
+
         return Results.redirect(redirectPath).withSession(createSessionMap(DEFAULT_ACTOR_URN.toString(), accessToken))
-            .withCookies(createActorCookie(DEFAULT_ACTOR_URN.toString(),
-                _configs.hasPath(SESSION_TTL_CONFIG_PATH) ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
-                    : DEFAULT_SESSION_TTL_HOURS));
+            .withCookies(createActorCookie(DEFAULT_ACTOR_URN.toString(), ttlInHours, authCookieSameSite, authCookieSecure));
     }
 
     /**
@@ -323,7 +332,12 @@ public class AuthenticationController extends Controller {
     private Result createSession(String userUrnString, String accessToken) {
         int ttlInHours = _configs.hasPath(SESSION_TTL_CONFIG_PATH) ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
             : DEFAULT_SESSION_TTL_HOURS;
+        String authCookieSameSite = _configs.hasPath(AUTH_COOKIE_SAME_SITE) ? _configs.getString(AUTH_COOKIE_SAME_SITE)
+            : DEFAULT_AUTH_COOKIE_SAME_SITE;
+        boolean authCookieSecure = _configs.hasPath(AUTH_COOKIE_SECURE) ? _configs.getBoolean(AUTH_COOKIE_SECURE)
+            : DEFAULT_AUTH_COOKIE_SECURE;
+
         return Results.ok().withSession(createSessionMap(userUrnString, accessToken))
-            .withCookies(createActorCookie(userUrnString, ttlInHours));
+            .withCookies(createActorCookie(userUrnString, ttlInHours, authCookieSameSite,  authCookieSecure));
     }
 }

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -33,10 +33,17 @@ play.modules.enabled += "auth.AuthModule"
 play.server.provider = server.CustomAkkaHttpServerProvider
 play.http.server.akka.max-header-count = 64
 play.http.server.akka.max-header-count = ${?DATAHUB_AKKA_MAX_HEADER_COUNT}
-play.http.session.sameSite = "None"
-play.http.session.secure = true
 play.server.akka.max-header-size = 8k
 play.server.akka.max-header-size = ${?DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH}
+
+# Update AUTH_COOKIE_SAME_SITE and AUTH_COOKIE_SECURE in order to change how authentication cookies
+# are configured. If you wish cookies to be sent in first and third party contexts, set
+# AUTH_COOKIE_SAME_SITE = "NONE" and AUTH_COOKIE_SECURE = true. If AUTH_COOKIE_SAME_SITE is "NONE",
+# AUTH_COOKIE_SECURE must be set true.
+play.http.session.sameSite = "LAX"
+play.http.session.sameSite = ${?AUTH_COOKIE_SAME_SITE}
+play.http.session.secure = false
+play.http.session.secure = ${?AUTH_COOKIE_SECURE}
 
 play.filters {
   enabled = [

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -39,7 +39,7 @@ play.server.akka.max-header-size = ${?DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH}
 # Update AUTH_COOKIE_SAME_SITE and AUTH_COOKIE_SECURE in order to change how authentication cookies
 # are configured. If you wish cookies to be sent in first and third party contexts, set
 # AUTH_COOKIE_SAME_SITE = "NONE" and AUTH_COOKIE_SECURE = true. If AUTH_COOKIE_SAME_SITE is "NONE",
-# AUTH_COOKIE_SECURE must be set true.
+# AUTH_COOKIE_SECURE must be set to true.
 play.http.session.sameSite = "LAX"
 play.http.session.sameSite = ${?AUTH_COOKIE_SAME_SITE}
 play.http.session.secure = false

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -33,6 +33,8 @@ play.modules.enabled += "auth.AuthModule"
 play.server.provider = server.CustomAkkaHttpServerProvider
 play.http.server.akka.max-header-count = 64
 play.http.server.akka.max-header-count = ${?DATAHUB_AKKA_MAX_HEADER_COUNT}
+play.http.session.sameSite = "None"
+play.http.session.secure = true
 play.server.akka.max-header-size = 8k
 play.server.akka.max-header-size = ${?DATAHUB_AKKA_MAX_HEADER_VALUE_LENGTH}
 

--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -60,6 +60,7 @@ dependencies {
   implementation externalDependency.kafkaClients
   implementation externalDependency.awsMskIamAuth
 
+  testImplementation 'org.seleniumhq.selenium:htmlunit-driver:2.67.0'
   testImplementation externalDependency.mockito
   testImplementation externalDependency.playTest
   testImplementation 'org.awaitility:awaitility:4.2.0'


### PR DESCRIPTION
In order to display our chrome extension's iFrame properly, we need to set same-site=NONE and secure=true so that we can authenticate users from an iFrame from another host (like Looker).

An article discussing this change: https://medium.com/trabe/cookies-and-iframes-f7cca58b3b9e


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
