### PR TITLE
fix(sso) Retrieve cookie configs separately from SSO configs

### DIFF
--- a/datahub-frontend/app/auth/AuthModule.java
+++ b/datahub-frontend/app/auth/AuthModule.java
@@ -105,9 +105,10 @@ public class AuthModule extends AbstractModule {
                 SsoManager.class,
                 Authentication.class,
                 EntityClient.class,
-                AuthServiceClient.class));
+                AuthServiceClient.class,
+                com.typesafe.config.Config.class));
         } catch (NoSuchMethodException | SecurityException e) {
-            throw new RuntimeException("Failed to bind to SsoCallbackController. Cannot find constructor, e");
+            throw new RuntimeException("Failed to bind to SsoCallbackController. Cannot find constructor", e);
         }
         // logout
         final LogoutController logoutController = new LogoutController();

--- a/datahub-frontend/app/auth/AuthUtils.java
+++ b/datahub-frontend/app/auth/AuthUtils.java
@@ -41,15 +41,7 @@ public class AuthUtils {
      */
     public static final String SYSTEM_CLIENT_SECRET_CONFIG_PATH = "systemClientSecret";
 
-    public static final String SESSION_TTL_CONFIG_PATH = "auth.session.ttlInHours";
-
-    public static final Integer DEFAULT_SESSION_TTL_HOURS = 720;
     public static final CorpuserUrn DEFAULT_ACTOR_URN = new CorpuserUrn("datahub");
-
-    public static final String AUTH_COOKIE_SAME_SITE = "play.http.session.sameSite";
-    public static final String DEFAULT_AUTH_COOKIE_SAME_SITE = "LAX";
-    public static final String AUTH_COOKIE_SECURE = "play.http.session.secure";
-    public static final boolean DEFAULT_AUTH_COOKIE_SECURE = false;
 
     public static final String LOGIN_ROUTE = "/login";
     public static final String USER_NAME = "username";

--- a/datahub-frontend/app/auth/CookieConfigs.java
+++ b/datahub-frontend/app/auth/CookieConfigs.java
@@ -24,9 +24,15 @@ public class CookieConfigs {
         : DEFAULT_AUTH_COOKIE_SECURE;
   }
 
-  public int getTtlInHours() { return _ttlInHours; }
+  public int getTtlInHours() {
+    return _ttlInHours;
+  }
 
-  public String getAuthCookieSameSite() { return _authCookieSameSite; }
+  public String getAuthCookieSameSite() {
+    return _authCookieSameSite;
+  }
 
-  public boolean getAuthCookieSecure() { return _authCookieSecure; }
+  public boolean getAuthCookieSecure() {
+    return _authCookieSecure;
+  }
 }

--- a/datahub-frontend/app/auth/CookieConfigs.java
+++ b/datahub-frontend/app/auth/CookieConfigs.java
@@ -1,0 +1,32 @@
+package auth;
+
+
+import com.typesafe.config.Config;
+
+public class CookieConfigs {
+  public static final String SESSION_TTL_CONFIG_PATH = "auth.session.ttlInHours";
+  public static final Integer DEFAULT_SESSION_TTL_HOURS = 720;
+  public static final String AUTH_COOKIE_SAME_SITE = "play.http.session.sameSite";
+  public static final String DEFAULT_AUTH_COOKIE_SAME_SITE = "LAX";
+  public static final String AUTH_COOKIE_SECURE = "play.http.session.secure";
+  public static final boolean DEFAULT_AUTH_COOKIE_SECURE = false;
+
+  private final int _ttlInHours;
+  private final String _authCookieSameSite;
+  private final boolean _authCookieSecure;
+
+  public CookieConfigs(final Config configs) {
+    _ttlInHours = configs.hasPath(SESSION_TTL_CONFIG_PATH) ? configs.getInt(SESSION_TTL_CONFIG_PATH)
+        : DEFAULT_SESSION_TTL_HOURS;
+    _authCookieSameSite = configs.hasPath(AUTH_COOKIE_SAME_SITE) ? configs.getString(AUTH_COOKIE_SAME_SITE)
+        : DEFAULT_AUTH_COOKIE_SAME_SITE;
+    _authCookieSecure = configs.hasPath(AUTH_COOKIE_SECURE) ? configs.getBoolean(AUTH_COOKIE_SECURE)
+        : DEFAULT_AUTH_COOKIE_SECURE;
+  }
+
+  public int getTtlInHours() { return _ttlInHours; }
+
+  public String getAuthCookieSameSite() { return _authCookieSameSite; }
+
+  public boolean getAuthCookieSecure() { return _authCookieSecure; }
+}

