### PR TITLE
feat(docs-website): deploy preview environments to vercel

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,16 +20,16 @@ jobs:
     permissions:
       deployments: write
     steps:
-    - name: Setup
-      id: setup
-      # perform secret check & put boolean result as an output
-      shell: bash
-      run: |
-        if [ "${{ secrets.VERCEL_TOKEN }}" != '' ]; then
-          echo "preview=true" >> $GITHUB_OUTPUT;
-        else
-          echo "preview=false" >> $GITHUB_OUTPUT;
-        fi
+      - name: Setup
+        id: setup
+        # perform secret check & put boolean result as an output
+        shell: bash
+        run: |
+          if [ "${{ secrets.VERCEL_TOKEN }}" != '' ]; then
+            echo "preview=true" >> $GITHUB_OUTPUT;
+          else
+            echo "preview=false" >> $GITHUB_OUTPUT;
+          fi
 
       - name: Start Deployment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,28 @@ concurrency:
 jobs:
   gh-pages:
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
+    - name: Setup
+      id: setup
+      # perform secret check & put boolean result as an output
+      shell: bash
+      run: |
+        if [ "${{ secrets.VERCEL_TOKEN }}" != '' ]; then
+          echo "preview=true" >> $GITHUB_OUTPUT;
+        else
+          echo "preview=false" >> $GITHUB_OUTPUT;
+        fi
+
+      - name: Start Deployment
+        if: github.event_name == 'pull_request'
+        uses: bobheadxi/deployments@v1.4.0
+        id: deployment
+        with:
+          step: start
+          env: Preview
+
       - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -39,3 +60,24 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs-website/build
           cname: datahubproject.io
+
+      - name: Deploy Preview
+        uses: amondnet/vercel-action@v25.1.1
+        if: github.event_name == 'pull_request'
+        id: vercel-action
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
+          github-comment: true
+          working-directory: ./docs-website
+
+      - name: Update Deployment Status
+        uses: bobheadxi/deployments@v1.4.0
+        if: always() && github.event_name == 'pull_request'
+        with:
+          step: finish
+          status: ${{ job.status }}
+          env: ${{ steps.deployment.outputs.env }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ steps.vercel-action.outputs.preview-url }}


### PR DESCRIPTION
This is an alternate approach vs https://github.com/datahub-project/datahub/pull/7644. This one requires that the PR is created from this repo and not a fork.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
