### PR TITLE
feat(ingest/kafka-connect): add stateful ingestion and platform instance support

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -183,9 +183,17 @@ def make_term_urn(term: str) -> str:
 
 
 def make_data_flow_urn(
-    orchestrator: str, flow_id: str, cluster: str = DEFAULT_FLOW_CLUSTER
+    orchestrator: str,
+    flow_id: str,
+    cluster: str = DEFAULT_FLOW_CLUSTER,
+    platform_instance: Optional[str] = None,
 ) -> str:
-    return f"urn:li:dataFlow:({orchestrator},{flow_id},{cluster})"
+    if platform_instance:
+        return (
+            f"urn:li:dataFlow:({orchestrator},{platform_instance}.{flow_id},{cluster})"
+        )
+    else:
+        return f"urn:li:dataFlow:({orchestrator},{flow_id},{cluster})"
 
 
 def make_data_job_urn_with_flow(flow_urn: str, job_id: str) -> str:
@@ -197,10 +205,14 @@ def make_data_process_instance_urn(dataProcessInstanceId: str) -> str:
 
 
 def make_data_job_urn(
-    orchestrator: str, flow_id: str, job_id: str, cluster: str = DEFAULT_FLOW_CLUSTER
+    orchestrator: str,
+    flow_id: str,
+    job_id: str,
+    cluster: str = DEFAULT_FLOW_CLUSTER,
+    platform_instance: Optional[str] = None,
 ) -> str:
     return make_data_job_urn_with_flow(
-        make_data_flow_urn(orchestrator, flow_id, cluster), job_id
+        make_data_flow_urn(orchestrator, flow_id, cluster, platform_instance), job_id
     )
 
 

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -37,6 +37,7 @@ from datahub.metadata.schema_classes import (
     _Aspect as AspectAbstract,
 )
 from datahub.utilities.urn_encoder import UrnEncoder
+from datahub.utilities.urns.data_flow_urn import DataFlowUrn
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 
 logger = logging.getLogger(__name__)
@@ -188,12 +189,14 @@ def make_data_flow_urn(
     cluster: str = DEFAULT_FLOW_CLUSTER,
     platform_instance: Optional[str] = None,
 ) -> str:
-    if platform_instance:
-        return (
-            f"urn:li:dataFlow:({orchestrator},{platform_instance}.{flow_id},{cluster})"
+    return str(
+        DataFlowUrn.create_from_ids(
+            orchestrator=orchestrator,
+            flow_id=flow_id,
+            env=cluster,
+            platform_instance=platform_instance,
         )
-    else:
-        return f"urn:li:dataFlow:({orchestrator},{flow_id},{cluster})"
+    )
 
 
 def make_data_job_urn_with_flow(flow_urn: str, job_id: str) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -13,7 +13,10 @@ from sqlalchemy.engine.url import make_url
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
 from datahub.configuration.common import AllowDenyPattern, ConfigModel
-from datahub.configuration.source_common import DatasetLineageProviderConfigBase
+from datahub.configuration.source_common import (
+    DatasetLineageProviderConfigBase,
+    PlatformInstanceConfigMixin,
+)
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
@@ -24,9 +27,23 @@ from datahub.ingestion.api.decorators import (
     platform_name,
     support_status,
 )
-from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.source import Source
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.sql_common import get_platform_from_sqlalchemy_uri
+from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
+from datahub.ingestion.source.state.stale_entity_removal_handler import (
+    StaleEntityRemovalHandler,
+    StaleEntityRemovalSourceReport,
+    StatefulStaleMetadataRemovalConfig,
+)
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    StatefulIngestionConfigBase,
+    StatefulIngestionSourceBase,
+)
+from datahub.utilities.source_helpers import (
+    auto_stale_entity_removal,
+    auto_status_aspect,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +60,11 @@ class GenericConnectorConfig(ConfigModel):
     source_platform: str
 
 
-class KafkaConnectSourceConfig(DatasetLineageProviderConfigBase):
+class KafkaConnectSourceConfig(
+    PlatformInstanceConfigMixin,
+    DatasetLineageProviderConfigBase,
+    StatefulIngestionConfigBase,
+):
     # See the Connect REST Interface for details
     # https://docs.confluent.io/platform/current/connect/references/restapi.html#
     connect_uri: str = Field(
@@ -79,9 +100,11 @@ class KafkaConnectSourceConfig(DatasetLineageProviderConfigBase):
         description="Provide lineage graph for sources connectors other than Confluent JDBC Source Connector, Debezium Source Connector, and Mongo Source Connector",
     )
 
+    stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = None
+
 
 @dataclass
-class KafkaConnectSourceReport(SourceReport):
+class KafkaConnectSourceReport(StaleEntityRemovalSourceReport):
     connectors_scanned: int = 0
     filtered: List[str] = field(default_factory=list)
 
@@ -898,13 +921,13 @@ def transform_connector_config(
 @config_class(KafkaConnectSourceConfig)
 @support_status(SupportStatus.CERTIFIED)
 @capability(SourceCapability.PLATFORM_INSTANCE, "Enabled by default")
-class KafkaConnectSource(Source):
-
+class KafkaConnectSource(StatefulIngestionSourceBase):
     config: KafkaConnectSourceConfig
     report: KafkaConnectSourceReport
+    platform: str = "kafka-connect"
 
     def __init__(self, config: KafkaConnectSourceConfig, ctx: PipelineContext):
-        super().__init__(ctx)
+        super().__init__(config, ctx)
         self.config = config
         self.report = KafkaConnectSourceReport()
         self.session = requests.Session()
@@ -913,6 +936,15 @@ class KafkaConnectSource(Source):
                 "Accept": "application/json",
                 "Content-Type": "application/json",
             }
+        )
+
+        # Create and register the stateful ingestion use-case handlers.
+        self.stale_entity_removal_handler = StaleEntityRemovalHandler(
+            source=self,
+            config=self.config,
+            state_type_class=GenericCheckpointState,
+            pipeline_name=self.ctx.pipeline_name,
+            run_id=self.ctx.run_id,
         )
 
         # Test the connection
