### PR TITLE
fix(ui) Display glossary term name in analytics page properly

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetChartsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetChartsResolver.java
@@ -180,7 +180,7 @@ public final class GetChartsResolver implements DataFetcher<List<AnalyticsChartG
             ImmutableList.of("glossaryTerms.keyword"), Collections.emptyMap(),
             ImmutableMap.of("removed", ImmutableList.of("true")), Optional.empty(), false);
     AnalyticsUtil.hydrateDisplayNameForBars(_entityClient, entitiesPerTerm, Constants.GLOSSARY_TERM_ENTITY_NAME,
-        ImmutableSet.of(Constants.GLOSSARY_TERM_KEY_ASPECT_NAME), AnalyticsUtil::getTermName, authentication);
+        ImmutableSet.of(Constants.GLOSSARY_TERM_KEY_ASPECT_NAME, Constants.GLOSSARY_TERM_INFO_ASPECT_NAME), AnalyticsUtil::getTermName, authentication);
     if (!entitiesPerTerm.isEmpty()) {
       charts.add(BarChart.builder().setTitle("Entities per Term").setBars(entitiesPerTerm).build());
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetMetadataAnalyticsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetMetadataAnalyticsResolver.java
@@ -107,7 +107,7 @@ public final class GetMetadataAnalyticsResolver implements DataFetcher<List<Anal
     if (termAggregation.isPresent()) {
       List<NamedBar> termChart = buildBarChart(termAggregation.get());
       AnalyticsUtil.hydrateDisplayNameForBars(_entityClient, termChart, Constants.GLOSSARY_TERM_ENTITY_NAME,
-          ImmutableSet.of(Constants.GLOSSARY_TERM_KEY_ASPECT_NAME), AnalyticsUtil::getTermName, authentication);
+          ImmutableSet.of(Constants.GLOSSARY_TERM_KEY_ASPECT_NAME, Constants.GLOSSARY_TERM_INFO_ASPECT_NAME), AnalyticsUtil::getTermName, authentication);
       charts.add(BarChart.builder().setTitle("Entities by Term").setBars(termChart).build());
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsUtil.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsUtil.java
@@ -16,6 +16,7 @@ import com.linkedin.domain.DomainProperties;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.glossary.GlossaryTermInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.key.DatasetKey;
 import com.linkedin.metadata.key.GlossaryTermKey;
@@ -140,11 +141,20 @@ public class AnalyticsUtil {
   }
 
   public static Optional<String> getTermName(EntityResponse entityResponse) {
-    EnvelopedAspect envelopedDatasetKey = entityResponse.getAspects().get(Constants.GLOSSARY_TERM_KEY_ASPECT_NAME);
-    if (envelopedDatasetKey == null) {
+    EnvelopedAspect envelopedTermInfo = entityResponse.getAspects().get(Constants.GLOSSARY_TERM_INFO_ASPECT_NAME);
+    if (envelopedTermInfo != null) {
+      GlossaryTermInfo glossaryTermInfo = new GlossaryTermInfo(envelopedTermInfo.getValue().data());
+      if (glossaryTermInfo.hasName()) {
+        return Optional.ofNullable(glossaryTermInfo.getName());
+      }
+    }
+
+    // if name is not set on GlossaryTermInfo or there is no GlossaryTermInfo
+    EnvelopedAspect envelopedGlossaryTermKey = entityResponse.getAspects().get(Constants.GLOSSARY_TERM_KEY_ASPECT_NAME);
+    if (envelopedGlossaryTermKey == null) {
       return Optional.empty();
     }
-    GlossaryTermKey glossaryTermKey = new GlossaryTermKey(envelopedDatasetKey.getValue().data());
+    GlossaryTermKey glossaryTermKey = new GlossaryTermKey(envelopedGlossaryTermKey.getValue().data());
     return Optional.of(glossaryTermKey.getName());
   }
 }


### PR DESCRIPTION
Previously, we hydrated glossary term names based off the entity key name. Now that's just a UUID. We need to get the term name from the info aspect, but we can fall back on the key if the info aspect or the name on that aspect doesn't exist.

**Before the fix:**
<img width="1410" alt="image" src="https://user-images.githubusercontent.com/28656603/214444924-5bbc590f-b488-4702-88be-0f0456de7b4c.png">


**After the fix:**
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/28656603/214444761-d769265a-13ba-4412-866d-be7821a659f4.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
