### PR TITLE
getting rid of build locally(broken) for ./gradlew quickstart(working)

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -70,7 +70,7 @@ cd ../
 
 Once you have compiled & packaged the project or appropriate module you can deploy the entire system via docker-compose by running:
 ```
-datahub docker quickstart --build-locally
+./gradlew quickstart
 ```
 
 Replace whatever container you want in the existing deployment.


### PR DESCRIPTION
## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