@@ -948,9 +980,12 @@ class KafkaConnectSource(Source):
         for c in payload:
             connector_url = f"{self.config.connect_uri}/connectors/{c}"
             connector_response = self.session.get(connector_url)
-
             manifest = connector_response.json()
             connector_manifest = ConnectorManifest(**manifest)
+            if not self.config.connector_patterns.allowed(connector_manifest.name):
+                self.report.report_dropped(connector_manifest.name)
+                continue
+
             if self.config.provided_configs:
                 transform_connector_config(
                     connector_manifest.config, self.config.provided_configs
@@ -1045,7 +1080,10 @@ class KafkaConnectSource(Source):
         flow_property_bag = connector.flow_property_bag
         # connector_url = connector.url  # NOTE: this will expose connector credential when used
         flow_urn = builder.make_data_flow_urn(
-            "kafka-connect", connector_name, self.config.env
+            self.platform,
+            connector_name,
+            self.config.env,
+            self.config.platform_instance,
         )
 
         mcp = MetadataChangeProposalWrapper(
@@ -1060,7 +1098,8 @@ class KafkaConnectSource(Source):
 
         for proposal in [mcp]:
             wu = MetadataWorkUnit(
-                id=f"kafka-connect.{connector_name}.{proposal.aspectName}", mcp=proposal
+                id=f"{self.platform}.{connector_name}.{proposal.aspectName}",
+                mcp=proposal,
             )
             self.report.report_workunit(wu)
             yield wu
@@ -1070,7 +1109,10 @@ class KafkaConnectSource(Source):
     ) -> Iterable[MetadataWorkUnit]:
         connector_name = connector.name
         flow_urn = builder.make_data_flow_urn(
-            "kafka-connect", connector_name, self.config.env
+            self.platform,
+            connector_name,
+            self.config.env,
+            self.config.platform_instance,
         )
 
         lineages = connector.lineages
@@ -1118,7 +1160,7 @@ class KafkaConnectSource(Source):
                 )
 
                 wu = MetadataWorkUnit(
-                    id=f"kafka-connect.{connector_name}.{job_id}.{mcp.aspectName}",
+                    id=f"{self.platform}.{connector_name}.{job_id}.{mcp.aspectName}",
                     mcp=mcp,
                 )
                 self.report.report_workunit(wu)
@@ -1133,23 +1175,26 @@ class KafkaConnectSource(Source):
                 )
 
                 wu = MetadataWorkUnit(
-                    id=f"kafka-connect.{connector_name}.{job_id}.{mcp.aspectName}",
+                    id=f"{self.platform}.{connector_name}.{job_id}.{mcp.aspectName}",
                     mcp=mcp,
                 )
                 self.report.report_workunit(wu)
                 yield wu
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        return auto_stale_entity_removal(
+            self.stale_entity_removal_handler,
+            auto_status_aspect(self.get_workunits_internal()),
+        )
+
+    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         connectors_manifest = self.get_connectors_manifest()
         for connector in connectors_manifest:
             name = connector.name
-            if self.config.connector_patterns.allowed(name):
-                yield from self.construct_flow_workunit(connector)
-                yield from self.construct_job_workunits(connector)
-                self.report.report_connector_scanned(name)
 
