### PR TITLE
feat(auth) Allow session ttl to be configurable by env variable

### DIFF
--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -183,7 +183,8 @@ auth.native.enabled = ${?AUTH_NATIVE_ENABLED}
 # auth.oidc.enabled = false # (or simply omit oidc configurations)
 
 # Login session expiration time
-# auth.session.ttlInHours = ${?AUTH_SESSION_TTL_HOURS}
+auth.session.ttlInHours = 720
+auth.session.ttlInHours = ${?AUTH_SESSION_TTL_HOURS}
 
 analytics.enabled = ${?DATAHUB_ANALYTICS_ENABLED}
 


### PR DESCRIPTION
Allow users to set the session TTL with an env variable. Defaults to 720 hours, the default that we already had in code.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
