### PR TITLE
fix(logging): increase log level for system-upgrade job to complete before starting

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
@@ -85,7 +85,7 @@ public class DataHubUpgradeKafkaListener implements ConsumerSeekAware, Bootstrap
       if (expectedVersion.equals(event.getVersion())) {
         IS_UPDATED.getAndSet(true);
       } else {
-        log.info("System version is not up to date: {}. Waiting for datahub-upgrade to complete...", expectedVersion);
+        log.error("System version is not up to date: {}. Waiting for datahub-upgrade to complete...", expectedVersion);
       }
 
     } catch (Exception e) {

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/kafka/DataHubUpgradeKafkaListener.java
@@ -85,7 +85,7 @@ public class DataHubUpgradeKafkaListener implements ConsumerSeekAware, Bootstrap
       if (expectedVersion.equals(event.getVersion())) {
         IS_UPDATED.getAndSet(true);
       } else {
-        log.error("System version is not up to date: {}. Waiting for datahub-upgrade to complete...", expectedVersion);
+        log.warn("System version is not up to date: {}. Waiting for datahub-upgrade to complete...", expectedVersion);
       }
 
     } catch (Exception e) {


### PR DESCRIPTION
…grade job to complete before starting

Users have been confused why GMS is not starting when there is no visible error in the logs. Increase log level to error for the log indicating that it is still waiting for the datahub-upgrade job to run. 


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
