### PR TITLE
fix(ingest): redshift # build late binding view lineage when sql written in upper case

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -961,7 +961,7 @@ class RedshiftSource(SQLAlchemySource):
             pg_catalog.pg_namespace AS n
             ON c.relnamespace = n.oid
         WHERE relkind = 'v'
-        and ddl like '%%with no schema binding%%'
+        and ddl ilike '%%with no schema binding%%'
         and
         n.nspname not in ('pg_catalog', 'information_schema')
         """


### PR DESCRIPTION
Change `like` to `ilike` as sometimes SQL is written in upper case.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
