### PR TITLE
fix(frontend logs): Silencing harmless log messages (and adding path for future) 

### DIFF
--- a/datahub-frontend/app/log/LogMessageFilter.java
+++ b/datahub-frontend/app/log/LogMessageFilter.java
@@ -1,0 +1,36 @@
+package log;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.AbstractMatcherFilter;
+import ch.qos.logback.core.spi.FilterReply;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * A Log Filter that can be configured to omit logs containing a specific message string.
+ * Configured inside logback.xml.
+ */
+public class LogMessageFilter extends AbstractMatcherFilter<ILoggingEvent> {
+
+  /**
+   * A set of messages to exclude.
+   */
+  private final List<String> excluded = new ArrayList<>();
+
+  @Override
+  public FilterReply decide(ILoggingEvent event) {
+    if (!isStarted()) {
+      return FilterReply.NEUTRAL;
+    }
+
+    if (this.excluded.stream().anyMatch(message -> event.getFormattedMessage().contains(message))) {
+      return FilterReply.DENY;
+    }
+    return FilterReply.ACCEPT;
+  }
+
+  public void addExcluded(String message) {
+    this.excluded.add(message);
+  }
+}

--- a/datahub-frontend/app/security/AuthenticationManager.java
+++ b/datahub-frontend/app/security/AuthenticationManager.java
@@ -58,8 +58,6 @@ public class AuthenticationManager {
         } else if (callback instanceof PasswordCallback) {
           pc = (PasswordCallback) callback;
           pc.setPassword(this.password.toCharArray());
-        } else {
-          Logger.warn("The submitted callback is unsupported! type: " + callback.getClass(), callback);
         }
       }
     }

--- a/datahub-frontend/conf/logback.xml
+++ b/datahub-frontend/conf/logback.xml
@@ -10,6 +10,10 @@
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>INFO</level>
     </filter>
+    <filter class="log.LogMessageFilter">
+      <excluded>Unable to renew the session. The session store may not support this feature</excluded>
+      <excluded>Preferred JWS algorithm: null not available. Using all metadata algorithms:</excluded>
+    </filter>
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">

--- a/datahub-frontend/run/logback.xml
+++ b/datahub-frontend/run/logback.xml
@@ -10,6 +10,10 @@
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>INFO</level>
     </filter>
+    <filter class="log.LogMessageFilter">
+      <excluded>Unable to renew the session. The session store may not support this feature</excluded>
+      <excluded>Preferred JWS algorithm: null not available. Using all metadata algorithms:</excluded>
+    </filter>
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
## Summary 

In this PR I've introduced a custom logback filter that will accept partial log messages and filter them out on a case by case basis. 

This is useful for hushing specific warnings or errors coming from the underlying libraries (like Pac4j) without having to silence them completely. (e.g. at class or package level). 

We only silence in the stdout logger, but keep in the file appender for our debugging purposes.

Specific warnings which are hushed:

- [Pac4j] Preferred JWS algorithm: null not available. Using all metadata algorithms: [RS256]
- [Pacj] Unable to renew the session. The session store may not support this feature
- [Our Code]2023-02-03 16:42:28,995 [application-akka.actor.default-dispatcher-16] WARN  application - The submitted callback is unsupported! type: class org.eclipse.jetty.jaas.callback.ObjectCallback

## Status

Ready for review 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
