### PR TITLE
fix(): Fix Query Detail Modal Scroll + add misc log messages

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Queries/QueryCardDetails.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Queries/QueryCardDetails.tsx
@@ -123,9 +123,10 @@ export default function QueryCardDetails({
                 )) || <EmptyText>No description</EmptyText>}
             </Description>
             <Date>
-                {createdAtMs && (
+                {(createdAtMs && (
                     <Typography.Text type="secondary">Created on {toLocalDateString(createdAtMs)}</Typography.Text>
-                )}
+                )) ||
+                    undefined}
             </Date>
         </Details>
     );

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Queries/QueryModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Queries/QueryModal.tsx
@@ -56,6 +56,9 @@ const QueryContainer = styled.div`
 const NestedSyntax = styled(SyntaxHighlighter)`
     background-color: transparent !important;
     border: none !important;
+    height: 100% !important;
+    margin: 0px !important;
+    padding: 12px !important;
 `;
 
 type Props = {

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
@@ -85,7 +85,7 @@ public class DataHubUpgradeKafkaListener implements ConsumerSeekAware, Bootstrap
       if (expectedVersion.equals(event.getVersion())) {
         IS_UPDATED.getAndSet(true);
       } else {
-        log.info("System version is not up to date: {}. Waiting...", expectedVersion);
+        log.info("System version is not up to date: {}. Waiting for datahub-upgrade to complete...", expectedVersion);
       }
 
     } catch (Exception e) {

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
@@ -85,7 +85,7 @@ public class DataHubUpgradeKafkaListener implements ConsumerSeekAware, Bootstrap
       if (expectedVersion.equals(event.getVersion())) {
         IS_UPDATED.getAndSet(true);
       } else {
-        log.debug("System version is not up to date: {}", expectedVersion);
+        log.info("System version is not up to date: {}. Waiting...", expectedVersion);
       }
 
     } catch (Exception e) {


### PR DESCRIPTION
## Summary

- Fixing the horizontal scroll for the Query Modal by making the Query full height of the parent container.
- Fixing a bug where a "0" will appear in the cast that createdAt time does not exist
- Adding a log info when GMS fails to startup due to waiting on kafka. 

## Status

Ready to review 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
