### PR TITLE
fix(ingest): limit typing_extensions classes to those available in min version

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -2,16 +2,18 @@ import re
 import unittest.mock
 from abc import ABC, abstractmethod
 from enum import auto
-from typing import IO, Any, ClassVar, Dict, List, Optional, Type
+from typing import IO, Any, ClassVar, Dict, List, Optional, Type, TypeVar
 
 import pydantic
 from cached_property import cached_property
 from pydantic import BaseModel, Extra, ValidationError
 from pydantic.fields import Field
-from typing_extensions import Protocol, Self, runtime_checkable
+from typing_extensions import Protocol, runtime_checkable
 
 from datahub.configuration._config_enum import ConfigEnum
 from datahub.utilities.dedup_list import deduplicate_list
+
+_ConfigSelf = TypeVar("_ConfigSelf", bound="ConfigModel")
 
 REDACT_KEYS = {
     "password",
@@ -86,7 +88,7 @@ class ConfigModel(BaseModel):
                 del schema["properties"][key]
 
     @classmethod
-    def parse_obj_allow_extras(cls, obj: Any) -> Self:
+    def parse_obj_allow_extras(cls: Type[_ConfigSelf], obj: Any) -> _ConfigSelf:
         with unittest.mock.patch.object(cls.Config, "extra", pydantic.Extra.allow):
             return cls.parse_obj(obj)
 

--- a/metadata-ingestion/src/datahub/ingestion/api/ingestion_job_checkpointing_provider_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/ingestion_job_checkpointing_provider_base.py
@@ -1,8 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, NewType
-
-from typing_extensions import Self
+from typing import Any, Dict, NewType, Type, TypeVar
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigModel
@@ -17,6 +15,9 @@ CheckpointJobStatesMap = Dict[JobId, CheckpointJobStateType]
 
 class IngestionCheckpointingProviderConfig(ConfigModel):
     pass
+
+
+_Self = TypeVar("_Self", bound="IngestionCheckpointingProviderBase")
 
 
 @dataclass()
@@ -34,8 +35,8 @@ class IngestionCheckpointingProviderBase(StatefulCommittable[CheckpointJobStates
     @classmethod
     @abstractmethod
     def create(
-        cls, config_dict: Dict[str, Any], ctx: PipelineContext, name: str
-    ) -> "Self":
+        cls: Type[_Self], config_dict: Dict[str, Any], ctx: PipelineContext, name: str
+    ) -> "_Self":
         pass
 
     @abstractmethod

--- a/metadata-ingestion/src/datahub/ingestion/api/sink.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/sink.py
@@ -3,8 +3,6 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Generic, Optional, Type, TypeVar, cast
 
-from typing_extensions import Self
-
 from datahub.configuration.common import ConfigModel
 from datahub.ingestion.api.closeable import Closeable
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope, WorkUnit
@@ -81,6 +79,7 @@ class NoopWriteCallback(WriteCallback):
 
 SinkReportType = TypeVar("SinkReportType", bound=SinkReport, covariant=True)
 SinkConfig = TypeVar("SinkConfig", bound=ConfigModel, covariant=True)
+Self = TypeVar("Self", bound="Sink")
 
 
 class Sink(Generic[SinkConfig, SinkReportType], Closeable, metaclass=ABCMeta):
@@ -91,7 +90,7 @@ class Sink(Generic[SinkConfig, SinkReportType], Closeable, metaclass=ABCMeta):
     report: SinkReportType
 
     @classmethod
-    def get_config_class(cls) -> Type[SinkConfig]:
+    def get_config_class(cls: Type[Self]) -> Type[SinkConfig]:
         config_class = get_class_from_annotation(cls, Sink, ConfigModel)
         assert config_class, "Sink subclasses must define a config class"
         return cast(Type[SinkConfig], config_class)
@@ -113,7 +112,7 @@ class Sink(Generic[SinkConfig, SinkReportType], Closeable, metaclass=ABCMeta):
         pass
 
     @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "Self":
+    def create(cls: Type[Self], config_dict: dict, ctx: PipelineContext) -> "Self":
         return cls(ctx, cls.get_config_class().parse_obj(config_dict))
 
     def handle_work_unit_start(self, workunit: WorkUnit) -> None:


### PR DESCRIPTION
Depending on python versions, the minimum typing_extensions is
`>=3.7.4.3` or `>=3.10.0.2`. (And needs to stay that way for Airflow.)
However, typing_extensions.Self is only available starting in `4.0.0` https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#added-in-version-400

This partially reverts #7313 to avoid the use of
typing_extensions.Self.

Fixes #7370


## Checklist

- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
