### PR TITLE
docs(website): fix homepage logo sizing

### DIFF
--- a/docs-website/src/pages/_components/Logos/logos.module.scss
+++ b/docs-website/src/pages/_components/Logos/logos.module.scss
@@ -83,19 +83,19 @@
   width: auto;
   mix-blend-mode: luminosity;
   opacity: 0.66;
-  height: 60px;
   margin: 2.5rem;
-}
-
-.default {
   height: 60px;
-}
-.large {
-  height: 100px;
-}
-.medium {
-  height: 30px;
-}
-.small {
-  height: 20px;
+
+  &.default {
+    height: 60px;
+  }
+  &.large {
+    height: 100px;
+  }
+  &.medium {
+    height: 30px;
+  }
+  &.small {
+    height: 20px;
+  }
 }


### PR DESCRIPTION
CSS order/specificity was different on the production build causing the logo size class heights to be overridden by the default height.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
