### PR TITLE
build(idea): mark metadata-ingestion sources and tests

### DIFF
--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'base'
+  id 'base'
 }
 
 ext {
@@ -167,3 +167,10 @@ clean {
   delete '.pytest_cache'
 }
 clean.dependsOn cleanPythonCache
+
+idea {
+  module {
+    sourceDirs += file('src')
+    testSourceDirs += file('tests')
+  }
+}


### PR DESCRIPTION
Automatically marks the metadata-ingestion `src` and `tests` directories as such in IntelliJ project structure. I find myself having to do this multiple times, so hopefully this makes it happen automatically

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
