### PR TITLE
fix(ingest/bigquery): Fixing double quoting in profiling approx count query

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -124,7 +124,7 @@ def get_column_unique_count_patch(self: SqlAlchemyDataset, column: str) -> int:
             sa.select(
                 [
                     sa.text(  # type:ignore
-                        f"APPROX_COUNT_DISTINCT(`{sa.column(column)}`)"
+                        f"APPROX_COUNT_DISTINCT(`{column}`)"
                     )
                 ]
             ).select_from(self._table)


### PR DESCRIPTION
SqlAlchemy quotes with '"' but we prefer ` quoting on BigQuery and currently there are columns where we double quoting.

See example from logs how it looks now:
```
[2023-02-23 08:32:38,107] DEBUG    {datahub.utilities.sqlalchemy_query_combiner:270} - Executing query normally: SELECT APPROX_COUNT_DISTINCT(`"My_Column"`) 
```
And this is how it should after the fix:
```
[2023-02-23 08:32:38,107] DEBUG    {datahub.utilities.sqlalchemy_query_combiner:270} - Executing query normally: SELECT APPROX_COUNT_DISTINCT(`My_Column`) 
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
