### PR TITLE
fix(ingest/s3): propagate s3 endpoint to profiling

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -307,10 +307,14 @@ class S3Source(Source):
                     "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider",
                 )
 
-            if self.source_config.aws_config.aws_endpoint_url is not None:  
-                conf.set("fs.s3a.endpoint" , self.source_config.aws_config.aws_endpoint_url)
-            if self.source_config.aws_config.aws_region is not None:  
-                conf.set("fs.s3a.endpoint.region" , self.source_config.aws_config.aws_region)   
+            if self.source_config.aws_config.aws_endpoint_url is not None:
+                conf.set(
+                    "fs.s3a.endpoint", self.source_config.aws_config.aws_endpoint_url
+                )
+            if self.source_config.aws_config.aws_region is not None:
+                conf.set(
+                    "fs.s3a.endpoint.region", self.source_config.aws_config.aws_region
+                )
 
         conf.set("spark.jars.excludes", pydeequ.f2j_maven_coord)
         conf.set("spark.driver.memory", self.source_config.spark_driver_memory)

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -307,6 +307,11 @@ class S3Source(Source):
                     "org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider",
                 )
 
+            if self.source_config.aws_config.aws_endpoint_url is not None:  
+                conf.set("fs.s3a.endpoint" , self.source_config.aws_config.aws_endpoint_url)
+            if self.source_config.aws_config.aws_region is not None:  
+                conf.set("fs.s3a.endpoint.region" , self.source_config.aws_config.aws_region)   
+
         conf.set("spark.jars.excludes", pydeequ.f2j_maven_coord)
         conf.set("spark.driver.memory", self.source_config.spark_driver_memory)
 


### PR DESCRIPTION
## Description

If you provide a custom endpoint in the s3 datalake source configuration, it is used to scan the bucket and identifying the datasets, but the endpoint and the region are not propagated to the spark job responsible for profiling the data. So in our case, we had a custom minio setup and noticed that the profiling job still used the aws s3 endpoint (resulting in not authorized errors)

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