-            else:
-                self.report.report_dropped(name)
+            yield from self.construct_flow_workunit(connector)
+            yield from self.construct_job_workunits(connector)
+            self.report.report_connector_scanned(name)
 
     def get_report(self) -> KafkaConnectSourceReport:
         return self.report
@@ -1167,6 +1212,12 @@ class KafkaConnectSource(Source):
         return builder.make_dataset_urn_with_platform_instance(
             platform, name, platform_instance, self.config.env
         )
+
+    def get_platform_instance_id(self) -> str:
+        return self.config.platform_instance or self.platform
+
+    def close(self):
+        StatefulIngestionSourceBase.close(self)
 
 
 # TODO: Find a more automated way to discover new platforms with 3 level naming hierarchy.

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -1213,12 +1213,6 @@ class KafkaConnectSource(StatefulIngestionSourceBase):
             platform, name, platform_instance, self.config.env
         )
 
-    def get_platform_instance_id(self) -> str:
-        return self.config.platform_instance or self.platform
-
-    def close(self):
-        StatefulIngestionSourceBase.close(self)
-
 
 # TODO: Find a more automated way to discover new platforms with 3 level naming hierarchy.
 def has_three_level_hierarchy(platform: str) -> bool:

--- a/metadata-ingestion/src/datahub/utilities/urns/data_flow_urn.py
+++ b/metadata-ingestion/src/datahub/utilities/urns/data_flow_urn.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from datahub.configuration.source_common import ALL_ENV_TYPES
 from datahub.utilities.urns.error import InvalidUrnError
@@ -49,13 +49,21 @@ class DataFlowUrn(Urn):
 
     @classmethod
     def create_from_ids(
-        cls, orchestrator: str, flow_id: str, env: str
+        cls,
+        orchestrator: str,
+        flow_id: str,
+        env: str,
+        platform_instance: Optional[str] = None,
     ) -> "DataFlowUrn":
-        entity_id: List[str] = [
-            orchestrator,
-            flow_id,
-            env,
-        ]
+        entity_id: List[str]
+        if platform_instance:
+            entity_id = [
+                orchestrator,
+                f"{platform_instance}.{flow_id}",
+                env,
+            ]
+        else:
+            entity_id = [orchestrator, flow_id, env]
         return cls(DataFlowUrn.ENTITY_TYPE, entity_id)
 
     @staticmethod

--- a/metadata-ingestion/tests/conftest.py
+++ b/metadata-ingestion/tests/conftest.py
@@ -17,7 +17,10 @@ os.environ["DATAHUB_REST_EMITTER_DEFAULT_RETRY_MAX_TIMES"] = "1"
 
 # We need our imports to go below the os.environ updates, since mere act
 # of importing some datahub modules will load env variables.
-from tests.test_helpers.docker_helpers import docker_compose_runner  # noqa: F401,E402
+from tests.test_helpers.docker_helpers import (  # noqa: F401,E402
+    docker_compose_command,
+    docker_compose_runner,
+)
 from tests.test_helpers.state_helpers import mock_datahub_graph  # noqa: F401,E402
 
 try:

--- a/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_after_golden_mces.json
+++ b/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_after_golden_mces.json
@@ -1,0 +1,264 @@
+[
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataFlowInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
+                "mode": "incrementing",
+                "incrementing.column.name": "id",
+                "topic.prefix": "test-mysql-jdbc-",
+                "tasks.max": "1",
+                "name": "mysql_source1",
+                "connection.url": "mysql://test_mysql:3306/librarydb"
+            },
+            "name": "mysql_source1",
+            "description": "Source connector using `io.confluent.connect.jdbc.JdbcSourceConnector` plugin."
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.MixedCaseTable",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.MixedCaseTable,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-MixedCaseTable,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.book",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.book,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-book,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.member",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.member,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-member,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": true
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": true
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": true
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": true
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_before_golden_mces.json
+++ b/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_before_golden_mces.json
@@ -1,0 +1,409 @@
+[
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataFlowInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
+                "mode": "incrementing",
+                "incrementing.column.name": "id",
+                "tasks.max": "1",
+                "transforms": "TotalReplacement",
+                "name": "mysql_source2",
+                "connection.url": "mysql://test_mysql:3306/librarydb",
+                "transforms.TotalReplacement.regex": ".*(book)",
+                "transforms.TotalReplacement.type": "org.apache.kafka.connect.transforms.RegexRouter",
+                "transforms.TotalReplacement.replacement": "my-new-topic-$1"
+            },
+            "name": "mysql_source2",
+            "description": "Source connector using `io.confluent.connect.jdbc.JdbcSourceConnector` plugin."
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source2:librarydb.MixedCaseTable",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.MixedCaseTable,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,MixedCaseTable,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source2:librarydb.book",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.book,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,my-new-topic-book,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source2:librarydb.member",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.member,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,member,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataFlowInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
+                "mode": "incrementing",
+                "incrementing.column.name": "id",
+                "topic.prefix": "test-mysql-jdbc-",
+                "tasks.max": "1",
+                "name": "mysql_source1",
+                "connection.url": "mysql://test_mysql:3306/librarydb"
+            },
+            "name": "mysql_source1",
+            "description": "Source connector using `io.confluent.connect.jdbc.JdbcSourceConnector` plugin."
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.MixedCaseTable",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.MixedCaseTable,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-MixedCaseTable,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.book",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.book,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-book,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.member",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,librarydb.member,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-member,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-stateful-test"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_mces_golden.json
@@ -112,6 +112,45 @@
     }
 },
 {
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "debezium-mysql-connector:librarydb.MixedCaseTable",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,mysql1.librarydb.mixedcasetable,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,debezium.topics.librarydb.mixedcasetable,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(kafka-connect,postgres_source,PROD)",
     "changeType": "UPSERT",
@@ -274,6 +313,45 @@
 },
 {
     "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source2:librarydb.MixedCaseTable",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,mysql1.librarydb.mixedcasetable,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,mixedcasetable,PROD)"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.book)",
     "changeType": "UPSERT",
     "aspectName": "dataJobInfo",
