### PR TITLE
fix(frontend proxy): Disable unnecessary URL encoding at the proxy layer

### DIFF
--- a/datahub-frontend/app/controllers/Application.java
+++ b/datahub-frontend/app/controllers/Application.java
@@ -263,6 +263,7 @@ public class Application extends Controller {
     Materializer materializer = ActorMaterializer.create(system);
     AsyncHttpClientConfig asyncHttpClientConfig =
         new DefaultAsyncHttpClientConfig.Builder()
+            .setDisableUrlEncodingForBoundRequests(true)
             .setMaxRequestRetry(0)
             .setShutdownQuietPeriod(0)
             .setShutdownTimeout(0)


### PR DESCRIPTION
## Summary

We recently upgraded to a newer version of Play framework (thanks @david-leifker ) which unlocked the ability to use a new config provided by Play to disable the automatic encoding that was being performed on inbound requests. This means that the proxy will be able to be used more effectively with the APIs served by gms.

## Status

Ready for review

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
