### PR TITLE
chore(ingest/glue): cleanup deprecated `underlying_platform` config

### DIFF
--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -3,11 +3,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Type, cast
 from unittest.mock import patch
 
+import pydantic
 import pytest
 from botocore.stub import Stubber
 from freezegun import freeze_time
 
-from datahub.configuration.common import ConfigurationError
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.extractor.schema_util import avro_schema_to_mce_fields
 from datahub.ingestion.run.pipeline import Pipeline
@@ -181,43 +181,23 @@ def test_glue_ingest(
     )
 
 
-def test_underlying_platform_takes_precendence():
+def test_platform_config():
     source = GlueSource(
         ctx=PipelineContext(run_id="glue-source-test"),
-        config=GlueSourceConfig(aws_region="us-west-2", underlying_platform="athena"),
+        config=GlueSourceConfig(aws_region="us-west-2", platform="athena"),
     )
     assert source.platform == "athena"
-
-
-def test_platform_takes_precendence_over_underlying_platform():
-    source = GlueSource(
-        ctx=PipelineContext(run_id="glue-source-test"),
-        config=GlueSourceConfig(
-            aws_region="us-west-2", platform="athena", underlying_platform="glue"
-        ),
-    )
-    assert source.platform == "athena"
-
-
-def test_underlying_platform_must_be_valid():
-    with pytest.raises(ConfigurationError):
-        GlueSource(
-            ctx=PipelineContext(run_id="glue-source-test"),
-            config=GlueSourceConfig(
-                aws_region="us-west-2", underlying_platform="data-warehouse"
-            ),
-        )
 
 
 def test_platform_must_be_valid():
-    with pytest.raises(ConfigurationError):
+    with pytest.raises(pydantic.ValidationError):
         GlueSource(
             ctx=PipelineContext(run_id="glue-source-test"),
             config=GlueSourceConfig(aws_region="us-west-2", platform="data-warehouse"),
         )
 
 
-def test_without_underlying_platform():
+def test_config_without_platform():
     source = GlueSource(
         ctx=PipelineContext(run_id="glue-source-test"),
         config=GlueSourceConfig(aws_region="us-west-2"),


### PR DESCRIPTION
This has been deprecated for 10 months now.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
