### PR TITLE
feat(ui) Update auto-complete functionality and design

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -79,6 +79,7 @@ import com.linkedin.datahub.graphql.generated.Owner;
 import com.linkedin.datahub.graphql.generated.PolicyMatchCriterionValue;
 import com.linkedin.datahub.graphql.generated.QueryEntity;
 import com.linkedin.datahub.graphql.generated.QuerySubject;
+import com.linkedin.datahub.graphql.generated.QuickFilter;
 import com.linkedin.datahub.graphql.generated.RecommendationContent;
 import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResult;
@@ -204,6 +205,7 @@ import com.linkedin.datahub.graphql.resolvers.role.GetInviteTokenResolver;
 import com.linkedin.datahub.graphql.resolvers.role.ListRolesResolver;
 import com.linkedin.datahub.graphql.resolvers.search.AutoCompleteForMultipleResolver;
 import com.linkedin.datahub.graphql.resolvers.search.AutoCompleteResolver;
+import com.linkedin.datahub.graphql.resolvers.search.GetQuickFiltersResolver;
 import com.linkedin.datahub.graphql.resolvers.search.ScrollAcrossEntitiesResolver;
 import com.linkedin.datahub.graphql.resolvers.search.ScrollAcrossLineageResolver;
 import com.linkedin.datahub.graphql.resolvers.search.SearchAcrossEntitiesResolver;
@@ -743,6 +745,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("listGlobalViews", new ListGlobalViewsResolver(this.entityClient))
             .dataFetcher("globalViewsSettings", new GlobalViewsSettingsResolver(this.settingsService))
             .dataFetcher("listQueries", new ListQueriesResolver(this.entityClient))
+            .dataFetcher("getQuickFilters", new GetQuickFiltersResolver(this.entityClient, this.viewService))
         );
     }
 
@@ -965,6 +968,10 @@ public class GmsGraphQLEngine {
                     (env) -> ((ListTestsResult) env.getSource()).getTests().stream()
                         .map(Test::getUrn)
                         .collect(Collectors.toList())))
