### PR TITLE
fix(graphql):fix issue: autorender aspect could not be displayed on t…

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/WeaklyTypedAspectsResolver.java
@@ -65,7 +65,7 @@ public class WeaklyTypedAspectsResolver implements DataFetcher<CompletableFuture
                     }
 
                     DataMap resolvedAspect = entityResponse.getAspects().get(aspectSpec.getName()).getValue().data();
-                    if (resolvedAspect == null || resolvedAspect.keySet().size() != 1) {
+                    if (resolvedAspect == null) {
                         return;
                     }
 


### PR DESCRIPTION
fix(graphql):fix issue: autorender aspect could not be displayed on the front end when aspect has multiple attributes(#6991)

I'm trying to add a custom Aspect to Dataset entity in the project of metadata-model-custome accroding to https://datahubproject.io/docs/metadata-models-custom/. It could not be displayed after inserting aspect data.
And my code base is v0.9.5.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
