### PR TITLE
fix(search): correctly filter fields in EDITABLE_FIELD_TO_QUERY_PAIRS with a list of values

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -143,6 +143,7 @@ public class ESUtils {
         criterionToQuery.setCondition(criterion.getCondition());
         criterionToQuery.setNegated(criterion.isNegated());
         criterionToQuery.setValue(criterion.getValue());
+        criterionToQuery.setValues(criterion.getValues());
         criterionToQuery.setField(field + KEYWORD_SUFFIX);
         orQueryBuilder.should(getQueryBuilderFromCriterionForSingleField(criterionToQuery));
       }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandlerTest.java
@@ -1,9 +1,16 @@
 package com.linkedin.metadata.search.elasticsearch.query.request;
 
 import com.google.common.collect.ImmutableList;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.TestEntitySpecBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.linkedin.metadata.query.filter.Condition;
@@ -15,6 +22,7 @@ import com.linkedin.metadata.query.filter.Filter;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -122,5 +130,178 @@ public class SearchRequestHandlerTest {
 
     assertFalse(mustNotHaveRemovedCondition.isPresent(), "Expect `must not have removed` condition to not"
             + " exist because filter already has it a condition for the removed property");
+  }
+
+  // For fields that are one of EDITABLE_FIELD_TO_QUERY_PAIRS, we want to make sure
+  // a filter that has a list of values like below will filter on all values by generating a terms query
+  //  field EQUAL [value1, value2, ...]
+  @Test
+  public void testFilterFieldTagsByValues() {
+    final Criterion filterCriterion = new Criterion()
+        .setField("fieldTags")
+        .setCondition(Condition.EQUAL)
+        .setValue("v1")
+        .setValues(new StringArray("v1", "v2"));
+
+    final BoolQueryBuilder testQuery = getQuery(filterCriterion);
+
+    // bool -> must -> [bool] -> should -> [bool] -> must -> [bool] -> should -> [terms]
+    List<TermsQueryBuilder> termsQueryBuilders = testQuery.must()
+        .stream()
+        .filter(or -> or instanceof BoolQueryBuilder)
+        .flatMap(or -> ((BoolQueryBuilder) or).should().stream())
+        .filter(should -> should instanceof BoolQueryBuilder)
+        .flatMap(should -> ((BoolQueryBuilder) should).must().stream())
+        .filter(must -> must instanceof BoolQueryBuilder)
+        .flatMap(must -> ((BoolQueryBuilder) must).should().stream())
+        .filter(should -> should instanceof TermsQueryBuilder)
+        .map(should -> (TermsQueryBuilder) should)
+        .collect(Collectors.toList());
+
+    assertTrue(termsQueryBuilders.size() == 2, "Expected to find two terms queries");
+    Map<String, List<String>> termsMap = new HashMap<>();
+    termsQueryBuilders.forEach(termsQueryBuilder -> {
+      String field = termsQueryBuilder.fieldName();
+      List<Object> values = termsQueryBuilder.values();
+      List<String> strValues = new ArrayList<>();
+      for (Object value : values) {
+        assertTrue(value instanceof String,
+            "Expected value to be String, got: " + value.getClass());
+        strValues.add((String) value);
+      }
+      Collections.sort(strValues);
+      termsMap.put(field, strValues);
+    });
+
+    assertTrue(termsMap.containsKey("fieldTags.keyword"));
+    assertTrue(termsMap.containsKey("editedFieldTags.keyword"));
+    for (List<String> values : termsMap.values()) {
+      assertTrue(values.size() == 2);
+      assertTrue(values.get(0).equals("v1"));
+      assertTrue(values.get(1).equals("v2"));
+    }
+  }
+
+  // For fields that are one of EDITABLE_FIELD_TO_QUERY_PAIRS, we want to make sure
+  // a filter that has a single value will result in one filter for each field in the
+  // pair of fields
+  @Test
+  public void testFilterFieldTagsByValue() {
+    final Criterion filterCriterion = new Criterion()
+        .setField("fieldTags")
+        .setCondition(Condition.EQUAL)
+        .setValue("v1");
+
+    final BoolQueryBuilder testQuery = getQuery(filterCriterion);
+
+    // bool -> must -> [bool] -> should -> [bool] -> must -> [bool] -> should -> [bool] -> should -> [match]
+    List<MatchQueryBuilder> matchQueryBuilders = testQuery.must()
+        .stream()
+        .filter(or -> or instanceof BoolQueryBuilder)
+        .flatMap(or -> ((BoolQueryBuilder) or).should().stream())
+        .filter(should -> should instanceof BoolQueryBuilder)
+        .flatMap(should -> ((BoolQueryBuilder) should).must().stream())
+        .filter(must -> must instanceof BoolQueryBuilder)
+        .flatMap(must -> ((BoolQueryBuilder) must).should().stream())
+        .filter(should -> should instanceof BoolQueryBuilder)
+        .flatMap(should -> ((BoolQueryBuilder) should).should().stream())
+        .filter(should -> should instanceof MatchQueryBuilder)
+        .map(should -> (MatchQueryBuilder) should)
+        .collect(Collectors.toList());
+
+    assertTrue(matchQueryBuilders.size() == 2, "Expected to find two match queries");
+    Map<String, String> matchMap = new HashMap<>();
+    matchQueryBuilders.forEach(matchQueryBuilder -> {
+      String field = matchQueryBuilder.fieldName();
+      assertTrue(matchQueryBuilder.value() instanceof String);
+      matchMap.put(field, (String) matchQueryBuilder.value());
+    });
+
+    assertTrue(matchMap.containsKey("fieldTags.keyword"));
+    assertTrue(matchMap.containsKey("editedFieldTags.keyword"));
+    for (String value : matchMap.values()) {
+      assertTrue(value.equals("v1"));
+    }
+  }
+
+  // Test fields not in EDITABLE_FIELD_TO_QUERY_PAIRS with a single value
+  @Test
+  public void testFilterPlatformByValue() {
+    final Criterion filterCriterion = new Criterion()
+        .setField("platform")
+        .setCondition(Condition.EQUAL)
+        .setValue("mysql");
+
+    final BoolQueryBuilder testQuery = getQuery(filterCriterion);
+
+    // bool -> must -> [bool] -> should -> [bool] -> must -> [bool] -> should -> [match]
+    List<MatchQueryBuilder> matchQueryBuilders = testQuery.must()
+        .stream()
+        .filter(or -> or instanceof BoolQueryBuilder)
+        .flatMap(or -> ((BoolQueryBuilder) or).should().stream())
+        .filter(should -> should instanceof BoolQueryBuilder)
+        .flatMap(should -> ((BoolQueryBuilder) should).must().stream())
+        .filter(must -> must instanceof BoolQueryBuilder)
+        .flatMap(must -> ((BoolQueryBuilder) must).should().stream())
+        .filter(should -> should instanceof MatchQueryBuilder)
+        .map(should -> (MatchQueryBuilder) should)
+        .collect(Collectors.toList());
+
+    assertTrue(matchQueryBuilders.size() == 1, "Expected to find one match query");
+    MatchQueryBuilder matchQueryBuilder = matchQueryBuilders.get(0);
+    assertEquals(matchQueryBuilder.fieldName(), "platform");
+    assertEquals(matchQueryBuilder.value(), "mysql");
+  }
+
+  // Test fields not in EDITABLE_FIELD_TO_QUERY_PAIRS with a list of values
+  @Test
+  public void testFilterPlatformByValues() {
+    final Criterion filterCriterion = new Criterion()
+        .setField("platform")
+        .setCondition(Condition.EQUAL)
+        .setValue("mysql")
+        .setValues(new StringArray("mysql", "bigquery"));
+
+    final BoolQueryBuilder testQuery = getQuery(filterCriterion);
+
+    // bool -> must -> [bool] -> should -> [bool] -> must -> [terms]
+    List<TermsQueryBuilder> termsQueryBuilders = testQuery.must()
+        .stream()
+        .filter(must -> must instanceof BoolQueryBuilder)
+        .flatMap(must -> ((BoolQueryBuilder) must).should().stream())
+        .filter(should -> should instanceof BoolQueryBuilder)
+        .flatMap(should -> ((BoolQueryBuilder) should).must().stream())
+        .filter(must -> must instanceof TermsQueryBuilder)
+        .map(must -> (TermsQueryBuilder) must)
+        .collect(Collectors.toList());
+
+    assertTrue(termsQueryBuilders.size() == 1, "Expected to find one terms query");
+    final TermsQueryBuilder termsQueryBuilder = termsQueryBuilders.get(0);
+    assertEquals(termsQueryBuilder.fieldName(), "platform");
+    Set<String> values = new HashSet<>();
+    termsQueryBuilder.values().forEach(value -> {
+      assertTrue(value instanceof String);
+      values.add((String) value);
+    });
+
+    assertEquals(values.size(), 2, "Expected two platform filter values");
+    assertTrue(values.contains("mysql"));
+    assertTrue(values.contains("bigquery"));
+  }
+
+  private BoolQueryBuilder getQuery(final Criterion filterCriterion) {
+    final Filter filter = new Filter().setOr(
+        new ConjunctiveCriterionArray(
+            new ConjunctiveCriterion().setAnd(
+                new CriterionArray(ImmutableList.of(filterCriterion)))
+        ));
+
+    final SearchRequestHandler requestHandler = SearchRequestHandler.getBuilder(
+        TestEntitySpecBuilder.getSpec());
+
+    return (BoolQueryBuilder) requestHandler
+        .getSearchRequest("", filter, null, 0, 10, false)
+        .source()
+        .query();
   }
 }


### PR DESCRIPTION
The GraphQL query below only returns datasets that contains the `user identifier` tag, whereas it should return datasets that contain either `user identifier` or `email address` tag.

```
query getSearchResultsForMultiple {
  searchAcrossEntities(input: {
    types: [DATASET], 
    query: "",
    orFilters: [
      {
        and: [
          {
            field: "fieldTags",
            values: ["urn:li:tag:user identifier", "urn:li:tag:email address"],
            condition: EQUAL
          }
        ]
      }
    ]
  }) {
    searchResults {
      entity {
        urn
        type
      }
    }
  }
}
```

The problem is that `values` is lost when we construct the new `Criterion` for a field that belongs to `EDITABLE_FIELD_TO_QUERY_PAIRS`. As a result, the query to ES doesn't have the terms query.

The fix is one line, but I took the opportunity to boost the test coverage a bit.

See below for details.
https://datahubspace.slack.com/archives/C029A3M079U/p1675905450676659