### PR TITLE
feat(cli): add 0.10 awareness to upgrade prompt

### DIFF
--- a/metadata-ingestion/src/datahub/upgrade/upgrade.py
+++ b/metadata-ingestion/src/datahub/upgrade/upgrade.py
@@ -223,11 +223,11 @@ def valid_client_version(version: Version) -> bool:
 
 
 def valid_server_version(version: Version) -> bool:
-    """Only version strings like 0.8.x or 0.9.x are valid. 0.1.x is not"""
+    """Only version strings like 0.8.x, 0.9.x or 0.10.x are valid. 0.1.x is not"""
     if version.is_prerelease or version.is_postrelease or version.is_devrelease:
         return False
 
-    if version.major == 0 and version.minor in [8, 9]:
+    if version.major == 0 and version.minor in [8, 9, 10]:
         return True
 
     return False


### PR DESCRIPTION
The current upgrade prompt only checks for server versions 0.8.x and 0.9.x as valid versions for suggesting upgrades. 
Adding 0.10.x to the mix as we prepare the server release.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
