### PR TITLE
fix(ingest): powerbi # use display name field as title for powerbi report page

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -567,7 +567,7 @@ class Mapper:
             # Create chartInfo mcp
             # Set chartUrl only if tile is created from Report
             chart_info_instance = ChartInfoClass(
-                title=page.name or "",
+                title=page.displayName or "",
                 description=page.displayName or "",
                 lastModified=ChangeAuditStamps(),
                 inputs=ds_input,

--- a/metadata-ingestion/tests/integration/powerbi/golden_test_report.json
+++ b/metadata-ingestion/tests/integration/powerbi/golden_test_report.json
@@ -5,8 +5,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"public issue_history\", \"description\": \"public issue_history\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "public issue_history",
+            "description": "public issue_history",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -19,8 +23,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -33,8 +38,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"SNOWFLAKE_TESTTABLE\", \"description\": \"SNOWFLAKE_TESTTABLE\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "SNOWFLAKE_TESTTABLE",
+            "description": "SNOWFLAKE_TESTTABLE",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -47,8 +56,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -61,8 +71,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"snowflake native-query\", \"description\": \"snowflake native-query\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "snowflake native-query",
+            "description": "snowflake native-query",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -75,8 +89,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -89,8 +104,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"snowflake native-query-with-join\", \"description\": \"snowflake native-query-with-join\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "snowflake native-query-with-join",
+            "description": "snowflake native-query-with-join",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -103,8 +122,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -117,8 +137,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"job-history\", \"description\": \"job-history\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "job-history",
+            "description": "job-history",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -131,8 +155,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -145,8 +170,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"postgres_test_table\", \"description\": \"postgres_test_table\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "postgres_test_table",
+            "description": "postgres_test_table",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -159,8 +188,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -173,8 +203,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"dbo_book_issue\", \"description\": \"dbo_book_issue\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "dbo_book_issue",
+            "description": "dbo_book_issue",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -187,8 +221,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -201,8 +236,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"ms_sql_native_table\", \"description\": \"ms_sql_native_table\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "ms_sql_native_table",
+            "description": "ms_sql_native_table",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -215,8 +254,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -229,8 +269,12 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserInfo",
     "aspect": {
-        "value": "{\"active\": true, \"displayName\": \"user1\", \"email\": \"User1@foo.com\", \"title\": \"user1\"}",
-        "contentType": "application/json"
+        "json": {
+            "active": true,
+            "displayName": "user1",
+            "email": "User1@foo.com",
+            "title": "user1"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -243,8 +287,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -257,8 +302,9 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserKey",
     "aspect": {
-        "value": "{\"username\": \"User1@foo.com\"}",
-        "contentType": "application/json"
+        "json": {
+            "username": "User1@foo.com"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -271,8 +317,12 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserInfo",
     "aspect": {
-        "value": "{\"active\": true, \"displayName\": \"user2\", \"email\": \"User2@foo.com\", \"title\": \"user2\"}",
-        "contentType": "application/json"
+        "json": {
+            "active": true,
+            "displayName": "user2",
+            "email": "User2@foo.com",
+            "title": "user2"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -285,8 +335,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -299,8 +350,9 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserKey",
     "aspect": {
-        "value": "{\"username\": \"User2@foo.com\"}",
-        "contentType": "application/json"
+        "json": {
+            "username": "User2@foo.com"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -313,8 +365,46 @@
     "changeType": "UPSERT",
     "aspectName": "chartInfo",
     "aspect": {
-        "value": "{\"customProperties\": {\"datasetId\": \"05169CD2-E713-41E6-9600-1D8066D95445\", \"reportId\": \"\", \"datasetWebUrl\": \"http://localhost/groups/64ED5CAD-7C10-4684-8180-826122881108/datasets/05169CD2-E713-41E6-9600-1D8066D95445/details\", \"createdFrom\": \"Dataset\"}, \"title\": \"test_tile\", \"description\": \"test_tile\", \"lastModified\": {\"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}, \"inputs\": [{\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.SNOWFLAKE_TESTTABLE,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query-with-join,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.job-history,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.postgres_test_table,DEV)\"}]}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {
+                "datasetId": "05169CD2-E713-41E6-9600-1D8066D95445",
+                "reportId": "",
+                "datasetWebUrl": "http://localhost/groups/64ED5CAD-7C10-4684-8180-826122881108/datasets/05169CD2-E713-41E6-9600-1D8066D95445/details",
+                "createdFrom": "Dataset"
+            },
+            "title": "test_tile",
+            "description": "test_tile",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.SNOWFLAKE_TESTTABLE,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query-with-join,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.job-history,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.postgres_test_table,DEV)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -327,8 +417,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -341,8 +432,10 @@
     "changeType": "UPSERT",
     "aspectName": "chartKey",
     "aspect": {
-        "value": "{\"dashboardTool\": \"powerbi\", \"chartId\": \"powerbi.linkedin.com/charts/B8E293DC-0C83-4AA0-9BB9-0A8738DF24A0\"}",
-        "contentType": "application/json"
+        "json": {
+            "dashboardTool": "powerbi",
+            "chartId": "powerbi.linkedin.com/charts/B8E293DC-0C83-4AA0-9BB9-0A8738DF24A0"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -355,8 +448,34 @@
     "changeType": "UPSERT",
     "aspectName": "chartInfo",
     "aspect": {
-        "value": "{\"customProperties\": {\"datasetId\": \"ba0130a1-5b03-40de-9535-b34e778ea6ed\", \"reportId\": \"\", \"datasetWebUrl\": \"http://localhost/groups/64ED5CAD-7C10-4684-8180-826122881108/datasets/ba0130a1-5b03-40de-9535-b34e778ea6ed/details\", \"createdFrom\": \"Dataset\"}, \"title\": \"yearly_sales\", \"description\": \"yearly_sales\", \"lastModified\": {\"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}, \"inputs\": [{\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,hr_pbi_test.dbo_book_issue,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,hr_pbi_test.ms_sql_native_table,DEV)\"}]}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {
+                "datasetId": "ba0130a1-5b03-40de-9535-b34e778ea6ed",
+                "reportId": "",
+                "datasetWebUrl": "http://localhost/groups/64ED5CAD-7C10-4684-8180-826122881108/datasets/ba0130a1-5b03-40de-9535-b34e778ea6ed/details",
+                "createdFrom": "Dataset"
+            },
+            "title": "yearly_sales",
+            "description": "yearly_sales",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,hr_pbi_test.dbo_book_issue,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,hr_pbi_test.ms_sql_native_table,DEV)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -369,8 +488,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -383,8 +503,10 @@
     "changeType": "UPSERT",
     "aspectName": "chartKey",
     "aspect": {
-        "value": "{\"dashboardTool\": \"powerbi\", \"chartId\": \"powerbi.linkedin.com/charts/23212598-23b5-4980-87cc-5fc0ecd84385\"}",
-        "contentType": "application/json"
+        "json": {
+            "dashboardTool": "powerbi",
+            "chartId": "powerbi.linkedin.com/charts/23212598-23b5-4980-87cc-5fc0ecd84385"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -397,8 +519,11 @@
     "changeType": "UPSERT",
     "aspectName": "browsePaths",
     "aspect": {
-        "value": "{\"paths\": [\"/powerbi/demo-workspace\"]}",
-        "contentType": "application/json"
+        "json": {
+            "paths": [
+                "/powerbi/demo-workspace"
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -411,8 +536,31 @@
     "changeType": "UPSERT",
     "aspectName": "dashboardInfo",
     "aspect": {
-        "value": "{\"customProperties\": {\"chartCount\": \"2\", \"workspaceName\": \"demo-workspace\", \"workspaceId\": \"64ED5CAD-7C10-4684-8180-826122881108\"}, \"title\": \"test_dashboard\", \"description\": \"test_dashboard\", \"charts\": [\"urn:li:chart:(powerbi,charts.B8E293DC-0C83-4AA0-9BB9-0A8738DF24A0)\", \"urn:li:chart:(powerbi,charts.23212598-23b5-4980-87cc-5fc0ecd84385)\"], \"datasets\": [], \"lastModified\": {\"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}, \"dashboardUrl\": \"https://localhost/dashboards/web/1\"}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {
+                "chartCount": "2",
+                "workspaceName": "demo-workspace",
+                "workspaceId": "64ED5CAD-7C10-4684-8180-826122881108"
+            },
+            "title": "test_dashboard",
+            "description": "test_dashboard",
+            "charts": [
+                "urn:li:chart:(powerbi,charts.B8E293DC-0C83-4AA0-9BB9-0A8738DF24A0)",
+                "urn:li:chart:(powerbi,charts.23212598-23b5-4980-87cc-5fc0ecd84385)"
+            ],
+            "datasets": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "dashboardUrl": "https://localhost/dashboards/web/1"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -425,8 +573,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -439,8 +588,10 @@
     "changeType": "UPSERT",
     "aspectName": "dashboardKey",
     "aspect": {
-        "value": "{\"dashboardTool\": \"powerbi\", \"dashboardId\": \"powerbi.linkedin.com/dashboards/7D668CAD-7FFC-4505-9215-655BCA5BEBAE\"}",
-        "contentType": "application/json"
+        "json": {
+            "dashboardTool": "powerbi",
+            "dashboardId": "powerbi.linkedin.com/dashboards/7D668CAD-7FFC-4505-9215-655BCA5BEBAE"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -453,8 +604,22 @@
     "changeType": "UPSERT",
     "aspectName": "ownership",
     "aspect": {
-        "value": "{\"owners\": [{\"owner\": \"urn:li:corpuser:users.User1@foo.com\", \"type\": \"NONE\"}, {\"owner\": \"urn:li:corpuser:users.User2@foo.com\", \"type\": \"NONE\"}], \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}",
-        "contentType": "application/json"
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:users.User1@foo.com",
+                    "type": "NONE"
+                },
+                {
+                    "owner": "urn:li:corpuser:users.User2@foo.com",
+                    "type": "NONE"
+                }
+            ],
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -467,8 +632,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"public issue_history\", \"description\": \"public issue_history\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "public issue_history",
+            "description": "public issue_history",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -481,8 +650,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -495,8 +665,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"SNOWFLAKE_TESTTABLE\", \"description\": \"SNOWFLAKE_TESTTABLE\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "SNOWFLAKE_TESTTABLE",
+            "description": "SNOWFLAKE_TESTTABLE",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -509,8 +683,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -523,8 +698,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"snowflake native-query\", \"description\": \"snowflake native-query\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "snowflake native-query",
+            "description": "snowflake native-query",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -537,8 +716,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -551,8 +731,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"snowflake native-query-with-join\", \"description\": \"snowflake native-query-with-join\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "snowflake native-query-with-join",
+            "description": "snowflake native-query-with-join",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -565,8 +749,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -579,8 +764,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"job-history\", \"description\": \"job-history\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "job-history",
+            "description": "job-history",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -593,8 +782,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -607,8 +797,12 @@
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"name\": \"postgres_test_table\", \"description\": \"postgres_test_table\", \"tags\": []}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "name": "postgres_test_table",
+            "description": "postgres_test_table",
+            "tags": []
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -621,8 +815,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -635,8 +830,12 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserInfo",
     "aspect": {
-        "value": "{\"active\": true, \"displayName\": \"user1\", \"email\": \"User1@foo.com\", \"title\": \"user1\"}",
-        "contentType": "application/json"
+        "json": {
+            "active": true,
+            "displayName": "user1",
+            "email": "User1@foo.com",
+            "title": "user1"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -649,8 +848,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -663,8 +863,9 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserKey",
     "aspect": {
-        "value": "{\"username\": \"User1@foo.com\"}",
-        "contentType": "application/json"
+        "json": {
+            "username": "User1@foo.com"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -677,8 +878,12 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserInfo",
     "aspect": {
-        "value": "{\"active\": true, \"displayName\": \"user2\", \"email\": \"User2@foo.com\", \"title\": \"user2\"}",
-        "contentType": "application/json"
+        "json": {
+            "active": true,
+            "displayName": "user2",
+            "email": "User2@foo.com",
+            "title": "user2"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -691,8 +896,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -705,8 +911,9 @@
     "changeType": "UPSERT",
     "aspectName": "corpUserKey",
     "aspect": {
-        "value": "{\"username\": \"User2@foo.com\"}",
-        "contentType": "application/json"
+        "json": {
+            "username": "User2@foo.com"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -719,8 +926,43 @@
     "changeType": "UPSERT",
     "aspectName": "chartInfo",
     "aspect": {
-        "value": "{\"customProperties\": {\"order\": \"0\"}, \"title\": \"ReportSection\", \"description\": \"Regional Sales Analysis\", \"lastModified\": {\"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}, \"inputs\": [{\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.SNOWFLAKE_TESTTABLE,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query-with-join,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.job-history,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.postgres_test_table,DEV)\"}]}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {
+                "order": "0"
+            },
+            "title": "Regional Sales Analysis",
+            "description": "Regional Sales Analysis",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.SNOWFLAKE_TESTTABLE,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query-with-join,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.job-history,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.postgres_test_table,DEV)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -733,8 +975,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -747,8 +990,43 @@
     "changeType": "UPSERT",
     "aspectName": "chartInfo",
     "aspect": {
-        "value": "{\"customProperties\": {\"order\": \"1\"}, \"title\": \"ReportSection1\", \"description\": \"Geographic Analysis\", \"lastModified\": {\"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}, \"inputs\": [{\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.SNOWFLAKE_TESTTABLE,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query-with-join,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.job-history,DEV)\"}, {\"string\": \"urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.postgres_test_table,DEV)\"}]}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {
+                "order": "1"
+            },
+            "title": "Geographic Analysis",
+            "description": "Geographic Analysis",
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "inputs": [
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.SNOWFLAKE_TESTTABLE,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.snowflake_native-query-with-join,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.job-history,DEV)"
+                },
+                {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.postgres_test_table,DEV)"
+                }
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -761,8 +1039,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -775,8 +1054,11 @@
     "changeType": "UPSERT",
     "aspectName": "browsePaths",
     "aspect": {
-        "value": "{\"paths\": [\"/powerbi/demo-workspace\"]}",
-        "contentType": "application/json"
+        "json": {
+            "paths": [
+                "/powerbi/demo-workspace"
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -789,8 +1071,27 @@
     "changeType": "UPSERT",
     "aspectName": "dashboardInfo",
     "aspect": {
-        "value": "{\"customProperties\": {}, \"title\": \"SalesMarketing\", \"description\": \"Acryl sales marketing report\", \"charts\": [\"urn:li:chart:(powerbi,pages.5b218778-e7a5-4d73-8187-f10824047715.ReportSection)\", \"urn:li:chart:(powerbi,pages.5b218778-e7a5-4d73-8187-f10824047715.ReportSection1)\"], \"datasets\": [], \"lastModified\": {\"created\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}, \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}, \"dashboardUrl\": \"https://app.powerbi.com/groups/f089354e-8366-4e18-aea3-4cb4a3a50b48/reports/5b218778-e7a5-4d73-8187-f10824047715\"}",
-        "contentType": "application/json"
+        "json": {
+            "customProperties": {},
+            "title": "SalesMarketing",
+            "description": "Acryl sales marketing report",
+            "charts": [
+                "urn:li:chart:(powerbi,pages.5b218778-e7a5-4d73-8187-f10824047715.ReportSection)",
+                "urn:li:chart:(powerbi,pages.5b218778-e7a5-4d73-8187-f10824047715.ReportSection1)"
+            ],
+            "datasets": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "dashboardUrl": "https://app.powerbi.com/groups/f089354e-8366-4e18-aea3-4cb4a3a50b48/reports/5b218778-e7a5-4d73-8187-f10824047715"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -803,8 +1104,9 @@
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
-        "value": "{\"removed\": false}",
-        "contentType": "application/json"
+        "json": {
+            "removed": false
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -817,8 +1119,10 @@
     "changeType": "UPSERT",
     "aspectName": "dashboardKey",
     "aspect": {
-        "value": "{\"dashboardTool\": \"powerbi\", \"dashboardId\": \"powerbi.linkedin.com/dashboards/5b218778-e7a5-4d73-8187-f10824047715\"}",
-        "contentType": "application/json"
+        "json": {
+            "dashboardTool": "powerbi",
+            "dashboardId": "powerbi.linkedin.com/dashboards/5b218778-e7a5-4d73-8187-f10824047715"
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -831,8 +1135,11 @@
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
-        "value": "{\"typeNames\": [\"Report\"]}",
-        "contentType": "application/json"
+        "json": {
+            "typeNames": [
+                "Report"
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,
@@ -845,8 +1152,22 @@
     "changeType": "UPSERT",
     "aspectName": "ownership",
     "aspect": {
-        "value": "{\"owners\": [{\"owner\": \"urn:li:corpuser:users.User1@foo.com\", \"type\": \"NONE\"}, {\"owner\": \"urn:li:corpuser:users.User2@foo.com\", \"type\": \"NONE\"}], \"lastModified\": {\"time\": 0, \"actor\": \"urn:li:corpuser:unknown\"}}",
-        "contentType": "application/json"
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:users.User1@foo.com",
+                    "type": "NONE"
+                },
+                {
+                    "owner": "urn:li:corpuser:users.User2@foo.com",
+                    "type": "NONE"
+                }
+            ],
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
     },
     "systemMetadata": {
         "lastObserved": 1643871600000,


### PR DESCRIPTION
Report page has the page ID (format `ReportSectioneaaaaa6eaaadb2b20414`) in name field, therefore it's more meaningful to use human readable name of the page as title.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