--- a/datahub-frontend/app/auth/sso/SsoConfigs.java
+++ b/datahub-frontend/app/auth/sso/SsoConfigs.java
@@ -1,6 +1,5 @@
 package auth.sso;
 
-import static auth.AuthUtils.*;
 import static auth.ConfigUtil.*;
 
 
@@ -26,10 +25,7 @@ public class SsoConfigs {
   private final String _authBaseUrl;
   private final String _authBaseCallbackPath;
   private final String _authSuccessRedirectPath;
-  private final Integer _sessionTtlInHours;
   private final Boolean _oidcEnabled;
-  private final String _authCookieSameSite;
-  private final Boolean _authCookieSecure;
 
   public SsoConfigs(final com.typesafe.config.Config configs) {
     _authBaseUrl = getRequired(configs, AUTH_BASE_URL_CONFIG_PATH);
@@ -41,21 +37,9 @@ public class SsoConfigs {
         configs,
         AUTH_SUCCESS_REDIRECT_PATH_CONFIG_PATH,
         DEFAULT_SUCCESS_REDIRECT_PATH);
-    _sessionTtlInHours = Integer.parseInt(getOptional(
-        configs,
-        SESSION_TTL_CONFIG_PATH,
-        DEFAULT_SESSION_TTL_HOURS.toString()));
     _oidcEnabled =  configs.hasPath(OIDC_ENABLED_CONFIG_PATH)
         && Boolean.TRUE.equals(
         Boolean.parseBoolean(configs.getString(OIDC_ENABLED_CONFIG_PATH)));
-    _authCookieSameSite = getOptional(
-        configs,
-        AUTH_COOKIE_SAME_SITE,
-        DEFAULT_AUTH_COOKIE_SAME_SITE);
-    _authCookieSecure = Boolean.parseBoolean(getOptional(
-        configs,
-        AUTH_COOKIE_SECURE,
-        String.valueOf(DEFAULT_AUTH_COOKIE_SECURE)));
   }
 
   public String getAuthBaseUrl() {
@@ -68,18 +52,6 @@ public class SsoConfigs {
 
   public String getAuthSuccessRedirectPath() {
     return _authSuccessRedirectPath;
-  }
-
-  public Integer getSessionTtlInHours() {
-    return _sessionTtlInHours;
-  }
-
-  public String getAuthCookieSameSite() {
-    return _authCookieSameSite;
-  }
-
-  public boolean getAuthCookieSecure() {
-    return _authCookieSecure;
   }
 
   public Boolean isOidcEnabled() {

--- a/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcCallbackLogic.java
@@ -1,5 +1,6 @@
 package auth.sso.oidc;
 
+import auth.CookieConfigs;
 import client.AuthServiceClient;
 import com.datahub.authentication.Authentication;
 import com.linkedin.common.AuditStamp;
@@ -57,12 +58,6 @@ import org.pac4j.play.PlayWebContext;
 import play.mvc.Result;
 import auth.sso.SsoManager;
 
-import static auth.AuthUtils.AUTH_COOKIE_SAME_SITE;
-import static auth.AuthUtils.AUTH_COOKIE_SECURE;
-import static auth.AuthUtils.DEFAULT_AUTH_COOKIE_SAME_SITE;
-import static auth.AuthUtils.DEFAULT_AUTH_COOKIE_SECURE;
-import static auth.AuthUtils.DEFAULT_SESSION_TTL_HOURS;
-import static auth.AuthUtils.SESSION_TTL_CONFIG_PATH;
 import static auth.AuthUtils.createActorCookie;
 import static auth.AuthUtils.createSessionMap;
 import static com.linkedin.metadata.Constants.CORP_USER_ENTITY_NAME;
@@ -86,15 +81,15 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
   private final EntityClient _entityClient;
   private final Authentication _systemAuthentication;
   private final AuthServiceClient _authClient;
-  private final com.typesafe.config.Config _configs;
+  private final CookieConfigs _cookieConfigs;
 
   public OidcCallbackLogic(final SsoManager ssoManager, final Authentication systemAuthentication,
-      final EntityClient entityClient, final AuthServiceClient authClient, final com.typesafe.config.Config configs) {
+      final EntityClient entityClient, final AuthServiceClient authClient, final CookieConfigs cookieConfigs) {
     _ssoManager = ssoManager;
     _systemAuthentication = systemAuthentication;
     _entityClient = entityClient;
     _authClient = authClient;
-    _configs = configs;
+    _cookieConfigs = cookieConfigs;
   }
 
   @Override
@@ -160,20 +155,14 @@ public class OidcCallbackLogic extends DefaultCallbackLogic<Result, PlayWebConte
 
       // Successfully logged in - Generate GMS login token
       final String accessToken = _authClient.generateSessionTokenForUser(corpUserUrn.getId());
-      int ttlInHours = _configs.hasPath(SESSION_TTL_CONFIG_PATH) ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
-          : DEFAULT_SESSION_TTL_HOURS;
-      String authCookieSameSite = _configs.hasPath(AUTH_COOKIE_SAME_SITE) ? _configs.getString(AUTH_COOKIE_SAME_SITE)
-          : DEFAULT_AUTH_COOKIE_SAME_SITE;
-      boolean authCookieSecure = _configs.hasPath(AUTH_COOKIE_SECURE) ? _configs.getBoolean(AUTH_COOKIE_SECURE)
-          : DEFAULT_AUTH_COOKIE_SECURE;
       return result
               .withSession(createSessionMap(corpUserUrn.toString(), accessToken))
               .withCookies(
                   createActorCookie(
                       corpUserUrn.toString(),
-                      ttlInHours,
-                      authCookieSameSite,
-                      authCookieSecure
+                      _cookieConfigs.getTtlInHours(),
+                      _cookieConfigs.getAuthCookieSameSite(),
+                      _cookieConfigs.getAuthCookieSecure()
                   )
               );
     }

--- a/datahub-frontend/app/controllers/SsoCallbackController.java
+++ b/datahub-frontend/app/controllers/SsoCallbackController.java
@@ -1,5 +1,6 @@
 package controllers;
 
+import auth.CookieConfigs;
 import client.AuthServiceClient;
 import com.datahub.authentication.Authentication;
 import com.linkedin.entity.client.EntityClient;
@@ -45,7 +46,7 @@ public class SsoCallbackController extends CallbackController {
     _ssoManager = ssoManager;
     setDefaultUrl("/"); // By default, redirects to Home Page on log in.
     setSaveInSession(false);
-    setCallbackLogic(new SsoCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient, configs));
+    setCallbackLogic(new SsoCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient, new CookieConfigs(configs)));
   }
 
   public CompletionStage<Result> handleCallback(String protocol, Http.Request request) {
@@ -78,8 +79,8 @@ public class SsoCallbackController extends CallbackController {
     private final OidcCallbackLogic _oidcCallbackLogic;
 
     SsoCallbackLogic(final SsoManager ssoManager, final Authentication systemAuthentication,
-        final EntityClient entityClient, final AuthServiceClient authClient, final com.typesafe.config.Config configs) {
-      _oidcCallbackLogic = new OidcCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient, configs);
+        final EntityClient entityClient, final AuthServiceClient authClient, final CookieConfigs cookieConfigs) {
+      _oidcCallbackLogic = new OidcCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient, cookieConfigs);
     }
 
     @Override

--- a/datahub-frontend/app/controllers/SsoCallbackController.java
+++ b/datahub-frontend/app/controllers/SsoCallbackController.java
@@ -40,11 +40,12 @@ public class SsoCallbackController extends CallbackController {
       @Nonnull SsoManager ssoManager,
       @Nonnull Authentication systemAuthentication,
       @Nonnull EntityClient entityClient,
-      @Nonnull AuthServiceClient authClient) {
+      @Nonnull AuthServiceClient authClient,
+      @Nonnull com.typesafe.config.Config configs) {
     _ssoManager = ssoManager;
     setDefaultUrl("/"); // By default, redirects to Home Page on log in.
     setSaveInSession(false);
-    setCallbackLogic(new SsoCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient));
+    setCallbackLogic(new SsoCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient, configs));
   }
 
   public CompletionStage<Result> handleCallback(String protocol, Http.Request request) {
@@ -77,8 +78,8 @@ public class SsoCallbackController extends CallbackController {
     private final OidcCallbackLogic _oidcCallbackLogic;
 
     SsoCallbackLogic(final SsoManager ssoManager, final Authentication systemAuthentication,
-        final EntityClient entityClient, final AuthServiceClient authClient) {
-      _oidcCallbackLogic = new OidcCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient);
+        final EntityClient entityClient, final AuthServiceClient authClient, final com.typesafe.config.Config configs) {
+      _oidcCallbackLogic = new OidcCallbackLogic(ssoManager, systemAuthentication, entityClient, authClient, configs);
     }
 
     @Override


### PR DESCRIPTION
Grabs the configs for setting out Actor cookie through the SSO from the configs object instead of trying to shoe-horn them into the SSO configs object. This fixes an issue where if you try to configure SSO through the UI and have these env variables set, we still read these values properly.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
