### PR TITLE
feat(datahub-lite): simplify get response

### DIFF
--- a/metadata-ingestion/src/datahub/lite/duckdb_lite.py
+++ b/metadata-ingestion/src/datahub/lite/duckdb_lite.py
@@ -238,9 +238,7 @@ class DuckDBLite(DataHubLiteLocal[DuckDBLiteConfig]):
         typed: bool = False,
         as_of: Optional[int] = None,
         details: Optional[bool] = False,
-    ) -> Optional[
-        Dict[str, Union[str, Dict[str, Union[dict, _Aspect, SystemMetadataClass]]]]
-    ]:
+    ) -> Optional[Dict[str, Union[str, dict, _Aspect]]]:
         base_query = "SELECT urn, aspect_name, metadata, system_metadata from metadata_aspect_v2 WHERE urn = ?"
         if aspects:
             base_query += (
@@ -253,9 +251,7 @@ class DuckDBLite(DataHubLiteLocal[DuckDBLiteConfig]):
 
         self.duckdb_client.execute(base_query, [id])
         results = self.duckdb_client.fetchall()
-        result_map: Dict[
-            str, Union[str, Dict[str, Union[dict, _Aspect, SystemMetadataClass]]]
-        ] = {}
+        result_map: Dict[str, Union[str, dict, _Aspect]] = {}
         for r in results:
             aspect_name: str = r[1]
             aspect: Union[dict, _Aspect] = json.loads(r[2])
@@ -263,13 +259,13 @@ class DuckDBLite(DataHubLiteLocal[DuckDBLiteConfig]):
                 assert isinstance(aspect, dict)
                 aspect = ASPECT_MAP[aspect_name].from_obj(post_json_transform(aspect))
 
-            result_map[aspect_name] = {"value": aspect}
+            result_map[aspect_name] = aspect
             if details:
                 system_metadata: Union[dict, SystemMetadataClass] = json.loads(r[3])
                 if typed:
                     assert isinstance(system_metadata, dict)
                     system_metadata = SystemMetadataClass.from_obj(system_metadata)
-                result_map[aspect_name].update({"systemMetadata": system_metadata})  # type: ignore
+                result_map[aspect_name].update({"__systemMetadata": system_metadata})  # type: ignore
         if result_map:
             result_map = {**{"urn": id}, **result_map}
             return result_map

--- a/metadata-ingestion/src/datahub/lite/lite_local.py
+++ b/metadata-ingestion/src/datahub/lite/lite_local.py
@@ -5,11 +5,7 @@ from typing import Dict, Generic, Iterable, List, Optional, Type, TypeVar, Union
 from datahub.configuration.common import ConfigModel
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.closeable import Closeable
-from datahub.metadata.schema_classes import (
-    MetadataChangeEventClass,
-    SystemMetadataClass,
-    _Aspect,
-)
+from datahub.metadata.schema_classes import MetadataChangeEventClass, _Aspect
 from datahub.utilities.type_annotations import get_class_from_annotation
 
 LiteConfig = TypeVar("LiteConfig", bound=ConfigModel)
@@ -86,9 +82,7 @@ class DataHubLiteLocal(Generic[LiteConfig], Closeable, metaclass=ABCMeta):
         typed: bool = False,
         as_of: Optional[int] = None,
         details: Optional[bool] = False,
-    ) -> Optional[
-        Dict[str, Union[str, Dict[str, Union[dict, _Aspect, SystemMetadataClass]]]]
-    ]:
+    ) -> Optional[Dict[str, Union[str, dict, _Aspect]]]:
         pass
 
     @abstractmethod

--- a/metadata-ingestion/src/datahub/lite/lite_util.py
+++ b/metadata-ingestion/src/datahub/lite/lite_util.py
@@ -14,11 +14,7 @@ from datahub.lite.lite_local import (
     SearchFlavor,
 )
 from datahub.lite.lite_registry import lite_registry
-from datahub.metadata.schema_classes import (
-    MetadataChangeEventClass,
-    SystemMetadataClass,
-    _Aspect,
-)
+from datahub.metadata.schema_classes import MetadataChangeEventClass, _Aspect
 
 logger = logging.getLogger(__name__)
 
@@ -67,9 +63,7 @@ class DataHubLiteWrapper(DataHubLiteLocal):
         typed: bool = False,
         as_of: Optional[int] = None,
         details: Optional[bool] = False,
-    ) -> Optional[
-        Dict[str, Union[str, Dict[str, Union[dict, _Aspect, SystemMetadataClass]]]]
-    ]:
+    ) -> Optional[Dict[str, Union[str, dict, _Aspect]]]:
         return self.get(id, aspects, typed, as_of, details)
 
     def search(


### PR DESCRIPTION
Simplifies the response to `datahub lite get` to make it simpler to consume:
- Avoids nesting of aspect under the `value` node. 
- Inlines systemMetadata as a special field `__systemMetadata`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
