### PR TITLE
fix(ingest): upgrade feast to avoid build issues

### DIFF
--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -18,7 +18,7 @@ task checkPythonVersion(type: Exec) {
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {
   inputs.file file('setup.py')
   outputs.dir("${venv_name}")
-  commandLine 'bash', '-c', "${python_executable} -m venv ${venv_name} && ${venv_name}/bin/python -m pip install --upgrade pip wheel setuptools==57.5.0"
+  commandLine 'bash', '-c', "${python_executable} -m venv ${venv_name} && ${venv_name}/bin/python -m pip install --upgrade pip wheel setuptools>=63.0.0"
 }
 
 task runPreFlightScript(type: Exec, dependsOn: environmentSetup) {

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=54.0.0", "wheel", "pip>=21.0.0"]
+requires = ["setuptools>=63.0.0", "wheel"]
 
 [tool.black]
 extend-exclude = '''

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -57,10 +57,7 @@ framework_common = {
     "requests_file",
 }
 
-rest_common = {
-    "requests",
-    "requests_file"
-}
+rest_common = {"requests", "requests_file"}
 
 kafka_common = {
     # The confluent_kafka package provides a number of pre-built wheels for
@@ -265,7 +262,12 @@ plugins: Dict[str, Set[str]] = {
     "azure-ad": set(),
     "bigquery": sql_common
     | bigquery_common
-    | {sqllineage_lib, "sql_metadata", "sqlalchemy-bigquery>=1.4.1", "google-cloud-datacatalog-lineage==0.2.0"},
+    | {
+        sqllineage_lib,
+        "sql_metadata",
+        "sqlalchemy-bigquery>=1.4.1",
+        "google-cloud-datacatalog-lineage==0.2.0",
+    },
     "bigquery-beta": sql_common
     | bigquery_common
     | {
@@ -286,7 +288,7 @@ plugins: Dict[str, Set[str]] = {
     # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/release-notes.html#rn-7-14-0
     # https://github.com/elastic/elasticsearch-py/issues/1639#issuecomment-883587433
     "elasticsearch": {"elasticsearch==7.13.4"},
-    "feast": {"feast~=0.26.0", "flask-openid>=1.3.0"},
+    "feast": {"feast~=0.29.0", "flask-openid>=1.3.0"},
     "glue": aws_common,
     # hdbcli is supported officially by SAP, sqlalchemy-hana is built on top but not officially supported
     "hana": sql_common
@@ -633,7 +635,6 @@ setuptools.setup(
         "datahub": ["py.typed"],
         "datahub.metadata": ["schema.avsc"],
         "datahub.metadata.schemas": ["*.avsc"],
-        "datahub.ingestion.source.feast_image": ["Dockerfile", "requirements.txt"],
         "datahub.ingestion.source.powerbi": ["powerbi-lexical-grammar.rule"],
     },
     entry_points=entry_points,


### PR DESCRIPTION
When building feast from source (which happens on M1 machines), setuptools (or maybe distutil/pip?) complained that the versions were invalid. This was fixed upstream in feast by https://github.com/feast-dev/feast/pull/3471, and so we want to take advantage of these changes.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