@@ -368,6 +446,45 @@
             },
             "name": "mysql_source1",
             "description": "Source connector using `io.confluent.connect.jdbc.JdbcSourceConnector` plugin."
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "mysql_source1:librarydb.MixedCaseTable",
+            "type": {
+                "string": "COMMAND"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "dataJobInputOutput",
+    "aspect": {
+        "json": {
+            "inputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:mysql,mysql1.librarydb.mixedcasetable,PROD)"
+            ],
+            "outputDatasets": [
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-mixedcasetable,PROD)"
+            ]
         }
     },
     "systemMetadata": {
@@ -657,17 +774,118 @@
     }
 },
 {
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD),librarydb.MixedCaseTable)",
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "customProperties": {},
-            "name": "debezium-mysql-connector:librarydb.MixedCaseTable",
-            "type": {
-                "string": "COMMAND"
-            }
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,mysql_sink,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,mysql_source1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,mysql_source2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,mysql_source3,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,mysql_source4,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,mysql_source5,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,postgres_source,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
         }
     },
     "systemMetadata": {
@@ -679,15 +897,10 @@
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD),librarydb.MixedCaseTable)",
     "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:mysql,mysql1.librarydb.mixedcasetable,PROD)"
-            ],
-            "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:kafka,debezium.topics.librarydb.mixedcasetable,PROD)"
-            ]
+            "removed": false
         }
     },
     "systemMetadata": {
@@ -697,16 +910,12 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD),librarydb.book)",
     "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "customProperties": {},
-            "name": "mysql_source2:librarydb.MixedCaseTable",
-            "type": {
-                "string": "COMMAND"
-            }
+            "removed": false
         }
     },
     "systemMetadata": {
@@ -716,17 +925,12 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,debezium-mysql-connector,PROD),librarydb.member)",
     "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:mysql,mysql1.librarydb.mixedcasetable,PROD)"
-            ],
-            "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:kafka,mixedcasetable,PROD)"
-            ]
+            "removed": false
         }
     },
     "systemMetadata": {
@@ -738,14 +942,10 @@
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source1,PROD),librarydb.MixedCaseTable)",
     "changeType": "UPSERT",
-    "aspectName": "dataJobInfo",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "customProperties": {},
-            "name": "mysql_source1:librarydb.MixedCaseTable",
-            "type": {
-                "string": "COMMAND"
-            }
+            "removed": false
         }
     },
     "systemMetadata": {
@@ -755,17 +955,162 @@
 },
 {
     "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source1,PROD),librarydb.MixedCaseTable)",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source1,PROD),librarydb.book)",
     "changeType": "UPSERT",
-    "aspectName": "dataJobInputOutput",
+    "aspectName": "status",
     "aspect": {
         "json": {
-            "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:mysql,mysql1.librarydb.mixedcasetable,PROD)"
-            ],
-            "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:kafka,test-mysql-jdbc-mixedcasetable,PROD)"
-            ]
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source1,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.MixedCaseTable)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source2,PROD),librarydb.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source3,PROD),librarydb.book)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source4,PROD),unknown_source.query-topic)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source5,PROD),unknown_source.Book1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source5,PROD),unknown_source.Book2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,mysql_source5,PROD),unknown_source.Book3)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,postgres_source,PROD),postgres1.postgres.public.member)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_mongo_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_mongo_mces_golden.json
@@ -54,5 +54,35 @@
         "lastObserved": 1635166800000,
         "runId": "kafka-connect-run"
     }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(kafka-connect,source_mongodb_connector,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,source_mongodb_connector,PROD),test_db.purchases)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1635166800000,
