### PR TITLE
Add setup job labels to compose files

### DIFF
--- a/docker/docker-compose-without-neo4j.override.yml
+++ b/docker/docker-compose-without-neo4j.override.yml
@@ -14,6 +14,8 @@ services:
       - mysqldata:/var/lib/mysql
 
   mysql-setup:
+    labels:
+      datahub_setup_job: true
     build:
       context: ../
       dockerfile: docker/mysql-setup/Dockerfile

--- a/docker/docker-compose-without-neo4j.yml
+++ b/docker/docker-compose-without-neo4j.yml
@@ -55,6 +55,8 @@ services:
 
   # This "container" is a workaround to pre-create search indices
   elasticsearch-setup:
+    labels:
+      datahub_setup_job: true
     build:
       context: ../
       dockerfile: docker/elasticsearch-setup/Dockerfile
@@ -102,6 +104,8 @@ services:
       - datahub-gms
 
   kafka-setup:
+    labels:
+      datahub_setup_job: true
     build:
       dockerfile: ./docker/kafka-setup/Dockerfile
       context: ../
@@ -114,6 +118,8 @@ services:
       - schema-registry
 
   datahub-upgrade:
+    labels:
+      datahub_setup_job: true
     build:
       context: ../
       dockerfile: docker/datahub-upgrade/Dockerfile

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -15,6 +15,8 @@ services:
       - mysqldata:/var/lib/mysql
 
   mysql-setup:
+    labels:
+      datahub_setup_job: true
     build:
       context: ../
       dockerfile: docker/mysql-setup/Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -68,6 +68,8 @@ services:
 
   # This "container" is a workaround to pre-create search indices
   elasticsearch-setup:
+    labels:
+      datahub_setup_job: true
     build:
       context: ../
       dockerfile: docker/elasticsearch-setup/Dockerfile
@@ -118,6 +120,8 @@ services:
   # This is not required in most cases, kept here for backwards compatibility with older clients that
   # explicitly wait for this container
   kafka-setup:
+    labels:
+      datahub_setup_job: true
     build:
       dockerfile: ./docker/kafka-setup/Dockerfile
       context: ../
@@ -130,6 +134,8 @@ services:
       - schema-registry
 
   datahub-upgrade:
+    labels:
+      datahub_setup_job: true
     build:
       context: ../
       dockerfile: docker/datahub-upgrade/Dockerfile

--- a/docker/quickstart/docker-compose-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-m1.quickstart.yml
@@ -127,6 +127,8 @@ services:
     - ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
     hostname: datahub-upgrade
     image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
     environment:
@@ -157,6 +159,8 @@ services:
     - ELASTICSEARCH_PROTOCOL=http
     hostname: elasticsearch-setup
     image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   kafka-setup:
     container_name: kafka-setup
     depends_on:
@@ -168,6 +172,8 @@ services:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     hostname: kafka-setup
     image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   mysql:
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
     container_name: mysql
@@ -195,6 +201,8 @@ services:
     - DATAHUB_DB_NAME=datahub
     hostname: mysql-setup
     image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   neo4j:
     container_name: neo4j
     environment:

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -192,6 +192,8 @@ services:
     - DATAHUB_DB_NAME=datahub
     hostname: mysql-setup
     image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   schema-registry:
     container_name: schema-registry
     depends_on:

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -118,6 +118,8 @@ services:
     - ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
     hostname: datahub-upgrade
     image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
     environment:
@@ -148,6 +150,8 @@ services:
     - ELASTICSEARCH_PROTOCOL=http
     hostname: elasticsearch-setup
     image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   kafka-setup:
     container_name: kafka-setup
     depends_on:
@@ -159,6 +163,8 @@ services:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     hostname: kafka-setup
     image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   mysql:
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
     container_name: mysql

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -116,6 +116,8 @@ services:
       - ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
     hostname: datahub-upgrade
     image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
     environment:
@@ -145,6 +147,8 @@ services:
       - ELASTICSEARCH_PROTOCOL=http
     hostname: elasticsearch-setup
     image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   kafka-setup:
     container_name: kafka-setup
     depends_on:
@@ -156,6 +160,8 @@ services:
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     hostname: kafka-setup
     image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   mysql:
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
     container_name: mysql

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -125,6 +125,8 @@ services:
       - ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
     hostname: datahub-upgrade
     image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
     environment:
@@ -154,6 +156,8 @@ services:
       - ELASTICSEARCH_PROTOCOL=http
     hostname: elasticsearch-setup
     image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   kafka-setup:
     container_name: kafka-setup
     depends_on:
@@ -165,6 +169,8 @@ services:
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     hostname: kafka-setup
     image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   mysql:
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
     container_name: mysql
@@ -192,6 +198,8 @@ services:
       - DATAHUB_DB_NAME=datahub
     hostname: mysql-setup
     image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
+    labels:
+      datahub_setup_job: true
   neo4j:
     container_name: neo4j
     environment:


### PR DESCRIPTION
These labels helps the CLI changes in PR state to know which compose file is a setup job and which is a service. 

Since the new CLI uses these labels AND it uses the compose file from the release version, it won't work for older releases. `datahub docker quickstart --version <v0.10.1`

To prevent failures CLI will use the compose files from merge commit of this PR for all `--version <v0.10.1`
