### PR TITLE
feat(ingest): fix edge cases + interface cleanup for file-system APIs

### DIFF
--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -74,6 +74,11 @@ def test_file_dict(tmp_path: pathlib.Path) -> None:
     assert len(cache) == 1
     assert cache["a"] == 1
 
+    # Test close.
+    cache.close()
+    with pytest.raises(Exception):
+        cache["a"] = 1
+
 
 def test_custom_serde(tmp_path: pathlib.Path) -> None:
     @dataclass(frozen=True)
@@ -293,6 +298,6 @@ def test_file_cleanup():
         cache.flush()
         assert len(cache) == 1
 
-        del cache
+        cache.close()
 
     assert not filename.exists()


### PR DESCRIPTION
- Sets pickle as the default serde method
- Fixes a subtle bug around the close() method
- Adds much better comments

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