+        "runId": "kafka-connect-run"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_mongo_to_file.yml
+++ b/metadata-ingestion/tests/integration/kafka-connect/kafka_connect_mongo_to_file.yml
@@ -7,7 +7,7 @@ source:
   config:
     connect_uri: "http://localhost:58083"    
     connector_patterns:
-      deny:
+      allow:
         - source_mongodb_connector
     provided_configs:
       - provider: env

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -8,7 +8,6 @@ import requests
 from freezegun import freeze_time
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.kafka_connect import KafkaConnectSource
 from datahub.ingestion.source.state.checkpoint import Checkpoint
 from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers import mce_helpers
@@ -493,6 +492,8 @@ def test_kafka_connect_ingest_stateful(
 def get_current_checkpoint_from_pipeline(
     pipeline: Pipeline,
 ) -> Optional[Checkpoint]:
+    from datahub.ingestion.source.kafka_connect import KafkaConnectSource
+
     kafka_connect_source = cast(KafkaConnectSource, pipeline.source)
     return kafka_connect_source.get_current_checkpoint(
         kafka_connect_source.stale_entity_removal_handler.job_id

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -353,6 +353,7 @@ def test_kafka_connect_mongosourceconnect_ingest(
 
 
 @freeze_time(FROZEN_TIME)
+@pytest.mark.integration_batch_1
 def test_kafka_connect_ingest_stateful(
     loaded_kafka_connect, pytestconfig, tmp_path, mock_datahub_graph, test_resources_dir
 ):

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -1,15 +1,26 @@
 import subprocess
 import time
+from typing import Any, Dict, List, Optional, cast
+from unittest import mock
 
 import pytest
 import requests
 from freezegun import freeze_time
 
+from datahub.ingestion.run.pipeline import Pipeline
+from datahub.ingestion.source.kafka_connect import KafkaConnectSource
+from datahub.ingestion.source.state.checkpoint import Checkpoint
+from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
+from tests.test_helpers.state_helpers import (
+    validate_all_providers_have_committed_successfully,
+)
 
 FROZEN_TIME = "2021-10-25 13:00:00"
+GMS_PORT = 8080
+GMS_SERVER = f"http://localhost:{GMS_PORT}"
 
 
 def is_mysql_up(container_name: str, port: int) -> bool:
@@ -23,10 +34,8 @@ def is_mysql_up(container_name: str, port: int) -> bool:
     return ret.returncode == 0
 
 
-@freeze_time(FROZEN_TIME)
-@pytest.mark.integration_batch_1
-def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
-    test_resources_dir = pytestconfig.rootpath / "tests/integration/kafka-connect"
+@pytest.fixture(scope="module")
+def kafka_connect_runner(docker_compose_runner, pytestconfig, test_resources_dir):
     test_resources_dir_kafka = pytestconfig.rootpath / "tests/integration/kafka"
 
     # Share Compose configurations between files and projects
@@ -62,12 +71,33 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
             ).status_code
             == 200,
         )
+        yield docker_services
 
-        # Creating MySQL source with no transformations , only topic prefix
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+
+@pytest.fixture(scope="module")
+def test_resources_dir(pytestconfig):
+    return pytestconfig.rootpath / "tests/integration/kafka-connect"
+
+
+@pytest.fixture(scope="module")
+def loaded_kafka_connect(kafka_connect_runner):
+    # Set up the container.
+    time.sleep(10)
+
+    # Setup mongo cluster
+    command = (
+        'docker exec test_mongo mongo admin -u admin -p admin --eval "rs.initiate();"'
+    )
+    ret = subprocess.run(
+        command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert ret.returncode == 0
+
+    # Creating MySQL source with no transformations , only topic prefix
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                         "name": "mysql_source1",
                         "config": {
                             "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
@@ -79,13 +109,13 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         }
                     }
                     """,
-        )
-        assert r.status_code == 201  # Created
-        # Creating MySQL source with regex router transformations , only topic prefix
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    )
+    assert r.status_code == 201  # Created
+    # Creating MySQL source with regex router transformations , only topic prefix
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                         "name": "mysql_source2",
                         "config": {
                             "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
@@ -100,13 +130,13 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         }
                     }
                     """,
-        )
-        assert r.status_code == 201  # Created
-        # Creating MySQL source with regex router transformations , no topic prefix, table whitelist
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    )
+    assert r.status_code == 201  # Created
+    # Creating MySQL source with regex router transformations , no topic prefix, table whitelist
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                         "name": "mysql_source3",
                         "config": {
                             "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
@@ -122,13 +152,13 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         }
                     }
                     """,
-        )
-        assert r.status_code == 201  # Created
-        # Creating MySQL source with query , topic prefix
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    )
+    assert r.status_code == 201  # Created
+    # Creating MySQL source with query , topic prefix
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                         "name": "mysql_source4",
                         "config": {
                             "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
@@ -141,13 +171,13 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         }
                     }
                     """,
