### PR TITLE
feat(graphql): enabling graphql for data platform instance aspects

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataplatforminstance/DataPlatformInstanceType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataplatforminstance/DataPlatformInstanceType.java
@@ -24,7 +24,15 @@ import java.util.stream.Collectors;
 
 public class DataPlatformInstanceType implements com.linkedin.datahub.graphql.types.EntityType<DataPlatformInstance, String> {
 
-    static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of();
+    static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of(
+        Constants.DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME,
+        Constants.DATASET_PROPERTIES_ASPECT_NAME,
+        Constants.DEPRECATION_ASPECT_NAME,
+        Constants.OWNERSHIP_ASPECT_NAME,
+        Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME,
+        Constants.GLOBAL_TAGS_ASPECT_NAME,
+        Constants.STATUS_ASPECT_NAME
+    );
     private final EntityClient _entityClient;
 
     public DataPlatformInstanceType(final EntityClient entityClient) {
@@ -72,7 +80,7 @@ public class DataPlatformInstanceType implements com.linkedin.datahub.graphql.ty
                     .collect(Collectors.toList());
 
         } catch (Exception e) {
-            throw new RuntimeException("Failed to batch load DataPlatformInstance");
+            throw new RuntimeException("Failed to batch load DataPlatformInstance", e);
         }
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataplatforminstance/mappers/DataPlatformInstanceMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataplatforminstance/mappers/DataPlatformInstanceMapper.java
@@ -1,13 +1,27 @@
 package com.linkedin.datahub.graphql.types.dataplatforminstance.mappers;
 
+import com.linkedin.common.Ownership;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.InstitutionalMemory;
+import com.linkedin.common.Status;
+import com.linkedin.common.Deprecation;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.InstitutionalMemoryMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.StatusMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.DeprecationMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
+import com.linkedin.dataplatforminstance.DataPlatformInstanceProperties;
 import com.linkedin.data.DataMap;
 import com.linkedin.datahub.graphql.generated.DataPlatform;
 import com.linkedin.datahub.graphql.generated.DataPlatformInstance;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.key.DataPlatformInstanceKey;
 
 import javax.annotation.Nonnull;
@@ -33,6 +47,39 @@ public class DataPlatformInstanceMapper {
     MappingHelper<DataPlatformInstance> mappingHelper = new MappingHelper<>(aspects, result);
     mappingHelper.mapToResult(DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME, this::mapDataPlatformInstanceKey);
 
+    final EnvelopedAspect envelopedDataPlatformInstanceProperties = aspects.get(Constants.DATA_PLATFORM_INSTANCE_PROPERTIES_ASPECT_NAME);
+    if (envelopedDataPlatformInstanceProperties != null) {
+      result.setProperties(mapDataPlatformInstanceProperties(
+              new DataPlatformInstanceProperties(envelopedDataPlatformInstanceProperties.getValue().data()), entityUrn)
+      );
+    }
+
+    final EnvelopedAspect envelopedOwnership = aspects.get(Constants.OWNERSHIP_ASPECT_NAME);
+    if (envelopedOwnership != null) {
+      result.setOwnership(OwnershipMapper.map(new Ownership(envelopedOwnership.getValue().data()), entityUrn));
+    }
+
+    final EnvelopedAspect envelopedTags = aspects.get(Constants.GLOBAL_TAGS_ASPECT_NAME);
+    if (envelopedTags != null) {
+      com.linkedin.datahub.graphql.generated.GlobalTags globalTags = GlobalTagsMapper.map(new GlobalTags(envelopedTags.getValue().data()), entityUrn);
+      result.setTags(globalTags);
+    }
+
+    final EnvelopedAspect envelopedInstitutionalMemory = aspects.get(Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME);
+    if (envelopedInstitutionalMemory != null) {
+      result.setInstitutionalMemory(InstitutionalMemoryMapper.map(new InstitutionalMemory(envelopedInstitutionalMemory.getValue().data())));
+    }
+
+    final EnvelopedAspect statusAspect = aspects.get(Constants.STATUS_ASPECT_NAME);
+    if (statusAspect != null) {
+      result.setStatus(StatusMapper.map(new Status(statusAspect.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedDeprecation = aspects.get(Constants.DEPRECATION_ASPECT_NAME);
+    if (envelopedDeprecation != null) {
+      result.setDeprecation(DeprecationMapper.map(new Deprecation(envelopedDeprecation.getValue().data())));
+    }
+
     return mappingHelper.getResult();
   }
 
@@ -44,4 +91,22 @@ public class DataPlatformInstanceMapper {
         .build());
     dataPlatformInstance.setInstanceId(gmsKey.getInstance());
   }
+
+  private com.linkedin.datahub.graphql.generated.DataPlatformInstanceProperties mapDataPlatformInstanceProperties(
+          final DataPlatformInstanceProperties gmsProperties, Urn entityUrn
+  ) {
+    final com.linkedin.datahub.graphql.generated.DataPlatformInstanceProperties propertiesResult =
+            new com.linkedin.datahub.graphql.generated.DataPlatformInstanceProperties();
+    propertiesResult.setName(gmsProperties.getName());
+    propertiesResult.setDescription(gmsProperties.getDescription());
+    if (gmsProperties.hasExternalUrl()) {
+      propertiesResult.setExternalUrl(gmsProperties.getExternalUrl().toString());
+    }
+    if (gmsProperties.hasCustomProperties()) {
+      propertiesResult.setCustomProperties(CustomPropertiesMapper.map(gmsProperties.getCustomProperties(), entityUrn));
+    }
+
+    return propertiesResult;
+  }
+
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -241,6 +241,11 @@ type Mutation {
     updateDataJob(urn: String!, input: DataJobUpdateInput!): DataJob
 
     """
+    Update the metadata about a particular DataPlatformInstance
+    """
+    updateDataPlatformInstance(urn: String!, input: DataPlatformInstanceUpdateInput!): DataPlatformInstance
+
+    """
     Create a new tag. Requires the 'Manage Tags' or 'Create Tags' Platform Privilege. If a Tag with the provided ID already exists,
     it will be overwritten.
     """
@@ -1511,6 +1516,32 @@ type DatasetProperties {
 
 
 """
+Additional read only properties about a DataPlatformInstance
+"""
+type DataPlatformInstanceProperties {
+
+    """
+    The name of the data platform instance used in display
+    """
+    name: String
+
+    """
+    Read only technical description for the data platform instance
+    """
+    description: String
+
+    """
+    Custom properties of the data platform instance
+    """
+    customProperties: [CustomPropertiesEntry!]
+
+    """
+    External URL associated with the data platform instance
+    """
+    externalUrl: String
+}
+
+"""
 A Glossary Term, or a node in a Business Glossary representing a standardized domain
 data type
 """
@@ -1824,6 +1855,36 @@ type DataPlatformInstance implements Entity {
     Edges extending from this entity
     """
     relationships(input: RelationshipsInput!): EntityRelationshipsResult
+
+    """
+    Additional read only properties associated with a data platform instance
+    """
+    properties: DataPlatformInstanceProperties
+
+    """
+    Ownership metadata of the data platform instance
+    """
+    ownership: Ownership
+
+    """
+    References to internal resources related to the data platform instance
+    """
+    institutionalMemory: InstitutionalMemory
+
+    """
+    Tags used for searching the data platform instance
+    """
+    tags: GlobalTags
+
+    """
+    The deprecation status of the data platform instance
+    """
+    deprecation: Deprecation
+
+    """
+    Status metadata of the container
+    """
+    status: Status
 }
 
 """
@@ -4018,6 +4079,31 @@ input TagUpdateInput {
     Ownership metadata of the tag
     """
     ownership: OwnershipUpdate
+}
+
+"""
+Arguments provided to update a DataPlatformInstance Entity
+"""
+input DataPlatformInstanceUpdateInput {
+    """
+    Update to ownership
+    """
+    ownership: OwnershipUpdate
+
+    """
+    Update to deprecation status
+    """
+    deprecation: DatasetDeprecationUpdate
+
+    """
+    Update to institutional memory, ie documentation
+    """
+    institutionalMemory: InstitutionalMemoryUpdate
+
+    """
+    Update to tags
+    """
+    tags: GlobalTagsUpdate
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataplatforminstance/DataPlatformInstanceTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataplatforminstance/DataPlatformInstanceTest.java
@@ -1,0 +1,204 @@
+package com.linkedin.datahub.graphql.types.dataplatforminstance;
+
+import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.*;
+import com.linkedin.common.url.Url;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.DataPlatformInstance;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.dataplatforminstance.DataPlatformInstanceProperties;
+import com.linkedin.entity.Aspect;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.entity.EnvelopedAspectMap;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.DataPlatformInstanceKey;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.execution.DataFetcherResult;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class DataPlatformInstanceTest {
+
+    private static final Urn TEST_ACTOR_URN = Urn.createFromTuple(Constants.CORP_USER_ENTITY_NAME, "test");
+
+    private static final String TEST_DATAPLATFORMINSTANCE_1_URN = "urn:li:dataPlatformInstance:(urn:li:dataPlatform:P,I1)";
+
+    private static final DataPlatformInstanceKey TEST_DATAPLATFORMINSTANCE_1_KEY
+            = new DataPlatformInstanceKey()
+            .setPlatform(Urn.createFromTuple(Constants.DATA_PLATFORM_ENTITY_NAME, "P"))
+            .setInstance("I1");
+
+    private static final DataPlatformInstanceProperties TEST_DATAPLATFORMINSTANCE_1_PROPERTIES
+            = new DataPlatformInstanceProperties()
+            .setDescription("test description")
+            .setName("Test Data Platform Instance");
+
+    private static final Deprecation TEST_DATAPLATFORMINSTANCE_1_DEPRECATION = new Deprecation()
+            .setDeprecated(true)
+            .setActor(TEST_ACTOR_URN)
+            .setNote("legacy");
+
+    private static final Ownership TEST_DATAPLATFORMINSTANCE_1_OWNERSHIP = new Ownership()
+            .setOwners(
+                    new OwnerArray(ImmutableList.of(
+                            new Owner()
+                                    .setType(OwnershipType.DATAOWNER)
+                                    .setOwner(TEST_ACTOR_URN))));
+
+    private static final InstitutionalMemory TEST_DATAPLATFORMINSTANCE_1_INSTITUTIONAL_MEMORY = new InstitutionalMemory()
+            .setElements(
+                    new InstitutionalMemoryMetadataArray(ImmutableList.of(
+                            new InstitutionalMemoryMetadata()
+                                    .setUrl(new Url("https://www.test.com"))
+                                    .setDescription("test description")
+                                    .setCreateStamp(new AuditStamp().setTime(0L).setActor(TEST_ACTOR_URN)))));
+
+    private static final GlobalTags TEST_DATAPLATFORMINSTANCE_1_TAGS = new GlobalTags()
+            .setTags(new TagAssociationArray(ImmutableList.of(new TagAssociation().setTag(new TagUrn("test")))));
+
+    private static final Status TEST_DATAPLATFORMINSTANCE_1_STATUS = new Status()
+            .setRemoved(false);
+
+    private static final String TEST_DATAPLATFORMINSTANCE_2_URN = "urn:li:dataPlatformInstance:(urn:li:dataPlatform:P,I2)";
+
+    @Test
+    public void testBatchLoad() throws Exception {
+        EntityClient client = Mockito.mock(EntityClient.class);
+
+        Urn dataPlatformInstance1Urn = Urn.createFromString(TEST_DATAPLATFORMINSTANCE_1_URN);
+        Urn dataPlatformInstance2Urn = Urn.createFromString(TEST_DATAPLATFORMINSTANCE_2_URN);
+
+        Map<String, EnvelopedAspect> dataPlatformInstance1Aspects = new HashMap<>();
+        dataPlatformInstance1Aspects.put(
+                Constants.DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_KEY.data()))
+        );
+        dataPlatformInstance1Aspects.put(
+                Constants.DATA_PLATFORM_INSTANCE_PROPERTIES_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_PROPERTIES.data()))
+        );
+        dataPlatformInstance1Aspects.put(
+                Constants.DEPRECATION_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_DEPRECATION.data()))
+        );
+        dataPlatformInstance1Aspects.put(
+                Constants.OWNERSHIP_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_OWNERSHIP.data()))
+        );
+        dataPlatformInstance1Aspects.put(
+                Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_INSTITUTIONAL_MEMORY.data()))
+        );
+        dataPlatformInstance1Aspects.put(
+                Constants.GLOBAL_TAGS_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_TAGS.data()))
+        );
+        dataPlatformInstance1Aspects.put(
+                Constants.STATUS_ASPECT_NAME,
+                new EnvelopedAspect().setValue(new Aspect(TEST_DATAPLATFORMINSTANCE_1_STATUS.data()))
+        );
+        Mockito.when(client.batchGetV2(
+                        Mockito.eq(Constants.DATA_PLATFORM_INSTANCE_ENTITY_NAME),
+                        Mockito.eq(new HashSet<>(ImmutableSet.of(dataPlatformInstance1Urn, dataPlatformInstance2Urn))),
+                        Mockito.eq(DataPlatformInstanceType.ASPECTS_TO_FETCH),
+                        Mockito.any(Authentication.class)))
+                .thenReturn(ImmutableMap.of(
+                        dataPlatformInstance1Urn,
+                        new EntityResponse()
+                                .setEntityName(Constants.DATA_PLATFORM_INSTANCE_ENTITY_NAME)
+                                .setUrn(dataPlatformInstance1Urn)
+                                .setAspects(new EnvelopedAspectMap(dataPlatformInstance1Aspects))));
+
+        DataPlatformInstanceType type = new DataPlatformInstanceType(client);
+
+        QueryContext mockContext = Mockito.mock(QueryContext.class);
+        Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+        Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
+        List<DataFetcherResult<DataPlatformInstance>> result = type.batchLoad(ImmutableList.of(TEST_DATAPLATFORMINSTANCE_1_URN, TEST_DATAPLATFORMINSTANCE_2_URN), mockContext);
+
+        // Verify response
+        Mockito.verify(client, Mockito.times(1)).batchGetV2(
+                Mockito.eq(Constants.DATA_PLATFORM_INSTANCE_ENTITY_NAME),
+                Mockito.eq(ImmutableSet.of(dataPlatformInstance1Urn, dataPlatformInstance2Urn)),
+                Mockito.eq(DataPlatformInstanceType.ASPECTS_TO_FETCH),
+                Mockito.any(Authentication.class)
+        );
+
+        assertEquals(result.size(), 2);
+
+        DataPlatformInstance dataPlatformInstance1 = result.get(0).getData();
+        assertEquals(
+                dataPlatformInstance1.getUrn(),
+                TEST_DATAPLATFORMINSTANCE_1_URN
+        );
+        assertEquals(
+                dataPlatformInstance1.getType(),
+                EntityType.DATA_PLATFORM_INSTANCE
+        );
+        assertEquals(
+                dataPlatformInstance1.getProperties().getDescription(),
+                TEST_DATAPLATFORMINSTANCE_1_PROPERTIES.getDescription()
+        );
+        assertEquals(
+                dataPlatformInstance1.getProperties().getName(),
+                TEST_DATAPLATFORMINSTANCE_1_PROPERTIES.getName()
+        );
+        assertEquals(
+                dataPlatformInstance1.getDeprecation().getDeprecated(),
+                TEST_DATAPLATFORMINSTANCE_1_DEPRECATION.isDeprecated().booleanValue()
+        );
+        assertEquals(
+                dataPlatformInstance1.getDeprecation().getNote(),
+                TEST_DATAPLATFORMINSTANCE_1_DEPRECATION.getNote()
+        );
+        assertEquals(
+                dataPlatformInstance1.getDeprecation().getActor(),
+                TEST_DATAPLATFORMINSTANCE_1_DEPRECATION.getActor().toString()
+        );
+        assertEquals(dataPlatformInstance1.getOwnership().getOwners().size(), 1);
+        assertEquals(dataPlatformInstance1.getInstitutionalMemory().getElements().size(), 1);
+        assertEquals(
+                dataPlatformInstance1.getTags().getTags().get(0).getTag().getUrn(),
+                TEST_DATAPLATFORMINSTANCE_1_TAGS.getTags().get(0).getTag().toString()
+        );
+        assertEquals(
+                dataPlatformInstance1.getStatus().getRemoved(),
+                TEST_DATAPLATFORMINSTANCE_1_STATUS.isRemoved().booleanValue()
+        );
+
+        // Assert second element is null.
+        assertNull(result.get(1));
+    }
+
+    @Test
+    public void testBatchLoadClientException() throws Exception {
+        EntityClient mockClient = Mockito.mock(EntityClient.class);
+        Mockito.doThrow(RemoteInvocationException.class).when(mockClient).batchGetV2(
+                Mockito.anyString(),
+                Mockito.anySet(),
+                Mockito.anySet(),
+                Mockito.any(Authentication.class));
+        com.linkedin.datahub.graphql.types.dataplatforminstance.DataPlatformInstanceType type
+                = new com.linkedin.datahub.graphql.types.dataplatforminstance.DataPlatformInstanceType(mockClient);
+
+        // Execute Batch load
+        QueryContext context = Mockito.mock(QueryContext.class);
+        Mockito.when(context.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
+        assertThrows(RuntimeException.class, () -> type.batchLoad(ImmutableList.of(
+                TEST_DATAPLATFORMINSTANCE_1_URN, TEST_DATAPLATFORMINSTANCE_2_URN), context));
+    }
+}

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -141,6 +141,7 @@ public class Constants {
 
   // DataPlatformInstance
   public static final String DATA_PLATFORM_INSTANCE_KEY_ASPECT_NAME = "dataPlatformInstanceKey";
+  public static final String DATA_PLATFORM_INSTANCE_PROPERTIES_ASPECT_NAME = "dataPlatformInstanceProperties";
 
   // ML Feature
   public static final String ML_FEATURE_KEY_ASPECT_NAME = "mlFeatureKey";


### PR DESCRIPTION
This continues the work started here https://github.com/datahub-project/datahub/pull/5728 and so it enables Data Platform Instance aspects being managed via GraphQL.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
