### PR TITLE
fix(ingest/bigquery): quoting for APPROX_COUNT_DISTINCT in BigQuery

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -124,7 +124,7 @@ def get_column_unique_count_patch(self: SqlAlchemyDataset, column: str) -> int:
             sa.select(
                 [
                     sa.text(  # type:ignore
-                        f'APPROX_COUNT_DISTINCT("{sa.column(column)}")'
+                        f'APPROX_COUNT_DISTINCT(`{sa.column(column)}`)'
                     )
                 ]
             ).select_from(self._table)

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -124,7 +124,7 @@ def get_column_unique_count_patch(self: SqlAlchemyDataset, column: str) -> int:
             sa.select(
                 [
                     sa.text(  # type:ignore
-                        f'APPROX_COUNT_DISTINCT(`{sa.column(column)}`)'
+                        f"APPROX_COUNT_DISTINCT(`{sa.column(column)}`)"
                     )
                 ]
             ).select_from(self._table)


### PR DESCRIPTION
Quoting a column name with doublequote here produces wrong results because it's equal to calling `APPROX_COUNT_DISTINCT` on a string constant. Column names should be quoted with the backtick character, see https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#quoted_identifiers.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
