### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ DataHub's project documentation is hosted at [datahubproject.io](https://datahub
 
 ### Feature Guide
 
-A Feature Guide should follow the [Feature Guide Template](/_feature-guide-template.md), and should provide the following value:
+A Feature Guide should follow the [Feature Guide Template](_feature-guide-template.md), and should provide the following value:
 
 * At a high level, what is the concept/feature within DataHub?
 * Why is the feature useful?


### PR DESCRIPTION
This fixes a broken link to the `Feature Guide Template`-section in the Documentation. GitHub web-editor also added a newline at end of file.

I just discovered this project. Thanks for this amazing tool!

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
