### PR TITLE
fix(ui) Fix duplicate schema field rendering with siblings

### DIFF
--- a/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
@@ -1,5 +1,5 @@
 import { dataset3WithLineage, dataset4WithLineage } from '../../../../Mocks';
-import { EntityType } from '../../../../types.generated';
+import { EntityType, SchemaFieldDataType } from '../../../../types.generated';
 import {
     combineEntityDataWithSiblings,
     combineSiblingsInSearchResults,
@@ -104,6 +104,26 @@ const datasetUnprimary = {
                     },
                 },
             },
+        ],
+    },
+    schemaMetadata: {
+        ...dataset4WithLineage.schemaMetadata,
+        fields: [
+            {
+                __typename: 'SchemaField',
+                nullable: false,
+                recursive: false,
+                fieldPath: 'new_one_at_beginning',
+                description: 'Test to make sure fields merge works',
+                type: SchemaFieldDataType.String,
+                nativeDataType: 'varchar(100)',
+                isPartOfKey: false,
+                jsonPath: null,
+                globalTags: null,
+                glossaryTerms: null,
+                label: 'hi',
+            },
+            ...(dataset4WithLineage.schemaMetadata?.fields || []),
         ],
     },
     siblings: {
@@ -470,6 +490,12 @@ describe('siblingUtils', () => {
             expect(combinedData.dataset.globalTags.tags).toHaveLength(2);
             expect(combinedData.dataset.globalTags.tags[0].tag.urn).toEqual('urn:li:tag:unprimary-tag');
             expect(combinedData.dataset.globalTags.tags[1].tag.urn).toEqual('urn:li:tag:primary-tag');
+
+            // merges schema metadata properly  by fieldPath
+            expect(combinedData.dataset.schemaMetadata?.fields).toHaveLength(3);
+            expect(combinedData.dataset.schemaMetadata?.fields[0].fieldPath).toEqual('new_one_at_beginning');
+            expect(combinedData.dataset.schemaMetadata?.fields[1].fieldPath).toEqual('user_id');
+            expect(combinedData.dataset.schemaMetadata?.fields[2].fieldPath).toEqual('user_name');
 
             // will overwrite string properties w/ primary
             expect(combinedData.dataset.editableProperties.description).toEqual('secondary description');

--- a/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
@@ -493,9 +493,9 @@ describe('siblingUtils', () => {
 
             // merges schema metadata properly  by fieldPath
             expect(combinedData.dataset.schemaMetadata?.fields).toHaveLength(3);
-            expect(combinedData.dataset.schemaMetadata?.fields[0].fieldPath).toEqual('user_id');
-            expect(combinedData.dataset.schemaMetadata?.fields[1].fieldPath).toEqual('user_name');
-            expect(combinedData.dataset.schemaMetadata?.fields[2].fieldPath).toEqual('new_one');
+            expect(combinedData.dataset.schemaMetadata?.fields[0].fieldPath).toEqual('new_one');
+            expect(combinedData.dataset.schemaMetadata?.fields[1].fieldPath).toEqual('user_id');
+            expect(combinedData.dataset.schemaMetadata?.fields[2].fieldPath).toEqual('user_name');
 
             // will overwrite string properties w/ primary
             expect(combinedData.dataset.editableProperties.description).toEqual('secondary description');

--- a/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
@@ -113,7 +113,7 @@ const datasetUnprimary = {
                 __typename: 'SchemaField',
                 nullable: false,
                 recursive: false,
-                fieldPath: 'new_one_at_beginning',
+                fieldPath: 'new_one',
                 description: 'Test to make sure fields merge works',
                 type: SchemaFieldDataType.String,
                 nativeDataType: 'varchar(100)',
@@ -493,9 +493,9 @@ describe('siblingUtils', () => {
 
             // merges schema metadata properly  by fieldPath
             expect(combinedData.dataset.schemaMetadata?.fields).toHaveLength(3);
-            expect(combinedData.dataset.schemaMetadata?.fields[0].fieldPath).toEqual('new_one_at_beginning');
-            expect(combinedData.dataset.schemaMetadata?.fields[1].fieldPath).toEqual('user_id');
-            expect(combinedData.dataset.schemaMetadata?.fields[2].fieldPath).toEqual('user_name');
+            expect(combinedData.dataset.schemaMetadata?.fields[0].fieldPath).toEqual('user_id');
+            expect(combinedData.dataset.schemaMetadata?.fields[1].fieldPath).toEqual('user_name');
+            expect(combinedData.dataset.schemaMetadata?.fields[2].fieldPath).toEqual('new_one');
 
             // will overwrite string properties w/ primary
             expect(combinedData.dataset.editableProperties.description).toEqual('secondary description');

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -71,8 +71,9 @@ const mergeOwners = (destinationArray, sourceArray, _options) => {
     return unionBy(destinationArray, sourceArray, 'owner.urn');
 };
 
+// unionBy sourceArray (primary) first to get its descriptions prioritized
 const mergeFields = (destinationArray, sourceArray, _options) => {
-    return unionBy(destinationArray, sourceArray, 'fieldPath');
+    return unionBy(sourceArray, destinationArray, 'fieldPath');
 };
 
 function getArrayMergeFunction(key) {

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -71,6 +71,10 @@ const mergeOwners = (destinationArray, sourceArray, _options) => {
     return unionBy(destinationArray, sourceArray, 'owner.urn');
 };
 
+const mergeFields = (destinationArray, sourceArray, _options) => {
+    return unionBy(destinationArray, sourceArray, 'fieldPath');
+};
+
 function getArrayMergeFunction(key) {
     switch (key) {
         case 'tags':
@@ -83,6 +87,8 @@ function getArrayMergeFunction(key) {
             return mergeProperties;
         case 'owners':
             return mergeOwners;
+        case 'fields':
+            return mergeFields;
         default:
             return undefined;
     }
@@ -96,7 +102,14 @@ const customMerge = (isPrimary, key) => {
     if (key === 'platform' || key === 'siblings') {
         return (secondary, primary) => (isPrimary ? primary : secondary);
     }
-    if (key === 'tags' || key === 'terms' || key === 'assertions' || key === 'customProperties' || key === 'owners') {
+    if (
+        key === 'tags' ||
+        key === 'terms' ||
+        key === 'assertions' ||
+        key === 'customProperties' ||
+        key === 'owners' ||
+        key === 'fields'
+    ) {
         return (secondary, primary) => {
             return merge(secondary, primary, {
                 arrayMerge: getArrayMergeFunction(key),

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -1,5 +1,5 @@
 import merge from 'deepmerge';
-import { unionBy } from 'lodash';
+import { unionBy, keyBy, values } from 'lodash';
 import { useLocation } from 'react-router-dom';
 import * as QueryString from 'query-string';
 import { Entity, MatchedField, Maybe, SiblingProperties } from '../../../types.generated';
@@ -51,6 +51,11 @@ const combineMerge = (target, source, options) => {
     return destination;
 };
 
+// use when you want to merge and array of objects by key in the object as opposed to by index of array
+const mergeArrayOfObjectsByKey = (destinationArray: any[], sourceArray: any[], key: string) => {
+    return values(merge(keyBy(destinationArray, key), keyBy(sourceArray, key)));
+};
+
 const mergeTags = (destinationArray, sourceArray, _options) => {
     return unionBy(destinationArray, sourceArray, 'tag.urn');
 };
@@ -71,9 +76,8 @@ const mergeOwners = (destinationArray, sourceArray, _options) => {
     return unionBy(destinationArray, sourceArray, 'owner.urn');
 };
 
-// unionBy sourceArray (primary) first to get its descriptions prioritized
 const mergeFields = (destinationArray, sourceArray, _options) => {
-    return unionBy(sourceArray, destinationArray, 'fieldPath');
+    return mergeArrayOfObjectsByKey(sourceArray, destinationArray, 'fieldPath');
 };
 
 function getArrayMergeFunction(key) {

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -77,7 +77,7 @@ const mergeOwners = (destinationArray, sourceArray, _options) => {
 };
 
 const mergeFields = (destinationArray, sourceArray, _options) => {
-    return mergeArrayOfObjectsByKey(sourceArray, destinationArray, 'fieldPath');
+    return mergeArrayOfObjectsByKey(destinationArray, sourceArray, 'fieldPath');
 };
 
 function getArrayMergeFunction(key) {


### PR DESCRIPTION
We had an issue reported by several users where scrolling on their schema caused the same field to be repeated and take over the whole schema. This was happening because the `key` of one (or more) the schema rows had a duplicate, causing bad rendering issues and duplicating the same rows.

This could happen when two siblings had different schemas. If one of the schemas had an extra row or two inserted in the middle, the two schemas would be merged by index and therefore we would produce duplicate fields, causing duplicate rows, breaking the schema renderer.

This fixes the issue by merging based on the `fieldPath` instead, so now we get a combined schema of the siblings with unique field paths, preventing duplicated.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
