### PR TITLE
refactor(ingest): Convert FileBackedDict to dataclass for cleaner init

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -138,9 +138,6 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
 
         return row[0] + len(self._active_object_cache)
 
-    def __repr__(self) -> str:
-        return f"FileBackedDict({self.filename})"
-
     def close(self) -> None:
         self._conn.close()
 

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -22,7 +22,7 @@ SqliteValue = Union[int, float, str, bytes, None]
 _VT = TypeVar("_VT")
 
 
-@dataclass
+@dataclass(eq=False)
 class FileBackedDict(MutableMapping[str, _VT], Generic[_VT]):
     """A dictionary that stores its data in a temporary SQLite database.
 


### PR DESCRIPTION
We don't talk about using dataclass for non-ingestion-data classes in the contribution guidelines, but I like this as it reduces the repeated types and is more declarative

EDIT: I guess the downside is we lose "private" status on some variables that shouldn't be adjusted by outside code. I feel like it should be obvious you're not supposed to change these values though (after init)

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
