### PR TITLE
chore(deps): bump Netty from 4.1.85.Final to 4.1.86.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,7 +245,7 @@ subprojects {
     dependencies {
       testCompile externalDependency.testng
       constraints {
-        implementation('io.netty:netty-all:4.1.85.Final')
+        implementation('io.netty:netty-all:4.1.86.Final')
         implementation('org.apache.commons:commons-compress:1.21')
         implementation('org.apache.velocity:velocity-engine-core:2.3')
         implementation('org.hibernate:hibernate-validator:6.0.20.Final')

--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -24,7 +24,7 @@ dependencies {
     play('com.nimbusds:nimbus-jose-jwt:8.18')
     play('com.typesafe.akka:akka-actor_2.12:2.6.20')
     play('net.minidev:json-smart:2.4.8')
-    play('io.netty:netty-all:4.1.85.Final')
+    play('io.netty:netty-all:4.1.86.Final')
     implementation(externalDependency.commonsText) {
       because("previous versions are vulnerable to CVE-2022-42889")
     }


### PR DESCRIPTION
This update fixes two security vulnerabilities:

* [CVE-2022-41811](https://access.redhat.com/security/cve/CVE-2022-41881)
* [CVE-2022-41915](https://nvd.nist.gov/vuln/detail/CVE-2022-41915)


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
