### PR TITLE
fix(ingest): Do not require platform_instance for stateful ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1252,5 +1252,5 @@ class GlueSource(StatefulIngestionSourceBase):
     def get_report(self):
         return self.report
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.source_config.platform_instance or self.platform

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -413,7 +413,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         else:
             return None
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         """
         The source identifier such as the specific source host address required for stateful ingestion.
         Individual subclasses need to override this method appropriately.

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_cloud.py
@@ -416,7 +416,7 @@ class DBTCloudSource(DBTSourceBase):
         # TODO: Once dbt Cloud supports deep linking to specific files, we can use that.
         return f"https://cloud.getdbt.com/next/accounts/{self.config.account_id}/projects/{self.config.project_id}/develop"
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         """The DBT project identifier is used as platform instance."""
 
         return f"{self.platform}_{self.config.project_id}"

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_core.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_core.py
@@ -483,7 +483,7 @@ class DBTCoreSource(DBTSourceBase):
             return self.config.git_info.get_url_for_file_path(node.dbt_file_path)
         return None
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         """The DBT project identifier is used as platform instance."""
 
         project_id = (

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -318,8 +318,7 @@ class IcebergSource(StatefulIngestionSourceBase):
             ],
         }
 
-    def get_platform_instance_id(self) -> str:
-        assert self.config.platform_instance is not None
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.config.platform_instance
 
     def get_report(self) -> SourceReport:

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
@@ -81,19 +81,6 @@ class IcebergSourceConfig(StatefulIngestionConfigBase):
     )
     profiling: IcebergProfilingConfig = IcebergProfilingConfig()
 
-    @pydantic.root_validator
-    def validate_platform_instance(cls: "IcebergSourceConfig", values: Dict) -> Dict:
-        stateful_ingestion = values.get("stateful_ingestion")
-        if (
-            stateful_ingestion
-            and stateful_ingestion.enabled
-            and not values.get("platform_instance")
-        ):
-            raise ConfigurationError(
-                "Enabling Iceberg stateful ingestion requires to specify a platform instance."
-            )
-        return values
-
     @root_validator()
     def _ensure_one_filesystem_is_configured(
         cls: "IcebergSourceConfig", values: Dict

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -15,7 +15,7 @@ from confluent_kafka.admin import (
     TopicMetadata,
 )
 
-from datahub.configuration.common import AllowDenyPattern, ConfigurationError
+from datahub.configuration.common import AllowDenyPattern
 from datahub.configuration.kafka import KafkaConsumerConnectionConfig
 from datahub.configuration.source_common import DatasetSourceConfigBase
 from datahub.emitter.mce_builder import (

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -97,19 +97,6 @@ class KafkaSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigBase):
         description="Disables warnings reported for non-AVRO/Protobuf value or key schemas if set.",
     )
 
-    @pydantic.root_validator
-    def validate_platform_instance(cls: "KafkaSourceConfig", values: Dict) -> Dict:
-        stateful_ingestion = values.get("stateful_ingestion")
-        if (
-            stateful_ingestion
-            and stateful_ingestion.enabled
-            and not values.get("platform_instance")
-        ):
-            raise ConfigurationError(
-                "Enabling kafka stateful ingestion requires to specify a platform instance."
-            )
-        return values
-
 
 @dataclass
 class KafkaSourceReport(StaleEntityRemovalSourceReport):
@@ -199,8 +186,7 @@ class KafkaSource(StatefulIngestionSourceBase):
                 f"Failed to create Kafka Admin Client due to error {e}.",
             )
 
-    def get_platform_instance_id(self) -> str:
-        assert self.source_config.platform_instance is not None
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.source_config.platform_instance
 
     @classmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -287,7 +287,7 @@ class LDAPSource(StatefulIngestionSourceBase):
 
             cookie = set_cookie(self.lc, pctrls)
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         """
         The source identifier such as the specific source host address required for stateful ingestion.
         Individual subclasses need to override this method appropriately.

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1353,7 +1353,7 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
     def get_report(self) -> SourceReport:
         return self.reporter
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.source_config.platform_instance or self.platform
 
     def close(self):

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
@@ -1746,7 +1746,7 @@ class LookMLSource(StatefulIngestionSourceBase):
     def get_report(self):
         return self.reporter
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.source_config.platform_instance or self.platform
 
     def close(self):

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -909,7 +909,7 @@ class PowerBiDashboardSource(StatefulIngestionSourceBase):
             run_id=ctx.run_id,
         )
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.source_config.platform_name
 
     @classmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/pulsar.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/pulsar.py
@@ -223,8 +223,7 @@ class PulsarSource(StatefulIngestionSourceBase):
                 f"An ambiguous exception occurred while handling the request: {e}"
             )
 