-        )
-        assert r.status_code == 201  # Created
-        # Creating MySQL source with ExtractTopic router transformations - source dataset not added
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    )
+    assert r.status_code == 201  # Created
+    # Creating MySQL source with ExtractTopic router transformations - source dataset not added
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                     "name": "mysql_source5",
                     "config": {
                         "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
@@ -163,13 +193,13 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                     }
                 }
                 """,
-        )
-        assert r.status_code == 201  # Created
-        # Creating MySQL sink connector - not added
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    )
+    assert r.status_code == 201  # Created
+    # Creating MySQL sink connector - not added
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                         "name": "mysql_sink",
                         "config": {
                             "connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",
@@ -181,14 +211,14 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         }
                     }
                     """,
-        )
-        assert r.status_code == 201  # Created
+    )
+    assert r.status_code == 201  # Created
 
-        # Creating Debezium MySQL source connector
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    # Creating Debezium MySQL source connector
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                         "name": "debezium-mysql-connector",
                         "config": {
                             "name": "debezium-mysql-connector",
@@ -204,14 +234,14 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         }
                     }
                     """,
-        )
-        assert r.status_code == 201  # Created
+    )
+    assert r.status_code == 201  # Created
 
-        # Creating Postgresql source
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    # Creating Postgresql source
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                     "name": "postgres_source",
                     "config": {
                         "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
@@ -223,14 +253,14 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         "connection.url": "${env:POSTGRES_CONNECTION_URL}"
                     }
                 }""",
-        )
-        assert r.status_code == 201  # Created
+    )
+    assert r.status_code == 201  # Created
 
