### PR TITLE
fix(ui): Sort top users by their query count in datasets stats tab

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, Typography } from 'antd';
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 import { CorpUser, Maybe, UserUsageCounts } from '../../../../../../../types.generated';
 import { InfoItem } from '../../../../components/styled/InfoItem';
@@ -50,6 +50,7 @@ export default function TableStats({
     ) {
         return null;
     }
+    const sortedUsers = useMemo(() => users?.slice().sort((a, b) => (b?.count || 0) - (a?.count || 0)), [users]);
     return (
         <StatSection>
             <Typography.Title level={5}>Table Stats</Typography.Title>
@@ -77,7 +78,7 @@ export default function TableStats({
                         </Typography.Text>
                     </InfoItem>
                 )}
-                {users && users.length > 0 && (
+                {sortedUsers && sortedUsers.length > 0 && (
                     <InfoItem title="Top Users">
                         <div style={{ paddingTop: 8 }}>
                             <ExpandedActorGroup
@@ -85,7 +86,7 @@ export default function TableStats({
                                     justifyContent: 'left',
                                 }}
                                 actors={
-                                    users
+                                    sortedUsers
                                         .filter((user) => user && user?.user !== undefined && user?.user !== null)
                                         .map((user) => user?.user as CorpUser) || []
                                 }

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, Typography } from 'antd';
-import React, { useMemo } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { CorpUser, Maybe, UserUsageCounts } from '../../../../../../../types.generated';
 import { InfoItem } from '../../../../components/styled/InfoItem';
@@ -50,7 +50,7 @@ export default function TableStats({
     ) {
         return null;
     }
-    const sortedUsers = useMemo(() => users?.slice().sort((a, b) => (b?.count || 0) - (a?.count || 0)), [users]);
+    const sortedUsers = users?.slice().sort((a, b) => (b?.count || 0) - (a?.count || 0));
     return (
         <StatSection>
             <Typography.Title level={5}>Table Stats</Typography.Title>


### PR DESCRIPTION
### Summary:
Currently the top users within the stats tab of a Dataset is not sorted by their query count. This change reflects the top users by their counts.

### Example:
||
| ------ |
|<img width="1164" alt="image" src="https://user-images.githubusercontent.com/49811128/214918201-f829bac7-0255-435d-bb9e-d2f6c7328ab9.png">|

### Sample usage statistics:
`    "aspectName" : "datasetUsageStatistics",
    "aspect" : {
      "value" : "{ \"timestampMillis\":1674749347000,\"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"totalSqlQueries\": 155, \"uniqueUserCount\": 1, \"userCounts\": [{\"user\": \"urn:li:corpuser:datahub\", \"count\": 21, \"userEmail\": \"datahub@abc.COM\"},{\"user\": \"urn:li:corpuser:jkadambi\", \"count\": 100, \"userEmail\": \"jkadambi@OPTUM.COM\"},{\"user\": \"urn:li:corpuser:eaipeas\", \"count\": 9920, \"userEmail\":\"eaipeas@abc.COM\"},{\"user\": \"urn:li:corpuser:jac_script\", \"count\": 35, \"userEmail\": \"jac_scriptt@abc.COM\"},{\"user\": \"urn:li:corpuser:dbrumba2\", \"count\": 2035, \"userEmail\": \"dbrumba2@abc.COM\"}]}",
      "contentType": "application/json"`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