-    def get_platform_instance_id(self) -> str:
-        assert self.config.platform_instance is not None
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.config.platform_instance
 
     @classmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -1399,7 +1399,7 @@ class SnowflakeV2Source(
             self.report.edition = None
 
     # Stateful Ingestion Overrides.
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.config.get_account()
 
     # Ideally we do not want null values in sample data for a column.

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -394,7 +394,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
     def get_schema_names(self, inspector):
         return inspector.get_schema_names()
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         """
         The source identifier such as the specific source host address required for stateful ingestion.
         Individual subclasses need to override this method appropriately.

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -281,7 +281,7 @@ class StatefulIngestionSourceBase(Source):
             raise ValueError(f"No use-case handler for job_id{job_id}")
         return self._usecase_handlers[job_id].is_checkpointing_enabled()
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         # This method is retained for backwards compatibility, but it is not
         # required that new sources implement it. We mainly need it for the
         # fallback logic in _get_last_checkpoint.

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -1805,5 +1805,5 @@ class TableauSource(StatefulIngestionSourceBase):
     def get_report(self) -> StaleEntityRemovalSourceReport:
         return self.report
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.config.platform_instance or self.platform

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -156,7 +156,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         config = UnityCatalogSourceConfig.parse_obj(config_dict)
         return cls(ctx=ctx, config=config)
 
-    def get_platform_instance_id(self) -> str:
+    def get_platform_instance_id(self) -> Optional[str]:
         return self.config.platform_instance or self.platform
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:

--- a/metadata-ingestion/src/datahub/ingestion/source_config/pulsar.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/pulsar.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict, List, Optional, Union
 from urllib.parse import urlparse
 
-from pydantic import Field, root_validator, validator
+from pydantic import Field, validator
 
 from datahub.configuration.common import AllowDenyPattern, ConfigurationError
 from datahub.configuration.source_common import DEFAULT_ENV, DatasetSourceConfigBase

--- a/metadata-ingestion/src/datahub/ingestion/source_config/pulsar.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/pulsar.py
@@ -132,16 +132,3 @@ class PulsarSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigBase):
             )
 
         return config_clean.remove_trailing_slashes(val)
-
-    @root_validator
-    def validate_platform_instance(cls: "PulsarSourceConfig", values: Dict) -> Dict:
-        stateful_ingestion = values.get("stateful_ingestion")
-        if (
-            stateful_ingestion
-            and stateful_ingestion.enabled
-            and not values.get("platform_instance")
-        ):
-            raise ConfigurationError(
-                "Enabling Pulsar stateful ingestion requires to specify a platform instance."
-            )
-        return values

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -8,7 +8,6 @@ from confluent_kafka.schema_registry.schema_registry_client import (
     Schema,
 )
 
-from datahub.configuration.common import ConfigurationError
 from datahub.emitter.mce_builder import (
     make_dataplatform_instance_urn,
     make_dataset_urn_with_platform_instance,

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -165,34 +165,6 @@ def test_close(mock_kafka, mock_admin_client):
     assert mock_kafka_instance.close.call_count == 1
 
 
-def test_kafka_source_stateful_ingestion_requires_platform_instance():
-    class StatefulProviderMock:
-        def __init__(self, config, ctx):
-            self.ctx = ctx
-            self.config = config
-
-        def is_stateful_ingestion_configured(self):
-            return self.config.stateful_ingestion.enabled
-
-    ctx = PipelineContext(run_id="test", pipeline_name="test")
-    with pytest.raises(ConfigurationError) as e:
-        KafkaSource.create(
-            {
-                "stateful_ingestion": {
-                    "enabled": "true",
-                    "fail_safe_threshold": 100.0,
-                },
-                "connection": {"bootstrap": "localhost:9092"},
-            },
-            ctx,
-        )
-
-    assert (
-        "Enabling kafka stateful ingestion requires to specify a platform instance"
-        in str(e)
-    )
-
-
 @patch(
     "datahub.ingestion.source.kafka.confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient",
     autospec=True,


### PR DESCRIPTION
Following the changes from https://github.com/datahub-project/datahub/pull/6795, I believe that `get_platform_instance_id` can now return `None`. See its only usage:

In `StatefulIngestionSourceBase._get_last_checkpoint`
```
                try:
                    platform_instance_id = self.get_platform_instance_id()
                except NotImplementedError:
                    pass
                else:
                    last_checkpoint_aspect = self.ingestion_checkpointing_state_provider.get_latest_checkpoint(  # type: ignore
                        pipeline_name=self.ctx.pipeline_name,
                        job_name=job_id,
                        platform_instance_id=platform_instance_id,
                    )
```
Note that in that PR, `get_latest_checkpoint` was configured to accept an optional `platform_instance_id` (and also note that in the not implemented case, `None` is implicitly passed?)

Since we still want to keep implementations of `get_platform_instance_id` for backwards compatibility, I allow it to return `None` for when you sometimes have a platform_instance, and other times don't, like with Kafka.
Also removes any validation around null `platform_instance` that I could find.

EDIT: Tested the following recipe
```
source:
  type: kafka
  config:
    connection: 
      bootstrap: localhost:9092
      schema_registry_url: http://localhost:8081/
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
