### PR TITLE
fix(ingest/bigquery): Correctly upsert lineage_map when parsing view ddl

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -711,21 +711,13 @@ timestamp < "{end_time}"
         lineage_metadata: Dict[str, Set[str]],
     ) -> Optional[Tuple[UpstreamLineageClass, Dict[str, str]]]:
         table_identifier = BigqueryTableIdentifier(project_id, dataset_name, table.name)
-
+        key = str(BigQueryTableRef(table_identifier).get_sanitized_table_ref())
         if self.config.lineage_parse_view_ddl and isinstance(table, BigqueryView):
+            lineage_metadata.setdefault(key, set())
             for table_id in self.parse_view_lineage(project_id, dataset_name, table):
-                if table_identifier.get_table_name() in lineage_metadata:
-                    lineage_metadata[
-                        str(
-                            BigQueryTableRef(table_identifier).get_sanitized_table_ref()
-                        )
-                    ].add(str(BigQueryTableRef(table_id).get_sanitized_table_ref()))
-                else:
-                    lineage_metadata[
-                        str(
-                            BigQueryTableRef(table_identifier).get_sanitized_table_ref()
-                        )
-                    ] = {str(BigQueryTableRef(table_id).get_sanitized_table_ref())}
+                lineage_metadata[key] = {
+                    str(BigQueryTableRef(table_id).get_sanitized_table_ref())
+                }
 
         bq_table = BigQueryTableRef.from_bigquery_table(table_identifier)
         if str(bq_table) in lineage_metadata:


### PR DESCRIPTION
`BigqueryTableIdentifier.get_table_name()` and `str(BigQueryTableRef(table_identifier).get_sanitized_table_ref())` are not equivalent:

```
>>> z = BigqueryTableIdentifier("project","dataset","table-name")
>>> z.get_table_name()
'project.dataset.table-name'
>>> str(BigQueryTableRef(z).get_sanitized_table_ref())
'projects/project/datasets/dataset/tables/table-name'
```

This means the if statement never returned `True`, and we would always set the lineage from view ddl to just the last processed upstream table.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
