### PR TITLE
fix(cli/delete): skip references prompt if deleting an aspect

### DIFF
--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -181,26 +181,31 @@ def delete(
         entity_type = guess_entity_type(urn=urn)
         logger.info(f"DataHub configured with {host}")
 
-        references_count, related_aspects = delete_references(
-            urn, dry_run=True, cached_session_host=(session, host)
-        )
-        remove_references: bool = False
-
-        if (not force) and references_count > 0:
-            click.echo(
-                f"This urn was referenced in {references_count} other aspects across your metadata graph:"
+        if not aspect_name:
+            references_count, related_aspects = delete_references(
+                urn, dry_run=True, cached_session_host=(session, host)
             )
-            click.echo(
-                tabulate(
-                    [x.values() for x in related_aspects],
-                    ["relationship", "entity", "aspect"],
-                    tablefmt="grid",
+            remove_references: bool = False
+
+            if (not force) and references_count > 0:
+                click.echo(
+                    f"This urn was referenced in {references_count} other aspects across your metadata graph:"
                 )
-            )
-            remove_references = click.confirm("Do you want to delete these references?")
+                click.echo(
+                    tabulate(
+                        [x.values() for x in related_aspects],
+                        ["relationship", "entity", "aspect"],
+                        tablefmt="grid",
+                    )
+                )
+                remove_references = click.confirm(
+                    "Do you want to delete these references?"
+                )
 
-        if force or remove_references:
-            delete_references(urn, dry_run=False, cached_session_host=(session, host))
+            if force or remove_references:
+                delete_references(
+                    urn, dry_run=False, cached_session_host=(session, host)
+                )
 
         deletion_result: DeletionResult = delete_one_urn_cmd(
             urn,


### PR DESCRIPTION
If you're trying to delete a single aspect, we shouldn't ask you to delete all references to the entire entity.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
