### PR TITLE
fix(ingest/bigquery): Prefer parsed lineage for view over lineage from audit logs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -620,6 +620,7 @@ timestamp < "{end_time}"
             config=self.config, report=self.report
         )
         lineage_metadata: Dict[str, Set[str]]
+
         try:
             if self.config.extract_lineage_from_catalog and self.config.include_tables:
                 lineage_metadata = (
@@ -713,8 +714,14 @@ timestamp < "{end_time}"
         table_identifier = BigqueryTableIdentifier(project_id, dataset_name, table.name)
         key = str(BigQueryTableRef(table_identifier).get_sanitized_table_ref())
         if self.config.lineage_parse_view_ddl and isinstance(table, BigqueryView):
-            lineage_metadata.setdefault(key, set())
-            for table_id in self.parse_view_lineage(project_id, dataset_name, table):
+            parsed_view_upstreams = self.parse_view_lineage(
+                project_id, dataset_name, table
+            )
+            if parsed_view_upstreams:
+                # Override upstreams obtained by parsing audit logs
+                # as they may contain indirectly referenced tables
+                lineage_metadata[key] = set()
+            for table_id in parsed_view_upstreams:
                 lineage_metadata[key].add(
                     str(BigQueryTableRef(table_id).get_sanitized_table_ref())
                 )


### PR DESCRIPTION
For scenarios such as 

Table->View1->View2

1. Lineage generated for View2 by parsing audit logs : Table, View1 -> View2
2. Lineage generated for View2 by parsing View DDL : View -> View2
Second is more accurate over first one. Hence in this PR we use SQL parsing lineage over lineage from audit logs, if SQL parsing lineage is available.

Another approach to fix this would be to fix point 1 above to not include tables that are not directly accessed in View DDL. However currently that happens only if config `lineage_use_sql_parser` is enabled

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
