### PR TITLE
feat(ingest): move datahub-lite to optional dep and add shim when missing

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -55,7 +55,6 @@ framework_common = {
     "ijson",
     "click-spinner",
     "requests_file",
-    "duckdb",
 }
 
 rest_common = {
@@ -242,6 +241,7 @@ plugins: Dict[str, Set[str]] = {
     "datahub-kafka": kafka_common,
     "datahub-rest": rest_common,
     "datahub-lite": {
+        "duckdb",
         "fastapi",
         "uvicorn",
     },
@@ -352,10 +352,14 @@ plugins: Dict[str, Set[str]] = {
     "unity-catalog": databricks_cli | {"requests"},
 }
 
+# This is mainly used to exclude plugins from the Docker image.
 all_exclude_plugins: Set[str] = {
     # SQL Server ODBC requires additional drivers, and so we don't want to keep
     # it included in the default "all" installation.
     "mssql-odbc",
+    # duckdb doesn't have a prebuilt wheel for Linux arm7l or aarch64, so we
+    # simply exclude it.
+    "datahub-lite",
 }
 
 mypy_stubs = {

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -704,3 +704,25 @@ def get_aspects_for_entity(
         return {k: v for (k, v) in aspect_map.items() if k in aspects}
     else:
         return dict(aspect_map)
+
+
+def make_shim_command(name: str, suggestion: str) -> None:
+    @click.command(
+        name=name,
+        context_settings=dict(
+            ignore_unknown_options=True,
+            allow_extra_args=True,
+        ),
+    )
+    @click.pass_context
+    def command(ctx: click.Context) -> None:
+        """<disabled due to missing dependencies>"""
+
+        click.secho(
+            "This command is disabled due to missing dependencies. "
+            f"Please {suggestion} to enable it.",
+            fg="red",
+        )
+        ctx.exit(1)
+
+    return command

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -706,7 +706,7 @@ def get_aspects_for_entity(
         return dict(aspect_map)
 
 
-def make_shim_command(name: str, suggestion: str) -> None:
+def make_shim_command(name: str, suggestion: str) -> click.Command:
     @click.command(
         name=name,
         context_settings=dict(

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -12,13 +12,13 @@ from datahub.cli.check_cli import check
 from datahub.cli.cli_utils import (
     DATAHUB_CONFIG_PATH,
     get_boolean_env_variable,
+    make_shim_command,
     write_gms_config,
 )
 from datahub.cli.delete_cli import delete
 from datahub.cli.docker_cli import docker
 from datahub.cli.get_cli import get
 from datahub.cli.ingest_cli import ingest
-from datahub.cli.lite_cli import lite
 from datahub.cli.migrate import migrate
 from datahub.cli.put_cli import put
 from datahub.cli.state_cli import state
@@ -155,15 +155,25 @@ datahub.add_command(state)
 datahub.add_command(telemetry_cli)
 datahub.add_command(migrate)
 datahub.add_command(timeline)
-datahub.add_command(lite)
+
+try:
+    from datahub.cli.lite_cli import lite
+
+    datahub.add_command(lite)
+except ImportError as e:
+    logger.debug(f"Failed to load datahub lite command: {e}")
+    datahub.add_command(
+        make_shim_command("lite", "run `pip install 'acryl-datahub[datahub-lite]'`")
+    )
+
 try:
     from datahub_actions.cli.actions import actions
 
     datahub.add_command(actions)
-except ImportError:
-    # TODO: Increase the log level once this approach has been validated.
-    logger.debug(
-        "Failed to load datahub actions framework. Please confirm that the acryl-datahub-actions package has been installed from PyPi."
+except ImportError as e:
+    logger.debug(f"Failed to load datahub actions framework: {e}")
+    datahub.add_command(
+        make_shim_command("actions", "run `pip install acryl-datahub-actions`")
     )
 
 


### PR DESCRIPTION

- excludes datahub-lite from docker images, which was causing issues for the arm64 build (https://github.com/datahub-project/datahub/actions/runs/3969149206/jobs/6803397567)
- also adds the shim for actions

Looks like this:

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/12566801/213824040-ff87c33a-a9b7-4057-92df-c388dbc1e0fe.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
