### PR TITLE
fix(ui) Safeguard ingestion execution request check

### DIFF
--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTable.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTable.tsx
@@ -113,14 +113,16 @@ function IngestionSourceTable({
         timezone: source.schedule?.timezone,
         execCount: source.executions?.total || 0,
         lastExecUrn:
-            source.executions?.total && source.executions?.total > 0 && source.executions?.executionRequests[0].urn,
+            source.executions &&
+            source.executions?.executionRequests.length > 0 &&
+            source.executions?.executionRequests[0].urn,
         lastExecTime:
-            source.executions?.total &&
-            source.executions?.total > 0 &&
+            source.executions &&
+            source.executions?.executionRequests.length > 0 &&
             source.executions?.executionRequests[0].result?.startTimeMs,
         lastExecStatus:
-            source.executions?.total &&
-            source.executions?.total > 0 &&
+            source.executions &&
+            source.executions?.executionRequests.length > 0 &&
             source.executions?.executionRequests[0].result?.status,
         cliIngestion: source.config?.executorId === CLI_EXECUTOR_ID,
     }));


### PR DESCRIPTION
If `total` is greater than 0 but we still somehow get no `executionRequests` then we will throw an error on the frontend and whitepage it. This checks the right thing before getting the first element in an array.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
