### PR TITLE
fix(ingest/unity): Use assigned metastore if not metastore listed in unity catalog

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -134,6 +134,13 @@ class UnityCatalogApiProxy:
         self._unity_catalog_api.list_metastores()
         return True
 
+    def assigned_metastore(self) -> Optional[Metastore]:
+        response: dict = self._unity_catalog_api.get_metastore_summary()
+        if response.get("metastore_id") is None:
+            logger.info("Not found assinged metastore")
+            return None
+        return self._create_metastore(response)
+
     def metastores(self) -> Iterable[Metastore]:
         response: dict = self._unity_catalog_api.list_metastores()
         if response.get("metastores") is None:


### PR DESCRIPTION
Based on oss community it seems like there are cases when list metastore doesn't return anything but we still can get metadata from the metastore which is assigned to the Workspace.

https://datahubspace.slack.com/archives/CUMUWQU66/p1676032592423079

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
