### PR TITLE
refactor(ingest,athena): update athena sample recipe

### DIFF
--- a/metadata-ingestion/docs/sources/athena/athena_recipe.yml
+++ b/metadata-ingestion/docs/sources/athena/athena_recipe.yml
@@ -6,7 +6,7 @@ source:
     work_group: primary
 
     # Options
-    s3_staging_dir: "s3://my_staging_athena_results_bucket/results/"
+    query_result_location: "s3://my_staging_athena_results_bucket/results/"
 
 sink:
 # sink configs


### PR DESCRIPTION
This PR updates the Athena sample recipe to replace the deprecated parameter `s3_staging_dir` by it's successor `query_result_location`

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
