### PR TITLE
fix(ingest): temporarily disable vertica tests

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -438,7 +438,6 @@ base_dev_requirements = {
             "starburst-trino-usage",
             "powerbi",
             "powerbi-report-server",
-            "vertica",
             "salesforce",
             "unity-catalog"
             # airflow is added below
@@ -474,7 +473,7 @@ full_test_dev_requirements = {
             "mysql",
             "mariadb",
             "redash",
-            "vertica",
+            # "vertica",
         ]
         for dependency in plugins[plugin]
     ),

--- a/metadata-ingestion/tests/integration/vertica/test_vertica.py
+++ b/metadata-ingestion/tests/integration/vertica/test_vertica.py
@@ -7,6 +7,10 @@ from tests.test_helpers.docker_helpers import is_responsive, wait_for_port
 
 FROZEN_TIME = "2020-04-14 07:00:00"
 
+pytestmark = pytest.mark.skip(
+    reason="Vertica tests are disabled due to a dependency conflict with SQLAlchemy 1.3.24"
+)
+
 
 @pytest.fixture(scope="module")
 def test_resources_dir(pytestconfig):


### PR DESCRIPTION
Something weird has happened that is causing our vertica tests to be failing now. Specifically, there's a conflict with SQLAlchemy 1.3.24.

Note that the CI did pass here: https://github.com/datahub-project/datahub/issues/7010.

Looking at https://pypi.org/project/vertica-sqlalchemy-dialect/0.0.1/#files, it seems like new files were uploaded ~6 hours ago, despite the original release having been from a week ago. I'm not sure how this happened, since PyPI releases are supposed to be immutable.

I've let the relevant folks know of the issue - we expect they'll be responsible for actually fixing this.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
