### PR TITLE
fix(ingest/snowflake): Allow SnowflakeObjectAccessEntry.objectId to be None

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
@@ -66,8 +66,9 @@ class SnowflakeColumnReference(PermissiveModel):
 class SnowflakeObjectAccessEntry(PermissiveModel):
     columns: Optional[List[SnowflakeColumnReference]]
     objectDomain: str
-    objectId: int
     objectName: str
+    # Seems like it should never be null, but in practice have seen null objectIds
+    objectId: Optional[int]
     stageKind: Optional[str]
 
 

--- a/metadata-ingestion/tests/unit/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_source.py
@@ -11,6 +11,9 @@ from datahub.ingestion.source.snowflake.constants import (
     SnowflakeCloudProvider,
 )
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
+from datahub.ingestion.source.snowflake.snowflake_usage_v2 import (
+    SnowflakeObjectAccessEntry,
+)
 from datahub.ingestion.source.snowflake.snowflake_v2 import SnowflakeV2Source
 
 
@@ -546,3 +549,16 @@ def test_unknown_cloud_region_from_snowflake_region_id():
             "somecloud_someregion"
         )
     assert "Unknown snowflake region" in str(e)
+
+
+def test_snowflake_object_access_entry_missing_object_id():
+    SnowflakeObjectAccessEntry(
+        **{
+            "columns": [
+                {"columnName": "A"},
+                {"columnName": "B"},
+            ],
+            "objectDomain": "View",
+            "objectName": "SOME.OBJECT.NAME",
+        }
+    )


### PR DESCRIPTION
Have seen usage ingestion errors from empty `objectId`. Since it seems to be unused, this relaxes the type constraint

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
