### PR TITLE
fix(revert): remove unnecessary class check

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -179,7 +179,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
 
     // Step 2. For all aspects, attempt to update Graph
     SystemMetadata systemMetadata = event.getSystemMetadata();
-    if (_graphDiffMode && _graphService instanceof ElasticSearchGraphService
+    if (_graphDiffMode
         && (systemMetadata == null || systemMetadata.getProperties() == null
         || !Boolean.parseBoolean(systemMetadata.getProperties().get(FORCE_INDEXING_KEY)))) {
       updateGraphServiceDiff(urn, aspectSpec, previousAspect, aspect, event);

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -179,7 +179,7 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
 
     // Step 2. For all aspects, attempt to update Graph
     SystemMetadata systemMetadata = event.getSystemMetadata();
-    if (_graphDiffMode
+    if (_graphDiffMode && !(_graphService instanceof DGraphGraphService)
         && (systemMetadata == null || systemMetadata.getProperties() == null
         || !Boolean.parseBoolean(systemMetadata.getProperties().get(FORCE_INDEXING_KEY)))) {
       updateGraphServiceDiff(urn, aspectSpec, previousAspect, aspect, event);


### PR DESCRIPTION
A PR went in for support of diffMode for Neo4J, the class check is no longer necessary although could cause an issue if someone is using DGraph.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
