### PR TITLE
fix(ingest/looker): do not instantiate LookerDashboardSource on test_connection

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -41,7 +41,6 @@ from datahub.ingestion.api.source import (
     SourceReport,
     TestableSource,
     TestConnectionReport,
-    Source,
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.looker import looker_usage
@@ -246,11 +245,6 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             pipeline_name=self.ctx.pipeline_name,
             run_id=self.ctx.run_id,
         )
-
-    @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "Source":
-        config = LookerDashboardSourceConfig.parse_obj(config_dict)
-        return cls(config, ctx)
 
     @staticmethod
     def test_connection(config_dict: dict) -> TestConnectionReport:

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -41,6 +41,7 @@ from datahub.ingestion.api.source import (
     SourceReport,
     TestableSource,
     TestConnectionReport,
+    Source,
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.looker import looker_usage
@@ -246,20 +247,20 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             run_id=self.ctx.run_id,
         )
 
+    @classmethod
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> "Source":
+        config = LookerDashboardSourceConfig.parse_obj(config_dict)
+        return cls(config, ctx)
+
     @staticmethod
     def test_connection(config_dict: dict) -> TestConnectionReport:
         test_report = TestConnectionReport()
         try:
-            self = cast(
-                LookerDashboardSource,
-                LookerDashboardSource.create(
-                    config_dict, PipelineContext("looker-test-connection")
-                ),
-            )
             test_report.basic_connectivity = CapabilityReport(capable=True)
             test_report.capability_report = {}
 
-            permissions = self.looker_api.get_available_permissions()
+            config = LookerDashboardSourceConfig.parse_obj_allow_extras(config_dict)
+            permissions = LookerAPI(config).get_available_permissions()
 
             BASIC_INGEST_REQUIRED_PERMISSIONS = {
                 # TODO: Make this a bit more granular.

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -316,13 +316,13 @@ class SnowflakeV2Source(
 
         except Exception as e:
             logger.error(f"Failed to test connection due to {e}", exc_info=e)
+            test_report.internal_failure = True
+            test_report.internal_failure_reason = f"{e}"
+
             if test_report.basic_connectivity is None:
                 test_report.basic_connectivity = CapabilityReport(
                     capable=False, failure_reason=f"{e}"
                 )
-            else:
-                test_report.internal_failure = True
-                test_report.internal_failure_reason = f"{e}"
         finally:
             return test_report
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -316,7 +316,6 @@ class SnowflakeV2Source(
 
         except Exception as e:
             logger.error(f"Failed to test connection due to {e}", exc_info=e)
-
             if test_report.basic_connectivity is None:
                 test_report.basic_connectivity = CapabilityReport(
                     capable=False, failure_reason=f"{e}"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -316,13 +316,14 @@ class SnowflakeV2Source(
 
         except Exception as e:
             logger.error(f"Failed to test connection due to {e}", exc_info=e)
-            test_report.internal_failure = True
-            test_report.internal_failure_reason = f"{e}"
 
             if test_report.basic_connectivity is None:
                 test_report.basic_connectivity = CapabilityReport(
                     capable=False, failure_reason=f"{e}"
                 )
+            else:
+                test_report.internal_failure = True
+                test_report.internal_failure_reason = f"{e}"
         finally:
             return test_report
 


### PR DESCRIPTION
Haven't been able to test end-to-end, but was able to run `datahub ingest -c looker.dhub.yaml --test-source-connection` on a basic looker recipe

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
