### PR TITLE
logging(cli): dropping neo4j message to debug to avoid confusion

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -166,7 +166,7 @@ def should_use_neo4j_for_graph_service(graph_service_override: Optional[str]) ->
             )
             return True
 
-        click.echo(
+        logger.debug(
             "No Datahub Neo4j volume found, starting with elasticsearch as graph service.\n"
             "To use neo4j as a graph backend, run \n"
             "`datahub docker quickstart --graph-service-impl neo4j`"


### PR DESCRIPTION
The original log message in the cli was added when DataHub's default graph backend was neo4j and we wanted to make sure that people were in the know when we selected elastic by default for them.

1.5 yrs later: people are actually more confused about this message and wonder whether they should instead be using neo4j and why. 

Example: https://datahubspace.slack.com/archives/CV2KB471C/p1676324646452419

This PR drops that message to debug level. 


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
