### PR TITLE
feat(cli): finalizing quickstart config commit hash

### DIFF
--- a/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
+++ b/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
@@ -10,7 +10,7 @@ from packaging.version import parse
 from pydantic import BaseModel
 
 DEFAULT_LOCAL_CONFIG_PATH = "~/.datahub/quickstart/quickstart_version_mapping.yaml"
-DEFAULT_REMOTE_CONFIG_PATH = "https://raw.githubusercontent.com/datahub-project/datahub/quickstart-stability/docker/quickstart/quickstart_version_mapping.yaml"
+DEFAULT_REMOTE_CONFIG_PATH = "https://raw.githubusercontent.com/datahub-project/datahub/master/docker/quickstart/quickstart_version_mapping.yaml"
 
 
 class QuickstartExecutionPlan(BaseModel):
@@ -111,7 +111,7 @@ class QuickstartVersionMappingConfig(BaseModel):
             if parse("v0.10.1") > parse(result.composefile_git_ref):
                 # The merge commit where the labels were added
                 # https://github.com/datahub-project/datahub/pull/7473
-                result.composefile_git_ref = "quickstart-stability"
+                result.composefile_git_ref = "1d3339276129a7cb8385c07a958fcc93acda3b4e"
 
         return result
 

--- a/metadata-ingestion/tests/cli/test_quickstart_version_mapping.py
+++ b/metadata-ingestion/tests/cli/test_quickstart_version_mapping.py
@@ -83,6 +83,6 @@ def test_quickstart_get_older_version():
     execution_plan = example_version_mapper.get_quickstart_execution_plan("v0.9.6")
     expected = QuickstartExecutionPlan(
         docker_tag="v0.9.6.1",
-        composefile_git_ref="quickstart-stability",
+        composefile_git_ref="1d3339276129a7cb8385c07a958fcc93acda3b4e",
     )
     assert execution_plan == expected


### PR DESCRIPTION
Now that the branch containg the change has been merged we have the merge commit, so we can look for it from the cli (1d3339276129a7cb8385c07a958fcc93acda3b4e)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
