### PR TITLE
feat(ingestion): pull metabase database, schema names from raw query and api

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/metabase.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metabase.py
@@ -436,12 +436,15 @@ class MetabaseSource(Source):
 
         return custom_properties
 
-    def get_datasource_urn(self, card_details):
-        platform, database_name, platform_instance = self.get_datasource_from_id(
-            card_details.get("database_id", "")
-        )
+    def get_datasource_urn(self, card_details: dict):
+        (
+            platform,
+            database_name,
+            database_schema,
+            platform_instance,
+        ) = self.get_datasource_from_id(card_details.get("database_id", ""))
         query_type = card_details.get("dataset_query", {}).get("type", {})
-        source_paths = set()
+        source_tables = set()
 
         if query_type == "query":
             source_table_id = (
@@ -452,8 +455,8 @@ class MetabaseSource(Source):
             if source_table_id is not None:
                 schema_name, table_name = self.get_source_table_from_id(source_table_id)
                 if table_name:
-                    source_paths.add(
-                        f"{f'{schema_name}.' if schema_name else ''}{table_name}"
+                    source_tables.add(
+                        f"{database_name + '.' if database_name else ''}{schema_name + '.' if schema_name else ''}{table_name}"
                     )
         else:
             try:
@@ -466,11 +469,19 @@ class MetabaseSource(Source):
 
                 for table in parser.source_tables:
                     sources = str(table).split(".")
+
+                    source_db = sources[-3] if len(sources) > 2 else database_name
                     source_schema, source_table = sources[-2], sources[-1]
                     if source_schema == "<default>":
-                        source_schema = str(self.config.default_schema)
+                        source_schema = (
+                            database_schema
+                            if database_schema is not None
+                            else str(self.config.default_schema)
+                        )
 
-                    source_paths.add(f"{source_schema}.{source_table}")
+                    source_tables.add(
+                        f"{source_db + '.' if source_db else ''}{source_schema}.{source_table}"
+                    )
             except Exception as e:
                 self.report.report_failure(
                     key="metabase-query",
@@ -480,10 +491,10 @@ class MetabaseSource(Source):
                 )
                 return None
 
+        if platform == "snowflake":
+            source_tables = [i.lower() for i in source_tables]
+
         # Create dataset URNs
-        dataset_urn = []
-        dbname = f"{f'{database_name}.' if database_name else ''}"
-        source_tables = list(map(lambda tbl: f"{dbname}{tbl}", source_paths))
         dataset_urn = [
             builder.make_dataset_urn_with_platform_instance(
                 platform=platform,
@@ -535,7 +546,6 @@ class MetabaseSource(Source):
         # Map engine names to what datahub expects in
         # https://github.com/datahub-project/datahub/blob/master/metadata-service/war/src/main/resources/boot/data_platforms.json
         engine = dataset_json.get("engine", "")
-        platform = engine
 
         engine_mapping = {
             "sparksql": "spark",
@@ -551,10 +561,13 @@ class MetabaseSource(Source):
         if engine in engine_mapping:
             platform = engine_mapping[engine]
         else:
+            platform = engine
+
             self.report.report_warning(
                 key=f"metabase-platform-{datasource_id}",
                 reason=f"Platform was not found in DataHub. Using {platform} name as is",
             )
+
         # Set platform_instance if configuration provides a mapping from platform name to instance
         platform_instance = (
             self.config.platform_instance_map.get(platform)
@@ -580,6 +593,8 @@ class MetabaseSource(Source):
             else None
         )
 
+        schema = dataset_json.get("details", {}).get("schema")
+
         if (
             self.config.database_alias_map is not None
             and platform in self.config.database_alias_map
@@ -591,7 +606,7 @@ class MetabaseSource(Source):
                 reason=f"Cannot determine database name for platform: {platform}",
             )
 
-        return platform, dbname, platform_instance
+        return platform, dbname, schema, platform_instance
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> Source:

--- a/metadata-ingestion/src/datahub/ingestion/source/metabase.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metabase.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Dict, Iterable, Optional
+from typing import Dict, Iterable, List, Optional
 
 import dateutil.parser as dp
 import pydantic
@@ -436,7 +436,7 @@ class MetabaseSource(Source):
 
         return custom_properties
 
-    def get_datasource_urn(self, card_details: dict):
+    def get_datasource_urn(self, card_details: dict) -> Optional[List]:
         (
             platform,
             database_name,
@@ -492,7 +492,7 @@ class MetabaseSource(Source):
                 return None
 
         if platform == "snowflake":
-            source_tables = [i.lower() for i in source_tables]
+            source_tables = set(i.lower() for i in source_tables)
 
         # Create dataset URNs
         dataset_urn = [


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

This is a follow up to https://github.com/datahub-project/datahub/pull/5647 to:
- pull the database name from the raw query when possible, see https://github.com/datahub-project/datahub/pull/5647#issuecomment-1242298818
- pull the schema name from the API when possible; this is not documented in https://www.metabase.com/docs/latest/api/database but the default schema can be stored in the API response under `[].details.schema`

Tested locally with `acryl-datahub==0.9.3.2`.