### PR TITLE
fix(ui) Fix UI flickering when switching between glossary entities

### DIFF
--- a/datahub-web-react/src/app/SearchRoutes.tsx
+++ b/datahub-web-react/src/app/SearchRoutes.tsx
@@ -10,7 +10,7 @@ import { SearchPage } from './search/SearchPage';
 import { AnalyticsPage } from './analyticsDashboard/components/AnalyticsPage';
 import { ManageDomainsPage } from './domain/ManageDomainsPage';
 import { ManageIngestionPage } from './ingest/ManageIngestionPage';
-import BusinessGlossaryPage from './glossary/BusinessGlossaryPage';
+import GlossaryRoutes from './glossary/GlossaryRoutes';
 import { SettingsPage } from './settings/SettingsPage';
 
 /**
@@ -21,7 +21,7 @@ export const SearchRoutes = (): JSX.Element => {
     return (
         <SearchablePage>
             <Switch>
-                {entityRegistry.getEntities().map((entity) => (
+                {entityRegistry.getNonGlossaryEntities().map((entity) => (
                     <Route
                         key={entity.getPathName()}
                         path={`/${entity.getPathName()}/:urn`}
@@ -41,7 +41,7 @@ export const SearchRoutes = (): JSX.Element => {
                 <Route path={PageRoutes.DOMAINS} render={() => <ManageDomainsPage />} />
                 <Route path={PageRoutes.INGESTION} render={() => <ManageIngestionPage />} />
                 <Route path={PageRoutes.SETTINGS} render={() => <SettingsPage />} />
-                <Route path={PageRoutes.GLOSSARY} render={() => <BusinessGlossaryPage />} />
+                <GlossaryRoutes />
                 <Route component={NoPageFound} />
             </Switch>
         </SearchablePage>

--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -1,6 +1,7 @@
 import { Entity as EntityInterface, EntityType, SearchResult } from '../../types.generated';
 import { FetchedEntity } from '../lineage/types';
 import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from './Entity';
+import { GLOSSARY_ENTITY_TYPES } from './shared/constants';
 import { GenericEntityProperties } from './shared/types';
 import { dictToQueryStringParams, urlEncodeUrn } from './shared/utils';
 
@@ -36,6 +37,14 @@ export default class EntityRegistry {
 
     getEntities(): Array<Entity<any>> {
         return this.entities;
+    }
+
+    getNonGlossaryEntities(): Array<Entity<any>> {
+        return this.entities.filter((entity) => !GLOSSARY_ENTITY_TYPES.includes(entity.type));
+    }
+
+    getGlossaryEntities(): Array<Entity<any>> {
+        return this.entities.filter((entity) => GLOSSARY_ENTITY_TYPES.includes(entity.type));
     }
 
     getSearchEntityTypes(): Array<EntityType> {

--- a/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryNode/GlossaryNodeEntity.tsx
@@ -2,7 +2,6 @@ import { FolderFilled, FolderOutlined } from '@ant-design/icons';
 import React from 'react';
 import { useGetGlossaryNodeQuery } from '../../../graphql/glossaryNode.generated';
 import { EntityType, GlossaryNode, SearchResult } from '../../../types.generated';
-import GlossaryEntitiesPath from '../../glossary/GlossaryEntitiesPath';
 import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '../Entity';
 import { EntityProfile } from '../shared/containers/profile/EntityProfile';
 import { SidebarOwnerSection } from '../shared/containers/profile/sidebar/Ownership/SidebarOwnerSection';
@@ -56,8 +55,8 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
                 entityType={EntityType.GlossaryNode}
                 useEntityQuery={useGetGlossaryNodeQuery}
                 getOverrideProperties={this.getOverridePropertiesFromEntity}
-                displayGlossaryBrowser
                 isNameEditable
+                hideBrowseBar
                 tabs={[
                     {
                         name: 'Contents',
@@ -82,7 +81,6 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
                         component: SidebarOwnerSection,
                     },
                 ]}
-                customNavBar={<GlossaryEntitiesPath />}
                 headerDropdownItems={
                     new Set([
                         EntityMenuItems.ADD_TERM_GROUP,

--- a/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
@@ -14,7 +14,6 @@ import { SidebarOwnerSection } from '../shared/containers/profile/sidebar/Owners
 import { PropertiesTab } from '../shared/tabs/Properties/PropertiesTab';
 import { DocumentationTab } from '../shared/tabs/Documentation/DocumentationTab';
 import { SidebarAboutSection } from '../shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
-import GlossaryEntitiesPath from '../../glossary/GlossaryEntitiesPath';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { EntityActionItem } from '../shared/entity/EntityActions';
 import { SidebarDomainSection } from '../shared/containers/profile/sidebar/Domain/SidebarDomainSection';
@@ -68,8 +67,8 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                 headerDropdownItems={
                     new Set([EntityMenuItems.UPDATE_DEPRECATION, EntityMenuItems.MOVE, EntityMenuItems.DELETE])
                 }
-                displayGlossaryBrowser
                 isNameEditable
+                hideBrowseBar
                 tabs={[
                     {
                         name: 'Documentation',
@@ -116,7 +115,6 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                     },
                 ]}
                 getOverrideProperties={this.getOverridePropertiesFromEntity}
-                customNavBar={<GlossaryEntitiesPath />}
             />
         );
     };

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
@@ -14,6 +14,8 @@ import { useEntityData, useRefetch } from '../EntityContext';
 import analytics, { EventType } from '../../../analytics';
 import DescriptionModal from '../components/legacy/DescriptionModal';
 import { validateCustomUrnId } from '../../../shared/textUtil';
+import { useGlossaryEntityData } from '../GlossaryEntityContext';
+import { getParentNodeToUpdate, updateGlossarySidebar } from '../../../glossary/utils';
 
 const StyledItem = styled(Form.Item)`
     margin-bottom: 0;
@@ -36,6 +38,7 @@ interface Props {
 function CreateGlossaryEntityModal(props: Props) {
     const { entityType, onClose, refetchData } = props;
     const entityData = useEntityData();
+    const { isInGlossaryContext, updatedUrns, setUpdatedUrns } = useGlossaryEntityData();
     const [form] = Form.useForm();
     const entityRegistry = useEntityRegistry();
     const [stagedId, setStagedId] = useState<string | undefined>(undefined);
@@ -77,6 +80,10 @@ function CreateGlossaryEntityModal(props: Props) {
                         duration: 2,
                     });
                     refetch();
+                    if (isInGlossaryContext) {
+                        const parentNodeToUpdate = getParentNodeToUpdate(entityData, entityType);
+                        updateGlossarySidebar([parentNodeToUpdate], updatedUrns, setUpdatedUrns);
+                    }
                     if (refetchData) {
                         refetchData();
                     }

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -71,7 +71,6 @@ interface Props {
     refetchForEntity?: () => void;
     refetchForTerms?: () => void;
     refetchForNodes?: () => void;
-    refreshBrowser?: () => void;
     onDeleteEntity?: () => void;
 }
 
@@ -84,7 +83,6 @@ function EntityDropdown(props: Props) {
         refetchForEntity,
         refetchForTerms,
         refetchForNodes,
-        refreshBrowser,
         onDeleteEntity: onDelete,
         size,
         options,
@@ -252,9 +250,7 @@ function EntityDropdown(props: Props) {
                     refetch={refetchForEntity}
                 />
             )}
-            {isMoveModalVisible && (
-                <MoveGlossaryEntityModal onClose={() => setIsMoveModalVisible(false)} refetchData={refreshBrowser} />
-            )}
+            {isMoveModalVisible && <MoveGlossaryEntityModal onClose={() => setIsMoveModalVisible(false)} />}
             {hasBeenDeleted && !onDelete && deleteRedirectPath && <Redirect to={deleteRedirectPath} />}
         </>
     );

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/MoveGlossaryEntityModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/MoveGlossaryEntityModal.tsx
@@ -5,6 +5,8 @@ import { useEntityData, useRefetch } from '../EntityContext';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { useUpdateParentNodeMutation } from '../../../../graphql/glossary.generated';
 import NodeParentSelect from './NodeParentSelect';
+import { useGlossaryEntityData } from '../GlossaryEntityContext';
+import { getGlossaryRootToUpdate, getParentNodeToUpdate, updateGlossarySidebar } from '../../../glossary/utils';
 
 const StyledItem = styled(Form.Item)`
     margin-bottom: 0;
@@ -16,12 +18,12 @@ const OptionalWrapper = styled.span`
 
 interface Props {
     onClose: () => void;
-    refetchData?: () => void;
 }
 
 function MoveGlossaryEntityModal(props: Props) {
-    const { onClose, refetchData } = props;
-    const { urn: entityDataUrn, entityType } = useEntityData();
+    const { onClose } = props;
+    const { urn: entityDataUrn, entityData, entityType } = useEntityData();
+    const { isInGlossaryContext, updatedUrns, setUpdatedUrns } = useGlossaryEntityData();
     const [form] = Form.useForm();
     const entityRegistry = useEntityRegistry();
     const [selectedParentUrn, setSelectedParentUrn] = useState('');
@@ -46,8 +48,10 @@ function MoveGlossaryEntityModal(props: Props) {
                         duration: 2,
                     });
                     refetch();
-                    if (refetchData) {
-                        refetchData();
+                    if (isInGlossaryContext) {
+                        const oldParentToUpdate = getParentNodeToUpdate(entityData, entityType);
+                        const newParentToUpdate = selectedParentUrn || getGlossaryRootToUpdate(entityType);
+                        updateGlossarySidebar([oldParentToUpdate, newParentToUpdate], updatedUrns, setUpdatedUrns);
                     }
                 }, 2000);
             })

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/useDeleteEntity.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/useDeleteEntity.tsx
@@ -4,6 +4,8 @@ import { EntityType } from '../../../../types.generated';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { getDeleteEntityMutation } from '../../../shared/deleteUtils';
 import analytics, { EventType } from '../../../analytics';
+import { useGlossaryEntityData } from '../GlossaryEntityContext';
+import { getParentNodeToUpdate, updateGlossarySidebar } from '../../../glossary/utils';
 
 /**
  * Performs the flow for deleting an entity of a given type.
@@ -22,6 +24,7 @@ function useDeleteEntity(
 ) {
     const [hasBeenDeleted, setHasBeenDeleted] = useState(false);
     const entityRegistry = useEntityRegistry();
+    const { isInGlossaryContext, updatedUrns, setUpdatedUrns } = useGlossaryEntityData();
 
     const maybeDeleteEntity = getDeleteEntityMutation(type)();
     const deleteEntity = (maybeDeleteEntity && maybeDeleteEntity[0]) || undefined;
@@ -48,6 +51,10 @@ function useDeleteEntity(
                     () => {
                         setHasBeenDeleted(true);
                         onDelete?.();
+                        if (isInGlossaryContext) {
+                            const parentNodeToUpdate = getParentNodeToUpdate(entityData, type);
+                            updateGlossarySidebar([parentNodeToUpdate], updatedUrns, setUpdatedUrns);
+                        }
                         if (!hideMessage) {
                             message.success({
                                 content: `Deleted ${entityRegistry.getEntityName(type)}!`,

--- a/datahub-web-react/src/app/entity/shared/GlossaryEntityContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/GlossaryEntityContext.tsx
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import { GenericEntityProperties } from './types';
+
+export interface GlossaryEntityContextType {
+    isInGlossaryContext: boolean;
+    entityData: GenericEntityProperties | null;
+    setEntityData: (entityData: GenericEntityProperties | null) => void;
+    updatedUrns: string[];
+    setUpdatedUrns: (updatdUrns: string[]) => void;
+}
+
+export const GlossaryEntityContext = React.createContext<GlossaryEntityContextType>({
+    isInGlossaryContext: false,
+    entityData: null,
+    setEntityData: () => {},
+    updatedUrns: [],
+    setUpdatedUrns: () => {},
+});
+
+export const useGlossaryEntityData = () => {
+    const { isInGlossaryContext, entityData, setEntityData, updatedUrns, setUpdatedUrns } =
+        useContext(GlossaryEntityContext);
+    return { isInGlossaryContext, entityData, setEntityData, updatedUrns, setUpdatedUrns };
+};

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -76,6 +76,8 @@ export const ENTITY_TYPES_WITH_MANUAL_LINEAGE = new Set([
     EntityType.DataJob,
 ]);
 
+export const GLOSSARY_ENTITY_TYPES = [EntityType.GlossaryTerm, EntityType.GlossaryNode];
+
 export const DEFAULT_SYSTEM_ACTOR_URNS = ['urn:li:corpuser:__datahub_system', 'urn:li:corpuser:unknown'];
 
 export const VIEW_ENTITY_PAGE = 'VIEW_ENTITY_PAGE';

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -72,20 +72,13 @@ export function getCanEditName(
 }
 
 type Props = {
-    refreshBrowser?: () => void;
     headerDropdownItems?: Set<EntityMenuItems>;
     headerActionItems?: Set<EntityActionItem>;
     isNameEditable?: boolean;
     subHeader?: EntitySubHeaderSection;
 };
 
-export const EntityHeader = ({
-    refreshBrowser,
-    headerDropdownItems,
-    headerActionItems,
-    isNameEditable,
-    subHeader,
-}: Props) => {
+export const EntityHeader = ({ headerDropdownItems, headerActionItems, isNameEditable, subHeader }: Props) => {
     const { urn, entityType, entityData } = useEntityData();
     const refetch = useRefetch();
     const me = useGetAuthenticatedUser();
@@ -147,7 +140,6 @@ export const EntityHeader = ({
                                 entityData={entityData}
                                 menuItems={headerDropdownItems}
                                 refetchForEntity={refetch}
-                                refreshBrowser={refreshBrowser}
                             />
                         )}
                     </TopButtonsWrapper>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
@@ -2,8 +2,10 @@ import { message, Typography } from 'antd';
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components/macro';
 import { useUpdateNameMutation } from '../../../../../../graphql/mutations.generated';
+import { getParentNodeToUpdate, updateGlossarySidebar } from '../../../../../glossary/utils';
 import { useEntityRegistry } from '../../../../../useEntityRegistry';
 import { useEntityData, useRefetch } from '../../../EntityContext';
+import { useGlossaryEntityData } from '../../../GlossaryEntityContext';
 
 const EntityTitle = styled(Typography.Title)`
     margin-right: 10px;
@@ -27,6 +29,7 @@ function EntityName(props: Props) {
     const { isNameEditable } = props;
     const refetch = useRefetch();
     const entityRegistry = useEntityRegistry();
+    const { isInGlossaryContext, updatedUrns, setUpdatedUrns } = useGlossaryEntityData();
     const { urn, entityType, entityData } = useEntityData();
     const entityName = entityData ? entityRegistry.getDisplayName(entityType, entityData) : '';
     const [updatedName, setUpdatedName] = useState(entityName);
@@ -43,6 +46,10 @@ function EntityName(props: Props) {
             .then(() => {
                 message.success({ content: 'Name Updated', duration: 2 });
                 refetch();
+                if (isInGlossaryContext) {
+                    const parentNodeToUpdate = getParentNodeToUpdate(entityData, entityType);
+                    updateGlossarySidebar([parentNodeToUpdate], updatedUrns, setUpdatedUrns);
+                }
             })
             .catch((e: unknown) => {
                 message.destroy();

--- a/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { useLocation } from 'react-router';
 import queryString from 'query-string';
+import { isEqual } from 'lodash';
 import { EntityType } from '../../../../../types.generated';
 import useIsLineageMode from '../../../../lineage/utils/useIsLineageMode';
 import { useEntityRegistry } from '../../../../useEntityRegistry';
@@ -17,6 +19,9 @@ import {
     ENTITY_PROFILE_SCHEMA_ID,
     ENTITY_PROFILE_TAGS_ID,
 } from '../../../../onboarding/config/EntityProfileOnboardingConfig';
+import { useGlossaryEntityData } from '../../GlossaryEntityContext';
+import usePrevious from '../../../../shared/usePrevious';
+import { GLOSSARY_ENTITY_TYPES } from '../../constants';
 
 export function getDataForEntityType<T>({
     data: entityData,
@@ -125,6 +130,21 @@ export function useEntityQueryParams() {
     }
 
     return response;
+}
+
+export function useUpdateGlossaryEntityDataOnChange(
+    entityData: GenericEntityProperties | null,
+    entityType: EntityType,
+) {
+    const { setEntityData } = useGlossaryEntityData();
+    const previousEntityData = usePrevious(entityData);
+
+    useEffect(() => {
+        // first check this is a glossary entity to prevent unnecessary comparisons in non-glossary context
+        if (GLOSSARY_ENTITY_TYPES.includes(entityType) && !isEqual(entityData, previousEntityData)) {
+            setEntityData(entityData);
+        }
+    });
 }
 
 export function getOnboardingStepIdsForEntityType(entityType: EntityType): string[] {

--- a/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
+++ b/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button, Typography } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import styled from 'styled-components/macro';
 import { useGetRootGlossaryNodesQuery, useGetRootGlossaryTermsQuery } from '../../graphql/glossary.generated';
 import TabToolbar from '../entity/shared/components/styled/TabToolbar';
 import GlossaryEntitiesList from './GlossaryEntitiesList';
-import GlossaryBrowser from './GlossaryBrowser/GlossaryBrowser';
-import GlossarySearch from './GlossarySearch';
-import { ProfileSidebarResizer } from '../entity/shared/containers/profile/sidebar/ProfileSidebarResizer';
 import EmptyGlossarySection from './EmptyGlossarySection';
 import CreateGlossaryEntityModal from '../entity/shared/EntityDropdown/CreateGlossaryEntityModal';
 import { EntityType } from '../../types.generated';
@@ -22,6 +19,7 @@ import {
     BUSINESS_GLOSSARY_CREATE_TERM_GROUP_ID,
 } from '../onboarding/config/BusinessGlossaryOnboardingConfig';
 import { OnboardingTour } from '../onboarding/OnboardingTour';
+import { useGlossaryEntityData } from '../entity/shared/GlossaryEntityContext';
 
 export const HeaderWrapper = styled(TabToolbar)`
     padding: 15px 45px 10px 24px;
@@ -50,7 +48,6 @@ export const MAX_BROWSER_WIDTH = 500;
 export const MIN_BROWSWER_WIDTH = 200;
 
 function BusinessGlossaryPage() {
-    const [browserWidth, setBrowserWidth] = useState(window.innerWidth * 0.2);
     const {
         data: termsData,
         refetch: refetchForTerms,
@@ -64,6 +61,11 @@ function BusinessGlossaryPage() {
         error: nodesError,
     } = useGetRootGlossaryNodesQuery();
     const entityRegistry = useEntityRegistry();
+    const { setEntityData } = useGlossaryEntityData();
+
+    useEffect(() => {
+        setEntityData(null);
+    }, [setEntityData]);
 
     const terms = termsData?.getRootGlossaryTerms?.terms.sort((termA, termB) =>
         sortGlossaryTerms(entityRegistry, termA, termB),
@@ -96,17 +98,6 @@ function BusinessGlossaryPage() {
                 {(termsError || nodesError) && (
                     <Message type="error" content="Failed to load glossary! An unexpected error occurred." />
                 )}
-                <BrowserWrapper width={browserWidth}>
-                    <GlossarySearch />
-                    <GlossaryBrowser rootNodes={nodes} rootTerms={terms} />
-                </BrowserWrapper>
-                <ProfileSidebarResizer
-                    setSidePanelWidth={(width) =>
-                        setBrowserWidth(Math.min(Math.max(width, MIN_BROWSWER_WIDTH), MAX_BROWSER_WIDTH))
-                    }
-                    initialSize={browserWidth}
-                    isSidebarOnLeft
-                />
                 <MainContentWrapper>
                     <HeaderWrapper>
                         <Typography.Title level={3}>Business Glossary</Typography.Title>

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/GlossaryBrowser.tsx
@@ -5,7 +5,9 @@ import { ChildGlossaryTermFragment } from '../../../graphql/glossaryNode.generat
 import { GlossaryNode } from '../../../types.generated';
 import { sortGlossaryNodes } from '../../entity/glossaryNode/utils';
 import { sortGlossaryTerms } from '../../entity/glossaryTerm/utils';
+import { useGlossaryEntityData } from '../../entity/shared/GlossaryEntityContext';
 import { useEntityRegistry } from '../../useEntityRegistry';
+import { ROOT_NODES, ROOT_TERMS } from '../utils';
 import NodeItem from './NodeItem';
 import TermItem from './TermItem';
 
@@ -42,6 +44,8 @@ function GlossaryBrowser(props: Props) {
         selectNode,
     } = props;
 
+    const { updatedUrns, setUpdatedUrns } = useGlossaryEntityData();
+
     const { data: nodesData, refetch: refetchNodes } = useGetRootGlossaryNodesQuery({ skip: !!rootNodes });
     const { data: termsData, refetch: refetchTerms } = useGetRootGlossaryTermsQuery({ skip: !!rootTerms });
 
@@ -58,6 +62,17 @@ function GlossaryBrowser(props: Props) {
             refetchTerms();
         }
     }, [refreshBrowser, refetchNodes, refetchTerms]);
+
+    useEffect(() => {
+        if (updatedUrns.includes(ROOT_NODES)) {
+            refetchNodes();
+            setUpdatedUrns(updatedUrns.filter((urn) => urn !== ROOT_NODES));
+        }
+        if (updatedUrns.includes(ROOT_TERMS)) {
+            refetchTerms();
+            setUpdatedUrns(updatedUrns.filter((urn) => urn !== ROOT_TERMS));
+        }
+    });
 
     return (
         <BrowserWrapper>

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/NodeItem.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/NodeItem.tsx
@@ -6,9 +6,9 @@ import { EntityType, GlossaryNode, GlossaryTerm } from '../../../types.generated
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { useGetGlossaryNodeQuery } from '../../../graphql/glossaryNode.generated';
 import TermItem, { TermLink as NodeLink, NameWrapper } from './TermItem';
-import { useEntityData } from '../../entity/shared/EntityContext';
 import { sortGlossaryNodes } from '../../entity/glossaryNode/utils';
 import { sortGlossaryTerms } from '../../entity/glossaryTerm/utils';
+import { useGlossaryEntityData } from '../../entity/shared/GlossaryEntityContext';
 
 const ItemWrapper = styled.div`
     display: flex;
@@ -73,8 +73,8 @@ function NodeItem(props: Props) {
 
     const [areChildrenVisible, setAreChildrenVisible] = useState(false);
     const entityRegistry = useEntityRegistry();
-    const { entityData } = useEntityData();
-    const { data, loading } = useGetGlossaryNodeQuery({
+    const { entityData, updatedUrns, setUpdatedUrns } = useGlossaryEntityData();
+    const { data, loading, refetch } = useGetGlossaryNodeQuery({
         variables: { urn: node.urn },
         skip: !areChildrenVisible || shouldHideNode,
     });
@@ -90,6 +90,13 @@ function NodeItem(props: Props) {
             setAreChildrenVisible(false);
         }
     }, [refreshBrowser]);
+
+    useEffect(() => {
+        if (updatedUrns.includes(node.urn)) {
+            refetch();
+            setUpdatedUrns(updatedUrns.filter((urn) => urn !== node.urn));
+        }
+    });
 
     const isOnEntityPage = entityData && entityData.urn === node.urn;
 

--- a/datahub-web-react/src/app/glossary/GlossaryBrowser/TermItem.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryBrowser/TermItem.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
-import { useEntityData } from '../../entity/shared/EntityContext';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { ANTD_GRAY } from '../../entity/shared/constants';
 import { ChildGlossaryTermFragment } from '../../../graphql/glossaryNode.generated';
+import { useGlossaryEntityData } from '../../entity/shared/GlossaryEntityContext';
 
 const TermWrapper = styled.div`
     font-weight: normal;
@@ -52,7 +52,7 @@ interface Props {
 function TermItem(props: Props) {
     const { term, isSelecting, selectTerm } = props;
 
-    const { entityData } = useEntityData();
+    const { entityData } = useGlossaryEntityData();
     const entityRegistry = useEntityRegistry();
 
     function handleSelectTerm() {

--- a/datahub-web-react/src/app/glossary/GlossaryEntitiesPath.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryEntitiesPath.tsx
@@ -7,7 +7,7 @@ import { PageRoutes } from '../../conf/Global';
 import { GlossaryNode, GlossaryTerm, ParentNodesResult } from '../../types.generated';
 import { ANTD_GRAY } from '../entity/shared/constants';
 import { BreadcrumbItem } from '../entity/shared/containers/profile/nav/ProfileNavBrowsePath';
-import { useEntityData } from '../entity/shared/EntityContext';
+import { useGlossaryEntityData } from '../entity/shared/GlossaryEntityContext';
 import { useEntityRegistry } from '../useEntityRegistry';
 
 const PathWrapper = styled.div`
@@ -29,7 +29,7 @@ function getGlossaryBreadcrumbs(parentNodes: Maybe<ParentNodesResult>, entity: M
 
 function GlossaryEntitiesPath() {
     const entityRegistry = useEntityRegistry();
-    const { entityData } = useEntityData();
+    const { entityData } = useGlossaryEntityData();
 
     const breadcrumbs = getGlossaryBreadcrumbs(entityData?.parentNodes, entityData as GlossaryNode | GlossaryTerm);
 

--- a/datahub-web-react/src/app/glossary/GlossaryRoutes.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryRoutes.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import styled from 'styled-components/macro';
+import { Switch, Route } from 'react-router-dom';
+import { PageRoutes } from '../../conf/Global';
+import { GlossaryEntityContext } from '../entity/shared/GlossaryEntityContext';
+import { GenericEntityProperties } from '../entity/shared/types';
+import BusinessGlossaryPage from './BusinessGlossaryPage';
+import GlossaryEntitiesPath from './GlossaryEntitiesPath';
+import { EntityPage } from '../entity/EntityPage';
+import GlossarySidebar from './GlossarySidebar';
+import { useEntityRegistry } from '../useEntityRegistry';
+
+const ContentWrapper = styled.div`
+    display: flex;
+    flex: 1;
+`;
+
+export default function GlossaryRoutes() {
+    const entityRegistry = useEntityRegistry();
+    const [entityData, setEntityData] = useState<GenericEntityProperties | null>(null);
+    const [updatedUrns, setUpdatedUrns] = useState<string[]>([]);
+
+    const isAtRootGlossary = window.location.pathname === PageRoutes.GLOSSARY;
+
+    return (
+        <GlossaryEntityContext.Provider
+            value={{ isInGlossaryContext: true, entityData, setEntityData, updatedUrns, setUpdatedUrns }}
+        >
+            {!isAtRootGlossary && <GlossaryEntitiesPath />}
+            <ContentWrapper>
+                <GlossarySidebar />
+                <Switch>
+                    {entityRegistry.getGlossaryEntities().map((entity) => (
+                        <Route
+                            key={entity.getPathName()}
+                            path={`/${entity.getPathName()}/:urn`}
+                            render={() => <EntityPage entityType={entity.type} />}
+                        />
+                    ))}
+                    <Route path={PageRoutes.GLOSSARY} render={() => <BusinessGlossaryPage />} />
+                </Switch>
+            </ContentWrapper>
+        </GlossaryEntityContext.Provider>
+    );
+}

--- a/datahub-web-react/src/app/glossary/GlossarySidebar.tsx
+++ b/datahub-web-react/src/app/glossary/GlossarySidebar.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import styled from 'styled-components/macro';
+import GlossarySearch from './GlossarySearch';
+import GlossaryBrowser from './GlossaryBrowser/GlossaryBrowser';
+import { ProfileSidebarResizer } from '../entity/shared/containers/profile/sidebar/ProfileSidebarResizer';
+
+const BrowserWrapper = styled.div<{ width: number }>`
+    max-height: 100%;
+    width: ${(props) => props.width}px;
+    min-width: ${(props) => props.width}px;
+`;
+
+export const MAX_BROWSER_WIDTH = 500;
+export const MIN_BROWSWER_WIDTH = 200;
+
+export default function GlossarySidebar() {
+    const [browserWidth, setBrowserWith] = useState(window.innerWidth * 0.2);
+
+    return (
+        <>
+            <BrowserWrapper width={browserWidth}>
+                <GlossarySearch />
+                <GlossaryBrowser openToEntity />
+            </BrowserWrapper>
+            <ProfileSidebarResizer
+                setSidePanelWidth={(width) =>
+                    setBrowserWith(Math.min(Math.max(width, MIN_BROWSWER_WIDTH), MAX_BROWSER_WIDTH))
+                }
+                initialSize={browserWidth}
+                isSidebarOnLeft
+            />
+        </>
+    );
+}

--- a/datahub-web-react/src/app/glossary/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/glossary/__tests__/utils.test.ts
@@ -1,0 +1,41 @@
+import { EntityType } from '../../../types.generated';
+import { glossaryNode1, glossaryNode3, glossaryTerm1 } from '../../../Mocks';
+import { getParentNodeToUpdate, getGlossaryRootToUpdate, ROOT_NODES, ROOT_TERMS } from '../utils';
+
+const glossaryTermWithParent = {
+    ...glossaryTerm1,
+    parentNodes: {
+        count: 1,
+        nodes: [glossaryNode1],
+    },
+};
+
+describe('glossary utils tests', () => {
+    it('should get the direct parent node urn in getParentNodeToUpdate for glossary nodes', () => {
+        const parentNode = getParentNodeToUpdate(glossaryNode3 as any, EntityType.GlossaryNode);
+        expect(parentNode).toBe(glossaryNode3.parentNodes?.nodes[0].urn);
+    });
+
+    it('should get the direct parent node urn in getParentNodeToUpdate for glossary terms', () => {
+        const parentNode = getParentNodeToUpdate(glossaryTermWithParent as any, EntityType.GlossaryTerm);
+        expect(parentNode).toBe(glossaryNode1.urn);
+    });
+
+    it('should return ROOT_NODES for glossary node with no parent nodes', () => {
+        const parentNode = getParentNodeToUpdate(glossaryNode1 as any, EntityType.GlossaryNode);
+        expect(parentNode).toBe(ROOT_NODES);
+    });
+
+    it('should return ROOT_TERMS for glossary term with no parent nodes', () => {
+        const parentNode = getParentNodeToUpdate(glossaryTerm1 as any, EntityType.GlossaryTerm);
+        expect(parentNode).toBe(ROOT_TERMS);
+    });
+
+    it('should return ROOT_NODES for glossary node', () => {
+        expect(getGlossaryRootToUpdate(EntityType.GlossaryNode)).toBe(ROOT_NODES);
+    });
+
+    it('should return ROOT_TERMS for glossary term', () => {
+        expect(getGlossaryRootToUpdate(EntityType.GlossaryTerm)).toBe(ROOT_TERMS);
+    });
+});

--- a/datahub-web-react/src/app/glossary/utils.ts
+++ b/datahub-web-react/src/app/glossary/utils.ts
@@ -1,0 +1,23 @@
+import { EntityType } from '../../types.generated';
+import { GenericEntityProperties } from '../entity/shared/types';
+
+export const ROOT_NODES = 'rootNodes';
+export const ROOT_TERMS = 'rootTerms';
+
+export function getGlossaryRootToUpdate(entityType: EntityType) {
+    return entityType === EntityType.GlossaryTerm ? ROOT_TERMS : ROOT_NODES;
+}
+
+export function getParentNodeToUpdate(entityData: GenericEntityProperties | null, entityType: EntityType) {
+    return entityData?.parentNodes?.nodes.length
+        ? entityData?.parentNodes?.nodes[0].urn
+        : getGlossaryRootToUpdate(entityType);
+}
+
+export function updateGlossarySidebar(
+    parentNodesToUpdate: string[],
+    updatedUrns: string[],
+    setUpdatedUrns: (updatdUrns: string[]) => void,
+) {
+    setUpdatedUrns([...updatedUrns, ...parentNodesToUpdate]);
+}


### PR DESCRIPTION
Fixes the whole page flickering we would see when switching between terms and nodes in the business glossary. This happened because each entity page itself rendered its own version of the lest side bar browse and the top parent nodes navigation. Whenever you switched to a new glossary entity, it would un-mount and re-mount the whole page causing the whole page to flicker. It also caused an excess of queries such as getting all root terms and root nodes on every change between glossary entities. It also refreshed your sidebar nav to close everything that's open which is a bad experience.

This PR pulls those components out and puts them in a new `GlossaryRoutes` component that wraps the term and node profiles with them as well as the root glossary page. These components are now fixed!

The tough part is that these components rely on information retrieved from the entity profile component such as the parent nodes and what the current entity is (to know whether or not to highlight it on the sidebar and which parent nodes to default open when you land on a page). There's a few ways we could tackle this, but the simplest and easiest way is to share `entityData` from the `EntityProfile` with a new higher `GlossaryEntityContext` which the two nav components can access. Whenever `entityData` changes and we're in a glossary context, we update the glossary context with new entity data.

Finally, when we make edits (edit name, move a node/term, delete a node/term, create a node/term) the sidebar browser needs to be aware of those updates. What I implemented was passing in `updatedUrns` to the glossary context and have the components in that sidebar listen for those changing and `refetch` and remove themselves from `updatedUrns` if need be. That way the sidebar component is always up to date with any mutation the user makes.

**Here's what it looks like now**
https://user-images.githubusercontent.com/28656603/221290287-ed9ed1e2-6380-46f8-ab71-58c2582b633e.mov



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
