### PR TITLE
fix(gms): Corrects MCP generation in async mode

### DIFF
--- a/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaEventProducer.java
+++ b/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaEventProducer.java
@@ -118,13 +118,10 @@ public class KafkaEventProducer implements EventProducer {
 
   @Override
   @WithSpan
-  public void produceMetadataChangeProposal(@Nonnull final MetadataChangeProposal metadataChangeProposal) {
+  public void produceMetadataChangeProposal(@Nonnull final Urn urn, @Nonnull final MetadataChangeProposal
+      metadataChangeProposal) {
     GenericRecord record;
 
-    Urn urn = metadataChangeProposal.getEntityUrn();
-    if (urn == null) {
-      throw new IllegalArgumentException("Urn for proposal cannot be null.");
-    }
     try {
       log.debug(String.format("Converting Pegasus snapshot to Avro snapshot urn %s\nMetadataChangeProposal: %s",
           urn,

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -882,7 +882,7 @@ private Map<Urn, List<EnvelopedAspect>> getCorrespondingAspects(Set<EntityAspect
         newSystemMetadata = result != null ? result.getNewSystemMetadata() : null;
       } else {
         // When async is turned on, we write to proposal log and return without waiting
-        _producer.produceMetadataChangeProposal(mcp);
+        _producer.produceMetadataChangeProposal(entityUrn, mcp);
         return new IngestProposalResult(mcp.getEntityUrn(), false, true);
       }
     } else {

--- a/metadata-io/src/main/java/com/linkedin/metadata/event/EventProducer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/event/EventProducer.java
@@ -63,7 +63,8 @@ public interface EventProducer {
    * @param metadataChangeProposal metadata change proposal to push into MCP kafka topic
    */
   @WithSpan
-  void produceMetadataChangeProposal(@Nonnull MetadataChangeProposal metadataChangeProposal);
+  void produceMetadataChangeProposal(@Nonnull final Urn urn, @Nonnull final MetadataChangeProposal
+      metadataChangeProposal);
 
   /**
    * Produces a generic platform "event".

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
@@ -461,7 +461,8 @@ abstract public class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
         _entityService.ingestProposal(gmce, TEST_AUDIT_STAMP, true);
         verify(_mockProducer, times(0)).produceMetadataChangeLog(Mockito.eq(entityUrn),
             Mockito.any(), Mockito.any());
-        verify(_mockProducer, times(1)).produceMetadataChangeProposal(entityUrn, Mockito.eq(gmce));
+        verify(_mockProducer, times(1)).produceMetadataChangeProposal(Mockito.eq(entityUrn),
+            Mockito.eq(gmce));
     }
 
 
@@ -486,7 +487,8 @@ abstract public class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
         _entityService.ingestProposal(gmce, TEST_AUDIT_STAMP, true);
         verify(_mockProducer, times(1)).produceMetadataChangeLog(Mockito.eq(entityUrn),
             Mockito.any(), Mockito.any());
-        verify(_mockProducer, times(0)).produceMetadataChangeProposal(entityUrn, Mockito.eq(gmce));
+        verify(_mockProducer, times(0)).produceMetadataChangeProposal(Mockito.eq(entityUrn),
+            Mockito.eq(gmce));
     }
 
     @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
@@ -461,7 +461,7 @@ abstract public class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
         _entityService.ingestProposal(gmce, TEST_AUDIT_STAMP, true);
         verify(_mockProducer, times(0)).produceMetadataChangeLog(Mockito.eq(entityUrn),
             Mockito.any(), Mockito.any());
-        verify(_mockProducer, times(1)).produceMetadataChangeProposal(Mockito.eq(gmce));
+        verify(_mockProducer, times(1)).produceMetadataChangeProposal(entityUrn, Mockito.eq(gmce));
     }
 
 
@@ -486,7 +486,7 @@ abstract public class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
         _entityService.ingestProposal(gmce, TEST_AUDIT_STAMP, true);
         verify(_mockProducer, times(1)).produceMetadataChangeLog(Mockito.eq(entityUrn),
             Mockito.any(), Mockito.any());
-        verify(_mockProducer, times(0)).produceMetadataChangeProposal(Mockito.eq(gmce));
+        verify(_mockProducer, times(0)).produceMetadataChangeProposal(entityUrn, Mockito.eq(gmce));
     }
 
     @Test


### PR DESCRIPTION
Fixes issue with async ingestion on GMS when using managed ingestion, where the entityUrn was not specified.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
