### PR TITLE
feat(elasticsearch): validate index.blocks.write setting

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesPostStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesPostStep.java
@@ -5,6 +5,7 @@ import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
+import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils;
 import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexConfig;
 import com.linkedin.metadata.shared.ElasticSearchIndexed;
@@ -18,7 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.client.RequestOptions;
 
-import static com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils.*;
+import static com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils.INDEX_BLOCKS_WRITE_SETTING;
+import static com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils.getAllReindexConfigs;
 
 
 @RequiredArgsConstructor
@@ -50,12 +52,18 @@ public class BuildIndicesPostStep implements UpgradeStep {
         // Reset write blocking
         for (ReindexConfig indexConfig : indexConfigs) {
           UpdateSettingsRequest request = new UpdateSettingsRequest(indexConfig.name());
-          Map<String, Object> indexSettings = ImmutableMap.of("index.blocks.write", "false");
+          Map<String, Object> indexSettings = ImmutableMap.of(INDEX_BLOCKS_WRITE_SETTING, "false");
 
           request.settings(indexSettings);
           boolean ack =
               _esComponents.getSearchClient().indices().putSettings(request, RequestOptions.DEFAULT).isAcknowledged();
           log.info("Updated index {} with new settings. Settings: {}, Acknowledged: {}", indexConfig.name(), indexSettings, ack);
+
+          if (ack) {
+            ack = IndexUtils.validateWriteBlock(_esComponents.getSearchClient(), indexConfig.name(), false);
+            log.info("Validated index {} with new settings. Settings: {}, Acknowledged: {}", indexConfig.name(), indexSettings, ack);
+          }
+
           if (!ack) {
             log.error(
                 "Partial index settings update, some indices may still be blocking writes."

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesPreStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesPreStep.java
@@ -12,7 +12,6 @@ import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -20,10 +19,8 @@ import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexConfig;
 import com.linkedin.metadata.shared.ElasticSearchIndexed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
-import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.indices.ResizeRequest;
 

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesPreStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/steps/BuildIndicesPreStep.java
@@ -5,6 +5,7 @@ import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
+import com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils;
 import com.linkedin.gms.factory.config.ConfigurationProvider;
 import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 
@@ -21,19 +22,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.indices.ResizeRequest;
 
+import static com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils.INDEX_BLOCKS_WRITE_SETTING;
 import static com.linkedin.datahub.upgrade.system.elasticsearch.util.IndexUtils.getAllReindexConfigs;
 
 
 @RequiredArgsConstructor
 @Slf4j
 public class BuildIndicesPreStep implements UpgradeStep {
-
   private final BaseElasticSearchComponentsFactory.BaseElasticSearchComponents _esComponents;
   private final List<ElasticSearchIndexed> _services;
   private final ConfigurationProvider _configurationProvider;
@@ -58,44 +58,12 @@ public class BuildIndicesPreStep implements UpgradeStep {
                 .collect(Collectors.toList());
 
         for (ReindexConfig indexConfig : indexConfigs) {
-          String indexName = indexConfig.name();
+          String indexName = IndexUtils.resolveAlias(_esComponents.getSearchClient(), indexConfig.name());
 
-          GetAliasesResponse aliasResponse = getAlias(indexConfig.name());
-          if (!aliasResponse.getAliases().isEmpty()) {
-            Set<String> indices = aliasResponse.getAliases().keySet();
-            if (indices.size() != 1) {
-              throw new NotImplementedException(
-                      String.format("Clone not supported for %s indices in alias %s. Indices: %s",
-                              indices.size(),
-                              indexConfig.name(),
-                              String.join(",", indices)));
-            }
-            indexName = indices.stream().findFirst().get();
-            log.info("Alias {} resolved to index {}", indexConfig.name(), indexName);
-          }
-
-          UpdateSettingsRequest request = new UpdateSettingsRequest(indexName);
-          Map<String, Object> indexSettings = ImmutableMap.of("index.blocks.write", "true");
-
-          request.settings(indexSettings);
-          boolean ack;
-          try {
-            ack =
-                _esComponents.getSearchClient().indices().putSettings(request, RequestOptions.DEFAULT).isAcknowledged();
-            log.info("Updated index {} with new settings. Settings: {}, Acknowledged: {}", indexName, indexSettings, ack);
-          } catch (ElasticsearchStatusException ese) {
-            // Cover first run case, indices won't exist so settings updates won't work nor will the rest of the preConfigure steps.
-            // Since no data are in there they are skippable.
-            // Have to hack around HighLevelClient not sending the actual Java type nor having an easy way to extract it :(
-            if (ese.getMessage().contains("index_not_found")) {
-              continue;
-            }
-            throw ese;
-          }
-
+          boolean ack = blockWrites(indexName);
           if (!ack) {
             log.error("Partial index settings update, some indices may still be blocking writes."
-                + " Please fix the error and re-run the BuildIndices upgrade job.");
+                    + " Please fix the error and re-run the BuildIndices upgrade job.");
             return new DefaultUpgradeStepResult(id(), UpgradeStepResult.Result.FAILED);
           }
 
@@ -120,8 +88,34 @@ public class BuildIndicesPreStep implements UpgradeStep {
     };
   }
 
-  private GetAliasesResponse getAlias(String name) throws IOException {
-    return _esComponents.getSearchClient().indices()
-            .getAlias(new GetAliasesRequest(name), RequestOptions.DEFAULT);
+
+
+  private boolean blockWrites(String indexName) throws InterruptedException, IOException {
+    UpdateSettingsRequest request = new UpdateSettingsRequest(indexName);
+    Map<String, Object> indexSettings = ImmutableMap.of(INDEX_BLOCKS_WRITE_SETTING, "true");
+
+    request.settings(indexSettings);
+    boolean ack;
+    try {
+      ack = _esComponents.getSearchClient().indices()
+              .putSettings(request, RequestOptions.DEFAULT).isAcknowledged();
+      log.info("Updated index {} with new settings. Settings: {}, Acknowledged: {}", indexName, indexSettings, ack);
+    } catch (ElasticsearchStatusException | IOException ese) {
+      // Cover first run case, indices won't exist so settings updates won't work nor will the rest of the preConfigure steps.
+      // Since no data are in there they are skippable.
+      // Have to hack around HighLevelClient not sending the actual Java type nor having an easy way to extract it :(
+      if (ese.getMessage().contains("index_not_found")) {
+        return true;
+      } else {
+        throw ese;
+      }
+    }
+
+    if (ack) {
+      ack = IndexUtils.validateWriteBlock(_esComponents.getSearchClient(), indexName, true);
+      log.info("Validated index {} with new settings. Settings: {}, Acknowledged: {}", indexName, indexSettings, ack);
+    }
+
+    return ack;
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexUtils.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/elasticsearch/util/IndexUtils.java
@@ -2,13 +2,26 @@ package com.linkedin.datahub.upgrade.system.elasticsearch.util;
 
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexConfig;
 import com.linkedin.metadata.shared.ElasticSearchIndexed;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.client.GetAliasesResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 
+@Slf4j
 public class IndexUtils {
+  public static final String INDEX_BLOCKS_WRITE_SETTING = "index.blocks.write";
+  public static final int INDEX_BLOCKS_WRITE_RETRY = 4;
+  public static final int INDEX_BLOCKS_WRITE_WAIT_SECONDS = 10;
   private IndexUtils() { }
 
   private static List<ReindexConfig> _reindexConfigs = new ArrayList<>();
@@ -24,5 +37,52 @@ public class IndexUtils {
     }
 
     return reindexConfigs;
+  }
+
+  public static boolean validateWriteBlock(RestHighLevelClient esClient, String indexName, boolean expectedState)
+          throws IOException, InterruptedException {
+    final String finalIndexName = resolveAlias(esClient, indexName);
+
+    GetSettingsRequest request = new GetSettingsRequest()
+            .indices(finalIndexName)
+            .names(INDEX_BLOCKS_WRITE_SETTING)
+            .includeDefaults(true);
+
+    int count = INDEX_BLOCKS_WRITE_RETRY;
+    while (count > 0) {
+      GetSettingsResponse response = esClient.indices().getSettings(request, RequestOptions.DEFAULT);
+      if (response.getSetting(finalIndexName, INDEX_BLOCKS_WRITE_SETTING).equals(String.valueOf(expectedState))) {
+        return true;
+      }
+      count = count - 1;
+
+      if (count != 0) {
+        Thread.sleep(INDEX_BLOCKS_WRITE_WAIT_SECONDS * 1000);
+      }
+    }
+
+    return false;
+  }
+
+  public static String resolveAlias(RestHighLevelClient esClient, String indexName) throws IOException {
+    String finalIndexName = indexName;
+
+    GetAliasesResponse aliasResponse = esClient.indices()
+            .getAlias(new GetAliasesRequest(indexName), RequestOptions.DEFAULT);
+
+    if (!aliasResponse.getAliases().isEmpty()) {
+      Set<String> indices = aliasResponse.getAliases().keySet();
+      if (indices.size() != 1) {
+        throw new NotImplementedException(
+                String.format("Clone not supported for %s indices in alias %s. Indices: %s",
+                        indices.size(),
+                        indexName,
+                        String.join(",", indices)));
+      }
+      finalIndexName = indices.stream().findFirst().get();
+      log.info("Alias {} resolved to index {}", indexName, finalIndexName);
+    }
+
+    return finalIndexName;
   }
 }


### PR DESCRIPTION
Attempt to validate the index.blocks.write setting is set as expected based on reports of increasing document counts even after the update setting is being accepted by elasticsearch. Not able to reproduce this behavior locally, however reading the setting back should not impact the operation.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
