### PR TITLE
fix(ingest/bigquery): fix missing materialized views

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -233,7 +233,7 @@ FROM
   and t.TABLE_NAME = tos.TABLE_NAME
   and tos.OPTION_NAME = "description"
 WHERE
-  table_type in ('VIEW MATERIALIZED', 'VIEW')
+  table_type in ('MATERIALIZED VIEW', 'VIEW')
 order by
   table_schema ASC,
   table_name ASC
@@ -255,7 +255,7 @@ FROM
   and t.TABLE_NAME = tos.TABLE_NAME
   and tos.OPTION_NAME = "description"
 WHERE
-  table_type in ('VIEW MATERIALIZED', 'VIEW')
+  table_type in ('MATERIALIZED VIEW', 'VIEW')
 order by
   table_schema ASC,
   table_name ASC


### PR DESCRIPTION
Due to incorrect table_type in query, materialized views were not getting ingested earlier.
See here for list of table_types in BigQuery - https://cloud.google.com/bigquery/docs/information-schema-tables#:~:text=the%20tableId.-,table_type,-STRING


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
