### PR TITLE
fix(ui-ingestion) Fix UI manual ingestion runs by consistently setting pipeline_name

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/execution/CreateIngestionExecutionRequestResolver.java
@@ -108,7 +108,7 @@ public class CreateIngestionExecutionRequestResolver implements DataFetcher<Comp
           Map<String, String> arguments = new HashMap<>();
           String recipe = ingestionSourceInfo.getConfig().getRecipe();
           recipe = injectRunId(recipe, executionRequestUrn.toString());
-          recipe = IngestionUtils.injectPipelineName(recipe, executionRequestUrn.toString());
+          recipe = IngestionUtils.injectPipelineName(recipe, ingestionSourceUrn.toString());
           arguments.put(RECIPE_ARG_NAME, recipe);
           arguments.put(VERSION_ARG_NAME, ingestionSourceInfo.getConfig().hasVersion()
               ? ingestionSourceInfo.getConfig().getVersion()


### PR DESCRIPTION
We were setting pipeline_name into manual ingestion runs (if there wasn't one already) inconsistently from how we injected it into scheduled runs. We should be doing the same thing for both and that's going to be the ingestion source urn.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
