### PR TITLE
feat(frontend): add additional tabs to glossary terms view

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
@@ -48,7 +48,7 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
         glossaryRelatedTermType === RelatedTermTypes.containedBy
             ? TermRelationshipType.HasA
             : TermRelationshipType.IsA;
-    const relatedTermsMutable =
+    const canEditRelatedTerms =
         glossaryRelatedTermType === RelatedTermTypes.isRelatedTerms ||
         glossaryRelatedTermType === RelatedTermTypes.hasRelatedTerms;
 
@@ -62,7 +62,7 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
                         <Typography.Title style={{ margin: '0' }} level={3}>
                             {glossaryRelatedTermType}
                         </Typography.Title>
-                        {relatedTermsMutable && (
+                        {canEditRelatedTerms && (
                             <Button type="text" onClick={() => setIsShowingAddModal(true)}>
                                 <PlusOutlined /> Add Terms
                             </Button>
@@ -73,7 +73,7 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
                             key={urn}
                             urn={urn}
                             relationshipType={relationshipType}
-                            mutable={relatedTermsMutable}
+                            isEditable={canEditRelatedTerms}
                         />
                     ))}
                     {glossaryRelatedTermUrns.length === 0 && (

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedTermsResult.tsx
@@ -12,6 +12,8 @@ import RelatedTerm from './RelatedTerm';
 export enum RelatedTermTypes {
     hasRelatedTerms = 'Contains',
     isRelatedTerms = 'Inherits',
+    containedBy = 'Contained by',
+    isAChildren = 'Inherited by',
 }
 
 export type Props = {
@@ -42,9 +44,13 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
     });
     const contentLoading = false;
     const relationshipType =
-        glossaryRelatedTermType === RelatedTermTypes.hasRelatedTerms
+        glossaryRelatedTermType === RelatedTermTypes.hasRelatedTerms ||
+        glossaryRelatedTermType === RelatedTermTypes.containedBy
             ? TermRelationshipType.HasA
             : TermRelationshipType.IsA;
+    const relatedTermsMutable =
+        glossaryRelatedTermType === RelatedTermTypes.isRelatedTerms ||
+        glossaryRelatedTermType === RelatedTermTypes.hasRelatedTerms;
 
     return (
         <>
@@ -56,12 +62,19 @@ export default function GlossaryRelatedTermsResult({ glossaryRelatedTermType, gl
                         <Typography.Title style={{ margin: '0' }} level={3}>
                             {glossaryRelatedTermType}
                         </Typography.Title>
-                        <Button type="text" onClick={() => setIsShowingAddModal(true)}>
-                            <PlusOutlined /> Add Terms
-                        </Button>
+                        {relatedTermsMutable && (
+                            <Button type="text" onClick={() => setIsShowingAddModal(true)}>
+                                <PlusOutlined /> Add Terms
+                            </Button>
+                        )}
                     </TitleContainer>
                     {glossaryRelatedTermUrns.map((urn) => (
-                        <RelatedTerm key={urn} urn={urn} relationshipType={relationshipType} />
+                        <RelatedTerm
+                            key={urn}
+                            urn={urn}
+                            relationshipType={relationshipType}
+                            mutable={relatedTermsMutable}
+                        />
                     ))}
                     {glossaryRelatedTermUrns.length === 0 && (
                         <EmptyTab tab={glossaryRelatedTermType.toLocaleLowerCase()} />

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/RelatedTerm.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/RelatedTerm.tsx
@@ -35,11 +35,11 @@ const MenuItem = styled.div`
 interface Props {
     urn: string;
     relationshipType: TermRelationshipType;
-    mutable: boolean;
+    isEditable: boolean;
 }
 
 function RelatedTerm(props: Props) {
-    const { urn, relationshipType, mutable } = props;
+    const { urn, relationshipType, isEditable } = props;
 
     const entityRegistry = useEntityRegistry();
     const { data, loading } = useGetGlossaryTermQuery({ variables: { urn } });
@@ -55,7 +55,7 @@ function RelatedTerm(props: Props) {
         <ListItem>
             <Profile>
                 {entityRegistry.renderPreview(EntityType.GlossaryTerm, PreviewType.PREVIEW, data?.glossaryTerm)}
-                {mutable && (
+                {isEditable && (
                     <Dropdown
                         overlay={
                             <Menu>

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/RelatedTerm.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/RelatedTerm.tsx
@@ -35,10 +35,11 @@ const MenuItem = styled.div`
 interface Props {
     urn: string;
     relationshipType: TermRelationshipType;
+    mutable: boolean;
 }
 
 function RelatedTerm(props: Props) {
-    const { urn, relationshipType } = props;
+    const { urn, relationshipType, mutable } = props;
 
     const entityRegistry = useEntityRegistry();
     const { data, loading } = useGetGlossaryTermQuery({ variables: { urn } });
@@ -54,20 +55,22 @@ function RelatedTerm(props: Props) {
         <ListItem>
             <Profile>
                 {entityRegistry.renderPreview(EntityType.GlossaryTerm, PreviewType.PREVIEW, data?.glossaryTerm)}
-                <Dropdown
-                    overlay={
-                        <Menu>
-                            <Menu.Item key="0">
-                                <MenuItem onClick={onRemove}>
-                                    <DeleteOutlined /> &nbsp; Remove Term
-                                </MenuItem>
-                            </Menu.Item>
-                        </Menu>
-                    }
-                    trigger={['click']}
-                >
-                    <MenuIcon />
-                </Dropdown>
+                {mutable && (
+                    <Dropdown
+                        overlay={
+                            <Menu>
+                                <Menu.Item key="0">
+                                    <MenuItem onClick={onRemove}>
+                                        <DeleteOutlined /> &nbsp; Remove Term
+                                    </MenuItem>
+                                </Menu.Item>
+                            </Menu>
+                        }
+                        trigger={['click']}
+                    >
+                        <MenuIcon />
+                    </Dropdown>
+                )}
             </Profile>
             <Divider style={{ margin: '20px 0' }} />
         </ListItem>

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -57,6 +57,14 @@ export const EMPTY_MESSAGES = {
         title: 'Does not inherit from any terms',
         description: 'Terms can inherit from other terms to represent an "Is A" style relationship.',
     },
+    'contained by': {
+        title: 'Does not contained by any terms',
+        description: 'Terms can be contained by other terms to represent an "Has A" style relationship.',
+    },
+    'inherited by': {
+        title: 'Does not inherited by any terms',
+        description: 'Terms can be inherited by other terms to represent an "Is A" style relationship.',
+    },
 };
 
 export const ELASTIC_MAX_COUNT = 10000;

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -51,18 +51,18 @@ export const EMPTY_MESSAGES = {
     },
     contains: {
         title: 'Contains no Terms',
-        description: 'Terms can contain other terms to represent an "Has A" style relationship.',
+        description: 'Terms can contain other terms to represent a "Has A" style relationship.',
     },
     inherits: {
         title: 'Does not inherit from any terms',
         description: 'Terms can inherit from other terms to represent an "Is A" style relationship.',
     },
     'contained by': {
-        title: 'Does not contained by any terms',
-        description: 'Terms can be contained by other terms to represent an "Has A" style relationship.',
+        title: 'Is not contained by any terms',
+        description: 'Terms can be contained by other terms to represent a "Has A" style relationship.',
     },
     'inherited by': {
-        title: 'Does not inherited by any terms',
+        title: 'Is not inherited by an terms',
         description: 'Terms can be inherited by other terms to represent an "Is A" style relationship.',
     },
 };

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -62,7 +62,7 @@ export const EMPTY_MESSAGES = {
         description: 'Terms can be contained by other terms to represent a "Has A" style relationship.',
     },
     'inherited by': {
-        title: 'Is not inherited by an terms',
+        title: 'Is not inherited by any terms',
         description: 'Terms can be inherited by other terms to represent an "Is A" style relationship.',
     },
 };

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -42,6 +42,18 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
                 }
             }
         }
+        containedBy: relationships(input: { types: ["HasA"], direction: INCOMING, start: $start, count: $count }) {
+            start
+            count
+            total
+            relationships {
+                entity {
+                    ... on GlossaryTerm {
+                        urn
+                    }
+                }
+            }
+        }
         parentNodes {
             ...parentNodesFields
         }


### PR DESCRIPTION
Add "Contained by" and "Inherited by" tabs to glossary related terms view as requested in feature request https://feature-requests.datahubproject.io/p/list-inbound-relationships-to-glossary-terms

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
