### PR TITLE
Add graphql error and call metrics at startuptime

### DIFF
--- a/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
+++ b/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/GraphQLController.java
@@ -36,7 +36,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class GraphQLController {
 
   public GraphQLController() {
-
+    MetricUtils.get().counter(MetricRegistry.name(this.getClass(), "error"));
+    MetricUtils.get().counter(MetricRegistry.name(this.getClass(), "call"));
   }
 
   @Inject
@@ -148,6 +149,7 @@ public class GraphQLController {
   private void submitMetrics(ExecutionResult executionResult) {
     try {
       observeErrors(executionResult);
+      MetricUtils.get().counter(MetricRegistry.name(this.getClass(), "call")).inc();
       Object tracingInstrumentation = executionResult.getExtensions().get("tracing");
       if (tracingInstrumentation instanceof Map) {
         Map<String, Object> tracingMap = (Map<String, Object>) tracingInstrumentation;


### PR DESCRIPTION
Also measure call for every graphql call. This would help to identify ratio of failures and alert better


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
