### PR TITLE
feat(ui) Build entity doesn't exist page for entity profiles

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1263,9 +1263,7 @@ public class GmsGraphQLEngine {
                         .filter(graphType -> graphType instanceof EntityType)
                         .map(graphType -> (EntityType<?, ?>) graphType)
                         .collect(Collectors.toList())
-                ))
-                .dataFetcher("exists", new EntityExistsResolver(entityService))
-            )
+                )))
             .type("EntityWithRelationships", typeWiring -> typeWiring
                 .typeResolver(new EntityInterfaceTypeResolver(loadableTypes.stream()
                         .filter(graphType -> graphType instanceof EntityType)

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -617,6 +617,7 @@ public class GmsGraphQLEngine {
             .type("Container", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("entities", new ContainerEntitiesResolver(entityClient))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("platform",
                     new LoadableTypeResolver<>(dataPlatformType,
                         (env) -> ((Container) env.getSource()).getPlatform().getUrn()))
@@ -984,6 +985,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("assertions", new EntityAssertionsResolver(entityClient, graphClient))
                 .dataFetcher("testResults", new TestResultsResolver(entityClient))
                 .dataFetcher("aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("subTypes", new SubTypesResolver(
                    this.entityClient,
                    "dataset",
@@ -1057,6 +1059,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("schemaMetadata", new AspectResolver())
             .dataFetcher("parentNodes", new ParentNodesResolver(entityClient))
             .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+            .dataFetcher("exists", new EntityExistsResolver(entityService))
         );
     }
 
@@ -1064,6 +1067,7 @@ public class GmsGraphQLEngine {
         builder.type("GlossaryNode", typeWiring -> typeWiring
             .dataFetcher("parentNodes", new ParentNodesResolver(entityClient))
             .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+            .dataFetcher("exists", new EntityExistsResolver(entityService))
         );
     }
 
@@ -1148,6 +1152,7 @@ public class GmsGraphQLEngine {
         .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.notebookType))
         .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
             (env) -> ((Notebook) env.getSource()).getPlatform().getUrn()))
+        .dataFetcher("exists", new EntityExistsResolver(entityService))
         .dataFetcher("dataPlatformInstance",
             new LoadableTypeResolver<>(dataPlatformInstanceType,
                 (env) -> {
@@ -1185,6 +1190,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("usageStats", new DashboardUsageStatsResolver(timeseriesAspectService))
             .dataFetcher("statsSummary", new DashboardStatsSummaryResolver(timeseriesAspectService))
             .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+            .dataFetcher("exists", new EntityExistsResolver(entityService))
         );
         builder.type("DashboardInfo", typeWiring -> typeWiring
             .dataFetcher("charts", new LoadableTypeBatchResolver<>(chartType,
@@ -1237,6 +1243,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("parentContainers", new ParentContainersResolver(entityClient))
             .dataFetcher("statsSummary", new ChartStatsSummaryResolver(this.timeseriesAspectService))
             .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+            .dataFetcher("exists", new EntityExistsResolver(entityService))
         );
         builder.type("ChartInfo", typeWiring -> typeWiring
             .dataFetcher("inputs", new LoadableTypeBatchResolver<>(datasetType,
@@ -1256,7 +1263,9 @@ public class GmsGraphQLEngine {
                         .filter(graphType -> graphType instanceof EntityType)
                         .map(graphType -> (EntityType<?, ?>) graphType)
                         .collect(Collectors.toList())
-                )))
+                ))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
+            )
             .type("EntityWithRelationships", typeWiring -> typeWiring
                 .typeResolver(new EntityInterfaceTypeResolver(loadableTypes.stream()
                         .filter(graphType -> graphType instanceof EntityType)
@@ -1314,6 +1323,7 @@ public class GmsGraphQLEngine {
                 )
                 .dataFetcher("runs", new DataJobRunsResolver(entityClient))
                 .dataFetcher("privileges", new EntityPrivilegesResolver(entityClient))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
             )
             .type("DataJobInputOutput", typeWiring -> typeWiring
                 .dataFetcher("inputDatasets", new LoadableTypeBatchResolver<>(datasetType,
@@ -1342,6 +1352,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                     (env) -> ((DataFlow) env.getSource()).getPlatform().getUrn()))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("dataPlatformInstance",
                     new LoadableTypeResolver<>(dataPlatformInstanceType,
                         (env) -> {
@@ -1361,6 +1372,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlFeatureTableType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("platform",
                         new LoadableTypeResolver<>(dataPlatformType,
                                 (env) -> ((MLFeatureTable) env.getSource()).getPlatform().getUrn()))
@@ -1416,6 +1428,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlModelType))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                     (env) -> ((MLModel) env.getSource()).getPlatform().getUrn()))
                 .dataFetcher("dataPlatformInstance",
@@ -1446,6 +1459,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("platform", new LoadableTypeResolver<>(dataPlatformType,
                                 (env) -> ((MLModelGroup) env.getSource()).getPlatform().getUrn())
                 )
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("dataPlatformInstance",
                     new LoadableTypeResolver<>(dataPlatformInstanceType,
                         (env) -> {
@@ -1457,6 +1471,7 @@ public class GmsGraphQLEngine {
             .type("MLFeature", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("lineage",  new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("dataPlatformInstance",
                     new LoadableTypeResolver<>(dataPlatformInstanceType,
                         (env) -> {
@@ -1468,6 +1483,7 @@ public class GmsGraphQLEngine {
             .type("MLPrimaryKey", typeWiring -> typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("exists", new EntityExistsResolver(entityService))
                 .dataFetcher("dataPlatformInstance",
                     new LoadableTypeResolver<>(dataPlatformInstanceType,
                         (env) -> {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolver.java
@@ -24,8 +24,8 @@ public class EntityExistsResolver implements DataFetcher<CompletableFuture<Boole
   @Override
   public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment) throws Exception {
     String entityUrnString = bindArgument(environment.getArgument("urn"), String.class);
-    if (entityUrnString == null) {
-      // resolver can be used as its own endpoint or when hydrating an entity
+    // resolver can be used as its own endpoint or when hydrating an entity
+    if (entityUrnString == null && environment.getSource() != null) {
       entityUrnString = ((Entity) environment.getSource()).getUrn();
     }
     Objects.requireNonNull(entityUrnString, "Entity urn must not be null!");

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.entity;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -22,15 +23,19 @@ public class EntityExistsResolver implements DataFetcher<CompletableFuture<Boole
 
   @Override
   public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment) throws Exception {
-    final String entityUrnString = bindArgument(environment.getArgument("urn"), String.class);
+    String entityUrnString = bindArgument(environment.getArgument("urn"), String.class);
+    if (entityUrnString == null) {
+      // resolver can be used as its own endpoint or when hydrating an entity
+      entityUrnString = ((Entity) environment.getSource()).getUrn();
+    }
     Objects.requireNonNull(entityUrnString, "Entity urn must not be null!");
 
-    Urn entityUrn = Urn.createFromString(entityUrnString);
+    final Urn entityUrn = Urn.createFromString(entityUrnString);
     return CompletableFuture.supplyAsync(() -> {
       try {
         return _entityService.exists(entityUrn);
       } catch (Exception e) {
-        throw new RuntimeException(String.format("Failed to check whether entity %s exists", entityUrnString));
+        throw new RuntimeException(String.format("Failed to check whether entity %s exists", entityUrn.toString()));
       }
     });
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -73,6 +73,13 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
         Long lastIngested = SystemMetadataUtils.getLastIngested(aspectMap);
         result.setLastIngested(lastIngested);
 
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~HERE~~~~~~~~~~~~~~~");
+        System.out.println(entityResponse);
+        System.out.println("..........");
+        System.out.println(aspectMap);
+        System.out.println("..........");
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~HERE~~~~~~~~~~~~~~~");
+
         MappingHelper<Dataset> mappingHelper = new MappingHelper<>(aspectMap, result);
         mappingHelper.mapToResult(DATASET_KEY_ASPECT_NAME, this::mapDatasetKey);
         mappingHelper.mapToResult(DATASET_PROPERTIES_ASPECT_NAME, (entity, dataMap) -> this.mapDatasetProperties(entity, dataMap, entityUrn));
@@ -110,6 +117,12 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
 
     private void mapDatasetKey(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
         final DatasetKey gmsKey = new DatasetKey(dataMap);
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~NOW~~~~~~~~~~~~~~~");
+        System.out.println(gmsKey);
+        System.out.println("........");
+        System.out.println(gmsKey.getName());
+        System.out.println("~~~~~~~~~~~~~~~~~~~~~~NOW~~~~~~~~~~~~~~~");
+
         dataset.setName(gmsKey.getName());
         dataset.setOrigin(FabricType.valueOf(gmsKey.getOrigin().toString()));
         dataset.setPlatform(DataPlatform.builder()

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -73,13 +73,6 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
         Long lastIngested = SystemMetadataUtils.getLastIngested(aspectMap);
         result.setLastIngested(lastIngested);
 
-        System.out.println("~~~~~~~~~~~~~~~~~~~~~~HERE~~~~~~~~~~~~~~~");
-        System.out.println(entityResponse);
-        System.out.println("..........");
-        System.out.println(aspectMap);
-        System.out.println("..........");
-        System.out.println("~~~~~~~~~~~~~~~~~~~~~~HERE~~~~~~~~~~~~~~~");
-
         MappingHelper<Dataset> mappingHelper = new MappingHelper<>(aspectMap, result);
         mappingHelper.mapToResult(DATASET_KEY_ASPECT_NAME, this::mapDatasetKey);
         mappingHelper.mapToResult(DATASET_PROPERTIES_ASPECT_NAME, (entity, dataMap) -> this.mapDatasetProperties(entity, dataMap, entityUrn));
@@ -117,12 +110,6 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
 
     private void mapDatasetKey(@Nonnull Dataset dataset, @Nonnull DataMap dataMap) {
         final DatasetKey gmsKey = new DatasetKey(dataMap);
-        System.out.println("~~~~~~~~~~~~~~~~~~~~~~NOW~~~~~~~~~~~~~~~");
-        System.out.println(gmsKey);
-        System.out.println("........");
-        System.out.println(gmsKey.getName());
-        System.out.println("~~~~~~~~~~~~~~~~~~~~~~NOW~~~~~~~~~~~~~~~");
-
         dataset.setName(gmsKey.getName());
         dataset.setOrigin(FabricType.valueOf(gmsKey.getOrigin().toString()));
         dataset.setPlatform(DataPlatform.builder()

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1243,7 +1243,7 @@ type Dataset implements EntityWithRelationships & Entity & BrowsableEntity {
     privileges: EntityPrivileges
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -1592,7 +1592,7 @@ type GlossaryTerm implements Entity {
     privileges: EntityPrivileges
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -1729,7 +1729,7 @@ type GlossaryNode implements Entity {
     privileges: EntityPrivileges
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -2099,7 +2099,7 @@ type Container implements Entity {
     status: Status
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -4237,7 +4237,7 @@ type Notebook implements Entity & BrowsableEntity {
     browsePaths: [BrowsePath!]
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -4552,7 +4552,7 @@ type Dashboard implements EntityWithRelationships & Entity & BrowsableEntity {
     privileges: EntityPrivileges
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -4852,7 +4852,7 @@ type Chart implements EntityWithRelationships & Entity & BrowsableEntity {
     privileges: EntityPrivileges
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -5204,7 +5204,7 @@ type DataFlow implements EntityWithRelationships & Entity & BrowsableEntity {
     platform: DataPlatform!
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -5396,7 +5396,7 @@ type DataJob implements EntityWithRelationships & Entity & BrowsableEntity {
     privileges: EntityPrivileges
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -8238,7 +8238,7 @@ type MLModel implements EntityWithRelationships & Entity & BrowsableEntity {
     editableProperties: MLModelEditableProperties
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -8344,7 +8344,7 @@ type MLModelGroup implements EntityWithRelationships & Entity & BrowsableEntity 
     editableProperties: MLModelGroupEditableProperties
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -8463,7 +8463,7 @@ type MLFeature implements EntityWithRelationships & Entity {
     editableProperties: MLFeatureEditableProperties
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -8632,7 +8632,7 @@ type MLPrimaryKey implements EntityWithRelationships & Entity {
     editableProperties: MLPrimaryKeyEditableProperties
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }
@@ -8754,7 +8754,7 @@ type MLFeatureTable implements EntityWithRelationships & Entity & BrowsableEntit
     editableProperties: MLFeatureTableEditableProperties
 
     """
-    Whether or not this entity exists in the database
+    Whether or not this entity exists on DataHub
     """
     exists: Boolean
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1241,6 +1241,11 @@ type Dataset implements EntityWithRelationships & Entity & BrowsableEntity {
     Privileges given to a user relevant to this entity
     """
     privileges: EntityPrivileges
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 type FineGrainedLineage {
@@ -1585,6 +1590,11 @@ type GlossaryTerm implements Entity {
     Privileges given to a user relevant to this entity
     """
     privileges: EntityPrivileges
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -1717,6 +1727,11 @@ type GlossaryNode implements Entity {
     Privileges given to a user relevant to this entity
     """
     privileges: EntityPrivileges
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -2082,6 +2097,11 @@ type Container implements Entity {
     Status metadata of the container
     """
     status: Status
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -4215,6 +4235,11 @@ type Notebook implements Entity & BrowsableEntity {
     The browse paths corresponding to the Notebook. If no Browse Paths have been generated before, this will be null.
     """
     browsePaths: [BrowsePath!]
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -4525,6 +4550,11 @@ type Dashboard implements EntityWithRelationships & Entity & BrowsableEntity {
     Privileges given to a user relevant to this entity
     """
     privileges: EntityPrivileges
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -4820,6 +4850,11 @@ type Chart implements EntityWithRelationships & Entity & BrowsableEntity {
     Privileges given to a user relevant to this entity
     """
     privileges: EntityPrivileges
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -5167,6 +5202,11 @@ type DataFlow implements EntityWithRelationships & Entity & BrowsableEntity {
     Standardized platform urn where the datflow is defined
     """
     platform: DataPlatform!
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -5354,6 +5394,11 @@ type DataJob implements EntityWithRelationships & Entity & BrowsableEntity {
     Privileges given to a user relevant to this entity
     """
     privileges: EntityPrivileges
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -8191,6 +8236,11 @@ type MLModel implements EntityWithRelationships & Entity & BrowsableEntity {
     An additional set of of read write properties
     """
     editableProperties: MLModelEditableProperties
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 """
@@ -8292,6 +8342,11 @@ type MLModelGroup implements EntityWithRelationships & Entity & BrowsableEntity 
     An additional set of of read write properties
     """
     editableProperties: MLModelGroupEditableProperties
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 type MLModelGroupProperties {
@@ -8406,6 +8461,11 @@ type MLFeature implements EntityWithRelationships & Entity {
     An additional set of of read write properties
     """
     editableProperties: MLFeatureEditableProperties
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 type MLHyperParam {
@@ -8570,6 +8630,11 @@ type MLPrimaryKey implements EntityWithRelationships & Entity {
     An additional set of of read write properties
     """
     editableProperties: MLPrimaryKeyEditableProperties
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 type MLPrimaryKeyProperties {
@@ -8687,6 +8752,11 @@ type MLFeatureTable implements EntityWithRelationships & Entity & BrowsableEntit
     An additional set of of read write properties
     """
     editableProperties: MLFeatureTableEditableProperties
+
+    """
+    Whether or not this entity exists in the database
+    """
+    exists: Boolean
 }
 
 type MLFeatureTableEditableProperties {

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -1212,7 +1212,6 @@ export const dataJob1 = {
     jobId: 'jobId1',
     lastIngested: null,
     exists: true,
-    exists: true,
     ownership: {
         __typename: 'Ownership',
         owners: [

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -147,6 +147,7 @@ export const dataset1 = {
         },
     },
     lastIngested: null,
+    exists: true,
     dataPlatformInstance: null,
     platformNativeType: 'TABLE',
     name: 'The Great Test Dataset',
@@ -258,6 +259,7 @@ export const dataset2 = {
         canEditEmbed: false,
     },
     lastIngested: null,
+    exists: true,
     dataPlatformInstance: null,
     platformNativeType: 'TABLE',
     name: 'Some Other Dataset',
@@ -350,6 +352,7 @@ export const dataset3 = {
         canEditLineage: false,
         canEditEmbed: false,
     },
+    exists: true,
     lastIngested: null,
     dataPlatformInstance: null,
     platformNativeType: 'STREAM',
@@ -827,6 +830,7 @@ export const container1 = {
     type: EntityType.Container,
     platform: dataPlatform,
     lastIngested: null,
+    exists: true,
     properties: {
         name: 'database1',
         externalUrl: null,
@@ -840,6 +844,7 @@ export const container2 = {
     type: EntityType.Container,
     platform: dataPlatform,
     lastIngested: null,
+    exists: true,
     properties: {
         name: 'schema1',
         externalUrl: null,
@@ -1136,6 +1141,7 @@ export const dataFlow1 = {
     flowId: 'flowId1',
     cluster: 'cluster1',
     lastIngested: null,
+    exists: true,
     properties: {
         name: 'DataFlowInfoName',
         description: 'DataFlowInfo1 Description',
@@ -1205,6 +1211,8 @@ export const dataJob1 = {
     dataFlow: dataFlow1,
     jobId: 'jobId1',
     lastIngested: null,
+    exists: true,
+    exists: true,
     ownership: {
         __typename: 'Ownership',
         owners: [
@@ -1359,6 +1367,7 @@ export const dataJob3 = {
     dataFlow: dataFlow1,
     jobId: 'jobId3',
     lastIngested: null,
+    exists: true,
     privileges: {
         canEditLineage: false,
         canEditEmbed: false,
@@ -1431,6 +1440,7 @@ export const mlModel = {
     description: 'a ml trust model',
     origin: 'PROD',
     lastIngested: null,
+    exists: true,
     platform: {
         urn: 'urn:li:dataPlatform:kafka',
         name: 'Kafka',

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -36,6 +36,7 @@ import { ErrorSection } from '../../../../shared/error/ErrorSection';
 import { EntityHead } from '../../../../shared/EntityHead';
 import { OnboardingTour } from '../../../../onboarding/OnboardingTour';
 import useGetDataForProfile from './useGetDataForProfile';
+import NonExistentEntityPage from '../../entity/NonExistentEntityPage';
 
 type Props<T, U> = {
     urn: string;
@@ -234,6 +235,10 @@ export const EntityProfile = <T, U>({
     );
 
     const routedTab = useRoutedTab(enabledAndVisibleTabs);
+
+    if (entityData?.exists === false) {
+        return <NonExistentEntityPage />;
+    }
 
     if (isCompact) {
         return (

--- a/datahub-web-react/src/app/entity/shared/embed/EmbeddedProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/embed/EmbeddedProfile.tsx
@@ -1,6 +1,6 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { QueryHookOptions, QueryResult } from '@apollo/client';
-import { Divider, Result } from 'antd';
+import { Divider } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 import { EntityType, Exact } from '../../../../types.generated';
@@ -13,6 +13,7 @@ import { SidebarOwnerSection } from '../containers/profile/sidebar/Ownership/Sid
 import { SidebarTagsSection } from '../containers/profile/sidebar/SidebarTagsSection';
 import { SidebarDomainSection } from '../containers/profile/sidebar/Domain/SidebarDomainSection';
 import UpstreamHealth from './UpstreamHealth/UpstreamHealth';
+import NonExistentEntityPage from '../entity/NonExistentEntityPage';
 
 const LoadingWrapper = styled.div`
     display: flex;
@@ -50,7 +51,7 @@ export default function EmbeddedProfile<T>({ urn, entityType, getOverridePropert
         useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
 
     if (entityData?.exists === false) {
-        return <Result status="404" title="Not Found" subTitle="Sorry, we are unable to find this entity in DataHub" />;
+        return <NonExistentEntityPage />;
     }
 
     return (

--- a/datahub-web-react/src/app/entity/shared/embed/EmbeddedProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/embed/EmbeddedProfile.tsx
@@ -1,6 +1,6 @@
 import { LoadingOutlined } from '@ant-design/icons';
 import { QueryHookOptions, QueryResult } from '@apollo/client';
-import { Divider } from 'antd';
+import { Divider, Result } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 import { EntityType, Exact } from '../../../../types.generated';
@@ -48,6 +48,10 @@ interface Props<T> {
 export default function EmbeddedProfile<T>({ urn, entityType, getOverrideProperties, useEntityQuery }: Props<T>) {
     const { entityData, dataPossiblyCombinedWithSiblings, dataNotCombinedWithSiblings, loading, refetch } =
         useGetDataForProfile({ urn, entityType, useEntityQuery, getOverrideProperties });
+
+    if (entityData?.exists === false) {
+        return <Result status="404" title="Not Found" subTitle="Sorry, we are unable to find this entity in DataHub" />;
+    }
 
     return (
         <EntityContext.Provider

--- a/datahub-web-react/src/app/entity/shared/entity/NonExistentEntityPage.tsx
+++ b/datahub-web-react/src/app/entity/shared/entity/NonExistentEntityPage.tsx
@@ -1,0 +1,6 @@
+import { Result } from 'antd';
+import React from 'react';
+
+export default function NonExistentEntityPage() {
+    return <Result status="404" title="Not Found" subTitle="Sorry, we are unable to find this entity in DataHub" />;
+}

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -103,6 +103,7 @@ export type GenericEntityProperties = {
     fineGrainedLineages?: Maybe<FineGrainedLineage[]>;
     privileges?: Maybe<EntityPrivileges>;
     embed?: Maybe<Embed>;
+    exists?: boolean;
 };
 
 export type GenericEntityUpdate = {

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -2,6 +2,7 @@ query getChart($urn: String!) {
     chart(urn: $urn) {
         urn
         type
+        exists
         lastIngested
         tool
         chartId

--- a/datahub-web-react/src/graphql/container.graphql
+++ b/datahub-web-react/src/graphql/container.graphql
@@ -1,6 +1,7 @@
 query getContainer($urn: String!) {
     container(urn: $urn) {
         urn
+        exists
         lastIngested
         platform {
             ...platformFields

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -1,6 +1,7 @@
 fragment dataFlowFields on DataFlow {
     urn
     type
+    exists
     lastIngested
     orchestrator
     flowId

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -24,6 +24,7 @@ query getDataProfiles($urn: String!, $limit: Int, $startTime: Long, $endTime: Lo
 
 query getDataset($urn: String!) {
     dataset(urn: $urn) {
+        exists
         ...nonSiblingDatasetFields
         siblings {
             isPrimary

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -316,6 +316,7 @@ fragment nonRecursiveDataJobFields on DataJob {
 fragment dataJobFields on DataJob {
     urn
     type
+    exists
     lastIngested
     dataFlow {
         ...nonRecursiveDataFlowFields
@@ -365,6 +366,7 @@ fragment dataJobFields on DataJob {
 fragment dashboardFields on Dashboard {
     urn
     type
+    exists
     lastIngested
     tool
     dashboardId
@@ -455,6 +457,7 @@ fragment dashboardFields on Dashboard {
 fragment nonRecursiveMLFeature on MLFeature {
     urn
     type
+    exists
     lastIngested
     name
     featureNamespace
@@ -523,6 +526,7 @@ fragment nonRecursiveMLFeature on MLFeature {
 fragment nonRecursiveMLPrimaryKey on MLPrimaryKey {
     urn
     type
+    exists
     lastIngested
     name
     featureNamespace
@@ -591,6 +595,7 @@ fragment nonRecursiveMLPrimaryKey on MLPrimaryKey {
 fragment nonRecursiveMLFeatureTable on MLFeatureTable {
     urn
     type
+    exists
     lastIngested
     name
     platform {
@@ -716,6 +721,7 @@ fragment schemaMetadataFields on SchemaMetadata {
 fragment nonRecursiveMLModel on MLModel {
     urn
     type
+    exists
     lastIngested
     name
     description
@@ -785,6 +791,7 @@ fragment nonRecursiveMLModel on MLModel {
 fragment nonRecursiveMLModelGroupFields on MLModelGroup {
     urn
     type
+    exists
     lastIngested
     name
     description

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -12,6 +12,7 @@ query getGlossaryNode($urn: String!) {
     glossaryNode(urn: $urn) {
         urn
         type
+        exists
         properties {
             name
             description

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -2,6 +2,7 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
     glossaryTerm(urn: $urn) {
         urn
         type
+        exists
         name
         hierarchicalName
         isRelatedTerms: relationships(input: { types: ["IsA"], direction: OUTGOING, start: $start, count: $count }) {


### PR DESCRIPTION
In the embedded profile for the chrome extension as well as any entity profile, we want to show a page saying that an entity doesn't exist in datahub if that's the case instead of pretending like we know about the entity and showing a bare bones page (like we do in the main app).

This adds a new `exists` field on entities that you can query in graphql. It reuses an existing `EntityExistsResolver` that was meant as its own endpoint with a `urn` in the params, but I repurpose it to get the urn from the source entity if it's not in the params so it can be used for both purposes.

Here's what the page looks like for embedded profiles:
<img width="1458" alt="image" src="https://user-images.githubusercontent.com/28656603/214596739-8a43b98d-9130-47eb-977f-35fa8b89a7f2.png">

and for regular profiles:
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/28656603/214966479-0398f4a2-ebc7-4890-bb74-66771aa7c94b.png">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
