### PR TITLE
fix(cli): protect against timeseries get_aspects

### DIFF
--- a/.github/workflows/check-datahub-jars.yml
+++ b/.github/workflows/check-datahub-jars.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   check_jars:
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         command:

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -12,6 +12,7 @@ from requests.models import HTTPError
 
 from datahub.cli.cli_utils import get_boolean_env_variable, get_url_and_token
 from datahub.configuration.common import ConfigModel, GraphError, OperationalError
+from datahub.emitter.aspect import TIMESERIES_ASPECT_MAP
 from datahub.emitter.mce_builder import Aspect
 from datahub.emitter.rest_emitter import DatahubRestEmitter
 from datahub.emitter.serialization_helper import post_json_transform
@@ -131,10 +132,16 @@ class DataHubGraph(DatahubRestEmitter):
         :param version: The version of the aspect to retrieve. The default of 0 means latest. Versions > 0 go from oldest to newest, so 1 is the oldest.
         :return: the Aspect as a dictionary if present, None if no aspect was found (HTTP status 404)
 
+        :raises TypeError: if the aspect type is a timeseries aspect
         :raises HttpError: if the HTTP response is not a 200 or a 404
         """
 
         aspect = aspect_type.ASPECT_NAME
+        if aspect in TIMESERIES_ASPECT_MAP:
+            raise TypeError(
+                'Cannot get a timeseries aspect using "get_aspect". Use "get_latest_timeseries_value" instead.'
+            )
+
         url: str = f"{self._gms_server}/aspects/{Urn.url_encode(entity_urn)}?aspect={aspect}&version={version}"
         response = self._session.get(url)
         if response.status_code == 404:


### PR DESCRIPTION
Previously we'd just return None, which was a confusing response for users.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
