### PR TITLE
fix(docker): fix gradle quickstart version parsing

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -11,7 +11,7 @@ import tempfile
 import time
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, NoReturn, Optional
+from typing import Dict, List, Optional
 
 import click
 import click_spinner
@@ -85,18 +85,6 @@ def docker() -> None:
     """Helper commands for setting up and interacting with a local
     DataHub instance using Docker."""
     pass
-
-
-def _print_issue_list_and_exit(
-    issues: List[str], header: str, footer: Optional[str] = None
-) -> NoReturn:
-    click.secho(header, fg="bright_red")
-    for issue in issues:
-        click.echo(f"- {issue}")
-    if footer:
-        click.echo()
-        click.echo(footer)
-    sys.exit(1)
 
 
 @docker.command()

--- a/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
+++ b/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
@@ -29,7 +29,7 @@ def _is_it_a_version(version: str) -> bool:
     :param version: The string to check.
     :return: True if the string is a valid version, False otherwise.
     """
-    return re.match(r"v?\d+\.\d+(\.\d+)?", version) is not None
+    return re.match(r"^v?\d+\.\d+(\.\d+)?$", version) is not None
 
 
 class QuickstartVersionMappingConfig(BaseModel):


### PR DESCRIPTION
Thanks to @pedro93 for finding the fix here.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
