### PR TITLE
docs(graphql): remove reference of non-existent gms.graphql

### DIFF
--- a/datahub-graphql-core/README.md
+++ b/datahub-graphql-core/README.md
@@ -8,7 +8,7 @@ permitting reads and writes against the entities and aspects on the Metadata Gra
 
 Contained within this module are 
 
-1. **GMS Schema**: A GQL schema that based on GMS models, located under `resources/gms.graphql`. 
+1. **GMS Schema**: A GQL schema based on GMS models, located under [resources](https://github.com/datahub-project/datahub/tree/master/datahub-graphql-core/src/main/resources) folder.
 2. **GMS Data Fetchers** (Resolvers): Components used by the GraphQL engine to resolve individual fields in the GQL schema.
 3. **GMS Data Loaders**: Components used by the GraphQL engine to fetch data from downstream sources efficiently (by batching). 
 4. **GraphQLEngine**: A wrapper on top of the default `GraphQL` object provided by `graphql-java`. Provides a way to configure all of the important stuff using a simple `Builder API`. 


### PR DESCRIPTION
Issue reported in this slack thread - https://datahubspace.slack.com/archives/C029A3M079U/p1675416618086009

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
