### PR TITLE
fix(tests): Fixing add_users smoke test

### DIFF
--- a/datahub-web-react/src/app/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/app/shared/ManageAccount.tsx
@@ -102,7 +102,7 @@ export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink, name }: Pr
                 <a href="/openapi/swagger-ui/index.html">OpenAPI</a>
             </MenuItem>
             <Menu.Divider />
-            <MenuItem danger key="logout" tabIndex={0}>
+            <MenuItem danger key="logout" tabIndex={0} data-testid="log-out-menu-item">
                 <a href="/logOut" onClick={handleLogout}>
                     Sign Out
                 </a>
@@ -112,7 +112,7 @@ export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink, name }: Pr
 
     return (
         <Dropdown overlay={menu} trigger={['click']}>
-            <DropdownWrapper>
+            <DropdownWrapper data-testid="manage-account-menu">
                 <CustomAvatar photoUrl={_pictureLink} style={{ marginRight: 4 }} name={name} />
                 <DownArrow />
             </DropdownWrapper>

--- a/datahub-web-react/src/app/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/app/shared/ManageAccount.tsx
@@ -102,8 +102,8 @@ export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink, name }: Pr
                 <a href="/openapi/swagger-ui/index.html">OpenAPI</a>
             </MenuItem>
             <Menu.Divider />
-            <MenuItem danger key="logout" tabIndex={0} data-testid="log-out-menu-item">
-                <a href="/logOut" onClick={handleLogout}>
+            <MenuItem danger key="logout" tabIndex={0}>
+                <a href="/logOut" onClick={handleLogout} data-testid="log-out-menu-item">
                     Sign Out
                 </a>
             </MenuItem>

--- a/smoke-test/tests/cypress/cypress/integration/mutations/add_users.js
+++ b/smoke-test/tests/cypress/cypress/integration/mutations/add_users.js
@@ -25,6 +25,7 @@ describe("add_user", () => {
         cy.waitTextVisible(/signup\?invite_token=\w+/).then(($elem) => {
             const inviteLink = $elem.text();
             cy.log(inviteLink);
+            cy.visit("/settings/identities/users");
             cy.logout();
             cy.visit(inviteLink);
             let name = tryToSignUp();

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -20,8 +20,8 @@ Cypress.Commands.add('login', () => {
       method: 'POST',
       url: '/logIn',
       body: {
-        username: "datahub",
-        password: "datahub",
+        username: Cypress.env('ADMIN_USERNAME'),
+        password: Cypress.env('ADMIN_PASSWORD'),
       },
       retryOnStatusCodeFailure: true,
     });
@@ -37,8 +37,7 @@ Cypress.Commands.add('deleteUrn', (urn) => {
 })
 
 Cypress.Commands.add("logout", () => {
-  cy.get(selectorWithtestId("manage-account-menu")).first().click();
-  cy.get(selectorWithtestId("log-out-menu-item")).first().click();
+  cy.visit("/logOut")
   cy.waitTextVisible("Username");
   cy.waitTextVisible("Password");
 });

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -20,8 +20,8 @@ Cypress.Commands.add('login', () => {
       method: 'POST',
       url: '/logIn',
       body: {
-        username: Cypress.env('ADMIN_USERNAME'),
-        password: Cypress.env('ADMIN_PASSWORD'),
+        username: "datahub",
+        password: "datahub",
       },
       retryOnStatusCodeFailure: true,
     });
@@ -37,7 +37,8 @@ Cypress.Commands.add('deleteUrn', (urn) => {
 })
 
 Cypress.Commands.add("logout", () => {
-  cy.visit("/logOut")
+  cy.get(selectorWithtestId("manage-account-menu")).first().click();
+  cy.get(selectorWithtestId("log-out-menu-item")).first().click();
   cy.waitTextVisible("Username");
   cy.waitTextVisible("Password");
 });

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -37,8 +37,8 @@ Cypress.Commands.add('deleteUrn', (urn) => {
 })
 
 Cypress.Commands.add("logout", () => {
-  cy.get(selectorWithtestId("manage-account-menu")).first().click();
-  cy.get(selectorWithtestId("log-out-menu-item")).first().click();
+  cy.get(selectorWithtestId("manage-account-menu")).click();
+  cy.get(selectorWithtestId("log-out-menu-item")).click({ force: true });
   cy.waitTextVisible("Username");
   cy.waitTextVisible("Password");
 });

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -37,7 +37,8 @@ Cypress.Commands.add('deleteUrn', (urn) => {
 })
 
 Cypress.Commands.add("logout", () => {
-  cy.visit("/logOut")
+  cy.get(selectorWithtestId("manage-account-menu")).first().click();
+  cy.get(selectorWithtestId("log-out-menu-item")).first().click();
   cy.waitTextVisible("Username");
   cy.waitTextVisible("Password");
 });


### PR DESCRIPTION
## Summary

Smoke test for add_users was recently broken. This change ensures that the log out flow goes through the normal browser flow to fix this issue.

## Status

Ready for review

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
