### PR TITLE
perf(ingest): Improve FileBackedDict iteration performance; minor refactoring

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -291,10 +291,9 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT], Closeable):
             Iterator of filtered (key, value) pairs.
         """
         self.flush()
+        sql = f"SELECT key, value FROM {self.tablename}"
         if cond_sql:
-            sql = f"SELECT key, value FROM {self.tablename} WHERE {cond_sql}"
-        else:
-            sql = f"SELECT key, value FROM {self.tablename}"
+            sql += f" WHERE {cond_sql}"
 
         cursor = self._conn.execute(sql)
         for row in cursor:

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -217,7 +217,6 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT], Closeable):
                 items_to_write.append(tuple(values))
 
         if items_to_write:
-            print("WRITING")
             self._conn.executemany(
                 f"""INSERT OR REPLACE INTO {self.tablename} (
                     key,

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -262,7 +262,7 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT], Closeable):
             raise KeyError(key)
 
     def mark_dirty(self, key: str) -> None:
-        if key in self._active_object_cache:
+        if key in self._active_object_cache and not self._active_object_cache[key][1]:
             self._active_object_cache[key] = self._active_object_cache[key][0], True
 
     def __iter__(self) -> Iterator[str]:

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -142,7 +142,7 @@ def test_custom_serde() -> None:
 
     assert cache["second"] == second
     assert cache["first"] == first
-    assert serializer_calls == 4  # Items written to cache on every access
+    assert serializer_calls == 2
     assert deserializer_calls == 2
 
 
@@ -163,6 +163,7 @@ def test_file_dict_stores_counter() -> None:
                 cache[str(i)][str(j)] += 100
                 in_memory_counters[i][str(j)] += 100
             cache[str(i)][str(j)] += j
+            cache.mark_dirty(str(i))
             in_memory_counters[i][str(j)] += j
 
     for i in range(n):

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -213,7 +213,13 @@ def test_custom_column(cache_max_size: int) -> None:
         ("second", Pair(100, "b")),
         ("third", Pair(27, "c")),
     ]
-    assert sorted(list(cache.filtered_items("x < 50"))) == [
+    assert sorted(list(cache.items_snapshot())) == [
+        ("first", Pair(4, "e")),
+        ("fourth", Pair(100, "d")),
+        ("second", Pair(100, "b")),
+        ("third", Pair(27, "c")),
+    ]
+    assert sorted(list(cache.items_snapshot("x < 50"))) == [
         ("first", Pair(4, "e")),
         ("third", Pair(27, "c")),
     ]
@@ -267,7 +273,7 @@ def test_shared_connection() -> None:
             == [("a", 45), ("b", 55)]
         )
 
-        assert list(cache2.filtered_items('y = "a"')) == [
+        assert list(cache2.items_snapshot('y = "a"')) == [
             ("ref-a-1", Pair(7, "a")),
             ("ref-a-2", Pair(8, "a")),
         ]

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -1,6 +1,7 @@
 import dataclasses
 import json
 import pathlib
+import sqlite3
 from dataclasses import dataclass
 from typing import Counter, Dict
 
@@ -246,15 +247,11 @@ def test_shared_connection() -> None:
         assert len(cache2) == 3
 
         # Test advanced SQL queries and sql_query_iterator.
-        for i, x in enumerate(
-            cache2.sql_query_iterator(
-                f"SELECT y, sum(x) FROM {cache2.tablename} GROUP BY y ORDER BY y"
-            )
-        ):
-            if i == 0:
-                assert x == ("a", 15)
-            elif i == 1:
-                assert x == ("b", 11)
+        iterator = cache2.sql_query_iterator(
+            f"SELECT y, sum(x) FROM {cache2.tablename} GROUP BY y ORDER BY y"
+        )
+        assert type(iterator) == sqlite3.Cursor
+        assert list(iterator) == [("a", 15), ("b", 11)]
 
         # Test joining between the two tables.
         assert (

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -178,7 +178,7 @@ class Pair:
 
 
 @pytest.mark.parametrize("cache_max_size", [0, 1, 10])
-def test_custom_column(cache_max_size) -> None:
+def test_custom_column(cache_max_size: int) -> None:
     cache = FileBackedDict[Pair](
         extra_columns={
             "x": lambda m: m.x,


### PR DESCRIPTION
- Refactors `__iter__`
- Manually implements `.items()` and `.values()`
- Adds `sql_query_iterator` and `filtered_items`
- Renames `connection` -> `shared_connection`
- Removes unnecessary flush during `close` if connection is not shared
- Adds context manager dunder methods

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
