### PR TITLE
chore(ingest): remove unused dependency for bigquery

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -149,7 +149,6 @@ looker_common = {
 }
 
 bigquery_common = {
-    "google-api-python-client",
     # Google cloud logging library
     "google-cloud-logging<=3.5.0",
     "google-cloud-bigquery",


### PR DESCRIPTION
This library has packages `googleapiclient` and `apiclient` and these are not used anywhere in codebase for BigQuery.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
