### PR TITLE
fix(docs): Renaming Business Glossary Doc

### DIFF
--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -1,6 +1,5 @@
 ---
-title: About DataHub Business Glossary
-sidebar_label: Business Glossary
+title: Business Glossary
 ---
 
 import FeatureAvailability from '@site/src/components/FeatureAvailability';


### PR DESCRIPTION
## Summary

In this PR, I rename the title of the Business Glossary Feature guide to be aligned with other names. 

## Screenshots

<img width="307" alt="Screen Shot 2023-01-10 at 12 37 31 PM" src="https://user-images.githubusercontent.com/17549204/211657264-b803885e-06d6-47c7-bc28-355f98c05249.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
