### PR TITLE
fix(ui ingest): Fix test connection when stateful ingest is enabled

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolver.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.ingest.execution;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
@@ -12,7 +13,9 @@ import com.linkedin.execution.ExecutionRequestSource;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.config.IngestionConfiguration;
 import com.linkedin.metadata.key.ExecutionRequestKey;
+import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.IngestionUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -64,6 +67,7 @@ public class CreateTestConnectionRequestResolver implements DataFetcher<Completa
         final UUID uuid = UUID.randomUUID();
         final String uuidStr = uuid.toString();
         key.setId(uuidStr);
+        final Urn executionRequestUrn = EntityKeyUtils.convertEntityKeyToUrn(key, Constants.EXECUTION_REQUEST_ENTITY_NAME);
         proposal.setEntityKeyAspect(GenericRecordUtils.serializeAspect(key));
 
         final ExecutionRequestInput execInput = new ExecutionRequestInput();
@@ -73,7 +77,7 @@ public class CreateTestConnectionRequestResolver implements DataFetcher<Completa
         execInput.setRequestedAt(System.currentTimeMillis());
 
         Map<String, String> arguments = new HashMap<>();
-        arguments.put(RECIPE_ARG_NAME, input.getRecipe());
+        arguments.put(RECIPE_ARG_NAME, IngestionUtils.injectPipelineName(input.getRecipe(), executionRequestUrn.toString()));
         if (input.getVersion() != null) {
           arguments.put(VERSION_ARG_NAME, input.getVersion());
         }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateTestConnectionRequestResolverTest.java
@@ -17,7 +17,7 @@ import static org.testng.Assert.*;
 public class CreateTestConnectionRequestResolverTest {
 
   private static final CreateTestConnectionRequestInput TEST_INPUT = new CreateTestConnectionRequestInput(
-      "test recipe",
+      "{}",
       "0.8.44"
   );
 


### PR DESCRIPTION
## Summary

When stateful ingest is enabled in the recipe, test connection fails unless a pipeline_name is provided (due to config constraints). We are fixing it here by doing the same thing we do for other ingestion sources, simply injecting it when we run the pipeline. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
