### PR TITLE
fix(ingest/bigquery): clear stateful ingestion correctly

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -52,6 +52,8 @@ class SourceReport(Report):
         self.events_produced += 1
 
         if isinstance(wu, MetadataWorkUnit):
+            urn = wu.get_urn()
+
             # Specialized entity reporting.
             if not isinstance(wu.metadata, MetadataChangeEvent):
                 mcps = [wu.metadata]
@@ -59,10 +61,6 @@ class SourceReport(Report):
                 mcps = list(mcps_from_mce(wu.metadata))
 
             for mcp in mcps:
-                urn = mcp.entityUrn
-                if not urn:  # this case is rare
-                    continue
-
                 entityType = mcp.entityType
                 aspectName = mcp.aspectName
 
@@ -70,7 +68,7 @@ class SourceReport(Report):
                     self._urns_seen.add(urn)
                     self.entities[entityType].append(urn)
 
-                if aspectName:  # usually true
+                if aspectName is not None:  # usually true
                     self.aspects[entityType][aspectName] += 1
 
     def report_warning(self, key: str, reason: str) -> None:

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -115,6 +115,7 @@ from datahub.utilities.registries.domain_registry import DomainRegistry
 from datahub.utilities.source_helpers import (
     auto_stale_entity_removal,
     auto_status_aspect,
+    auto_workunit_reporter,
 )
 from datahub.utilities.time import datetime_to_ts_millis
 
@@ -462,16 +463,12 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
         database_container_key = self.gen_project_id_key(database)
 