+            )
+            .type("QuickFilter", typeWiring -> typeWiring
+                .dataFetcher("entity", new EntityTypeResolver(entityTypes,
+                    (env) -> ((QuickFilter) env.getSource()).getEntity()))
             );
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolver.java
@@ -41,12 +41,12 @@ public class AutoCompleteForMultipleResolver implements DataFetcher<CompletableF
     public CompletableFuture<AutoCompleteMultipleResults> get(DataFetchingEnvironment environment) {
         final AutoCompleteMultipleInput input = bindArgument(environment.getArgument("input"), AutoCompleteMultipleInput.class);
 
-        // escape forward slash since it is a reserved character in Elasticsearch
-        final String sanitizedQuery = ResolverUtils.escapeForwardSlash(input.getQuery());
-        if (isBlank(sanitizedQuery)) {
+        if (isBlank(input.getQuery())) {
             _logger.error("'query' parameter was null or empty");
             throw new ValidationException("'query' parameter can not be null or empty");
         }
+        // escape forward slash since it is a reserved character in Elasticsearch
+        final String sanitizedQuery = ResolverUtils.escapeForwardSlash(input.getQuery());
 
         List<EntityType> types = input.getTypes();
         if (types != null && types.size() > 0) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteResolver.java
@@ -6,6 +6,7 @@ import com.linkedin.datahub.graphql.generated.AutoCompleteInput;
 import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.metadata.query.filter.Filter;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
@@ -49,6 +50,7 @@ public class AutoCompleteResolver implements DataFetcher<CompletableFuture<AutoC
             throw new ValidationException("'query' parameter can not be null or empty");
         }
 
+        final Filter filter = ResolverUtils.buildFilter(input.getFilters(), input.getOrFilters());
         final int limit = input.getLimit() != null ? input.getLimit() : DEFAULT_LIMIT;
             return CompletableFuture.supplyAsync(() -> {
                 try {
@@ -62,7 +64,7 @@ public class AutoCompleteResolver implements DataFetcher<CompletableFuture<AutoC
                     return _typeToEntity.get(input.getType()).autoComplete(
                             sanitizedQuery,
                             input.getField(),
-                            input.getFilters(),
+                            filter,
                             limit,
                             environment.getContext()
                     );

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutocompleteUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutocompleteUtils.java
@@ -4,7 +4,9 @@ import com.linkedin.datahub.graphql.generated.AutoCompleteMultipleInput;
 import com.linkedin.datahub.graphql.generated.AutoCompleteMultipleResults;
 import com.linkedin.datahub.graphql.generated.AutoCompleteResultForEntity;
 import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
 import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.metadata.query.filter.Filter;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,11 +33,12 @@ public class AutocompleteUtils {
     final int limit = input.getLimit() != null ? input.getLimit() : DEFAULT_LIMIT;
 
     final List<CompletableFuture<AutoCompleteResultForEntity>> autoCompletesFuture = entities.stream().map(entity -> CompletableFuture.supplyAsync(() -> {
+      final Filter filter = ResolverUtils.buildFilter(input.getFilters(), input.getOrFilters());
       try {
         final AutoCompleteResults searchResult = entity.autoComplete(
             sanitizedQuery,
             input.getField(),
-            input.getFilters(),
+            filter,
             limit,
             environment.getContext()
         );
@@ -49,7 +52,7 @@ public class AutocompleteUtils {
             + String.format("field %s, query %s, filters: %s, limit: %s",
             input.getField(),
             input.getQuery(),
-            input.getFilters(),
+            filter,
             input.getLimit()), e);
         return new AutoCompleteResultForEntity(entity.type(), Collections.emptyList(), Collections.emptyList());
       }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/GetQuickFiltersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/GetQuickFiltersResolver.java
@@ -1,0 +1,177 @@
+package com.linkedin.datahub.graphql.resolvers.search;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.GetQuickFiltersInput;
+import com.linkedin.datahub.graphql.generated.GetQuickFiltersResult;
+import com.linkedin.datahub.graphql.generated.QuickFilter;
+import com.linkedin.datahub.graphql.resolvers.EntityTypeMapper;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.AggregationMetadataArray;
+import com.linkedin.metadata.search.FilterValue;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.view.DataHubViewInfo;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.SEARCHABLE_ENTITY_TYPES;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.resolveView;
+
+@Slf4j
+@RequiredArgsConstructor
+public class GetQuickFiltersResolver implements DataFetcher<CompletableFuture<GetQuickFiltersResult>> {
+
+  private final EntityClient _entityClient;
+  private final ViewService _viewService;
+
+  private static final String PLATFORM = "platform";
+  private static final int PLATFORM_COUNT = 5;
+  private static final String ENTITY = "entity";
+  private static final int SOURCE_ENTITY_COUNT = 3;
+  private static final int DATAHUB_ENTITY_COUNT = 2;
+
+  public CompletableFuture<GetQuickFiltersResult> get(final DataFetchingEnvironment environment) throws Exception {
+    final GetQuickFiltersInput input =  bindArgument(environment.getArgument("input"), GetQuickFiltersInput.class);
+
+    return CompletableFuture.supplyAsync(() -> {
+      final GetQuickFiltersResult result = new GetQuickFiltersResult();
+      final List<QuickFilter> quickFilters = new ArrayList<>();
+
+      try {
+        final SearchResult searchResult = getSearchResults(ResolverUtils.getAuthentication(environment), input);
+        final AggregationMetadataArray aggregations = searchResult.getMetadata().getAggregations();
+
+        quickFilters.addAll(getPlatformQuickFilters(aggregations));
+        quickFilters.addAll(getEntityTypeQuickFilters(aggregations));
+      } catch (Exception e) {
+        log.error("Failed getting quick filters", e);
+        throw new RuntimeException("Failed to to get quick filters", e);
+      }
+
+      result.setQuickFilters(quickFilters);
+      return result;
+    });
+  }
+
+  /**
+   * Do a star search with view filter applied to get info about all data in this instance.
+   */
+  private SearchResult getSearchResults(@Nonnull final Authentication authentication, @Nonnull final GetQuickFiltersInput input) throws Exception {
+    final DataHubViewInfo maybeResolvedView = (input.getViewUrn() != null)
+        ? resolveView(_viewService, UrnUtils.getUrn(input.getViewUrn()), authentication)
+        : null;
+    final List<String> entityNames = SEARCHABLE_ENTITY_TYPES.stream().map(EntityTypeMapper::getName).collect(Collectors.toList());
+
+    return _entityClient.searchAcrossEntities(
+        maybeResolvedView != null
+            ? SearchUtils.intersectEntityTypes(entityNames, maybeResolvedView.getDefinition().getEntityTypes())
+            : entityNames,
+        "*",
+        maybeResolvedView != null
+            ? SearchUtils.combineFilters(null, maybeResolvedView.getDefinition().getFilter())
+            : null,
+        0,
+        0,
+        null,
+        authentication);
+  }
+
+  /**
+   * Get platforms and their count from an aggregations array, sorts by entity count, and map the top 5 to quick filters
+   */
+  private List<QuickFilter> getPlatformQuickFilters(@Nonnull final AggregationMetadataArray aggregations) {
+    final List<QuickFilter> platforms = new ArrayList<>();
+    final Optional<AggregationMetadata> platformAggregations = aggregations.stream().filter(agg -> agg.getName().equals(PLATFORM)).findFirst();
+    if (platformAggregations.isPresent()) {
+      final List<FilterValue> sortedPlatforms =
+          platformAggregations.get().getFilterValues().stream().sorted(Comparator.comparingLong(val -> -val.getFacetCount())).collect(Collectors.toList());
+      sortedPlatforms.forEach(platformFilter -> {
+        if (platforms.size() < PLATFORM_COUNT && platformFilter.getFacetCount() > 0) {
+          platforms.add(mapQuickFilter(PLATFORM, platformFilter));
+        }
+      });
+    }
+
+    // return platforms sorted alphabetically by their name
+    return platforms.stream().sorted(Comparator.comparing(QuickFilter::getValue)).collect(Collectors.toList());
+  }
+
+  /**
+   * Gets entity type quick filters from search aggregations. First, get source entity type quick filters
+   * from a prioritized list. Do the same for datathub entity types.
+   */
+  private List<QuickFilter> getEntityTypeQuickFilters(@Nonnull final AggregationMetadataArray aggregations) {
+    final List<QuickFilter> entityTypes = new ArrayList<>();
+    final Optional<AggregationMetadata> entityAggregations = aggregations.stream().filter(agg -> agg.getName().equals(ENTITY)).findFirst();
+
+    if (entityAggregations.isPresent()) {
+      final List<QuickFilter> sourceEntityTypeFilters =
+          getQuickFiltersFromList(SearchUtils.PRIORITIZED_SOURCE_ENTITY_TYPES, SOURCE_ENTITY_COUNT, entityAggregations.get());
+      entityTypes.addAll(sourceEntityTypeFilters);
+
+      final List<QuickFilter> dataHubEntityTypeFilters =
+          getQuickFiltersFromList(SearchUtils.PRIORITIZED_DATAHUB_ENTITY_TYPES, DATAHUB_ENTITY_COUNT, entityAggregations.get());
+      entityTypes.addAll(dataHubEntityTypeFilters);
+    }
+    return entityTypes;
+  }
+
+  /**
+   * Create a quick filters list by looping over prioritized list and adding filters that exist until we reach the maxListSize defined
+   */
+  private List<QuickFilter> getQuickFiltersFromList(
+      @Nonnull final List<String> prioritizedList,
+      final int maxListSize,
+      @Nonnull final AggregationMetadata entityAggregations
+  ) {
+    final List<QuickFilter> entityTypes = new ArrayList<>();
+    prioritizedList.forEach(entityType -> {
+      if (entityTypes.size() < maxListSize) {
+        final Optional<FilterValue> entityFilter = entityAggregations.getFilterValues().stream().filter(val -> val.getValue().equals(entityType)).findFirst();
+        if (entityFilter.isPresent() && entityFilter.get().getFacetCount() > 0) {
+          entityTypes.add(mapQuickFilter(ENTITY, entityFilter.get()));
+        }
+      }
+    });
+
+    return entityTypes;
+  }
+
+  private QuickFilter mapQuickFilter(@Nonnull final String field, @Nonnull final FilterValue filterValue) {
+    final boolean isEntityTypeFilter = field.equals(ENTITY);
+    final QuickFilter quickFilter = new QuickFilter();
+    quickFilter.setField(field);
+    quickFilter.setValue(convertFilterValue(filterValue.getValue(), isEntityTypeFilter));
+    if (filterValue.getEntity() != null) {
+      final Entity entity = UrnToEntityMapper.map(filterValue.getEntity());
+      quickFilter.setEntity(entity);
+    }
+    return quickFilter;
+  }
+
+  /**
+   * If we're working with an entity type filter, we need to convert the value to an EntityType
+   */
+  public static String convertFilterValue(String filterValue, boolean isEntityType) {
+    if (isEntityType) {
+      return EntityTypeMapper.getType(filterValue).toString();
+    }
+    return filterValue;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -17,10 +17,27 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.codehaus.plexus.util.CollectionUtils;
+
+import static com.linkedin.metadata.Constants.CHART_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.CONTAINER_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.CORP_GROUP_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.CORP_USER_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DASHBOARD_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATA_FLOW_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATA_JOB_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DOMAIN_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.GLOSSARY_TERM_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.ML_FEATURE_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.ML_FEATURE_TABLE_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.ML_MODEL_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.ML_MODEL_GROUP_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.ML_PRIMARY_KEY_ENTITY_NAME;
 
 
 @Slf4j
@@ -72,6 +89,32 @@ public class SearchUtils {
           EntityType.CORP_GROUP,
           EntityType.NOTEBOOK);
 
+  /**
+   * A prioritized list of source filter types used to generate quick filters
+   */
+  public static final List<String> PRIORITIZED_SOURCE_ENTITY_TYPES = Stream.of(
+      DATASET_ENTITY_NAME,
+      DASHBOARD_ENTITY_NAME,
+      DATA_FLOW_ENTITY_NAME,
+      DATA_JOB_ENTITY_NAME,
+      CHART_ENTITY_NAME,
+      CONTAINER_ENTITY_NAME,
+      ML_MODEL_ENTITY_NAME,
+      ML_MODEL_GROUP_ENTITY_NAME,
+      ML_FEATURE_ENTITY_NAME,
+      ML_FEATURE_TABLE_ENTITY_NAME,
+      ML_PRIMARY_KEY_ENTITY_NAME
+  ).map(String::toLowerCase).collect(Collectors.toList());
+
+  /**
+   * A prioritized list of DataHub filter types used to generate quick filters
+   */
+  public static final List<String> PRIORITIZED_DATAHUB_ENTITY_TYPES = Stream.of(
+      DOMAIN_ENTITY_NAME,
+      GLOSSARY_TERM_ENTITY_NAME,
+      CORP_GROUP_ENTITY_NAME,
+      CORP_USER_ENTITY_NAME
+  ).map(String::toLowerCase).collect(Collectors.toList());
 
   /**
    * Combines two {@link Filter} instances in a conjunction and returns a new instance of {@link Filter}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/SearchableEntityType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/SearchableEntityType.java
@@ -5,6 +5,7 @@ import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.metadata.query.filter.Filter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -49,7 +50,7 @@ public interface SearchableEntityType<T extends Entity, K> extends EntityType<T,
      */
     AutoCompleteResults autoComplete(@Nonnull String query,
                                      @Nullable String field,
-                                     @Nullable List<FacetFilterInput> filters,
+                                     @Nullable Filter filters,
                                      int limit,
                                      @Nonnull final QueryContext context) throws Exception;
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -36,6 +36,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -152,14 +153,13 @@ public class ChartType implements SearchableEntityType<Chart, String>, Browsable
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
         final AutoCompleteResult result = _entityClient.autoComplete(
             "chart",
             query,
-            facetFilters,
+            filters,
             limit,
             context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/container/ContainerType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/container/ContainerType.java
@@ -18,6 +18,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.net.URISyntaxException;
@@ -125,11 +126,10 @@ public class ContainerType implements SearchableEntityType<Container, String>,
   @Override
   public AutoCompleteResults autoComplete(@Nonnull String query,
                                           @Nullable String field,
-                                          @Nullable List<FacetFilterInput> filters,
+                                          @Nullable Filter filters,
                                           int limit,
                                           @Nonnull final QueryContext context) throws Exception {
-    final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-    final AutoCompleteResult result = _entityClient.autoComplete(ENTITY_NAME, query, facetFilters, limit, context.getAuthentication());
+    final AutoCompleteResult result = _entityClient.autoComplete(ENTITY_NAME, query, filters, limit, context.getAuthentication());
     return AutoCompleteResultsMapper.map(result);
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpgroup/CorpGroupType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpgroup/CorpGroupType.java
@@ -28,6 +28,7 @@ import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.identity.CorpGroupEditableInfo;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -110,10 +111,10 @@ public class CorpGroupType implements SearchableEntityType<CorpGroup, String>, M
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final AutoCompleteResult result = _entityClient.autoComplete("corpGroup", query, Collections.emptyMap(), limit,
+        final AutoCompleteResult result = _entityClient.autoComplete("corpGroup", query, filters, limit,
             context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/CorpUserType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/CorpUserType.java
@@ -31,6 +31,7 @@ import com.linkedin.identity.CorpUserEditableInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -113,10 +114,10 @@ public class CorpUserType implements SearchableEntityType<CorpUser, String>, Mut
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final AutoCompleteResult result = _entityClient.autoComplete("corpuser", query, Collections.emptyMap(), limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("corpuser", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -37,6 +37,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -147,11 +148,10 @@ public class DashboardType implements SearchableEntityType<Dashboard, String>, B
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("dashboard", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("dashboard", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/DataFlowType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/DataFlowType.java
@@ -37,6 +37,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -142,11 +143,10 @@ public class DataFlowType implements SearchableEntityType<DataFlow, String>, Bro
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("dataFlow", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("dataFlow", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/DataJobType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/DataJobType.java
@@ -37,6 +37,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -142,11 +143,10 @@ public class DataJobType implements SearchableEntityType<DataJob, String>, Brows
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("dataJob", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("dataJob", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
@@ -37,6 +37,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -162,11 +163,10 @@ public class DatasetType implements SearchableEntityType<Dataset, String>, Brows
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete(ENTITY_NAME, query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete(ENTITY_NAME, query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/domain/DomainType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/domain/DomainType.java
@@ -3,13 +3,22 @@ package com.linkedin.datahub.graphql.types.domain;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import graphql.execution.DataFetcherResult;
+import org.apache.commons.lang3.NotImplementedException;
+
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -19,9 +28,10 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
-public class DomainType implements com.linkedin.datahub.graphql.types.EntityType<Domain, String> {
+public class DomainType implements SearchableEntityType<Domain, String>, com.linkedin.datahub.graphql.types.EntityType<Domain, String> {
 
   static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of(
     Constants.DOMAIN_KEY_ASPECT_NAME,
@@ -78,6 +88,26 @@ public class DomainType implements com.linkedin.datahub.graphql.types.EntityType
       throw new RuntimeException("Failed to batch load Domains", e);
     }
   }
+
+  @Override
+  public SearchResults search(@Nonnull String query,
+      @Nullable List<FacetFilterInput> filters,
+      int start,
+      int count,
+      @Nonnull final QueryContext context) throws Exception {
+    throw new NotImplementedException("Searchable type (deprecated) not implemented on Domain entity type");
+  }
+
+  @Override
+  public AutoCompleteResults autoComplete(@Nonnull String query,
+      @Nullable String field,
+      @Nullable Filter filters,
+      int limit,
+      @Nonnull final QueryContext context) throws Exception {
+    final AutoCompleteResult result = _entityClient.autoComplete(Constants.DOMAIN_ENTITY_NAME, query, filters, limit, context.getAuthentication());
+    return AutoCompleteResultsMapper.map(result);
+  }
+
 
   private Urn getUrn(final String urnStr) {
     try {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/GlossaryTermType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/GlossaryTermType.java
@@ -25,6 +25,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.util.ArrayList;
@@ -119,12 +120,11 @@ public class GlossaryTermType implements SearchableEntityType<GlossaryTerm, Stri
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
         final AutoCompleteResult result = _entityClient.autoComplete(
-            "glossaryTerm", query, facetFilters, limit, context.getAuthentication());
+            "glossaryTerm", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLFeatureTableType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLFeatureTableType.java
@@ -25,6 +25,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.util.HashSet;
@@ -105,11 +106,10 @@ public class MLFeatureTableType implements SearchableEntityType<MLFeatureTable, 
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("mlFeatureTable", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("mlFeatureTable", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLFeatureType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLFeatureType.java
@@ -18,6 +18,7 @@ import com.linkedin.datahub.graphql.types.mlmodel.mappers.MLFeatureMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.util.HashSet;
@@ -97,11 +98,10 @@ public class MLFeatureType implements SearchableEntityType<MLFeature, String> {
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("mlFeature", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("mlFeature", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLModelGroupType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLModelGroupType.java
@@ -25,6 +25,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.util.HashSet;
@@ -106,11 +107,10 @@ public class MLModelGroupType implements SearchableEntityType<MLModelGroup, Stri
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("mlModelGroup", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("mlModelGroup", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLModelType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLModelType.java
@@ -25,6 +25,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.util.HashSet;
@@ -104,11 +105,10 @@ public class MLModelType implements SearchableEntityType<MLModel, String>, Brows
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("mlModel", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("mlModel", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLPrimaryKeyType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/MLPrimaryKeyType.java
@@ -18,6 +18,7 @@ import com.linkedin.datahub.graphql.types.mlmodel.mappers.MLPrimaryKeyMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import graphql.execution.DataFetcherResult;
 import java.util.HashSet;
@@ -97,11 +98,10 @@ public class MLPrimaryKeyType implements SearchableEntityType<MLPrimaryKey, Stri
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull final QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("mlPrimaryKey", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("mlPrimaryKey", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/NotebookType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/notebook/NotebookType.java
@@ -35,6 +35,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -93,13 +94,10 @@ public class NotebookType implements SearchableEntityType<Notebook, String>, Bro
   @Override
   public AutoCompleteResults autoComplete(@Nonnull String query,
       @Nullable String field,
-      @Nullable List<FacetFilterInput> filters,
+      @Nullable Filter filters,
       int limit,
       @Nonnull final QueryContext context) throws Exception {
-    // Put empty map here according to
-    // https://datahubspace.slack.com/archives/C029A3M079U/p1646288772126639
-    final Map<String, String> facetFilters = Collections.emptyMap();
-    final AutoCompleteResult result = _entityClient.autoComplete(NOTEBOOK_ENTITY_NAME, query, facetFilters, limit, context.getAuthentication());
+    final AutoCompleteResult result = _entityClient.autoComplete(NOTEBOOK_ENTITY_NAME, query, filters, limit, context.getAuthentication());
     return AutoCompleteResultsMapper.map(result);
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/tag/TagType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/tag/TagType.java
@@ -26,6 +26,7 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.r2.RemoteInvocationException;
@@ -117,11 +118,10 @@ public class TagType implements com.linkedin.datahub.graphql.types.SearchableEnt
     @Override
     public AutoCompleteResults autoComplete(@Nonnull String query,
                                             @Nullable String field,
-                                            @Nullable List<FacetFilterInput> filters,
+                                            @Nullable Filter filters,
                                             int limit,
                                             @Nonnull QueryContext context) throws Exception {
-        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
-        final AutoCompleteResult result = _entityClient.autoComplete("tag", query, facetFilters, limit, context.getAuthentication());
+        final AutoCompleteResult result = _entityClient.autoComplete("tag", query, filters, limit, context.getAuthentication());
         return AutoCompleteResultsMapper.map(result);
     }
 

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -205,6 +205,11 @@ type Query {
     listQueries(
       "Input required for listing queries"
       input: ListQueriesInput!): ListQueriesResult
+
+    """
+    Get quick filters to display in auto-complete
+    """
+    getQuickFilters(input: GetQuickFiltersInput!): GetQuickFiltersResult
 }
 
 """
@@ -1332,7 +1337,7 @@ type SiblingProperties {
 }
 
 """
-All of the parent containers for a given entity
+All of the parent containers for a given entity. Returns parents with direct parent first followed by the parent's parent etc.
 """
 type ParentContainersResult {
     """

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -661,6 +661,12 @@ input AutoCompleteInput {
   Faceted filters applied to autocomplete results
   """
   filters: [FacetFilterInput!]
+
+
+  """
+  A list of disjunctive criterion for the filter. (or operation to combine filters)
+  """
+  orFilters: [AndFilterInput!]
 }
 
 """
@@ -692,6 +698,11 @@ input AutoCompleteMultipleInput {
   Faceted filters applied to autocomplete results
   """
   filters: [FacetFilterInput!]
+
+  """
+  A list of disjunctive criterion for the filter. (or operation to combine filters)
+  """
+  orFilters: [AndFilterInput!]
 }
 
 """
@@ -908,4 +919,44 @@ type FacetFilter {
   If the filter should or should not be matched
   """
   negated: Boolean
+}
+
+"""
+Input for getting Quick Filters
+"""
+input GetQuickFiltersInput {
+  """
+  Optional - A View to apply when generating results
+  """
+  viewUrn: String
+}
+
+"""
+The result object when fetching quick filters
+"""
+type GetQuickFiltersResult {
+  """
+  The list of quick filters to render in the UI
+  """
+  quickFilters: [QuickFilter]!
+}
+
+"""
+A quick filter in search and auto-complete
+"""
+type QuickFilter {
+  """
+  Name of field to filter by
+  """
+  field: String!
+
+  """
+  Value to filter on
+  """
+  value: String!
+
+  """
+  Entity that the value maps to if any
+  """
+  entity: Entity
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolverTest.java
@@ -1,0 +1,151 @@
+package com.linkedin.datahub.graphql.resolvers.search;
+
+import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableList;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.exception.ValidationException;
+import com.linkedin.datahub.graphql.generated.AutoCompleteMultipleInput;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.dashboard.DashboardType;
+import com.linkedin.datahub.graphql.types.dataflow.DataFlowType;
+import com.linkedin.datahub.graphql.types.dataset.DatasetType;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.query.AutoCompleteEntityArray;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.Filter;
+import graphql.schema.DataFetchingEnvironment;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+
+public class AutoCompleteForMultipleResolverTest {
+
+  private AutoCompleteForMultipleResolverTest() { }
+
+  public static void testAutoCompleteResolverSuccess(
+      EntityClient mockClient,
+      String entityName,
+      EntityType entityType,
+      SearchableEntityType<?, ?> entity
+  ) throws Exception {
+    final AutoCompleteForMultipleResolver resolver = new AutoCompleteForMultipleResolver(ImmutableList.of(entity));
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    AutoCompleteMultipleInput input = new AutoCompleteMultipleInput();
+    input.setQuery("test");
+    input.setTypes(ImmutableList.of(entityType));
+    input.setLimit(10);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    resolver.get(mockEnv).get();
+    verifyMockEntityClient(
+        mockClient,
+        entityName,
+        "test",
+        null,
+        10
+    );
+  }
+
+  // test our main entity types
+  @Test
+  public static void testAutoCompleteResolverSuccessForDifferentEntities() throws Exception {
+    // Daatasets
+    EntityClient mockClient = initMockEntityClient(
+      Constants.DATASET_ENTITY_NAME,
+      "test",
+      null,
+      10,
+      new AutoCompleteResult()
+          .setQuery("test")
+          .setEntities(new AutoCompleteEntityArray())
+          .setSuggestions(new StringArray())
+    );
+    testAutoCompleteResolverSuccess(mockClient, Constants.DATASET_ENTITY_NAME, EntityType.DATASET, new DatasetType(mockClient));
+
+    // Dashboards
+    mockClient = initMockEntityClient(
+      Constants.DASHBOARD_ENTITY_NAME,
+      "test",
+      null,
+      10,
+      new AutoCompleteResult()
+          .setQuery("test")
+          .setEntities(new AutoCompleteEntityArray())
+          .setSuggestions(new StringArray())
+    );
+    testAutoCompleteResolverSuccess(mockClient, Constants.DASHBOARD_ENTITY_NAME, EntityType.DASHBOARD, new DashboardType(mockClient));
+
+    //DataFlows
+    mockClient = initMockEntityClient(
+      Constants.DATA_FLOW_ENTITY_NAME,
+      "test",
+      null,
+      10,
+      new AutoCompleteResult()
+          .setQuery("test")
+          .setEntities(new AutoCompleteEntityArray())
+          .setSuggestions(new StringArray())
+    );
+    testAutoCompleteResolverSuccess(mockClient, Constants.DATA_FLOW_ENTITY_NAME, EntityType.DATA_FLOW, new DataFlowType(mockClient));
+  }
+
+  @Test
+  public static void testAutoCompleteResolverFailNoQuery() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    final AutoCompleteForMultipleResolver resolver = new AutoCompleteForMultipleResolver(ImmutableList.of(new DatasetType(mockClient)));
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    AutoCompleteMultipleInput input = new AutoCompleteMultipleInput();
+    // don't set query on input
+    input.setTypes(ImmutableList.of(EntityType.DATASET));
+    input.setLimit(10);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Assert.assertThrows(ValidationException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  private static EntityClient initMockEntityClient(
+      String entityName,
+      String query,
+      Filter filters,
+      int limit,
+      AutoCompleteResult result
+  ) throws Exception {
+    EntityClient client = Mockito.mock(EntityClient.class);
+    Mockito.when(client.autoComplete(
+        Mockito.eq(entityName),
+        Mockito.eq(query),
+        Mockito.eq(filters),
+        Mockito.eq(limit),
+        Mockito.any(Authentication.class)
+    )).thenReturn(result);
+    return client;
+  }
+
+  private static void verifyMockEntityClient(
+      EntityClient mockClient,
+      String entityName,
+      String query,
+      Filter filters,
+      int limit
+  ) throws Exception {
+    Mockito.verify(mockClient, Mockito.times(1))
+        .autoComplete(
+            Mockito.eq(entityName),
+            Mockito.eq(query),
+            Mockito.eq(filters),
+            Mockito.eq(limit),
+            Mockito.any(Authentication.class)
+        );
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/GetQuickFiltersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/GetQuickFiltersResolverTest.java
@@ -1,0 +1,278 @@
+package com.linkedin.datahub.graphql.resolvers.search;
+
+import com.datahub.authentication.Authentication;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.GetQuickFiltersInput;
+import com.linkedin.datahub.graphql.generated.GetQuickFiltersResult;
+import com.linkedin.datahub.graphql.generated.QuickFilter;
+import com.linkedin.datahub.graphql.resolvers.EntityTypeMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.AggregationMetadataArray;
+import com.linkedin.metadata.search.FilterValue;
+import com.linkedin.metadata.search.FilterValueArray;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.r2.RemoteInvocationException;
+import graphql.schema.DataFetchingEnvironment;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.linkedin.datahub.graphql.TestUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.search.SearchUtils.SEARCHABLE_ENTITY_TYPES;
+
+public class GetQuickFiltersResolverTest {
+
+  @Test
+  public static void testGetQuickFiltersHappyPathSuccess() throws Exception {
+    SearchResultMetadata mockData = getHappyPathTestData();
+    ViewService mockService = Mockito.mock(ViewService.class);
+    EntityClient mockClient = initMockEntityClient(
+        SEARCHABLE_ENTITY_TYPES.stream().map(EntityTypeMapper::getName).collect(Collectors.toList()),
+        "*",
+        null,
+        0,
+        0,
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(0)
+            .setMetadata(mockData)
+    );
+
+    final GetQuickFiltersResolver resolver = new GetQuickFiltersResolver(mockClient, mockService);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(new GetQuickFiltersInput());
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    GetQuickFiltersResult result = resolver.get(mockEnv).get();
+
+    Assert.assertEquals(result.getQuickFilters().size(), 10);
+    compareResultToExpectedData(result, getHappyPathResultData());
+  }
+
+  @Test
+  public static void testGetQuickFiltersUnhappyPathSuccess() throws Exception {
+    SearchResultMetadata mockData = getUnHappyPathTestData();
+    ViewService mockService = Mockito.mock(ViewService.class);
+    EntityClient mockClient = initMockEntityClient(
+        SEARCHABLE_ENTITY_TYPES.stream().map(EntityTypeMapper::getName).collect(Collectors.toList()),
+        "*",
+        null,
+        0,
+        0,
+        new SearchResult()
+            .setEntities(new SearchEntityArray())
+            .setNumEntities(0)
+            .setFrom(0)
+            .setPageSize(0)
+            .setMetadata(mockData)
+    );
+
+    final GetQuickFiltersResolver resolver = new GetQuickFiltersResolver(mockClient, mockService);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(new GetQuickFiltersInput());
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    GetQuickFiltersResult result = resolver.get(mockEnv).get();
+
+    Assert.assertEquals(result.getQuickFilters().size(), 8);
+    compareResultToExpectedData(result, getUnHappyPathResultData());
+  }
+
+  @Test
+  public static void testGetQuickFiltersFailure() throws Exception {
+    ViewService mockService = Mockito.mock(ViewService.class);
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(mockClient.searchAcrossEntities(
+        Mockito.anyList(),
+        Mockito.anyString(),
+        Mockito.any(),
+        Mockito.anyInt(),
+        Mockito.anyInt(),
+        Mockito.eq(null),
+        Mockito.any(Authentication.class)
+    )).thenThrow(new RemoteInvocationException());
+
+    final GetQuickFiltersResolver resolver = new GetQuickFiltersResolver(mockClient, mockService);
+
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    QueryContext mockContext = getMockAllowContext();
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(new GetQuickFiltersInput());
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    Assert.assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
+  }
+
+  private static void compareResultToExpectedData(GetQuickFiltersResult result, GetQuickFiltersResult expected) {
+    IntStream.range(0, result.getQuickFilters().size()).forEach(index -> {
+      QuickFilter resultFilter = result.getQuickFilters().get(index);
+      QuickFilter expectedFilter = expected.getQuickFilters().get(index);
+      Assert.assertEquals(resultFilter.getField(), expectedFilter.getField());
+      Assert.assertEquals(resultFilter.getValue(), expectedFilter.getValue());
+      if (resultFilter.getEntity() != null) {
+        Assert.assertEquals(resultFilter.getEntity().getUrn(), expectedFilter.getEntity().getUrn());
+      }
+    });
+  }
+
+  private static SearchResultMetadata getHappyPathTestData() {
+    FilterValueArray platformFilterValues = new FilterValueArray();
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:snowflake", 100, "urn:li:dataPlatform:snowflake"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:looker", 99, "urn:li:dataPlatform:looker"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:dbt", 98, "urn:li:dataPlatform:dbt"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:bigquery", 97, "urn:li:dataPlatform:bigquery"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:test", 1, "urn:li:dataPlatform:test"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:custom", 96, "urn:li:dataPlatform:custom"));
+
+    FilterValueArray entityTypeFilters = new FilterValueArray();
+    entityTypeFilters.add(createFilterValue("dataset", 100, null));
+    entityTypeFilters.add(createFilterValue("dashboard", 100, null));
+    entityTypeFilters.add(createFilterValue("dataflow", 100, null));
+    entityTypeFilters.add(createFilterValue("datajob", 200, null));
+    entityTypeFilters.add(createFilterValue("chart", 200, null));
+    entityTypeFilters.add(createFilterValue("domain", 200, null));
+    entityTypeFilters.add(createFilterValue("corpuser", 200, null));
+    entityTypeFilters.add(createFilterValue("glossaryterm", 200, null));
+
+    AggregationMetadataArray aggregationMetadataArray = new AggregationMetadataArray();
+    aggregationMetadataArray.add(createAggregationMetadata("platform", platformFilterValues));
+    aggregationMetadataArray.add(createAggregationMetadata("entity", entityTypeFilters));
+
+    SearchResultMetadata resultMetadata = new SearchResultMetadata();
+    resultMetadata.setAggregations(aggregationMetadataArray);
+    return resultMetadata;
+  }
+
+  private static GetQuickFiltersResult getHappyPathResultData() {
+    GetQuickFiltersResult result = new GetQuickFiltersResult();
+    List<QuickFilter> quickFilters = new ArrayList<>();
+    // platforms should be in alphabetical order
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:bigquery", "urn:li:dataPlatform:bigquery"));
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:custom", "urn:li:dataPlatform:custom"));
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:dbt", "urn:li:dataPlatform:dbt"));
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:looker", "urn:li:dataPlatform:looker"));
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:snowflake", "urn:li:dataPlatform:snowflake"));
+    quickFilters.add(createQuickFilter("entity", "DATASET", null));
+    quickFilters.add(createQuickFilter("entity", "DASHBOARD", null));
+    quickFilters.add(createQuickFilter("entity", "DATA_FLOW", null));
+    quickFilters.add(createQuickFilter("entity", "DOMAIN", null));
+    quickFilters.add(createQuickFilter("entity", "GLOSSARY_TERM", null));
+    result.setQuickFilters(quickFilters);
+
+    return result;
+  }
+
+  private static SearchResultMetadata getUnHappyPathTestData() {
+    FilterValueArray platformFilterValues = new FilterValueArray();
+    // only 3 platforms available
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:snowflake", 98, "urn:li:dataPlatform:snowflake"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:looker", 100, "urn:li:dataPlatform:looker"));
+    platformFilterValues.add(createFilterValue("urn:li:dataPlatform:dbt", 99, "urn:li:dataPlatform:dbt"));
+
+    FilterValueArray entityTypeFilters = new FilterValueArray();
+    // no dashboard, data flows, or glossary terms
+    entityTypeFilters.add(createFilterValue("datajob", 200, null));
+    entityTypeFilters.add(createFilterValue("chart", 200, null));
+    entityTypeFilters.add(createFilterValue("domain", 200, null));
+    entityTypeFilters.add(createFilterValue("corpuser", 200, null));
+    entityTypeFilters.add(createFilterValue("dataset", 100, null));
+
+    AggregationMetadataArray aggregationMetadataArray = new AggregationMetadataArray();
+    aggregationMetadataArray.add(createAggregationMetadata("platform", platformFilterValues));
+    aggregationMetadataArray.add(createAggregationMetadata("entity", entityTypeFilters));
+
+    SearchResultMetadata resultMetadata = new SearchResultMetadata();
+    resultMetadata.setAggregations(aggregationMetadataArray);
+    return resultMetadata;
+  }
+
+  private static GetQuickFiltersResult getUnHappyPathResultData() {
+    GetQuickFiltersResult result = new GetQuickFiltersResult();
+    List<QuickFilter> quickFilters = new ArrayList<>();
+    // in correct order by count for platforms (alphabetical). In correct order by priority for entity types
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:dbt", "urn:li:dataPlatform:dbt"));
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:looker", "urn:li:dataPlatform:looker"));
+    quickFilters.add(createQuickFilter("platform", "urn:li:dataPlatform:snowflake", "urn:li:dataPlatform:snowflake"));
+    quickFilters.add(createQuickFilter("entity", "DATASET", null));
+    quickFilters.add(createQuickFilter("entity", "DATA_JOB", null));
+    quickFilters.add(createQuickFilter("entity", "CHART", null));
+    quickFilters.add(createQuickFilter("entity", "DOMAIN", null));
+    quickFilters.add(createQuickFilter("entity", "CORP_USER", null));
+    result.setQuickFilters(quickFilters);
+
+    return result;
+  }
+
+  private static QuickFilter createQuickFilter(@Nonnull final String field, @Nonnull final String value, @Nullable final String entityUrn) {
+    QuickFilter quickFilter = new QuickFilter();
+    quickFilter.setField(field);
+    quickFilter.setValue(value);
+    if (entityUrn != null) {
+      quickFilter.setEntity(UrnToEntityMapper.map(UrnUtils.getUrn(entityUrn)));
+    }
+    return quickFilter;
+  }
+
+  private static FilterValue createFilterValue(@Nonnull final String value, final int count, @Nullable final String entity) {
+    FilterValue filterValue = new FilterValue();
+    filterValue.setValue(value);
+    filterValue.setFacetCount(count);
+    if (entity != null) {
+      filterValue.setEntity(UrnUtils.getUrn(entity));
+    }
+    return filterValue;
+  }
+
+  private static AggregationMetadata createAggregationMetadata(@Nonnull final String name, @Nonnull final FilterValueArray filterValues) {
+    AggregationMetadata aggregationMetadata = new AggregationMetadata();
+    aggregationMetadata.setName(name);
+    aggregationMetadata.setFilterValues(filterValues);
+    return aggregationMetadata;
+  }
+
+  private static EntityClient initMockEntityClient(
+      List<String> entityTypes,
+      String query,
+      Filter filter,
+      int start,
+      int limit,
+      SearchResult result
+  ) throws Exception {
+    EntityClient client = Mockito.mock(EntityClient.class);
+    Mockito.when(client.searchAcrossEntities(
+        Mockito.eq(entityTypes),
+        Mockito.eq(query),
+        Mockito.eq(filter),
+        Mockito.eq(start),
+        Mockito.eq(limit),
+        Mockito.eq(null),
+        Mockito.any(Authentication.class)
+    )).thenReturn(
+        result
+    );
+    return client;
+  }
+
+  private GetQuickFiltersResolverTest() { }
+
+}

--- a/datahub-web-react/src/app/AppProviders.tsx
+++ b/datahub-web-react/src/app/AppProviders.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import AppConfigProvider from '../AppConfigProvider';
+import { EducationStepsProvider } from '../providers/EducationStepsProvider';
+import UserContextProvider from './context/UserContextProvider';
+import QuickFiltersProvider from '../providers/QuickFiltersProvider';
+
+interface Props {
+    children: React.ReactNode;
+}
+
+export default function AppProviders({ children }: Props) {
+    return (
+        <AppConfigProvider>
+            <UserContextProvider>
+                <EducationStepsProvider>
+                    <QuickFiltersProvider>{children}</QuickFiltersProvider>
+                </EducationStepsProvider>
+            </UserContextProvider>
+        </AppConfigProvider>
+    );
+}

--- a/datahub-web-react/src/app/ProtectedRoutes.tsx
+++ b/datahub-web-react/src/app/ProtectedRoutes.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { Layout } from 'antd';
 import { HomePage } from './home/HomePage';
-import AppConfigProvider from '../AppConfigProvider';
 import { SearchRoutes } from './SearchRoutes';
-import { EducationStepsProvider } from '../providers/EducationStepsProvider';
-import UserContextProvider from './context/UserContextProvider';
 import { PageRoutes } from '../conf/Global';
 import EmbeddedPage from './embed/EmbeddedPage';
 import { useEntityRegistry } from './useEntityRegistry';
+import AppProviders from './AppProviders';
 
 /**
  * Container for all views behind an authentication wall.
@@ -17,26 +15,22 @@ export const ProtectedRoutes = (): JSX.Element => {
     const entityRegistry = useEntityRegistry();
 
     return (
-        <AppConfigProvider>
-            <UserContextProvider>
-                <EducationStepsProvider>
-                    <Layout style={{ height: '100%', width: '100%' }}>
-                        <Layout>
-                            <Switch>
-                                <Route exact path="/" render={() => <HomePage />} />
-                                {entityRegistry.getEntities().map((entity) => (
-                                    <Route
-                                        key={`${entity.getPathName()}/${PageRoutes.EMBED}`}
-                                        path={`${PageRoutes.EMBED}/${entity.getPathName()}/:urn`}
-                                        render={() => <EmbeddedPage entityType={entity.type} />}
-                                    />
-                                ))}
-                                <Route path="/*" render={() => <SearchRoutes />} />
-                            </Switch>
-                        </Layout>
-                    </Layout>
-                </EducationStepsProvider>
-            </UserContextProvider>
-        </AppConfigProvider>
+        <AppProviders>
+            <Layout style={{ height: '100%', width: '100%' }}>
+                <Layout>
+                    <Switch>
+                        <Route exact path="/" render={() => <HomePage />} />
+                        {entityRegistry.getEntities().map((entity) => (
+                            <Route
+                                key={`${entity.getPathName()}/${PageRoutes.EMBED}`}
+                                path={`${PageRoutes.EMBED}/${entity.getPathName()}/:urn`}
+                                render={() => <EmbeddedPage entityType={entity.type} />}
+                            />
+                        ))}
+                        <Route path="/*" render={() => <SearchRoutes />} />
+                    </Switch>
+                </Layout>
+            </Layout>
+        </AppProviders>
     );
 };

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -61,6 +61,9 @@ export enum EventType {
     CreateQueryEvent,
     UpdateQueryEvent,
     DeleteQueryEvent,
+    SelectAutoCompleteOption,
+    SelectQuickFilterEvent,
+    DeselectQuickFilterEvent,
 }
 
 /**
@@ -127,6 +130,8 @@ export interface SearchEvent extends BaseEvent {
     entityTypeFilter?: EntityType;
     pageNumber: number;
     originPath: string;
+    selectedQuickFilterValues?: string[];
+    selectedQuickFilterTypes?: string[];
 }
 
 /**
@@ -137,6 +142,8 @@ export interface HomePageSearchEvent extends BaseEvent {
     query: string;
     entityTypeFilter?: EntityType;
     pageNumber: number;
+    selectedQuickFilterValues?: string[];
+    selectedQuickFilterTypes?: string[];
 }
 
 /**
@@ -470,6 +477,25 @@ export interface DeleteQueryEvent extends BaseEvent {
     type: EventType.DeleteQueryEvent;
 }
 
+export interface SelectAutoCompleteOption extends BaseEvent {
+    type: EventType.SelectAutoCompleteOption;
+    optionType: string;
+    entityType?: EntityType;
+    entityUrn?: string;
+}
+
+export interface SelectQuickFilterEvent extends BaseEvent {
+    type: EventType.SelectQuickFilterEvent;
+    quickFilterType: string;
+    quickFilterValue: string;
+}
+
+export interface DeselectQuickFilterEvent extends BaseEvent {
+    type: EventType.DeselectQuickFilterEvent;
+    quickFilterType: string;
+    quickFilterValue: string;
+}
+
 /**
  * Event consisting of a union of specific event types.
  */
@@ -529,4 +555,7 @@ export type Event =
     | LineageTabTimeRangeSelectionEvent
     | CreateQueryEvent
     | UpdateQueryEvent
-    | DeleteQueryEvent;
+    | DeleteQueryEvent
+    | SelectAutoCompleteOption
+    | SelectQuickFilterEvent
+    | DeselectQuickFilterEvent;

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -8,8 +8,8 @@ import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/tim
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 import { FormattedBytesStat } from './FormattedBytesStat';
 
-const StatText = styled.span`
-    color: ${ANTD_GRAY[8]};
+const StatText = styled.span<{ color: string }>`
+    color: ${(props) => props.color};
 `;
 
 const PopoverContent = styled.div`
@@ -23,6 +23,7 @@ type Props = {
     queryCountLast30Days?: number | null;
     uniqueUserCountLast30Days?: number | null;
     lastUpdatedMs?: number | null;
+    color?: string;
 };
 
 export const DatasetStatsSummary = ({
@@ -32,11 +33,14 @@ export const DatasetStatsSummary = ({
     queryCountLast30Days,
     uniqueUserCountLast30Days,
     lastUpdatedMs,
+    color,
 }: Props) => {
+    const displayedColor = color !== undefined ? color : ANTD_GRAY[7];
+
     const statsViews = [
         !!rowCount && (
-            <StatText>
-                <TableOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+            <StatText color={displayedColor}>
+                <TableOutlined style={{ marginRight: 8, color: displayedColor }} />
                 <b>{formatNumberWithoutAbbreviation(rowCount)}</b> rows
                 {!!columnCount && (
                     <>
@@ -46,20 +50,20 @@ export const DatasetStatsSummary = ({
             </StatText>
         ),
         !!sizeInBytes && (
-            <StatText>
-                <HddOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+            <StatText color={displayedColor}>
+                <HddOutlined style={{ marginRight: 8, color: displayedColor }} />
                 <FormattedBytesStat bytes={sizeInBytes} />
             </StatText>
         ),
         !!queryCountLast30Days && (
-            <StatText>
-                <ConsoleSqlOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+            <StatText color={displayedColor}>
+                <ConsoleSqlOutlined style={{ marginRight: 8, color: displayedColor }} />
                 <b>{formatNumberWithoutAbbreviation(queryCountLast30Days)}</b> queries last month
             </StatText>
         ),
         !!uniqueUserCountLast30Days && (
-            <StatText>
-                <TeamOutlined style={{ marginRight: 8, color: ANTD_GRAY[7] }} />
+            <StatText color={displayedColor}>
+                <TeamOutlined style={{ marginRight: 8, color: displayedColor }} />
                 <b>{formatNumberWithoutAbbreviation(uniqueUserCountLast30Days)}</b> unique users
             </StatText>
         ),

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/editor/extensions/mentions/MentionsDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/editor/extensions/mentions/MentionsDropdown.tsx
@@ -7,7 +7,7 @@ import { AutoCompleteResultForEntity, Entity, EntityType } from '../../../../../
 import { useEntityRegistry } from '../../../../../../../../useEntityRegistry';
 import { ANTD_GRAY } from '../../../../../../constants';
 import { useDataHubMentions } from './useDataHubMentions';
-import { renderEntitySuggestion } from '../../../../../../../../search/SearchBar';
+import AutoCompleteItem from '../../../../../../../../search/autoComplete/AutoCompleteItem';
 
 const HeaderItem = styled(Typography.Text)`
     display: block;
@@ -105,7 +105,7 @@ export const MentionsDropdown = ({ suggestions }: Props) => {
 
                 return (
                     <OptionItem active={highlight} key={entity.urn} onMouseDown={onMouseDown} role="option">
-                        {renderEntitySuggestion(filter ?? '', entity, entityRegistry)}
+                        <AutoCompleteItem query={filter ?? ''} entity={entity} />
                     </OptionItem>
                 );
             })}

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -1,38 +1,33 @@
 import React, { useEffect, useMemo, useState, useRef } from 'react';
-import { Input, AutoComplete, Image, Typography } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { Input, AutoComplete, Typography } from 'antd';
+import { CloseCircleFilled, SearchOutlined } from '@ant-design/icons';
 import styled from 'styled-components/macro';
 import { useHistory } from 'react-router';
-import { AutoCompleteResultForEntity, CorpUser, Entity, EntityType, ScenarioType, Tag } from '../../types.generated';
-import { IconStyleType } from '../entity/Entity';
+import { AutoCompleteResultForEntity, Entity, EntityType, FacetFilterInput, ScenarioType } from '../../types.generated';
 import EntityRegistry from '../entity/EntityRegistry';
 import filterSearchQuery from './utils/filterSearchQuery';
 import { ANTD_GRAY } from '../entity/shared/constants';
 import { getEntityPath } from '../entity/shared/containers/profile/utils';
 import { EXACT_SEARCH_PREFIX } from './utils/constants';
-import { CustomAvatar } from '../shared/avatar';
-import { StyledTag } from '../entity/shared/components/styled/StyledTag';
 import { useListRecommendationsQuery } from '../../graphql/recommendations.generated';
 import { useGetAuthenticatedUserUrn } from '../useGetAuthenticatedUser';
-import { getPlatformName } from '../entity/shared/utils';
-
-const SuggestionContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: left;
-    align-items: center;
-`;
-
-const SuggestionText = styled.span`
-    margin-left: 8px;
-    margin-top: 2px;
-    margin-bottom: 2px;
-    color: ${ANTD_GRAY[9]};
-`;
+import AutoCompleteItem, { SuggestionContainer } from './autoComplete/AutoCompleteItem';
+import { useQuickFiltersContext } from '../../providers/QuickFiltersContext';
+import QuickFilters from './autoComplete/quickFilters/QuickFilters';
+import { getFiltersWithQuickFilter } from './utils/filterUtils';
+import usePrevious from '../shared/usePrevious';
+import analytics, { Event, EventType } from '../analytics';
+import RecommendedOption from './autoComplete/RecommendedOption';
+import SectionHeader, { EntityTypeLabel } from './autoComplete/SectionHeader';
 
 const ExploreForEntity = styled.span`
     font-weight: light;
-    font-size: 11px;
+    font-size: 16px;
+    padding: 5px 0;
+`;
+
+const ExploreForEntityText = styled.span`
+    margin-left: 10px;
 `;
 
 const StyledAutoComplete = styled(AutoComplete)`
@@ -55,106 +50,48 @@ const StyledSearchBar = styled(Input)`
     > .ant-input {
         font-size: 14px;
     }
+    .ant-input-clear-icon {
+        height: 15px;
+        width: 15px;
+    }
 `;
 
-const PreviewImage = styled(Image)`
-    max-height: 16px;
-    width: auto;
-    object-fit: contain;
-    background-color: transparent;
+const ClearIcon = styled(CloseCircleFilled)`
+    svg {
+        height: 15px;
+        width: 15px;
+    }
 `;
 
 const EXACT_AUTOCOMPLETE_OPTION_TYPE = 'exact_query';
 const RECOMMENDED_QUERY_OPTION_TYPE = 'recommendation';
 
-const renderTagSuggestion = (tag: Tag, registry: EntityRegistry) => {
-    return (
-        <>
-            <StyledTag $colorHash={tag?.urn} $color={tag?.properties?.colorHex}>
-                {registry.getDisplayName(EntityType.Tag, tag)}
-            </StyledTag>
-        </>
-    );
+const QUICK_FILTER_AUTO_COMPLETE_OPTION = {
+    label: <EntityTypeLabel>Filter by</EntityTypeLabel>,
+    options: [
+        {
+            value: '',
+            type: '',
+            label: <QuickFilters />,
+            style: { padding: '10px 12px 12px 16px', cursor: 'auto' },
+            disabled: true,
+        },
+    ],
 };
 
-const renderUserSuggestion = (query: string, user: CorpUser, registry: EntityRegistry) => {
-    const displayName = registry.getDisplayName(EntityType.CorpUser, user);
-    const isPrefixMatch = displayName.toLowerCase().indexOf(query.toLowerCase()) > -1;
-    const matchedText = (isPrefixMatch && displayName.substring(0, query.length)) || '';
-    const unmatchedText = (isPrefixMatch && displayName.substring(query.length, displayName.length)) || displayName;
-    return (
-        <>
-            <CustomAvatar
-                size={20}
-                name={displayName}
-                photoUrl={user.editableProperties?.pictureLink || undefined}
-                useDefaultAvatar={false}
-                style={{
-                    marginRight: 0,
-                }}
-            />
-            <SuggestionText>
-                {matchedText}
-                <Typography.Text strong>{unmatchedText}</Typography.Text>
-            </SuggestionText>
-        </>
-    );
-};
-
-const getDisplayName = (registry: EntityRegistry, entity: Entity) => {
-    const genericEntityProps = registry.getGenericEntityProperties(entity.type, entity);
-    if (entity.type === EntityType.GlossaryTerm) {
-        return registry.getDisplayName(entity.type, entity);
-    }
-    return (
-        genericEntityProps?.properties?.qualifiedName ||
-        genericEntityProps?.name ||
-        registry.getDisplayName(entity.type, entity)
-    );
-};
-
-export const renderEntitySuggestion = (query: string, entity: Entity, registry: EntityRegistry) => {
-    // Special rendering.
-    if (entity.type === EntityType.CorpUser) {
-        return renderUserSuggestion(query, entity as CorpUser, registry);
-    }
-    if (entity.type === EntityType.Tag) {
-        return renderTagSuggestion(entity as Tag, registry);
-    }
-    const genericEntityProps = registry.getGenericEntityProperties(entity.type, entity);
-    const platformName = getPlatformName(genericEntityProps);
-    const platformLogoUrl = genericEntityProps?.platform?.properties?.logoUrl;
-    const displayName = getDisplayName(registry, entity);
-    const icon =
-        (platformLogoUrl && <PreviewImage preview={false} src={platformLogoUrl} alt={platformName || ''} />) ||
-        registry.getIcon(entity.type, 12, IconStyleType.ACCENT);
-    const isPrefixMatch = displayName.toLowerCase().startsWith(query.toLowerCase());
-    const matchedText = isPrefixMatch ? displayName.substring(0, query.length) : '';
-    const unmatchedText = isPrefixMatch ? displayName.substring(query.length, displayName.length) : displayName;
-    return (
-        <>
-            {icon}
-            <SuggestionText>
-                <Typography.Text strong>{matchedText}</Typography.Text>
-                {unmatchedText}
-            </SuggestionText>
-        </>
-    );
-};
-
-const renderItem = (query: string, entity: Entity, registry: EntityRegistry) => {
+const renderItem = (query: string, entity: Entity) => {
     return {
         value: entity.urn,
-        label: <SuggestionContainer>{renderEntitySuggestion(query, entity, registry)}</SuggestionContainer>,
+        label: <AutoCompleteItem query={query} entity={entity} />,
         type: entity.type,
-        style: { paddingLeft: 16 },
+        style: { padding: '12px 12px 12px 16px' },
     };
 };
 
 const renderRecommendedQuery = (query: string) => {
     return {
         value: query,
-        label: query,
+        label: <RecommendedOption text={query} />,
         type: RECOMMENDED_QUERY_OPTION_TYPE,
     };
 };
@@ -163,7 +100,7 @@ interface Props {
     initialQuery?: string;
     placeholderText: string;
     suggestions: Array<AutoCompleteResultForEntity>;
-    onSearch: (query: string, type?: EntityType) => void;
+    onSearch: (query: string, type?: EntityType, filters?: FacetFilterInput[]) => void;
     onQueryChange: (query: string) => void;
     style?: React.CSSProperties;
     inputStyle?: React.CSSProperties;
@@ -171,6 +108,7 @@ interface Props {
     entityRegistry: EntityRegistry;
     fixAutoComplete?: boolean;
     hideRecommendations?: boolean;
+    showQuickFilters?: boolean;
     setIsSearchBarFocused?: (isSearchBarFocused: boolean) => void;
     onFocus?: () => void;
     onBlur?: () => void;
@@ -195,13 +133,15 @@ export const SearchBar = ({
     autoCompleteStyle,
     fixAutoComplete,
     hideRecommendations,
+    showQuickFilters,
     setIsSearchBarFocused,
     onFocus,
     onBlur,
 }: Props) => {
     const history = useHistory();
-    const [searchQuery, setSearchQuery] = useState<string>();
+    const [searchQuery, setSearchQuery] = useState<string | undefined>(initialQuery);
     const [selected, setSelected] = useState<string>();
+    const [isDropdownVisible, setIsDropdownVisible] = useState(false);
     useEffect(() => setSelected(initialQuery), [initialQuery]);
 
     const searchEntityTypes = entityRegistry.getSearchEntityTypes();
@@ -226,7 +166,7 @@ export const SearchBar = ({
         // Map each module to a set of
         return (
             data?.listRecommendations?.modules.map((module) => ({
-                label: module.title,
+                label: <EntityTypeLabel>{module.title}</EntityTypeLabel>,
                 options: [...module.content.map((content) => renderRecommendedQuery(content.value))],
             })) || []
         );
@@ -241,7 +181,10 @@ export const SearchBar = ({
                         label: (
                             <SuggestionContainer key={EXACT_AUTOCOMPLETE_OPTION_TYPE}>
                                 <ExploreForEntity>
-                                    View all results for <Typography.Text strong>{effectiveQuery}</Typography.Text>
+                                    <SearchOutlined />
+                                    <ExploreForEntityText>
+                                        View all results for <Typography.Text strong>{effectiveQuery}</Typography.Text>
+                                    </ExploreForEntityText>
                                 </ExploreForEntity>
                             </SuggestionContainer>
                         ),
@@ -255,19 +198,33 @@ export const SearchBar = ({
     const autoCompleteEntityOptions = useMemo(
         () =>
             suggestions.map((entity: AutoCompleteResultForEntity) => ({
-                label: entityRegistry.getCollectionName(entity.type),
-                options: [...entity.entities.map((e: Entity) => renderItem(effectiveQuery, e, entityRegistry))],
+                label: <SectionHeader entityType={entity.type} />,
+                options: [...entity.entities.map((e: Entity) => renderItem(effectiveQuery, e))],
             })),
-        [effectiveQuery, suggestions, entityRegistry],
+        [effectiveQuery, suggestions],
     );
+
+    const { quickFilters, selectedQuickFilter, setSelectedQuickFilter } = useQuickFiltersContext();
+
+    const previousSelectedQuickFilterValue = usePrevious(selectedQuickFilter?.value);
+    useEffect(() => {
+        // if we change the selected quick filter, re-issue auto-complete
+        if (searchQuery && selectedQuickFilter?.value !== previousSelectedQuickFilterValue) {
+            onQueryChange(searchQuery);
+        }
+    });
+
+    const quickFilterOption = useMemo(() => {
+        return showQuickFilters && quickFilters && quickFilters.length > 0 ? [QUICK_FILTER_AUTO_COMPLETE_OPTION] : [];
+    }, [quickFilters, showQuickFilters]);
 
     const options = useMemo(() => {
         // Display recommendations when there is no search query, autocomplete suggestions otherwise.
         if (autoCompleteEntityOptions.length > 0) {
-            return [...autoCompleteQueryOptions, ...autoCompleteEntityOptions];
+            return [...quickFilterOption, ...autoCompleteQueryOptions, ...autoCompleteEntityOptions];
         }
-        return emptyQueryOptions;
-    }, [emptyQueryOptions, autoCompleteEntityOptions, autoCompleteQueryOptions]);
+        return [...quickFilterOption, ...emptyQueryOptions];
+    }, [emptyQueryOptions, autoCompleteEntityOptions, autoCompleteQueryOptions, quickFilterOption]);
 
     const searchBarWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -291,6 +248,13 @@ export const SearchBar = ({
         handleSearchBarClick(false);
     }
 
+    function handleSearch(query: string, type?: EntityType, appliedQuickFilters?: FacetFilterInput[]) {
+        onSearch(query, type, appliedQuickFilters);
+        if (selectedQuickFilter) {
+            setSelectedQuickFilter(null);
+        }
+    }
+
     return (
         <AutoCompleteContainer style={style} ref={searchBarWrapperRef}>
             <StyledAutoComplete
@@ -304,14 +268,25 @@ export const SearchBar = ({
                         option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
                         option.type === RECOMMENDED_QUERY_OPTION_TYPE
                     ) {
-                        onSearch(
+                        handleSearch(
                             `${filterSearchQuery(value as string)}`,
                             searchEntityTypes.indexOf(option.type) >= 0 ? option.type : undefined,
+                            getFiltersWithQuickFilter(selectedQuickFilter),
                         );
+                        analytics.event({
+                            type: EventType.SelectAutoCompleteOption,
+                            optionType: option.type,
+                        } as Event);
                     } else {
                         // Navigate directly to the entity profile.
                         history.push(getEntityPath(option.type, value as string, entityRegistry, false, false));
                         setSelected('');
+                        analytics.event({
+                            type: EventType.SelectAutoCompleteOption,
+                            optionType: option.type,
+                            entityType: option.type,
+                            entityUrn: value,
+                        } as Event);
                     }
                 }}
                 onSearch={(value: string) => onQueryChange(value)}
@@ -323,12 +298,27 @@ export const SearchBar = ({
                     overflowY: 'visible',
                     position: (fixAutoComplete && 'fixed') || 'relative',
                 }}
+                onDropdownVisibleChange={(isOpen) => {
+                    if (!isOpen) {
+                        setIsDropdownVisible(isOpen);
+                    } else {
+                        // set timeout so that we allow search bar to grow in width and therefore allow autocomplete to grow
+                        setTimeout(() => {
+                            setIsDropdownVisible(isOpen);
+                        }, 0);
+                    }
+                }}
+                open={isDropdownVisible}
+                listHeight={480}
             >
                 <StyledSearchBar
                     placeholder={placeholderText}
                     onPressEnter={() => {
-                        // e.stopPropagation();
-                        onSearch(filterSearchQuery(searchQuery || ''));
+                        handleSearch(
+                            filterSearchQuery(searchQuery || ''),
+                            undefined,
+                            getFiltersWithQuickFilter(selectedQuickFilter),
+                        );
                     }}
                     style={inputStyle}
                     value={searchQuery}
@@ -336,8 +326,18 @@ export const SearchBar = ({
                     data-testid="search-input"
                     onFocus={handleFocus}
                     onBlur={handleBlur}
-                    allowClear
-                    prefix={<SearchOutlined onClick={() => onSearch(filterSearchQuery(searchQuery || ''))} />}
+                    allowClear={{ clearIcon: <ClearIcon /> }}
+                    prefix={
+                        <SearchOutlined
+                            onClick={() => {
+                                handleSearch(
+                                    filterSearchQuery(searchQuery || ''),
+                                    undefined,
+                                    getFiltersWithQuickFilter(selectedQuickFilter),
+                                );
+                            }}
+                        />
+                    }
                 />
             </StyledAutoComplete>
         </AutoCompleteContainer>

--- a/datahub-web-react/src/app/search/SearchHeader.tsx
+++ b/datahub-web-react/src/app/search/SearchHeader.tsx
@@ -107,6 +107,7 @@ export const SearchHeader = ({
                     entityRegistry={entityRegistry}
                     setIsSearchBarFocused={setIsSearchBarFocused}
                     fixAutoComplete
+                    showQuickFilters
                 />
             </LogoSearchContainer>
             <NavGroup>

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -14,6 +14,8 @@ import { useGetAuthenticatedUser } from '../useGetAuthenticatedUser';
 import analytics, { EventType } from '../analytics';
 import useFilters from './utils/useFilters';
 import { PageRoutes } from '../../conf/Global';
+import { getAutoCompleteInputFromQuickFilter } from './utils/filterUtils';
+import { useQuickFiltersContext } from '../../providers/QuickFiltersContext';
 
 const styles = {
     children: {
@@ -54,6 +56,7 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
     const history = useHistory();
     const entityRegistry = useEntityRegistry();
     const themeConfig = useTheme();
+    const { selectedQuickFilter } = useQuickFiltersContext();
 
     const [getAutoCompleteResults, { data: suggestionsData }] = useGetAutoCompleteMultipleResultsLazyQuery();
     const user = useGetAuthenticatedUser()?.corpUser;
@@ -65,7 +68,7 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
         }
     }, [suggestionsData]);
 
-    const search = (query: string, type?: EntityType) => {
+    const search = (query: string, type?: EntityType, quickFilters?: FacetFilterInput[]) => {
         if (!query || query.trim().length === 0) {
             return;
         }
@@ -74,12 +77,16 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
             query,
             pageNumber: 1,
             originPath: window.location.pathname,
+            selectedQuickFilterTypes: selectedQuickFilter ? [selectedQuickFilter.field] : undefined,
+            selectedQuickFilterValues: selectedQuickFilter ? [selectedQuickFilter.value] : undefined,
         });
+
+        const appliedFilters = quickFilters && quickFilters?.length > 0 ? quickFilters : filters;
 
         navigateToSearchUrl({
             type,
             query,
-            filters,
+            filters: appliedFilters,
             history,
         });
     };
@@ -90,6 +97,7 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
                 variables: {
                     input: {
                         query,
+                        ...getAutoCompleteInputFromQuickFilter(selectedQuickFilter),
                     },
                 },
             });

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteEntity.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteEntity.tsx
@@ -1,0 +1,75 @@
+import { Image, Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { Entity } from '../../../types.generated';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { getPlatformName } from '../../entity/shared/utils';
+import { IconStyleType } from '../../entity/Entity';
+import { getAutoCompleteEntityText } from './utils';
+import { SuggestionText } from './AutoCompleteUser';
+import ParentContainers from './ParentContainers';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+
+const AutoCompleteEntityWrapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    align-items: center;
+`;
+
+const PreviewImage = styled(Image)`
+    height: 22px;
+    width: 22px;
+    width: auto;
+    object-fit: contain;
+    background-color: transparent;
+`;
+
+const ContentWrapper = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const Subtype = styled.span`
+    color: ${ANTD_GRAY[9]};
+    border: 1px solid ${ANTD_GRAY[9]};
+    border-radius: 16px;
+    padding: 2px 6px;
+    line-height: 12px;
+    font-size: 12px;
+`;
+
+interface Props {
+    query: string;
+    entity: Entity;
+}
+
+export default function AutoCompleteEntity({ query, entity }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const genericEntityProps = entityRegistry.getGenericEntityProperties(entity.type, entity);
+    const platformName = getPlatformName(genericEntityProps);
+    const platformLogoUrl = genericEntityProps?.platform?.properties?.logoUrl;
+    const displayName = entityRegistry.getDisplayName(entity.type, entity);
+    const icon =
+        (platformLogoUrl && <PreviewImage preview={false} src={platformLogoUrl} alt={platformName || ''} />) ||
+        entityRegistry.getIcon(entity.type, 12, IconStyleType.ACCENT);
+    const { matchedText, unmatchedText } = getAutoCompleteEntityText(displayName, query);
+    const parentContainers = genericEntityProps?.parentContainers?.containers || [];
+    // Need to reverse parentContainers since it returns direct parent first.
+    const orderedParentContainers = [...parentContainers].reverse();
+    const subtype = genericEntityProps?.subTypes?.typeNames?.[0];
+
+    return (
+        <AutoCompleteEntityWrapper>
+            <ContentWrapper>
+                {icon}
+                <SuggestionText>
+                    <ParentContainers parentContainers={orderedParentContainers} />
+                    <Typography.Text strong>{matchedText}</Typography.Text>
+                    {unmatchedText}
+                </SuggestionText>
+            </ContentWrapper>
+            {subtype && <Subtype>{subtype}</Subtype>}
+        </AutoCompleteEntityWrapper>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteItem.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteItem.tsx
@@ -1,0 +1,47 @@
+import { Tooltip } from 'antd';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { CorpUser, Entity, EntityType, Tag } from '../../../types.generated';
+import AutoCompleteEntity from './AutoCompleteEntity';
+import AutoCompleteTag from './AutoCompleteTag';
+import AutoCompleteTooltipContent from './AutoCompleteTooltipContent';
+import AutoCompleteUser from './AutoCompleteUser';
+
+export const SuggestionContainer = styled.div`
+    display: flex;
+    justify-content: left;
+    align-items: center;
+`;
+
+interface Props {
+    query: string;
+    entity: Entity;
+}
+
+export default function AutoCompleteItem({ query, entity }: Props) {
+    let componentToRender: React.ReactNode = null;
+
+    switch (entity.type) {
+        case EntityType.CorpUser:
+            componentToRender = <AutoCompleteUser query={query} user={entity as CorpUser} />;
+            break;
+        case EntityType.Tag:
+            componentToRender = <AutoCompleteTag tag={entity as Tag} />;
+            break;
+        default:
+            componentToRender = <AutoCompleteEntity query={query} entity={entity} />;
+            break;
+    }
+
+    return (
+        <Tooltip
+            overlayStyle={{ maxWidth: 500 }}
+            style={{ width: '100%' }}
+            title={<AutoCompleteTooltipContent entity={entity} />}
+            placement="bottomLeft"
+            color="rgba(0, 0, 0, 0.9)"
+        >
+            <SuggestionContainer data-testid="auto-complete-option">{componentToRender}</SuggestionContainer>
+        </Tooltip>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteTag.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteTag.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { EntityType, Tag } from '../../../types.generated';
+import { StyledTag } from '../../entity/shared/components/styled/StyledTag';
+import { useEntityRegistry } from '../../useEntityRegistry';
+
+interface Props {
+    tag: Tag;
+}
+
+export default function AutoCompleteTag({ tag }: Props) {
+    const entityRegistry = useEntityRegistry();
+
+    return (
+        <StyledTag $colorHash={tag?.urn} $color={tag?.properties?.colorHex}>
+            {entityRegistry.getDisplayName(EntityType.Tag, tag)}
+        </StyledTag>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteTooltipContent.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteTooltipContent.tsx
@@ -1,0 +1,61 @@
+import { FolderOpenOutlined } from '@ant-design/icons';
+import React from 'react';
+import styled from 'styled-components';
+import { Dataset, Entity, EntityType } from '../../../types.generated';
+import { DatasetStatsSummary } from '../../entity/dataset/shared/DatasetStatsSummary';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { ArrowWrapper } from './ParentContainers';
+
+const ContentWrapper = styled.div`
+    font-size: 12px;
+    color: white;
+`;
+
+const Container = styled.span`
+    margin-left: 4px;
+`;
+
+const EntityName = styled.div`
+    font-size: 14px;
+`;
+
+interface Props {
+    entity: Entity;
+}
+
+export default function AutoCompleteTooltipContent({ entity }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const genericEntityProps = entityRegistry.getGenericEntityProperties(entity.type, entity);
+    const displayName = entityRegistry.getDisplayName(entity.type, entity);
+    const parentContainers = genericEntityProps?.parentContainers?.containers || [];
+
+    return (
+        <ContentWrapper>
+            {parentContainers.length > 0 && (
+                <>
+                    {[...parentContainers].reverse().map((container, index) => (
+                        <>
+                            <FolderOpenOutlined />
+                            <Container>{entityRegistry.getDisplayName(EntityType.Container, container)}</Container>
+                            {index !== parentContainers.length - 1 && <ArrowWrapper>{'>'}</ArrowWrapper>}
+                        </>
+                    ))}
+                </>
+            )}
+            <EntityName>{displayName}</EntityName>
+            {entity.type === EntityType.Dataset && (
+                <DatasetStatsSummary
+                    rowCount={(entity as any).lastProfile?.length && (entity as any).lastProfile[0].rowCount}
+                    columnCount={(entity as any).lastProfile?.length && (entity as any).lastProfile[0].columnCount}
+                    sizeInBytes={(entity as any).lastProfile?.length && (entity as any).lastProfile[0].sizeInBytes}
+                    lastUpdatedMs={
+                        (entity as any).lastOperation?.length && (entity as any).lastOperation[0].lastUpdatedTimestamp
+                    }
+                    queryCountLast30Days={(entity as Dataset).statsSummary?.queryCountLast30Days}
+                    uniqueUserCountLast30Days={(entity as Dataset).statsSummary?.uniqueUserCountLast30Days}
+                    color="" // need to pass in empty color so that tooltip decides the color here
+                />
+            )}
+        </ContentWrapper>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteUser.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteUser.tsx
@@ -1,0 +1,46 @@
+import { Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import { CorpUser, EntityType } from '../../../types.generated';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { CustomAvatar } from '../../shared/avatar';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { getAutoCompleteEntityText } from './utils';
+
+export const SuggestionText = styled.div`
+    margin-left: 12px;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    color: ${ANTD_GRAY[9]};
+    font-size: 16px;
+    overflow: hidden;
+`;
+
+interface Props {
+    query: string;
+    user: CorpUser;
+}
+
+export default function AutoCompleteUser({ query, user }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const displayName = entityRegistry.getDisplayName(EntityType.CorpUser, user);
+    const { matchedText, unmatchedText } = getAutoCompleteEntityText(displayName, query);
+
+    return (
+        <>
+            <CustomAvatar
+                size={20}
+                name={displayName}
+                photoUrl={user.editableProperties?.pictureLink || undefined}
+                useDefaultAvatar={false}
+                style={{
+                    marginRight: 0,
+                }}
+            />
+            <SuggestionText>
+                <Typography.Text strong>{matchedText}</Typography.Text>
+                {unmatchedText}
+            </SuggestionText>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/ParentContainers.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/ParentContainers.tsx
@@ -1,0 +1,57 @@
+import { FolderOpenOutlined } from '@ant-design/icons';
+import { Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { Container, EntityType } from '../../../types.generated';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+
+const NUM_VISIBLE_CONTAINERS = 2;
+
+const ParentContainersWrapper = styled.div`
+    font-size: 12px;
+    color: ${ANTD_GRAY[9]};
+    display: flex;
+    align-items: center;
+    margin-bottom: 3px;
+`;
+
+const ParentContainer = styled(Typography.Text)`
+    margin-left: 4px;
+`;
+
+export const ArrowWrapper = styled.span`
+    margin: 0 3px;
+`;
+
+interface Props {
+    parentContainers: Container[];
+}
+
+export default function ParentContainers({ parentContainers }: Props) {
+    const entityRegistry = useEntityRegistry();
+
+    const visibleContainers = parentContainers.slice(parentContainers.length - NUM_VISIBLE_CONTAINERS);
+    const numHiddenContainers = parentContainers.length - NUM_VISIBLE_CONTAINERS;
+
+    return (
+        <ParentContainersWrapper>
+            {numHiddenContainers > 0 &&
+                [...Array(numHiddenContainers)].map(() => (
+                    <>
+                        <FolderOpenOutlined />
+                        <ArrowWrapper>{'>'}</ArrowWrapper>
+                    </>
+                ))}
+            {visibleContainers.map((container, index) => (
+                <>
+                    <FolderOpenOutlined />
+                    <ParentContainer ellipsis={{ tooltip: '' }}>
+                        {entityRegistry.getDisplayName(EntityType.Container, container)}
+                    </ParentContainer>
+                    {index !== visibleContainers.length - 1 && <ArrowWrapper>{'>'}</ArrowWrapper>}
+                </>
+            ))}
+        </ParentContainersWrapper>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/RecommendedOption.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/RecommendedOption.tsx
@@ -1,0 +1,29 @@
+import { SearchOutlined } from '@ant-design/icons';
+import React from 'react';
+import styled from 'styled-components/macro';
+import { SuggestionText } from './AutoCompleteUser';
+
+const TextWrapper = styled.span``;
+
+const RecommendedOptionWrapper = styled(SuggestionText)`
+    margin-left: 0;
+    display: flex;
+    align-items: center;
+
+    ${TextWrapper} {
+        margin-left: 8px;
+    }
+`;
+
+interface Props {
+    text: string;
+}
+
+export default function RecommendedOption({ text }: Props) {
+    return (
+        <RecommendedOptionWrapper>
+            <SearchOutlined />
+            <TextWrapper>{text}</TextWrapper>
+        </RecommendedOptionWrapper>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/SectionHeader.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/SectionHeader.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+import { EntityType } from '../../../types.generated';
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { useEntityRegistry } from '../../useEntityRegistry';
+
+export const EntityTypeLabel = styled.div<{ showBorder?: boolean }>`
+    font-size: 14px;
+    color: ${ANTD_GRAY[8]};
+    ${(props) => props.showBorder && `border-bottom: 1px solid ${ANTD_GRAY[4]};`}
+`;
+
+const SubtypesDescription = styled.span`
+    font-size: 12px;
+    font-weight: 400;
+    margin-left: 8px;
+`;
+
+interface Props {
+    entityType: EntityType;
+}
+
+export default function SectionHeader({ entityType }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const isDatasetType = entityType === EntityType.Dataset;
+
+    return (
+        <EntityTypeLabel showBorder>
+            {entityRegistry.getCollectionName(entityType)}
+            {isDatasetType && <SubtypesDescription>tables, topics, views, and more</SubtypesDescription>}
+        </EntityTypeLabel>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/search/autoComplete/__tests__/utils.test.ts
@@ -1,0 +1,27 @@
+import { getAutoCompleteEntityText } from '../utils';
+
+describe('utils tests', () => {
+    it('should return matched and unmatched text when the name begins with the query', () => {
+        const { matchedText, unmatchedText } = getAutoCompleteEntityText('testing123', 'test');
+        expect(matchedText).toBe('test');
+        expect(unmatchedText).toBe('ing123');
+    });
+
+    it('should return matched and unmatched text when the name begins with the query regardless of casing', () => {
+        const { matchedText, unmatchedText } = getAutoCompleteEntityText('TESTING123', 'test');
+        expect(matchedText).toBe('TEST');
+        expect(unmatchedText).toBe('ING123');
+    });
+
+    it('should return matched and unmatched text when the name is the same as the query', () => {
+        const { matchedText, unmatchedText } = getAutoCompleteEntityText('testing123', 'testing123');
+        expect(matchedText).toBe('testing123');
+        expect(unmatchedText).toBe('');
+    });
+
+    it('should return matched and unmatched text when there is no overlap', () => {
+        const { matchedText, unmatchedText } = getAutoCompleteEntityText('testing123', 'query');
+        expect(matchedText).toBe('');
+        expect(unmatchedText).toBe('testing123');
+    });
+});

--- a/datahub-web-react/src/app/search/autoComplete/quickFilters/QuickFilter.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/quickFilters/QuickFilter.tsx
@@ -1,0 +1,82 @@
+import { Button } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import { useQuickFiltersContext } from '../../../../providers/QuickFiltersContext';
+import { QuickFilter as QuickFilterType } from '../../../../types.generated';
+import { useEntityRegistry } from '../../../useEntityRegistry';
+import { getQuickFilterDetails } from './utils';
+import { ANTD_GRAY } from '../../../entity/shared/constants';
+import analytics, { Event, EventType } from '../../../analytics';
+
+const QuickFilterWrapper = styled(Button)<{ isSelected: boolean }>`
+    border: 1px solid ${ANTD_GRAY[4]};
+    border-radius: 16px;
+    box-shadow: none;
+    font-weight: 400;
+    color: black;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    padding: 2px 10px;
+    font-size: 12px;
+    margin: 4px;
+
+    &:hover {
+        color: black;
+    }
+
+    ${(props) =>
+        props.isSelected &&
+        `
+        border: 1px solid ${props.theme.styles['primary-color-dark']};
+        background-color: ${props.theme.styles['primary-color-light']};
+        &:hover {
+            background-color: ${props.theme.styles['primary-color-light']};
+        }
+    `}
+`;
+
+const LabelWrapper = styled.span`
+    margin-left: 4px;
+`;
+
+interface Props {
+    quickFilter: QuickFilterType;
+}
+
+export default function QuickFilter({ quickFilter }: Props) {
+    const entityRegistry = useEntityRegistry();
+    const { selectedQuickFilter, setSelectedQuickFilter } = useQuickFiltersContext();
+
+    const isSelected = selectedQuickFilter?.value === quickFilter.value;
+    const { label, icon } = getQuickFilterDetails(quickFilter, entityRegistry);
+
+    function emitTrackingEvent(isSelecting: boolean) {
+        analytics.event({
+            type: isSelecting ? EventType.SelectQuickFilterEvent : EventType.DeselectQuickFilterEvent,
+            quickFilterType: quickFilter.field,
+            quickFilterValue: quickFilter.value,
+        } as Event);
+    }
+
+    function handleClick() {
+        if (isSelected) {
+            setSelectedQuickFilter(null);
+            emitTrackingEvent(false);
+        } else {
+            setSelectedQuickFilter(quickFilter);
+            emitTrackingEvent(true);
+        }
+    }
+
+    return (
+        <QuickFilterWrapper
+            onClick={handleClick}
+            isSelected={isSelected}
+            data-testid={`quick-filter-${quickFilter.value}`}
+        >
+            {icon}
+            <LabelWrapper>{label}</LabelWrapper>
+        </QuickFilterWrapper>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/quickFilters/QuickFilters.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/quickFilters/QuickFilters.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useQuickFiltersContext } from '../../../../providers/QuickFiltersContext';
+import QuickFilter from './QuickFilter';
+
+const QuickFiltersWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-flow: wrap;
+`;
+
+export default function QuickFilters() {
+    const { quickFilters } = useQuickFiltersContext();
+
+    return (
+        <QuickFiltersWrapper>
+            {quickFilters?.map((quickFilter) => (
+                <QuickFilter quickFilter={quickFilter} />
+            ))}
+        </QuickFiltersWrapper>
+    );
+}

--- a/datahub-web-react/src/app/search/autoComplete/quickFilters/utils.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/quickFilters/utils.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import styled from 'styled-components';
+import { EntityType, QuickFilter } from '../../../../types.generated';
+import { IconStyleType } from '../../../entity/Entity';
+import EntityRegistry from '../../../entity/EntityRegistry';
+
+const StyledIcon = styled.img`
+    width: 12px;
+    height: 12px;
+`;
+
+export enum QuickFilterField {
+    Platform = 'platform',
+    Entity = 'entity',
+}
+
+export function getQuickFilterDetails(quickFilter: QuickFilter, entityRegistry: EntityRegistry) {
+    let label = '';
+    let icon: JSX.Element | null = null;
+    if (quickFilter.field === QuickFilterField.Platform) {
+        label = entityRegistry.getDisplayName(EntityType.DataPlatform, quickFilter.entity);
+        const genericProps = entityRegistry.getGenericEntityProperties(EntityType.DataPlatform, quickFilter.entity);
+        const logoUrl = genericProps?.platform?.properties?.logoUrl || '';
+        icon = <StyledIcon alt="icon" src={logoUrl} />;
+    } else if (quickFilter.field === QuickFilterField.Entity) {
+        label = entityRegistry.getCollectionName(quickFilter.value as EntityType);
+        icon = entityRegistry.getIcon(quickFilter.value as EntityType, 12, IconStyleType.ACCENT, 'black');
+    }
+
+    return { label, icon };
+}

--- a/datahub-web-react/src/app/search/autoComplete/utils.ts
+++ b/datahub-web-react/src/app/search/autoComplete/utils.ts
@@ -1,0 +1,7 @@
+export function getAutoCompleteEntityText(displayName: string, query: string) {
+    const isPrefixMatch = displayName.toLowerCase().startsWith(query.toLowerCase());
+    const matchedText = isPrefixMatch ? displayName.substring(0, query.length) : '';
+    const unmatchedText = isPrefixMatch ? displayName.substring(query.length, displayName.length) : displayName;
+
+    return { matchedText, unmatchedText };
+}

--- a/datahub-web-react/src/app/search/utils/__tests__/filterUtils.test.ts
+++ b/datahub-web-react/src/app/search/utils/__tests__/filterUtils.test.ts
@@ -1,0 +1,45 @@
+import { QuickFilterField } from '../../autoComplete/quickFilters/utils';
+import { getAutoCompleteInputFromQuickFilter, getFiltersWithQuickFilter } from '../filterUtils';
+
+describe('getAutoCompleteInputFromQuickFilter', () => {
+    it('should create a platform filter if the selected quick filter is a platform', () => {
+        const selectedQuickFilter = { field: QuickFilterField.Platform, value: 'urn:li:dataPlatform:dbt' };
+        const filterResult = getAutoCompleteInputFromQuickFilter(selectedQuickFilter);
+
+        expect(filterResult).toMatchObject({
+            filters: [{ field: selectedQuickFilter.field, values: [selectedQuickFilter.value] }],
+            types: [],
+        });
+    });
+
+    it('should create an entity type filter if the selected quick filter is an entity', () => {
+        const selectedQuickFilter = { field: QuickFilterField.Entity, value: 'DASHBOARD' };
+        const filterResult = getAutoCompleteInputFromQuickFilter(selectedQuickFilter);
+
+        expect(filterResult).toMatchObject({
+            filters: [],
+            types: [selectedQuickFilter.value],
+        });
+    });
+
+    it('should return empty filters if there is no selected quick filter', () => {
+        const filterResult = getAutoCompleteInputFromQuickFilter(null);
+
+        expect(filterResult).toMatchObject({ filters: [], types: [] });
+    });
+});
+
+describe('getFiltersWithQuickFilter', () => {
+    it('should create a filters list with a quick filter as a FacetFilter when there is a quick filter', () => {
+        const selectedQuickFilter = { field: QuickFilterField.Platform, value: 'urn:li:dataPlatform:dbt' };
+        const filterResult = getFiltersWithQuickFilter(selectedQuickFilter);
+
+        expect(filterResult).toMatchObject([{ field: selectedQuickFilter.field, values: [selectedQuickFilter.value] }]);
+    });
+
+    it('should return empty filters if there is no selected quick filter', () => {
+        const filterResult = getFiltersWithQuickFilter(null);
+
+        expect(filterResult).toMatchObject([]);
+    });
+});

--- a/datahub-web-react/src/app/search/utils/filterUtils.ts
+++ b/datahub-web-react/src/app/search/utils/filterUtils.ts
@@ -1,5 +1,6 @@
-import { FacetFilterInput, AndFilterInput } from '../../../types.generated';
+import { FacetFilterInput, AndFilterInput, QuickFilter, EntityType } from '../../../types.generated';
 import { FilterSet } from '../../entity/shared/components/styled/search/types';
+import { QuickFilterField } from '../autoComplete/quickFilters/utils';
 import { UnionType } from './constants';
 
 /**
@@ -162,3 +163,33 @@ export const mergeFilterSets = (filterSet1: FilterSet, filterSet2: FilterSet): A
     }
     return [];
 };
+
+function generateFilterInputFromQuickFilter(selectedQuickFilter: QuickFilter) {
+    return { field: selectedQuickFilter.field, values: [selectedQuickFilter.value] };
+}
+
+/**
+ * Generates a list of a singular facet filter with the selected quick filter.
+ * If no selected quick filter, return an empty list
+ */
+export function getFiltersWithQuickFilter(selectedQuickFilter: QuickFilter | null) {
+    const filters: FacetFilterInput[] = [];
+    if (selectedQuickFilter) {
+        filters.push(generateFilterInputFromQuickFilter(selectedQuickFilter));
+    }
+    return filters;
+}
+
+export function getAutoCompleteInputFromQuickFilter(selectedQuickFilter: QuickFilter | null) {
+    const filters: FacetFilterInput[] = [];
+    const types: EntityType[] = [];
+    if (selectedQuickFilter) {
+        if (selectedQuickFilter.field === QuickFilterField.Entity) {
+            types.push(selectedQuickFilter.value as EntityType);
+        } else if (selectedQuickFilter.field === QuickFilterField.Platform) {
+            filters.push(generateFilterInputFromQuickFilter(selectedQuickFilter));
+        }
+    }
+
+    return { filters, types };
+}

--- a/datahub-web-react/src/conf/theme/theme_dark.config.json
+++ b/datahub-web-react/src/conf/theme/theme_dark.config.json
@@ -1,6 +1,8 @@
 {
     "styles": {
         "primary-color": "#1890ff",
+        "primary-color-light": "#F0F5FF",
+        "primary-color-dark": "#002766",
         "layout-header-background": "#333E4C",
         "layout-header-color": "white",
         "layout-body-background": "#333E4C",

--- a/datahub-web-react/src/conf/theme/theme_light.config.json
+++ b/datahub-web-react/src/conf/theme/theme_light.config.json
@@ -1,6 +1,8 @@
 {
     "styles": {
         "primary-color": "#1890ff",
+        "primary-color-light": "#F0F5FF",
+        "primary-color-dark": "#002766",
         "layout-header-background": "white",
         "layout-header-color": "#434343",
         "layout-body-background": "white",

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -66,7 +66,7 @@ fragment deprecationFields on Deprecation {
 fragment parentContainersFields on ParentContainersResult {
     count
     containers {
-        ...entityContainer
+        ...parentContainerFields
     }
 }
 
@@ -888,6 +888,13 @@ fragment entityContainer on Container {
     }
     deprecation {
         ...deprecationFields
+    }
+}
+
+fragment parentContainerFields on Container {
+    urn
+    properties {
+        name
     }
 }
 

--- a/datahub-web-react/src/graphql/quickFilters.graphql
+++ b/datahub-web-react/src/graphql/quickFilters.graphql
@@ -1,0 +1,15 @@
+query getQuickFilters($input: GetQuickFiltersInput!) {
+    getQuickFilters(input: $input) {
+        quickFilters {
+            field
+            value
+            entity {
+                urn
+                type
+                ... on DataPlatform {
+                    ...platformFields
+                }
+            }
+        }
+    }
+}

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -13,6 +13,13 @@ fragment autoCompleteFields on Entity {
             name
             qualifiedName
         }
+        parentContainers {
+            ...parentContainersFields
+        }
+        subTypes {
+            typeNames
+        }
+        ...datasetStatsFields
     }
     ... on CorpUser {
         username
@@ -43,6 +50,9 @@ fragment autoCompleteFields on Entity {
         dataPlatformInstance {
             ...dataPlatformInstanceFields
         }
+        parentContainers {
+            ...parentContainersFields
+        }
     }
     ... on Chart {
         chartId
@@ -54,6 +64,9 @@ fragment autoCompleteFields on Entity {
         }
         dataPlatformInstance {
             ...dataPlatformInstanceFields
+        }
+        parentContainers {
+            ...parentContainersFields
         }
     }
     ... on DataFlow {
@@ -190,6 +203,38 @@ query getAutoCompleteMultipleResults($input: AutoCompleteMultipleInput!) {
     }
 }
 
+fragment datasetStatsFields on Dataset {
+    lastProfile: datasetProfiles(limit: 1) {
+        rowCount
+        columnCount
+        sizeInBytes
+        timestampMillis
+    }
+    lastOperation: operations(limit: 1) {
+        lastUpdatedTimestamp
+        timestampMillis
+    }
+    statsSummary {
+        queryCountLast30Days
+        uniqueUserCountLast30Days
+        topUsersLast30Days {
+            urn
+            type
+            username
+            properties {
+                displayName
+                firstName
+                lastName
+                fullName
+            }
+            editableProperties {
+                displayName
+                pictureLink
+            }
+        }
+    }
+}
+
 fragment searchResultFields on Entity {
     urn
     type
@@ -257,35 +302,7 @@ fragment searchResultFields on Entity {
                 }
             }
         }
-        lastProfile: datasetProfiles(limit: 1) {
-            rowCount
-            columnCount
-            sizeInBytes
-            timestampMillis
-        }
-        lastOperation: operations(limit: 1) {
-            lastUpdatedTimestamp
-            timestampMillis
-        }
-        statsSummary {
-            queryCountLast30Days
-            uniqueUserCountLast30Days
-            topUsersLast30Days {
-                urn
-                type
-                username
-                properties {
-                    displayName
-                    firstName
-                    lastName
-                    fullName
-                }
-                editableProperties {
-                    displayName
-                    pictureLink
-                }
-            }
-        }
+        ...datasetStatsFields
     }
     ... on CorpUser {
         username

--- a/datahub-web-react/src/providers/QuickFiltersContext.tsx
+++ b/datahub-web-react/src/providers/QuickFiltersContext.tsx
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { QuickFilter } from '../types.generated';
+
+interface AppStateType {
+    quickFilters: QuickFilter[] | null;
+    setQuickFilters: React.Dispatch<React.SetStateAction<QuickFilter[] | null>>;
+    selectedQuickFilter: QuickFilter | null;
+    setSelectedQuickFilter: React.Dispatch<React.SetStateAction<QuickFilter | null>>;
+}
+
+export const QuickFiltersContext = React.createContext<AppStateType>({
+    quickFilters: [],
+    setQuickFilters: () => {},
+    selectedQuickFilter: null,
+    setSelectedQuickFilter: () => {},
+});
+
+export function useQuickFiltersContext() {
+    return useContext(QuickFiltersContext);
+}
+
+export default QuickFiltersContext;

--- a/datahub-web-react/src/providers/QuickFiltersProvider.tsx
+++ b/datahub-web-react/src/providers/QuickFiltersProvider.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+import { QuickFiltersContext } from './QuickFiltersContext';
+import { QuickFilter } from '../types.generated';
+import { useGetQuickFiltersQuery } from '../graphql/quickFilters.generated';
+
+export default function QuickFiltersProvider({ children }: { children: React.ReactNode }) {
+    const { data } = useGetQuickFiltersQuery({ variables: { input: {} } });
+    const [quickFilters, setQuickFilters] = useState<QuickFilter[] | null>(null);
+    const [selectedQuickFilter, setSelectedQuickFilter] = useState<QuickFilter | null>(null);
+
+    useEffect(() => {
+        if (data && data.getQuickFilters && quickFilters === null) {
+            setQuickFilters(data.getQuickFilters.quickFilters as QuickFilter[]);
+        }
+    }, [data, quickFilters]);
+
+    return (
+        <QuickFiltersContext.Provider
+            value={{ quickFilters, setQuickFilters, selectedQuickFilter, setSelectedQuickFilter }}
+        >
+            {children}
+        </QuickFiltersContext.Provider>
+    );
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -142,11 +142,11 @@ public class JavaEntityClient implements EntityClient {
     public AutoCompleteResult autoComplete(
         @Nonnull String entityType,
         @Nonnull String query,
-        @Nonnull Map<String, String> requestFilters,
+        @Nullable Filter requestFilters,
         @Nonnull int limit,
         @Nullable String field,
         @Nonnull final Authentication authentication) throws RemoteInvocationException {
-      return _cachingEntitySearchService.autoComplete(entityType, query, field, newFilter(requestFilters), limit, null);
+      return _cachingEntitySearchService.autoComplete(entityType, query, field, filterOrDefaultEmptyFilter(requestFilters), limit, null);
     }
 
     /**
@@ -162,10 +162,10 @@ public class JavaEntityClient implements EntityClient {
     public AutoCompleteResult autoComplete(
         @Nonnull String entityType,
         @Nonnull String query,
-        @Nonnull Map<String, String> requestFilters,
+        @Nullable Filter requestFilters,
         @Nonnull int limit,
         @Nonnull final Authentication authentication) throws RemoteInvocationException {
-        return _cachingEntitySearchService.autoComplete(entityType, query, "", newFilter(requestFilters), limit, null);
+        return _cachingEntitySearchService.autoComplete(entityType, query, "", filterOrDefaultEmptyFilter(requestFilters), limit, null);
     }
 
     /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -60,7 +60,10 @@ public enum DataHubUsageEventType {
   LINEAGE_TAB_TIME_RANGE_SELECTION_EVENT("LineageTabTimeRangeSelectionEvent"),
   CREATE_QUERY_EVENT("CreateQueryEvent"),
   DELETE_QUERY_EVENT("DeleteQueryEvent"),
-  UPDATE_QUERY_EVENT("UpdateQueryEvent");
+  UPDATE_QUERY_EVENT("UpdateQueryEvent"),
+  SELECT_AUTO_COMPLETE_OPTION("SelectAutoCompleteOption"),
+  SELECT_QUICK_FILTER_EVENT("SelectQuickFilterEvent"),
+  DESELECT_QUICK_FILTER_EVENT("DeselectQuickFilterEvent");
 
   private final String type;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
@@ -71,6 +71,11 @@ public class QueryUtils {
         ImmutableList.of(new ConjunctiveCriterion().setAnd(new CriterionArray(ImmutableList.of(criterion))))));
   }
 
+  @Nonnull
+  public static Filter filterOrDefaultEmptyFilter(@Nullable Filter filter) {
+    return filter != null ? filter : EMPTY_FILTER;
+  }
+
   /**
    * Converts a set of aspect classes to a set of {@link AspectVersion} with the version all set to latest.
    */

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -81,7 +81,7 @@ public interface EntityClient {
    */
   @Nonnull
   public AutoCompleteResult autoComplete(@Nonnull String entityType, @Nonnull String query,
-      @Nonnull Map<String, String> requestFilters, @Nonnull int limit, @Nullable String field,
+      @Nullable Filter requestFilters, @Nonnull int limit, @Nullable String field,
       @Nonnull Authentication authentication) throws RemoteInvocationException;
 
   /**
@@ -94,7 +94,7 @@ public interface EntityClient {
    */
   @Nonnull
   public AutoCompleteResult autoComplete(@Nonnull String entityType, @Nonnull String query,
-      @Nonnull Map<String, String> requestFilters, @Nonnull int limit, @Nonnull Authentication authentication)
+      @Nullable Filter requestFilters, @Nonnull int limit, @Nonnull Authentication authentication)
       throws RemoteInvocationException;
 
   /**

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -237,13 +237,13 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    */
   @Nonnull
   public AutoCompleteResult autoComplete(@Nonnull String entityType, @Nonnull String query,
-      @Nonnull Map<String, String> requestFilters, @Nonnull int limit, @Nullable String field,
+      @Nullable Filter requestFilters, @Nonnull int limit, @Nullable String field,
       @Nonnull final Authentication authentication) throws RemoteInvocationException {
     EntitiesDoAutocompleteRequestBuilder requestBuilder = ENTITIES_REQUEST_BUILDERS.actionAutocomplete()
         .entityParam(entityType)
         .queryParam(query)
         .fieldParam(field)
-        .filterParam(newFilter(requestFilters))
+        .filterParam(filterOrDefaultEmptyFilter(requestFilters))
         .limitParam(limit);
     return sendClientRequest(requestBuilder, authentication).getEntity();
   }
@@ -259,12 +259,12 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    */
   @Nonnull
   public AutoCompleteResult autoComplete(@Nonnull String entityType, @Nonnull String query,
-      @Nonnull Map<String, String> requestFilters, @Nonnull int limit, @Nonnull final Authentication authentication)
+      @Nullable Filter requestFilters, @Nonnull int limit, @Nonnull final Authentication authentication)
       throws RemoteInvocationException {
     EntitiesDoAutocompleteRequestBuilder requestBuilder = ENTITIES_REQUEST_BUILDERS.actionAutocomplete()
         .entityParam(entityType)
         .queryParam(query)
-        .filterParam(newFilter(requestFilters))
+        .filterParam(filterOrDefaultEmptyFilter(requestFilters))
         .limitParam(limit);
     return sendClientRequest(requestBuilder, authentication).getEntity();
   }
@@ -835,5 +835,10 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   @Nonnull
   public static Criterion newCriterion(@Nonnull String field, @Nonnull String value, @Nonnull Condition condition) {
     return new Criterion().setField(field).setValue(value).setCondition(condition);
+  }
+
+  @Nonnull
+  public static Filter filterOrDefaultEmptyFilter(@Nullable Filter filter) {
+    return filter != null ? filter : new Filter().setOr(new ConjunctiveCriterionArray());
   }
 }

--- a/smoke-test/tests/cypress/cypress.config.js
+++ b/smoke-test/tests/cypress/cypress.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('./cypress/plugins/index.js')(on, config)
     },
-    baseUrl: 'http://localhost:9002/',
+    baseUrl: 'http://localhost:3000/',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
     experimentalStudio: true,
   },

--- a/smoke-test/tests/cypress/cypress/e2e/auto_complete/auto_complete.js
+++ b/smoke-test/tests/cypress/cypress/e2e/auto_complete/auto_complete.js
@@ -1,0 +1,56 @@
+
+describe('auto-complete', () => {
+    it('should see auto-complete results after typing in a search query', () => {
+        cy.login();
+        cy.visit("/");
+        
+        // look for a dataset
+        cy.get("input[data-testid=search-input]").type("SampleCypressHive");
+        cy.contains("Datasets")
+        cy.contains("SampleCypressHiveDataset")
+        cy.focused().clear();
+        
+        // look for a dashboard
+        cy.get("input[data-testid=search-input]").type("baz");
+        cy.contains("Dashboards")
+        cy.contains("Baz Dashboard")
+        cy.focused().clear();
+
+        // look for a dataflow
+        cy.get("input[data-testid=search-input]").type("dataflow user");
+        cy.contains("Pipelines")
+        cy.contains("Users")
+        cy.focused().clear();
+    });
+
+    it('should send you to the entity profile after clicking on an auto-complete option', () => {
+        cy.login();
+        cy.visit("/");
+        cy.get("input[data-testid=search-input]").type("SampleCypressHiveDataset");
+        cy.get('[data-testid="auto-complete-option"]').first().click();
+        cy.url().should('include', 'dataset/urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)');
+        cy.wait(2000);
+    });
+
+    it('should filter auto-complete results when clicking on a quick filter', () => {
+        cy.login();
+        cy.visit("/");
+        cy.get("input[data-testid=search-input]").type("baz");
+        cy.contains("Baz Chart 2")
+        cy.get('[data-testid="quick-filter-DASHBOARD"]').click();
+        cy.wait(2000);
+        cy.ensureTextNotPresent("Baz Chart 2");
+        cy.contains("Baz Dashboard");
+        cy.wait(1000);
+    });
+
+    it('should filter search results when when searching with a quick filter selected', () => {
+        cy.login();
+        cy.visit("/");
+        cy.get("input[data-testid=search-input]").type("baz");
+        cy.contains("Baz Chart 2")
+        cy.get('[data-testid="quick-filter-urn:li:dataPlatform:looker"]').click();
+        cy.focused().type("{enter}");
+        cy.url().should('include', '?filter_platform___false___EQUAL___0=urn%3Ali%3AdataPlatform%3Alooker');
+    });
+})

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
@@ -23,7 +23,7 @@ describe("add remove domain", () => {
         cy.waitTextVisible("Add assets")
         cy.clickOptionWithText("Add assets")     
         cy.get(".ant-modal-content").within(() => {
-            cy.get('[data-testid="search-input"]').click().type("jaffle")
+            cy.get('[data-testid="search-input"]').click().type("jaffle_shop")
             cy.waitTextVisible("jaffle_shop")
             cy.get(".ant-checkbox-input").first().click()
             cy.get("#continueButton").click()

--- a/smoke-test/tests/cypress/cypress/support/commands.js
+++ b/smoke-test/tests/cypress/cypress/support/commands.js
@@ -27,8 +27,8 @@ Cypress.Commands.add('login', () => {
       method: 'POST',
       url: '/logIn',
       body: {
-         username: Cypress.env('ADMIN_USERNAME'),
-         password: Cypress.env('ADMIN_PASSWORD'),
+         username: 'datahub',
+         password: 'datahub',
       },
       retryOnStatusCodeFailure: true,
     });


### PR DESCRIPTION
This PR applies some updates to auto-complete that are long overdue. In this PR I am:
- Updating the design of auto-complete results to show container paths, update styles, have a hover state showing the full container path and dataset usage stats
- Introduce a new concept of "quick filters" in autocomplete that filter down auto-complete results when applied and also sets the filter as a search filter if you search with a quick filter applied
- Ensure the auto-complete dropdown is always wide enough even on small screens by expanding it with the search bar
- Add cypress tests for auto-complete in general and this new functionality

Some fun screenshots (to come in a minute):

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
