### PR TITLE
fix(ingest/redshift): Lineage query fix to work with the latest redshift

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -846,7 +846,7 @@ class RedshiftSource(SQLAlchemySource):
                 distinct cluster,
                 target_schema,
                 target_table,
-                username,
+                username as username,
                 source_schema,
                 source_table
             from
@@ -868,7 +868,7 @@ class RedshiftSource(SQLAlchemySource):
                     ) as target_tables
             join ( (
                 select
-                    pu.usename::varchar(40) as username,
+                    sui.usename as username,
                     ss.tbl as source_table_id,
                     sti.schema as source_schema,
                     sti.table as source_table,
@@ -886,12 +886,12 @@ class RedshiftSource(SQLAlchemySource):
                 ) ss
                 join SVV_TABLE_INFO sti on
                     sti.table_id = ss.tbl
-                left join pg_user pu on
-                    pu.usesysid = ss.userid
                 left join stl_query sq on
                     ss.query = sq.query
+                left join svl_user_info sui on
+                    sq.userid = sui.usesysid
                 where
-                    pu.usename <> 'rdsdb')
+                    sui.usename <> 'rdsdb')
             ) as source_tables
                     using (query)
             where


### PR DESCRIPTION
Fixing the Redshift lineage query, which got broken with the latest redshift upgrade

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