-        container_workunits = gen_containers(
+        yield from gen_containers(
             container_key=database_container_key,
             name=database,
             sub_types=["Project"],
             domain_urn=domain_urn,
         )
-
-        for wu in container_workunits:
-            self.report.report_workunit(wu)
-            yield wu
 
     def gen_dataset_containers(
         self, dataset: str, project_id: str
@@ -480,7 +477,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
         database_container_key = self.gen_project_id_key(database=project_id)
 
-        container_workunits = gen_containers(
+        yield from gen_containers(
             schema_container_key,
             dataset,
             ["Dataset"],
@@ -492,21 +489,15 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             else None,
         )
 
-        for wu in container_workunits:
-            self.report.report_workunit(wu)
-            yield wu
-
     def add_table_to_dataset_container(
         self, dataset_urn: str, db_name: str, schema: str
     ) -> Iterable[MetadataWorkUnit]:
         schema_container_key = self.gen_dataset_key(db_name, schema)
-        container_workunits = add_dataset_to_container(
+
+        yield from add_dataset_to_container(
             container_key=schema_container_key,
             dataset_urn=dataset_urn,
         )
-        for wu in container_workunits:
-            self.report.report_workunit(wu)
-            yield wu
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         logger.info("Getting projects")
@@ -555,7 +546,10 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         return auto_stale_entity_removal(
             self.stale_entity_removal_handler,
-            auto_status_aspect(self.get_workunits_internal()),
+            auto_workunit_reporter(
+                self.report,
+                auto_status_aspect(self.get_workunits_internal()),
+            ),
         )
 
     def _process_project(
@@ -566,11 +560,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         self.db_tables[project_id] = {}
         self.db_views[project_id] = {}
 
-        database_workunits = self.gen_project_id_containers(project_id)
-
-        for wu in database_workunits:
-            self.report.report_workunit(wu)
-            yield wu
+        yield from self.gen_project_id_containers(project_id)
 
         try:
             bigquery_project.datasets = (
@@ -710,14 +700,11 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         self, conn: bigquery.Client, project_id: str, bigquery_dataset: BigqueryDataset
     ) -> Iterable[MetadataWorkUnit]:
         dataset_name = bigquery_dataset.name
-        schema_workunits = self.gen_dataset_containers(
+
+        yield from self.gen_dataset_containers(
             dataset_name,
             project_id,
         )
-
-        for wu in schema_workunits:
-            self.report.report_workunit(wu)
-            yield wu
 
         if self.config.include_tables:
             bigquery_dataset.tables = self.get_tables_for_dataset(
@@ -757,12 +744,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                 f"Table doesn't have any column or unable to get columns for table: {table_identifier}"
             )
 
-        table_workunits = self.gen_table_dataset_workunits(
-            table, project_id, schema_name
-        )
-        for wu in table_workunits:
-            self.report.report_workunit(wu)
-            yield wu
+        yield from self.gen_table_dataset_workunits(table, project_id, schema_name)
 
     def _process_view(
         self,
@@ -788,10 +770,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
         self.db_views[project_id][dataset_name].append(view)
 
-        view_workunits = self.gen_view_dataset_workunits(view, project_id, dataset_name)
-        for wu in view_workunits:
-            self.report.report_workunit(wu)
-            yield wu
+        yield from self.gen_view_dataset_workunits(view, project_id, dataset_name)
 
     def _get_domain_wu(
         self,
@@ -800,13 +779,10 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
     ) -> Iterable[MetadataWorkUnit]:
         domain_urn = self._gen_domain_urn(dataset_name)
         if domain_urn:
-            wus = add_domain_to_entity_wu(
+            yield from add_domain_to_entity_wu(
                 entity_urn=entity_urn,
                 domain_urn=domain_urn,
             )
-            for wu in wus:
-                self.report.report_workunit(wu)
-                yield wu
 
     def gen_table_dataset_workunits(
         self,
@@ -879,14 +855,12 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         view_properties_aspect = ViewProperties(
             materialized=False, viewLanguage="SQL", viewLogic=view_definition_string
         )
-        wu = wrap_aspect_as_workunit(
+        yield wrap_aspect_as_workunit(
             "dataset",
             self.gen_dataset_urn(dataset_name, project_id, table.name),
             "viewProperties",
             view_properties_aspect,
         )
-        yield wu
-        self.report.report_workunit(wu)
 
     def gen_dataset_workunits(
         self,
@@ -900,9 +874,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         dataset_urn = self.gen_dataset_urn(dataset_name, project_id, table.name)
 
         status = Status(removed=False)
-        wu = wrap_aspect_as_workunit("dataset", dataset_urn, "status", status)
-        yield wu
-        self.report.report_workunit(wu)
+        yield wrap_aspect_as_workunit("dataset", dataset_urn, "status", status)
 
         datahub_dataset_name = BigqueryTableIdentifier(
             project_id, dataset_name, table.name
@@ -931,11 +903,9 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         if custom_properties:
             dataset_properties.customProperties.update(custom_properties)
 
-        wu = wrap_aspect_as_workunit(
+        yield wrap_aspect_as_workunit(
             "dataset", dataset_urn, "datasetProperties", dataset_properties
         )
-        yield wu
-        self.report.report_workunit(wu)
 
         if tags_to_add:
             yield self.gen_tags_aspect_workunit(dataset_urn, tags_to_add)
@@ -947,13 +917,10 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         )
         dpi_aspect = self.get_dataplatform_instance_aspect(dataset_urn=dataset_urn)
         if dpi_aspect:
-            self.report.report_workunit(dpi_aspect)
             yield dpi_aspect
 
         subTypes = SubTypes(typeNames=sub_types)
-        wu = wrap_aspect_as_workunit("dataset", dataset_urn, "subTypes", subTypes)
-        yield wu
-        self.report.report_workunit(wu)
+        yield wrap_aspect_as_workunit("dataset", dataset_urn, "subTypes", subTypes)
 
         yield from self._get_domain_wu(
             dataset_name=str(datahub_dataset_name),
@@ -977,7 +944,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                 for upstream in upstream_lineage.upstreams:
                     patch_builder.add_upstream_lineage(upstream)
 
-                lineage_workunits = [
+                yield from [
                     MetadataWorkUnit(
                         id=f"upstreamLineage-for-{dataset_urn}",
                         mcp_raw=mcp,
@@ -985,15 +952,11 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                     for mcp in patch_builder.build()
                 ]
             else:
-                lineage_workunits = [
+                yield from [
                     wrap_aspect_as_workunit(
                         "dataset", dataset_urn, "upstreamLineage", upstream_lineage
                     )
                 ]
-
-            for wu in lineage_workunits:
-                yield wu
-                self.report.report_workunit(wu)
 
     def gen_tags_aspect_workunit(
         self, dataset_urn: str, tags_to_add: List[str]
@@ -1001,9 +964,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         tags = GlobalTagsClass(
             tags=[TagAssociationClass(tag_to_add) for tag_to_add in tags_to_add]
         )
-        wu = wrap_aspect_as_workunit("dataset", dataset_urn, "globalTags", tags)
-        self.report.report_workunit(wu)
-        return wu
+        return wrap_aspect_as_workunit("dataset", dataset_urn, "globalTags", tags)
 
     def gen_dataset_urn(self, dataset_name: str, project_id: str, table: str) -> str:
         datahub_dataset_name = BigqueryTableIdentifier(project_id, dataset_name, table)
@@ -1080,11 +1041,9 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             platformSchema=MySqlDDL(tableSchema=""),
             fields=self.gen_schema_fields(table.columns),
         )
-        wu = wrap_aspect_as_workunit(
+        return wrap_aspect_as_workunit(
             "dataset", dataset_urn, "schemaMetadata", schema_metadata
         )
-        self.report.report_workunit(wu)
-        return wu
 
     def get_report(self) -> BigQueryV2Report:
         return self.report

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -552,9 +552,6 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             logger.info("Starting profiling...")
             yield from self.profiler.get_workunits(self.db_tables)
 
-        # Clean up stale entities if configured.
-        yield from self.stale_entity_removal_handler.gen_removed_entity_workunits()
-
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         return auto_stale_entity_removal(
             self.stale_entity_removal_handler,

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
@@ -234,14 +234,12 @@ WHERE
                     dataset_urn, int(datetime.now().timestamp() * 1000)
                 )
 
-            wu = wrap_aspect_as_workunit(
+            yield wrap_aspect_as_workunit(
                 "dataset",
                 dataset_urn,
                 "datasetProfile",
                 profile,
             )
-            self.report.report_workunit(wu)
-            yield wu
 
     def get_bigquery_profile_request(
         self, project: str, dataset: str, table: BigqueryTable

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/usage.py
@@ -218,7 +218,6 @@ class BigQueryUsageExtractor:
                     if self.config.usage.include_operational_stats:
                         operational_wu = self._create_operation_aspect_work_unit(event)
                         if operational_wu:
-                            self.report.report_workunit(operational_wu)
                             yield operational_wu
                             self.report.num_operational_stats_workunits_emitted += 1
                     if event.read_event:
@@ -799,9 +798,7 @@ class BigQueryUsageExtractor:
         self.report.num_usage_workunits_emitted = 0
         for time_bucket in aggregated_info.values():
             for aggregate in time_bucket.values():
-                wu = self._make_usage_stat(aggregate)
-                self.report.report_workunit(wu)
-                yield wu
+                yield self._make_usage_stat(aggregate)
                 self.report.num_usage_workunits_emitted += 1
 
     def _make_usage_stat(self, agg: AggregatedDataset) -> MetadataWorkUnit:


### PR DESCRIPTION
Prior to this change, we would correctly soft-delete entities, but we wouldn't clear them out of the state payload. This means that every subsequent ingestion run would also try to soft delete those entities. This should require no intervention to roll out the changes.

Minor related change: fixes the reporting usage so that we only report each entity once. This ensures that the ingestion reports we produce are accurate. We were previously double-counting everything.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
