### PR TITLE
docs(posts): add examples

### DIFF
--- a/docs/posts.md
+++ b/docs/posts.md
@@ -46,7 +46,77 @@ Here are some examples of Posts displayed on the home page, with one **TEXT** po
 
 * [createPost](../graphql/mutations.md#createpost)
 * [listPosts](../graphql/queries.md#listposts)
+* [deletePosts](../graphql/queries.md#listposts)
 
+### Examples
+
+##### Create Post
+```graphql
+mutation test {
+  createPost(
+    input: {
+      postType: HOME_PAGE_ANNOUNCEMENT, 
+      content: {
+        contentType: TEXT, 
+        title: "Planed Upgrade 2023-03-23 20:05 - 2023-03-23 23:05", 
+        description: "datahub upgrade to v0.10.1"
+      }
+    }
+  )
+}
+
+```
+
+##### List Post
+
+```graphql
+query listPosts($input: ListPostsInput!) {
+  listPosts(input: $input) {
+    start
+    count
+    total
+    posts {
+      urn
+      type
+      postType
+      content {
+        contentType
+        title
+        description
+        link
+        media {
+          type
+          location
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}
+
+```
+##### Input for list post
+```shell
+{
+  "input": {
+    "start": 0,
+    "count": 10
+  }
+}
+```
+
+##### Delete Post
+
+```graphql
+mutation deletePosting { 
+  deletePost (
+    urn: "urn:li:post:61dd86fa-9e76-4924-ad45-3a533671835e"
+  )
+}
+```
 
 ## FAQ and Troubleshooting
 


### PR DESCRIPTION
added graphql examples for creating, listing and deleting posts.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
