### PR TITLE
fix(ingest/ldap): set user urn to  firstname.lastname

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -150,6 +150,9 @@ def guess_person_ldap(
 ) -> Optional[str]:
     """Determine the user's LDAP based on the DN and attributes."""
     if config.user_attrs_map["urn"] in attrs:
+        if config.user_attrs_map["urn"] == "mail":
+            response = attrs[config.user_attrs_map["urn"]][0].decode().split('@')[0]
+            return response
         return attrs[config.user_attrs_map["urn"]][0].decode()
     else:  # for backward compatiblity
         if "sAMAccountName" in attrs:


### PR DESCRIPTION
If we specify user_attrs_map["urn"]: "[mail](https://datahubproject.io/docs/generated/ingestion/sources/ldap#config-details)" in ldap source ingestion yaml  then the user created is "firstname.lastname@domain".
In the frontend settings if we specify "AUTH_OIDC_USER_NAME_CLAIM_REGEX=([^@]+)" then the user created is "firstname.lastname"

This fix will prevent duplication of users created by frontend and ldap ingestion.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
