### PR TITLE
feat(metadata-io): add support in Neo4jGraphService for lineage time filter

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
@@ -98,8 +98,8 @@ public class Neo4jGraphService implements GraphService {
     String startUrn = sourceUrn;
 
     // Get startUrn, endUrn by check INCOMING/OUTGOING direction and RelationshipType
-    try {
-      LineageRegistry.LineageSpec sourceLineageSpec = getLineageRegistry().getLineageSpec(sourceType);
+    LineageRegistry.LineageSpec sourceLineageSpec = getLineageRegistry().getLineageSpec(sourceType);
+    if (sourceLineageSpec != null) {
       List<LineageRegistry.EdgeInfo> upstreamCheck = sourceLineageSpec.getUpstreamEdges()
           .stream()
           .filter(
@@ -109,9 +109,6 @@ public class Neo4jGraphService implements GraphService {
         endUrn = sourceUrn;
         startUrn = destinationUrn;
       }
-    } catch (NullPointerException ignored) {
-      log.warn(
-          String.format("Can't get UpstreamEdges for relationType = %s, Error = %s", sourceType, ignored.getMessage()));
     }
 
     final List<Statement> statements = new ArrayList<>();
@@ -153,7 +150,7 @@ public class Neo4jGraphService implements GraphService {
       for (Map.Entry<String, Object> entry : edge.getProperties().entrySet()) {
         // Make sure extra keys in properties are not preserved
         final Set<String> preservedKeySet =
-            Set.of("createdOn", "createdActor", "updatedOn", "updatedActor", "source", "startUrn", "endUrn");
+            Set.of("createdOn", "createdActor", "updatedOn", "updatedActor", "startUrn", "endUrn");
         if (preservedKeySet.contains(entry.getKey())) {
           throw new UnsupportedOperationException(
               String.format("Tried setting properties on graph edge but property key is preserved. Key: %s",

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphService.java
@@ -101,7 +101,7 @@ public class Neo4jGraphService implements GraphService {
     // Extra relationship typename start with r_ for direct-outgoing-downstream/indirect-incoming-upstream relationships
     String reverseRelationshipType = "r_" + edge.getRelationshipType();
 
-    if (reverseSourceDest(sourceType, edge.getRelationshipType())) {
+    if (isSourceDestReversed(sourceType, edge.getRelationshipType())) {
       endUrn = sourceUrn;
       endType = sourceType;
       startUrn = destinationUrn;
@@ -198,7 +198,7 @@ public class Neo4jGraphService implements GraphService {
     String startType = sourceType;
     String reverseRelationshipType = "r_" + edge.getRelationshipType();
 
-    if (reverseSourceDest(sourceType, edge.getRelationshipType())) {
+    if (isSourceDestReversed(sourceType, edge.getRelationshipType())) {
       endUrn = sourceUrn;
       endType = sourceType;
       startUrn = destinationUrn;
@@ -692,7 +692,7 @@ public class Neo4jGraphService implements GraphService {
    * @param relationshipType Entity relationship type
    *
    */
-  private boolean reverseSourceDest(@Nonnull String sourceType, @Nonnull String relationshipType) {
+  private boolean isSourceDestReversed(@Nonnull String sourceType, @Nonnull String relationshipType) {
     // Get real direction by check INCOMING/OUTGOING direction and RelationshipType
     LineageRegistry.LineageSpec sourceLineageSpec = getLineageRegistry().getLineageSpec(sourceType);
     if (sourceLineageSpec != null) {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -166,7 +166,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
         event.hasSystemMetadata() ? event.getSystemMetadata().getRunId() : null);
 
     // Step 2. For all aspects, attempt to update Graph
-    if (_diffMode && (_graphService instanceof ElasticSearchGraphService || _graphService instanceof Neo4jGraphService)) {
+    if (_diffMode) {
       updateGraphServiceDiff(urn, aspectSpec, previousAspect, aspect, event);
     } else {
       updateGraphService(urn, aspectSpec, aspect, event);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.graph.Edge;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
+import com.linkedin.metadata.graph.neo4j.Neo4jGraphService;
 import com.linkedin.metadata.key.SchemaFieldKey;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
@@ -165,7 +166,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
         event.hasSystemMetadata() ? event.getSystemMetadata().getRunId() : null);
 
     // Step 2. For all aspects, attempt to update Graph
-    if (_diffMode && _graphService instanceof ElasticSearchGraphService) {
+    if (_diffMode && (_graphService instanceof ElasticSearchGraphService || _graphService instanceof Neo4jGraphService)) {
       updateGraphServiceDiff(urn, aspectSpec, previousAspect, aspect, event);
     } else {
       updateGraphService(urn, aspectSpec, aspect, event);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -21,8 +21,6 @@ import com.linkedin.gms.factory.timeseries.TimeseriesAspectServiceFactory;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.graph.Edge;
 import com.linkedin.metadata.graph.GraphService;
-import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
-import com.linkedin.metadata.graph.neo4j.Neo4jGraphService;
 import com.linkedin.metadata.key.SchemaFieldKey;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;


### PR DESCRIPTION
support lineage time filter for neo4j backend graphservice.
1. modify addEdge to support createdOn, createdActor, updatedOn, updatedActor, startUrn, endUrn, properties (store lineage source from ui)
1.1 startUrn is real source node and endUrn is real destination node
1.2 add r_ relationships for real upstream downstream lineage
```mermaid
graph LR
B(table_B) --> |DownstreamOf| A(table_A)
A(table_A) --> |startUrn: table_A -r_DownstreamOf- endUrn: table_B| B(table_B)

```
2. implement upsertEdge, removeEdge
3. modify getLineage to support:
3.1 start, end time filtering on (createdOn or updatedOn)
3.2 createdOn not exists and updatedOn not exists
3.3 lineage created from ui
3.4 pattern matching for case by using r_ relationships:
```mermaid
graph LR
C(job1) --> |Consumes| A(table_A)
A(table_A)--> |startUrn: table_A -r_Consumes- endUrn: job1| C(job1) 
C(job1) --> |Produces| B(table_B)
C(job1) --> |startUrn: job1 -r_Produces- endUrn: table_B| B(table_B)
```
and lineage should be:
```mermaid
graph LR
A(table_A) --> C(job1)
C(job1) --> B(table_B)
```

```cypher
// for upstream
MATCH p = shortestPath((a {urn: 'urn:li:dataset:(urn:li:dataPlatform:bigquery,table_B,PROD)'})<-[r*1..1000]-(b))
WHERE (b:dataProcess OR b:dataJob OR b:mlFeature OR b:chart OR b:dataset OR b:mlPrimaryKey OR b:dashboard) 
AND b.urn <> 'urn:li:dataset:(urn:li:dataPlatform:bigquery,table_B,PROD)' 
AND ALL(rt IN relationships(p) WHERE left(type(rt), 2)='r_') // make sure use r_ relationships to filter upstream/downstream lineage
RETURN a, r, b
// for downstream
MATCH p = shortestPath((a {urn: 'urn:li:dataset:(urn:li:dataPlatform:bigquery,table_B,PROD)'})-[r*1..1000]->(b))
WHERE (b:dataProcess OR b:dataJob OR b:mlFeature OR b:chart OR b:dataset OR b:mlPrimaryKey OR b:dashboard) 
AND b.urn <> 'urn:li:dataset:(urn:li:dataPlatform:bigquery,table_B,PROD)' 
AND ALL(rt IN relationships(p) WHERE left(type(rt), 2)='r_') // make sure use r_ relationships to filter upstream/downstream lineage
RETURN a, r, b
```
4. add setPaths for schemafield lineage (UrnArrayArray), reverse path for upstream lineage
5. implement ut for removeEdge

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