-        # Creating Generic source
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data="""{
+    # Creating Generic source
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data="""{
                     "name": "generic_source",
                     "config": {
                         "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
@@ -244,66 +274,15 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
                         "tasks.max": "1"
                     }
                 }""",
-        )
-        r.raise_for_status()
-        assert r.status_code == 201  # Created
+    )
+    r.raise_for_status()
+    assert r.status_code == 201  # Created
 
-        # Give time for connectors to process the table data
-        time.sleep(60)
-
-        # Run the metadata ingestion pipeline.
-        config_file = (test_resources_dir / "kafka_connect_to_file.yml").resolve()
-        run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
-
-        # Verify the output.
-        mce_helpers.check_golden_file(
-            pytestconfig,
-            output_path=tmp_path / "kafka_connect_mces.json",
-            golden_path=test_resources_dir / "kafka_connect_mces_golden.json",
-            ignore_paths=[],
-        )
-
-
-@freeze_time(FROZEN_TIME)
-@pytest.mark.integration_batch_1
-def test_kafka_connect_mongosourceconnect_ingest(
-    docker_compose_runner, pytestconfig, tmp_path, mock_time
-):
-    test_resources_dir = pytestconfig.rootpath / "tests/integration/kafka-connect"
-    test_resources_dir_kafka = pytestconfig.rootpath / "tests/integration/kafka"
-
-    # Share Compose configurations between files and projects
-    # https://docs.docker.com/compose/extends/
-    docker_compose_file = [
-        str(test_resources_dir_kafka / "docker-compose.yml"),
-        str(test_resources_dir / "docker-compose.override.yml"),
-    ]
-    with docker_compose_runner(docker_compose_file, "kafka-connect") as docker_services:
-        time.sleep(10)
-        # Run the setup.sql file to populate the database.
-        command = 'docker exec test_mongo mongo admin -u admin -p admin --eval "rs.initiate();"'
-        ret = subprocess.run(
-            command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        assert ret.returncode == 0
-        time.sleep(10)
-
-        wait_for_port(docker_services, "test_broker", 59092, timeout=120)
-        wait_for_port(docker_services, "test_connect", 58083, timeout=120)
-        docker_services.wait_until_responsive(
-            timeout=30,
-            pause=1,
-            check=lambda: requests.get(
-                "http://localhost:58083/connectors",
-            ).status_code
-            == 200,
-        )
-
-        # Creating MongoDB source
-        r = requests.post(
-            "http://localhost:58083/connectors",
-            headers={"Content-Type": "application/json"},
-            data=r"""{
+    # Creating MongoDB source
+    r = requests.post(
+        "http://localhost:58083/connectors",
+        headers={"Content-Type": "application/json"},
+        data=r"""{
                     "name": "source_mongodb_connector",
                     "config": {
                         "tasks.max": "1",
@@ -329,21 +308,180 @@ def test_kafka_connect_mongosourceconnect_ingest(
                         "publish.full.document.only":true
                     }
                 }""",
+    )
+    r.raise_for_status()
+    assert r.status_code == 201  # Created
+
+    # Give time for connectors to process the table data
+    time.sleep(60)
+
+
+@freeze_time(FROZEN_TIME)
+@pytest.mark.integration_batch_1
+def test_kafka_connect_ingest(
+    loaded_kafka_connect, pytestconfig, tmp_path, test_resources_dir
+):
+    # Run the metadata ingestion pipeline.
+    config_file = (test_resources_dir / "kafka_connect_to_file.yml").resolve()
+    run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
+
+    # Verify the output.
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / "kafka_connect_mces.json",
+        golden_path=test_resources_dir / "kafka_connect_mces_golden.json",
+        ignore_paths=[],
+    )
+
+
+@freeze_time(FROZEN_TIME)
+@pytest.mark.integration_batch_1
+def test_kafka_connect_mongosourceconnect_ingest(
+    loaded_kafka_connect, pytestconfig, tmp_path, test_resources_dir
+):
+    # Run the metadata ingestion pipeline.
+    config_file = (test_resources_dir / "kafka_connect_mongo_to_file.yml").resolve()
+    run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
+
+    # Verify the output.
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / "kafka_connect_mces.json",
+        golden_path=test_resources_dir / "kafka_connect_mongo_mces_golden.json",
+        ignore_paths=[],
+    )
+
+
+@freeze_time(FROZEN_TIME)
+def test_kafka_connect_ingest_stateful(
+    loaded_kafka_connect, pytestconfig, tmp_path, mock_datahub_graph, test_resources_dir
+):
+    output_file_name: str = "kafka_connect_before_mces.json"
+    golden_file_name: str = "kafka_connect_before_golden_mces.json"
+    output_file_deleted_name: str = "kafka_connect_after_mces.json"
+    golden_file_deleted_name: str = "kafka_connect_after_golden_mces.json"
+
+    base_pipeline_config = {
+        "run_id": "kafka-connect-stateful-test",
+        "pipeline_name": "kafka-connect-stateful",
+        "source": {
+            "type": "kafka-connect",
+            "config": {
+                "platform_instance": "connect-instance-1",
+                "connect_uri": "http://localhost:58083",
+                "connector_patterns": {"allow": [".*"]},
+                "provided_configs": [
+                    {
+                        "provider": "env",
+                        "path_key": "MYSQL_CONNECTION_URL",
+                        "value": "jdbc:mysql://test_mysql:3306/librarydb",
+                    }
+                ],
+                "stateful_ingestion": {
+                    "enabled": True,
+                    "remove_stale_metadata": True,
+                    "fail_safe_threshold": 100.0,
+                    "state_provider": {
+                        "type": "datahub",
+                        "config": {"datahub_api": {"server": GMS_SERVER}},
+                    },
+                },
+            },
+        },
+        "sink": {
+            "type": "file",
+            "config": {},
+        },
+    }
+
+    pipeline_run1 = None
+    with mock.patch(
+        "datahub.ingestion.source.state_provider.datahub_ingestion_checkpointing_provider.DataHubGraph",
+        mock_datahub_graph,
+    ) as mock_checkpoint:
+        mock_checkpoint.return_value = mock_datahub_graph
+        pipeline_run1_config: Dict[str, Dict[str, Dict[str, Any]]] = dict(  # type: ignore
+            base_pipeline_config  # type: ignore
         )
-        r.raise_for_status()
-        assert r.status_code == 201  # Created
+        # Set the special properties for this run
+        pipeline_run1_config["source"]["config"]["connector_patterns"]["allow"] = [
+            "mysql_source1",
+            "mysql_source2",
+        ]
+        pipeline_run1_config["sink"]["config"][
+            "filename"
+        ] = f"{tmp_path}/{output_file_name}"
+        pipeline_run1 = Pipeline.create(pipeline_run1_config)
+        pipeline_run1.run()
+        pipeline_run1.raise_from_status()
+        pipeline_run1.pretty_print_summary()
 
