### PR TITLE
refactor(ingest/athena): Replace `s3_staging_dir` parameter in Athena source with `query_result_location`

### DIFF
--- a/metadata-ingestion/tests/unit/test_athena_source.py
+++ b/metadata-ingestion/tests/unit/test_athena_source.py
@@ -11,7 +11,22 @@ FROZEN_TIME = "2020-04-14 07:00:00"
 
 
 @pytest.mark.integration
-def test_athena_uri():
+def test_athena_config_query_location_old_plus_new_value_not_allowed():
+    from datahub.ingestion.source.sql.athena import AthenaConfig
+
+    with pytest.raises(ValueError):
+        AthenaConfig.parse_obj(
+            {
+                "aws_region": "us-west-1",
+                "s3_staging_dir": "s3://sample-staging-dir/",
+                "query_result_location": "s3://query_result_location",
+                "work_group": "test-workgroup",
+            }
+        )
+
+
+@pytest.mark.integration
+def test_athena_config_staging_dir_is_set_as_query_result():
     from datahub.ingestion.source.sql.athena import AthenaConfig
 
     config = AthenaConfig.parse_obj(
@@ -21,9 +36,32 @@ def test_athena_uri():
             "work_group": "test-workgroup",
         }
     )
+
+    expected_config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://sample-staging-dir/",
+            "work_group": "test-workgroup",
+        }
+    )
+
+    assert config.json() == expected_config.json()
+
+
+@pytest.mark.integration
+def test_athena_uri():
+    from datahub.ingestion.source.sql.athena import AthenaConfig
+
+    config = AthenaConfig.parse_obj(
+        {
+            "aws_region": "us-west-1",
+            "query_result_location": "s3://query-result-location/",
+            "work_group": "test-workgroup",
+        }
+    )
     assert (
         config.get_sql_alchemy_url()
-        == "awsathena+rest://@athena.us-west-1.amazonaws.com:443/?s3_staging_dir=s3%3A%2F%2Fsample-staging-dir%2F&work_group=test-workgroup&catalog_name=awsdatacatalog&duration_seconds=3600"
+        == "awsathena+rest://@athena.us-west-1.amazonaws.com:443/?s3_staging_dir=s3%3A%2F%2Fquery-result-location%2F&work_group=test-workgroup&catalog_name=awsdatacatalog&duration_seconds=3600"
     )
 
 


### PR DESCRIPTION
## Description
This PR is an outcome of this [Slack discussion](https://datahubspace.slack.com/archives/CUMUWQU66/p1673249859730469).
It deprecates the parameter `s3_staging_dir` in the Athena source and introduces `query_result_location` instead.
Downwards compatibility is ensured.
While writing the tests I didn't found an integration test for Athena.
If someone could provide me with some background information about writing integration tests for sources, I could add one to this PR.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
