### PR TITLE
fix(docs): Fixing timeseries delete doc until code path is fixed 

### DIFF
--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -1,8 +1,9 @@
 # Removing Metadata from DataHub
 
 There are a two ways to delete metadata from DataHub. 
-- Delete metadata attached to entities by providing a specific urn or a filter that identifies a set of entities
-- Delete metadata affected by a single ingestion run
+
+- Delete metadata attached to entities by providing a specific urn or filters that identify a set of entities
+- Delete metadata created by a single ingestion run
 
 To follow this guide you need to use [DataHub CLI](../cli.md).
 
@@ -63,7 +64,7 @@ _Note: All these commands below support the soft-delete option (`-s/--soft`) as 
 
 ### Delete all Datasets from the Snowflake platform
 ```
-datahub delete --entity_type dataset --platform nowflake
+datahub delete --entity_type dataset --platform snowflake
 ```
 
 ### Delete all containers for a particular platform
@@ -78,8 +79,8 @@ datahub delete --env DEV --entity_type dataset
 
 ### Delete all Pipelines and Tasks in the DEV environment
 ```
-datahub delete --env DEV --entity_type "datajob"
-datahub delete --env DEV --entity_type "dataflow"
+datahub delete --env DEV --entity_type "dataJob"
+datahub delete --env DEV --entity_type "dataFlow"
 ```
 
 ### Delete all bigquery datasets in the PROD environment
@@ -95,7 +96,7 @@ datahub delete --entity_type chart --platform looker
 
 ### Delete all datasets that match a query
 ```
-datahub delete --entity_type dataset --query "_tmp" -n
+datahub delete --entity_type dataset --query "_tmp"
 ```
 
 ## Rollback Ingestion Run

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -1,9 +1,9 @@
 # Removing Metadata from DataHub
 
-There are a two ways to delete metadata from DataHub. 
+There are a two ways to delete metadata from DataHub:
 
-- Delete metadata attached to entities by providing a specific urn or filters that identify a set of entities
-- Delete metadata created by a single ingestion run
+1. Delete metadata attached to entities by providing a specific urn or filters that identify a set of entities
+2. Delete metadata created by a single ingestion run
 
 To follow this guide you need to use [DataHub CLI](../cli.md).
 

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -57,7 +57,7 @@ If you wish to hard-delete using a curl request you can use something like below
 curl "http://localhost:8080/entities?action=delete" -X POST --data '{"urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"}'
 ```
 
-## Delete using Broader Filters
+## Delete by filters
 
 _Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`). 
 

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -98,7 +98,7 @@ datahub delete --entity_type chart --platform looker
 datahub delete --entity_type dataset --query "_tmp" -n
 ```
 
-## Rollback Ingestion Batch Run
+## Rollback Ingestion Run
 
 The second way to delete metadata is to identify entities (and the aspects affected) by using an ingestion `run-id`. Whenever you run `datahub ingest -c ...`, all the metadata ingested with that run will have the same run id.
 

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -40,25 +40,6 @@ datahub delete --urn "<my urn>" --hard
 As of datahub v0.8.35 doing a hard delete by urn will also provide you with a way to remove references to the urn being deleted across the metadata graph. This is important to use if you don't want to have ghost references in your metadata model and want to save space in the graph database.
 For now, this behaviour must be opted into by a prompt that will appear for you to manually accept or deny.
 
-Starting v0.8.44.2, this also supports deletion of a specific `timeseries` aspect associated with the entity, optionally for a specific time range.
-
-_Note: Deletion by a specific aspect and time range is currently supported only for timeseries aspects._
-
-```bash
-# Delete all of the aspect values for a given entity and a timeseries aspect.
-datahub delete --urn "<entity urn>" -a "<timeseries aspect>" --hard
-Eg: datahub delete --urn "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_dataset,TEST)" -a "datasetProfile" --hard
-
-# Delete all of the aspect values for a given platform and a timeseries aspect.
-datahub delete -p "<platform>" -a "<timeseries aspect>" --hard
-Eg: datahub delete -p "snowflake" -a "datasetProfile" --hard
-
-# Delete the aspect values for a given platform and a timeseries aspect corresponding to a specific time range.
-datahub delete -p "<platform>" -a "<timeseries aspect>" --start-time '<start_time>' --end-time '<end_time>' --hard
-Eg: datahub delete -p "snowflake" -a "datasetProfile" --start-time '2022-05-29 00:00:00' --end-time '2022-05-31 00:00:00' --hard
-```
-
-
 You can optionally add `-n` or `--dry-run` to execute a dry run before issuing the final delete command.
 You can optionally add `-f` or `--force` to skip confirmations
 You can optionally add `--only-soft-deleted` flag to remove soft-deleted items only.
@@ -80,14 +61,19 @@ curl "http://localhost:8080/entities?action=delete" -X POST --data '{"urn": "urn
 _Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`). 
 
 
-### Delete all datasets in the DEV environment
+### Delete all Datasets from the Snowflake platform
 ```
-datahub delete --env DEV --entity_type dataset
+datahub delete --entity_type dataset --platform nowflake
 ```
 
 ### Delete all containers for a particular platform
 ```
 datahub delete --entity_type container --platform s3
+```
+
+### Delete all datasets in the DEV environment
+```
+datahub delete --env DEV --entity_type dataset
 ```
 
 ### Delete all Pipelines and Tasks in the DEV environment


### PR DESCRIPTION
## Summary

Currently the timeseries delete doc is mis-leading, allowing users to delete the wrong fields. Removing this so no one shoots themselves in the foot. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
