### PR TITLE
Update data_platforms.json

### DIFF
--- a/metadata-service/war/src/main/resources/boot/data_platforms.json
+++ b/metadata-service/war/src/main/resources/boot/data_platforms.json
@@ -82,7 +82,7 @@
     "aspect": {
       "datasetNameDelimiter": ".",
       "name": "hana",
-      "displayName": "SAP HANA",
+      "displayName": "HANA",
       "type": "RELATIONAL_DB",
       "logoUrl": "/assets/platforms/hanalogo.png"
     }


### PR DESCRIPTION
SAP Hana (SAP is the Company behind SAP Hana).

Reason 1)
Everywhere (directory, python scripts and so on) is only used "hana" Cause of consistency it should be "Hana" in the Navigation.

Reason 2)
"SAP Hana" is actually in the Alphabetic order after "G" (S after G, not really :-) cause internally it is sorted for the word "Hana"

BUT
The best would be to use the Name "SAP Hana". Cause this is the used Name in the IT industry. But I dont know for what the "name:" Attribute is used for. Only for sorting or are there other dependencies?


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
