### PR TITLE
doc(access): move heading above the images

### DIFF
--- a/docs/authorization/access-policies-guide.md
+++ b/docs/authorization/access-policies-guide.md
@@ -117,18 +117,17 @@ In this step, we can select the actors who should be granted Privileges appearin
 
 To do so, simply search and select the Users or Groups that the Policy should apply to.
 
+**Assigning a Policy to a User**
+
 <p align="center">
   <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/policies-select-users.png"/>
 </p>
 
-**Assigning a Policy to a User**
+**Assigning a Policy to a Group**
 
 <p align="center">
   <img width="80%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/policies-select-groups.png"/>
 </p>
-
-**Assigning a Policy to a Group**
-
 
 ### Creating a Metadata Policy
 


### PR DESCRIPTION
Makes more sense to have heading above the image

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
