### PR TITLE
feat(glue): Use table name as human-readable name for Glue ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1099,6 +1099,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 },
                 uri=table.get("Location"),
                 tags=[],
+                name=table["Name"],
                 qualifiedName=self.get_glue_arn(
                     account_id=table["CatalogId"],
                     database=table["DatabaseName"],

--- a/metadata-ingestion/tests/unit/glue/glue_deleted_actor_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_deleted_actor_mces_golden.json
@@ -100,6 +100,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "test_jsons_markers",
                         "qualifiedName": "arn:aws:glue:eu-east-1:795586375822:table/test-database/test_jsons_markers",
                         "tags": []
                     }
@@ -283,6 +284,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:eu-east-1:795586375822:table/test-database/test_parquet",
                         "tags": []
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -85,6 +85,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
                         "tags": []
                     }
@@ -360,6 +361,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "test_jsons_markers",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_jsons_markers",
                         "tags": []
                     }
@@ -543,6 +545,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
                         "tags": []
                     }

--- a/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
@@ -86,6 +86,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "avro",
                         "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
                         "tags": []
                     }
@@ -363,6 +364,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "test_jsons_markers",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_jsons_markers",
                         "tags": []
                     }
@@ -547,6 +549,7 @@
                             "SortColumns": "[]",
                             "StoredAsSubDirectories": "False"
                         },
+                        "name": "test_parquet",
                         "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
                         "tags": []
                     }


### PR DESCRIPTION
(re-raised from #7190)

The FQN includes the catalog ID and database name. Add in the 'name' field that is just the table name, like the SQL-based sources, to make it more readable in the UI

Before:
![Screenshot 2023-01-31 at 12 15 01](https://user-images.githubusercontent.com/2053018/215757332-526c21fd-a3a7-47d5-af9c-d85dc2e7cec3.png)

After:
![Screenshot 2023-01-31 at 12 16 08](https://user-images.githubusercontent.com/2053018/215757378-ab253c9e-18b7-463e-9cc3-49ae49768115.png)


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
