### PR TITLE
docs(sso) move root user warning to earlier in SSO guides

### DIFF
--- a/docs/authentication/guides/sso/configure-oidc-react-azure.md
+++ b/docs/authentication/guides/sso/configure-oidc-react-azure.md
@@ -6,6 +6,13 @@ delegate authentication responsibility to identity providers like Microsoft Azur
 
 This guide will provide steps for configuring DataHub authentication using Microsoft Azure.
 
+:::caution
+Even when OIDC is configured, the root user can still login without OIDC by going
+to `/login` URL endpoint. It is recommended that you don't use the default
+credentials by mounting a different file in the front end container. To do this
+please see [this guide](../jaas.md) to mount a custom user.props file for a JAAS authenticated deployment.
+:::
+
 ## Steps
 
 ### 1. Create an application registration in Microsoft Azure portal

--- a/docs/authentication/guides/sso/configure-oidc-react-google.md
+++ b/docs/authentication/guides/sso/configure-oidc-react-google.md
@@ -6,6 +6,13 @@ authentication responsibility to identity providers like Google.
 
 This guide will provide steps for configuring DataHub authentication using Google.
 
+:::caution
+Even when OIDC is configured, the root user can still login without OIDC by going
+to `/login` URL endpoint. It is recommended that you don't use the default
+credentials by mounting a different file in the front end container. To do this
+please see [this guide](../jaas.md) to mount a custom user.props file for a JAAS authenticated deployment.
+:::
+
 ## Steps
 
 ### 1. Create a project in the Google API Console

--- a/docs/authentication/guides/sso/configure-oidc-react-okta.md
+++ b/docs/authentication/guides/sso/configure-oidc-react-okta.md
@@ -6,6 +6,13 @@ delegate authentication responsibility to identity providers like Okta.
 
 This guide will provide steps for configuring DataHub authentication using Okta.
 
+:::caution
+Even when OIDC is configured, the root user can still login without OIDC by going
+to `/login` URL endpoint. It is recommended that you don't use the default
+credentials by mounting a different file in the front end container. To do this
+please see [this guide](../jaas.md) to mount a custom user.props file for a JAAS authenticated deployment.
+:::
+
 ## Steps
 
 ### 1. Create an application in Okta Developer Console

--- a/docs/authentication/guides/sso/configure-oidc-react.md
+++ b/docs/authentication/guides/sso/configure-oidc-react.md
@@ -6,6 +6,13 @@ This enables operators of DataHub to integrate with 3rd party identity providers
 When configured, OIDC auth will be enabled between clients of the DataHub UI & `datahub-frontend` server. Beyond this point is considered
 to be a secure environment and as such authentication is validated & enforced only at the "front door" inside datahub-frontend.
 
+:::caution
+Even if OIDC is configured the root user can still login without OIDC by going
+to `/login` URL endpoint. It is recommended that you don't use the default
+credentials by mounting a different file in the front end container. To do this
+please see [this guide](../jaas.md) to mount a custom user.props file for a JAAS authenticated deployment.
+:::
+
 ## Provider-Specific Guides
 
 1. [Configuring OIDC using Google](configure-oidc-react-google.md)
@@ -182,10 +189,3 @@ A brief summary of the steps that occur when the user navigates to the React app
 6. DataHub fetches the authenticated user's profile and extracts a username to identify the user on DataHub (eg. urn:li:corpuser:username)
 7. DataHub sets session cookies for the newly authenticated user
 8. DataHub redirects the user to the homepage ("/")
-
-### Root user
-
-Even if OIDC is configured the root user can still login without OIDC by going
-to `/login` URL endpoint. It is recommended that you don't use the default
-credentials by mounting a different file in the front end container. To do this
-please see how to mount a custom user.props file for a JAAS authenticated deployment.


### PR DESCRIPTION
Moves root user warning to earlier in Overview docs and adds Warning icon/callout box.

Warning also added to individual OIDC guides. 

![CleanShot 2023-01-12 at 17 14 51@2x](https://user-images.githubusercontent.com/15873986/212201429-09e426db-1e03-4547-b250-95d7f1ccec04.png)
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
