### PR TITLE
fix(ui) Update Looker/Lookml forms to set client id and deploy key as Secrets

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/looker.ts
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/looker.ts
@@ -15,7 +15,7 @@ export const LOOKER_CLIENT_ID: RecipeField = {
     name: 'client_id',
     label: 'Client ID',
     tooltip: 'Looker API Client ID.',
-    type: FieldType.TEXT,
+    type: FieldType.SECRET,
     fieldPath: 'source.config.client_id',
     placeholder: 'client_id',
     required: true,

--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/lookml.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/lookml.tsx
@@ -15,7 +15,6 @@ export const LOOKML_GITHUB_INFO_REPO: RecipeField = {
     required: true,
 };
 
-const deployKeyFieldPath = 'source.config.github_info.deploy_key';
 export const DEPLOY_KEY: RecipeField = {
     name: 'github_info.deploy_key',
     label: 'GitHub Deploy Key',
@@ -36,14 +35,10 @@ export const DEPLOY_KEY: RecipeField = {
             </div>
         </>
     ),
-    type: FieldType.TEXTAREA,
+    type: FieldType.SECRET,
     fieldPath: 'source.config.github_info.deploy_key',
     placeholder: '-----BEGIN OPENSSH PRIVATE KEY-----\n...',
     rules: [{ required: true, message: 'Github Deploy Key is required' }],
-    setValueOnRecipeOverride: (recipe: any, value: string) => {
-        const valueWithNewLine = `${value}\n`;
-        return setFieldValueOnRecipe(recipe, valueWithNewLine, deployKeyFieldPath);
-    },
     required: true,
 };
 


### PR DESCRIPTION
These two fields should be secrets. The add new line thing was kind of a hack for setting a deploy ssh key as plain text anyways. we should be able to do that now with secrets.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