-        # Give time for connectors to process the table data
-        time.sleep(60)
-
-        # Run the metadata ingestion pipeline.
-        config_file = (test_resources_dir / "kafka_connect_to_file.yml").resolve()
-        run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
-
-        # Verify the output.
         mce_helpers.check_golden_file(
             pytestconfig,
-            output_path=tmp_path / "kafka_connect_mces.json",
-            golden_path=test_resources_dir / "kafka_connect_mongo_mces_golden.json",
-            ignore_paths=[],
+            output_path=tmp_path / output_file_name,
+            golden_path=f"{test_resources_dir}/{golden_file_name}",
         )
+
+    checkpoint1 = get_current_checkpoint_from_pipeline(pipeline_run1)
+    assert checkpoint1
+    assert checkpoint1.state
+
+    pipeline_run2 = None
+    with mock.patch(
+        "datahub.ingestion.source.state_provider.datahub_ingestion_checkpointing_provider.DataHubGraph",
+        mock_datahub_graph,
+    ) as mock_checkpoint:
+        mock_checkpoint.return_value = mock_datahub_graph
+        pipeline_run2_config: Dict[str, Dict[str, Dict[str, Any]]] = dict(base_pipeline_config)  # type: ignore
+        # Set the special properties for this run
+        pipeline_run1_config["source"]["config"]["connector_patterns"]["allow"] = [
+            "mysql_source1",
+        ]
+        pipeline_run2_config["sink"]["config"][
+            "filename"
+        ] = f"{tmp_path}/{output_file_deleted_name}"
+        pipeline_run2 = Pipeline.create(pipeline_run2_config)
+        pipeline_run2.run()
+        pipeline_run2.raise_from_status()
+        pipeline_run2.pretty_print_summary()
+
+        mce_helpers.check_golden_file(
+            pytestconfig,
+            output_path=tmp_path / output_file_deleted_name,
+            golden_path=f"{test_resources_dir}/{golden_file_deleted_name}",
+        )
+    checkpoint2 = get_current_checkpoint_from_pipeline(pipeline_run2)
+    assert checkpoint2
+    assert checkpoint2.state
+
+    # Validate that all providers have committed successfully.
+    validate_all_providers_have_committed_successfully(
+        pipeline=pipeline_run1, expected_providers=1
+    )
+    validate_all_providers_have_committed_successfully(
+        pipeline=pipeline_run2, expected_providers=1
+    )
+
+    # Perform all assertions on the states. The deleted table should not be
+    # part of the second state
+    state1 = cast(GenericCheckpointState, checkpoint1.state)
+    state2 = cast(GenericCheckpointState, checkpoint2.state)
+
+    difference_pipeline_urns = list(
+        state1.get_urns_not_in(type="dataFlow", other_checkpoint_state=state2)
+    )
+    # the difference in dataset urns are all the views that are not reachable from the model file
+    assert len(difference_pipeline_urns) == 1
+    deleted_pipeline_urns: List[str] = [
+        "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD)"
+    ]
+    assert sorted(deleted_pipeline_urns) == sorted(difference_pipeline_urns)
+
+
+def get_current_checkpoint_from_pipeline(
+    pipeline: Pipeline,
+) -> Optional[Checkpoint]:
+    kafka_connect_source = cast(KafkaConnectSource, pipeline.source)
+    return kafka_connect_source.get_current_checkpoint(
+        kafka_connect_source.stale_entity_removal_handler.job_id
+    )

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -470,12 +470,23 @@ def test_kafka_connect_ingest_stateful(
     difference_pipeline_urns = list(
         state1.get_urns_not_in(type="dataFlow", other_checkpoint_state=state2)
     )
-    # the difference in dataset urns are all the views that are not reachable from the model file
+
     assert len(difference_pipeline_urns) == 1
     deleted_pipeline_urns: List[str] = [
         "urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD)"
     ]
     assert sorted(deleted_pipeline_urns) == sorted(difference_pipeline_urns)
+
+    difference_job_urns = list(
+        state1.get_urns_not_in(type="dataJob", other_checkpoint_state=state2)
+    )
+    assert len(difference_job_urns) == 3
+    deleted_job_urns = [
+        "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.MixedCaseTable)",
+        "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.book)",
+        "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.member)",
+    ]
+    assert sorted(deleted_job_urns) == sorted(difference_job_urns)
 
 
 def get_current_checkpoint_from_pipeline(


### PR DESCRIPTION
Items covered in this PR
- add platform instance support for kafka connect platform entities
- add stateful ingestion support
- move connector pattern allow/deny check earlier in the code execution, to avoid processing lineage for denied connectors
- rewrite tests for reducing overall kafka connect test time

It also appears that this source can use some refractor for readability and better exception handling, however, I would create separate PR for that after this PR is merged, in order to avoid difficulty in reviewing.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
