### PR TITLE
fix(ui) Make tooltip on search results stats summary clearer

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { Popover } from 'antd';
 import { ClockCircleOutlined, ConsoleSqlOutlined, TableOutlined, TeamOutlined, HddOutlined } from '@ant-design/icons';
 import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
@@ -67,7 +67,7 @@ export const DatasetStatsSummary = ({
             <Popover
                 content={
                     <PopoverContent>
-                        The time at which the data was last changed in the source platform:{' '}
+                        Data was last changed in the source platform on{' '}
                         <strong>{toLocalDateTimeString(lastUpdatedMs)}</strong>
                     </PopoverContent>
                 }

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Popover, Tooltip } from 'antd';
-import {
-    ClockCircleOutlined,
-    ConsoleSqlOutlined,
-    TableOutlined,
-    TeamOutlined,
-    QuestionCircleOutlined,
-    HddOutlined,
-} from '@ant-design/icons';
+import { Popover } from 'antd';
+import { ClockCircleOutlined, ConsoleSqlOutlined, TableOutlined, TeamOutlined, HddOutlined } from '@ant-design/icons';
 import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
@@ -19,9 +12,8 @@ const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
 `;
 
-const HelpIcon = styled(QuestionCircleOutlined)`
-    color: ${ANTD_GRAY[7]};
-    padding-left: 4px;
+const PopoverContent = styled.div`
+    max-width: 300px;
 `;
 
 type Props = {
@@ -48,7 +40,7 @@ export const DatasetStatsSummary = ({
                 <b>{formatNumberWithoutAbbreviation(rowCount)}</b> rows
                 {!!columnCount && (
                     <>
-                        , `<b>{formatNumberWithoutAbbreviation(columnCount)}</b> columns
+                        , <b>{formatNumberWithoutAbbreviation(columnCount)}</b> columns
                     </>
                 )}
             </StatText>
@@ -74,12 +66,10 @@ export const DatasetStatsSummary = ({
         !!lastUpdatedMs && (
             <Popover
                 content={
-                    <div>
-                        Changed on {toLocalDateTimeString(lastUpdatedMs)}.{' '}
-                        <Tooltip title="The time at which the data was last changed in the source platform">
-                            <HelpIcon />
-                        </Tooltip>
-                    </div>
+                    <PopoverContent>
+                        The time at which the data was last changed in the source platform:{' '}
+                        <strong>{toLocalDateTimeString(lastUpdatedMs)}</strong>
+                    </PopoverContent>
                 }
             >
                 <StatText>

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -67,14 +67,14 @@ export const DatasetStatsSummary = ({
             <Popover
                 content={
                     <PopoverContent>
-                        Data was last changed in the source platform on{' '}
+                        Data was last updated in the source platform on{' '}
                         <strong>{toLocalDateTimeString(lastUpdatedMs)}</strong>
                     </PopoverContent>
                 }
             >
                 <StatText>
                     <ClockCircleOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
-                    Changed {toRelativeTimeString(lastUpdatedMs)}
+                    Updated {toRelativeTimeString(lastUpdatedMs)}
                 </StatText>
             </Popover>
         ),


### PR DESCRIPTION
We've heard that the tooltip for the "changed <time ago>" on search results cards is not helpful. This makes things a bit clearer.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
