### PR TITLE
[docs] fix typo / add missing line for docker compose / attach overwriting system action config for confluent.

### DIFF
--- a/docs/deploy/confluent-cloud.md
+++ b/docs/deploy/confluent-cloud.md
@@ -89,10 +89,13 @@ Specifically `sasl.username` and `sasl.password` are the differences from the ba
 Additionally, you will need to set up environment variables for `KAFKA_PROPERTIES_SASL_USERNAME` and `KAFKA_PROPERTIES_SASL_PASSWORD`
 which will use the same username and API Key you generated for the JAAS config.
 
-Next, configure datahub-frontend to connect to Confluent Cloud by changing `docker/datahub-actions/env/docker.env`:
+See [Overwriting a System Action Config](https://github.com/acryldata/datahub-actions/blob/main/docker/README.md#overwriting-a-system-action-config) for detailed reflection procedures.
+
+Next, configure datahub-actions to connect to Confluent Cloud by changing `docker/datahub-actions/env/docker.env`:
 
 ```
 KAFKA_BOOTSTRAP_SERVER=pkc-g4ml2.eu-west-2.aws.confluent.cloud:9092
+SCHEMA_REGISTRY_URL=https://plrm-qwlpp.us-east-2.aws.confluent.cloud
 
 # Confluent Cloud Configs
 KAFKA_PROPERTIES_SECURITY_PROTOCOL=SASL_SSL
@@ -203,6 +206,8 @@ Specifically `sasl.username` and `sasl.password` are the differences from the ba
 
 Additionally, you will need to set up secrets for `KAFKA_PROPERTIES_SASL_USERNAME` and `KAFKA_PROPERTIES_SASL_PASSWORD`
 which will use the same username and API Key you generated for the JAAS config.
+
+See [Overwriting a System Action Config](https://github.com/acryldata/datahub-actions/blob/main/docker/README.md#overwriting-a-system-action-config) for detailed reflection procedures.
 
 ```yaml
 credentialsAndCertsSecrets:


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

- fix typo
Next, configure datahub-frontend --> Next, configure datahub-actions

- add missing line
SCHEMA_REGISTRY_URL=https://plrm-qwlpp.us-east-2.aws.confluent.cloud

- attach overwriting system action config
See [Overwriting a System Action Config](https://github.com/acryldata/datahub-actions/blob/main/docker/README.md#overwriting-a-system-action-config) for detailed reflection procedures.

When i built self hosted datahub, find overwriting system action config document.
If there is a detailed document link together, it will be helpful to others.
