### PR TITLE
refactor(ingest): Minor cleanup of File, CsvEnricher, BusinessGlossary, and FileLineage sources

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -106,6 +106,7 @@ class CSVEnricherSource(Source):
 
     :::note
     This source will not work on very large csv files that do not fit in memory.
+    :::
     """
 
     def __init__(self, config: CSVEnricherConfig, ctx: PipelineContext):

--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -33,6 +33,7 @@ from datahub.metadata.schema_classes import (
     OwnershipTypeClass,
     TagAssociationClass,
 )
+from datahub.utilities.source_helpers import auto_workunit_reporter
 from datahub.utilities.urns.dataset_urn import DatasetUrn
 from datahub.utilities.urns.urn import Urn
 
@@ -102,6 +103,9 @@ class CSVEnricherSource(Source):
     be applied at the entity field. If a subresource IS populated (as it is for the second and third rows), glossary
     terms and tags will be applied on the subresource. Every row MUST have a resource. Also note that owners can only
     be applied at the resource level and will be ignored if populated for a row with a subresource.
+
+    :::note
+    This source will not work on very large csv files that do not fit in memory.
     """
 
     def __init__(self, config: CSVEnricherConfig, ctx: PipelineContext):
@@ -305,7 +309,6 @@ class CSVEnricherSource(Source):
         )
         if maybe_terms_wu:
             self.report.num_glossary_term_workunits_produced += 1
-            self.report.report_workunit(maybe_terms_wu)
             yield maybe_terms_wu
 
         maybe_tags_wu: Optional[MetadataWorkUnit] = self.get_resource_tags_work_unit(
@@ -314,7 +317,6 @@ class CSVEnricherSource(Source):
         )
         if maybe_tags_wu:
             self.report.num_tag_workunits_produced += 1
-            self.report.report_workunit(maybe_tags_wu)
             yield maybe_tags_wu
 
         maybe_owners_wu: Optional[
@@ -325,7 +327,6 @@ class CSVEnricherSource(Source):
         )
         if maybe_owners_wu:
             self.report.num_owners_workunits_produced += 1
-            self.report.report_workunit(maybe_owners_wu)
             yield maybe_owners_wu
 
         maybe_domain_wu: Optional[
@@ -336,7 +337,6 @@ class CSVEnricherSource(Source):
         )
         if maybe_domain_wu:
             self.report.num_domain_workunits_produced += 1
-            self.report.report_workunit(maybe_domain_wu)
             yield maybe_domain_wu
 
         maybe_description_wu: Optional[
@@ -347,7 +347,6 @@ class CSVEnricherSource(Source):
         )
         if maybe_description_wu:
             self.report.num_description_workunits_produced += 1
-            self.report.report_workunit(maybe_description_wu)
             yield maybe_description_wu
 
     def process_sub_resource_row(
@@ -469,9 +468,7 @@ class CSVEnricherSource(Source):
                 needs_write = True
 
             # Iterate over each sub resource row
-            for sub_resource_row in self.editable_schema_metadata_map[
-                entity_urn
-            ]:  # type: SubResourceRow
+            for sub_resource_row in self.editable_schema_metadata_map[entity_urn]:
                 (
                     current_editable_schema_metadata,
                     needs_write,
@@ -481,6 +478,7 @@ class CSVEnricherSource(Source):
 
             # Write an MCPW if needed.
             if needs_write:
+                self.report.num_editable_schema_metadata_workunits_produced += 1
                 yield MetadataChangeProposalWrapper(
                     entityUrn=entity_urn,
                     aspect=current_editable_schema_metadata,
@@ -538,48 +536,47 @@ class CSVEnricherSource(Source):
         return owners
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+        return auto_workunit_reporter(self.report, self.get_workunits_internal())
+
+    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         # As per https://stackoverflow.com/a/49150749/5004662, we want to use
         # the 'utf-8-sig' encoding to handle any BOM character that may be
         # present in the file. Excel is known to add a BOM to CSV files.
         # As per https://stackoverflow.com/a/63508823/5004662,
         # this is also safe with normal files that don't have a BOM.
         parsed_location = parse.urlparse(self.config.filename)
-        keep_rows = []
         if parsed_location.scheme in ("file", ""):
             with open(
                 pathlib.Path(self.config.filename), mode="r", encoding="utf-8-sig"
             ) as f:
-                rows = csv.DictReader(f, delimiter=self.config.delimiter)
-                keep_rows = [row for row in rows]
+                rows = list(csv.DictReader(f, delimiter=self.config.delimiter))
         else:
             try:
                 resp = requests.get(self.config.filename)
                 decoded_content = resp.content.decode("utf-8-sig")
-                rows = csv.DictReader(
-                    decoded_content.splitlines(), delimiter=self.config.delimiter
+                rows = list(
+                    csv.DictReader(
+                        decoded_content.splitlines(), delimiter=self.config.delimiter
+                    )
                 )
-                keep_rows = [row for row in rows]
             except Exception as e:
                 raise ConfigurationError(
                     f"Cannot read remote file {self.config.filename}, error:{e}"
                 )
 
-        for row in keep_rows:
+        for row in rows:
             # We need the resource to move forward
             if not row["resource"]:
                 continue
 
             is_resource_row: bool = not row["subresource"]
-
             entity_urn = row["resource"]
             entity_type = Urn.create_from_string(row["resource"]).get_type()
 
             term_associations: List[
                 GlossaryTermAssociationClass
             ] = self.maybe_extract_glossary_terms(row)
-
             tag_associations: List[TagAssociationClass] = self.maybe_extract_tags(row)
-
             owners: List[OwnerClass] = self.maybe_extract_owners(row, is_resource_row)
 
             domain: Optional[str] = (
@@ -587,7 +584,6 @@ class CSVEnricherSource(Source):
                 if row["domain"] and entity_type == DATASET_ENTITY_TYPE
                 else None
             )
-
             description: Optional[str] = (
                 row["description"]
                 if row["description"] and entity_type == DATASET_ENTITY_TYPE
@@ -595,31 +591,23 @@ class CSVEnricherSource(Source):
             )
 
             if is_resource_row:
-                for wu in self.get_resource_workunits(
+                yield from self.get_resource_workunits(
                     entity_urn=entity_urn,
                     term_associations=term_associations,
                     tag_associations=tag_associations,
                     owners=owners,
                     domain=domain,
                     description=description,
-                ):
-                    yield wu
-
-            # If this row is not applying changes at the resource level, modify the EditableSchemaMetadata map.
-            else:
+                )
+            elif entity_type == DATASET_ENTITY_TYPE:
                 # Only dataset sub-resources are currently supported.
-                if entity_type != DATASET_ENTITY_TYPE:
-                    continue
-
-                field_path = row["subresource"]
-                if entity_urn not in self.editable_schema_metadata_map:
-                    self.editable_schema_metadata_map[entity_urn] = []
                 # Add the row to the map from entity (dataset) to SubResource rows. We cannot emit work units for
                 # EditableSchemaMetadata until we parse the whole CSV due to read-modify-write issues.
+                self.editable_schema_metadata_map.setdefault(entity_urn, [])
                 self.editable_schema_metadata_map[entity_urn].append(
                     SubResourceRow(
                         entity_urn=entity_urn,
-                        field_path=field_path,
+                        field_path=row["subresource"],
                         term_associations=term_associations,
                         tag_associations=tag_associations,
                         description=description,
@@ -627,11 +615,7 @@ class CSVEnricherSource(Source):
                     )
                 )
 
-        # Yield sub resource work units once the map has been fully populated.
-        for wu in self.get_sub_resource_work_units():
-            self.report.num_editable_schema_metadata_workunits_produced += 1
-            self.report.report_workunit(wu)
-            yield wu
+        yield from self.get_sub_resource_work_units()
 
     def get_report(self):
         return self.report

--- a/metadata-ingestion/src/datahub/ingestion/source/file.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/file.py
@@ -52,7 +52,6 @@ class FileReadMode(ConfigEnum):
 class FileSourceConfig(ConfigModel):
     _filename = pydantic_field_deprecated(
         "filename",
-        new_field="path",
         message="filename is deprecated. Use path instead.",
     )
     path: str = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/lineage.py
@@ -15,8 +15,8 @@ from datahub.configuration.common import (
 from datahub.configuration.config_loader import load_config_file
 from datahub.configuration.source_common import EnvConfigMixin
 from datahub.emitter.mce_builder import (
-    make_dataset_urn_with_platform_instance,
     get_sys_time,
+    make_dataset_urn_with_platform_instance,
 )
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext

--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/lineage.py
@@ -14,7 +14,10 @@ from datahub.configuration.common import (
 )
 from datahub.configuration.config_loader import load_config_file
 from datahub.configuration.source_common import EnvConfigMixin
-from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
+from datahub.emitter.mce_builder import (
+    make_dataset_urn_with_platform_instance,
+    get_sys_time,
+)
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
@@ -166,6 +169,9 @@ def _get_lineage_mcp(
                 models.UpstreamClass(
                     dataset=upstream_entity_urn,
                     type=models.DatasetLineageTypeClass.TRANSFORMED,
+                    auditStamp=models.AuditStampClass(
+                        time=get_sys_time(), actor="urn:li:corpUser:ingestion"
+                    ),
                 )
             )
         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/lineage.py
@@ -25,6 +25,7 @@ from datahub.ingestion.api.decorators import (
 )
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit, UsageStatsWorkUnit
+from datahub.utilities.source_helpers import auto_workunit_reporter
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +56,7 @@ EntityNodeConfig.update_forward_refs()
 
 
 class LineageFileSourceConfig(ConfigModel):
-    file: str = Field(
-        description="Path to lineage file to ingest. This may also be in the form of a URL."
-    )
+    file: str = Field(description="File path or URL to lineage file to ingest.")
     preserve_upstream: bool = Field(
         default=True,
         description="Whether we want to query datahub-gms for upstream data. False means it will hard replace upstream data for a given entity. True means it will query the backend for existing upstreams and include it in the ingestion run",
@@ -98,103 +97,84 @@ class LineageFileSource(Source):
         lineage_config = LineageConfig.parse_obj(config)
         return lineage_config
 
-    @staticmethod
-    def get_lineage_metadata_change_event_proposal(
-        entities: List[EntityNodeConfig], preserve_upstream: bool
-    ) -> Iterable[MetadataChangeProposalWrapper]:
-        """
-        Builds a list of events to be emitted to datahub by going through each entity and its upstream nodes
-        :param preserve_upstream: This field determines if we want to query the datahub backend to extract
-        the existing upstream lineages for each entity and preserve it
-        :param entities: A list of entities we want to build a proposal on
-        :return: Returns a list of metadata change event proposals to be emitted to datahub
-        """
-
-        def _get_entity_urn(entity_config: EntityConfig) -> Optional[str]:
-            """Helper inner function to extract a given entity_urn
-            A return value of None represents an unsupported entity type
-            """
-            if entity_config.type == "dataset":
-                return make_dataset_urn_with_platform_instance(
-                    platform=entity_config.platform,
-                    name=entity_config.name,
-                    env=entity_config.env,
-                    platform_instance=entity_config.platform_instance,
-                )
-            logger.warning(f"Entity type: {entity_config.type} is not supported!")
-            return None
-
-        # loop through all the entities
-        for entity_node in entities:
-            new_upstreams: List[models.UpstreamClass] = []
-            # if this entity has upstream nodes defined, we'll want to do some work.
-            # if no upstream nodes are present, we don't emit an MCP for it.
-            if entity_node.upstream:
-                entity = entity_node.entity
-                logger.info(f"Upstream detected for {entity}. Extracting urn...")
-                entity_urn = _get_entity_urn(entity)
-                if entity_urn:
-                    # extract the old lineage and save it for the new mcp
-                    if preserve_upstream:
-                        old_upstream_lineage = get_aspects_for_entity(
-                            entity_urn=entity_urn,
-                            aspects=["upstreamLineage"],
-                            typed=True,
-                        ).get("upstreamLineage")
-                        if old_upstream_lineage:
-                            # Can't seem to get mypy to be happy about
-                            # `Argument 1 to "list" has incompatible type "Optional[Any]";
-                            # expected "Iterable[UpstreamClass]"`
-                            new_upstreams.extend(
-                                old_upstream_lineage.get("upstreams")  # type: ignore
-                            )
-                    for upstream_entity_node in entity_node.upstream:
-                        upstream_entity = upstream_entity_node.entity
-                        upstream_entity_urn = _get_entity_urn(upstream_entity)
-                        if upstream_entity_urn:
-                            new_upstream = models.UpstreamClass(
-                                dataset=upstream_entity_urn,
-                                type=models.DatasetLineageTypeClass.TRANSFORMED,
-                            )
-                            new_upstreams.append(new_upstream)
-                        else:
-                            logger.warning(
-                                f"Entity type: {upstream_entity.type} is unsupported. Upstream lineage will be skipped "
-                                f"for {upstream_entity.name}->{entity.name}"
-                            )
-                    new_upstream_lineage = models.UpstreamLineageClass(
-                        upstreams=new_upstreams
-                    )
-                    yield MetadataChangeProposalWrapper(
-                        entityType=entity.type,
-                        changeType=models.ChangeTypeClass.UPSERT,
-                        entityUrn=entity_urn,
-                        aspectName="upstreamLineage",
-                        aspect=new_upstream_lineage,
-                    )
-                else:
-                    logger.warning(
-                        f"Entity type: {entity.type} is unsupported. Entity node {entity.name} and its "
-                        f"upstream lineages will be skipped"
-                    )
-
     def get_workunits(self) -> Iterable[Union[MetadataWorkUnit, UsageStatsWorkUnit]]:
-        lineage_config = self.load_lineage_config(self.config.file)
-        lineage = lineage_config.lineage
-        preserve_upstream = self.config.preserve_upstream
-        logger.debug(lineage_config)
-        logger.info(f"preserve_upstream is set to {self.config.preserve_upstream}")
-        for (
-            metadata_change_event_proposal
-        ) in self.get_lineage_metadata_change_event_proposal(
-            lineage, preserve_upstream
-        ):
-            work_unit = MetadataWorkUnit(
-                f"lineage-{metadata_change_event_proposal.entityUrn}",
-                mcp=metadata_change_event_proposal,
-            )
-            self.report.report_workunit(work_unit)
-            yield work_unit
+        return auto_workunit_reporter(self.report, self.get_workunits_internal())
+
+    def get_workunits_internal(
+        self,
+    ) -> Iterable[Union[MetadataWorkUnit, UsageStatsWorkUnit]]:
+        config = self.load_lineage_config(self.config.file)
+        logger.debug(config)
+        for entity_node in config.lineage:
+            mcp = _get_lineage_mcp(entity_node, self.config.preserve_upstream)
+            if mcp:
+                yield mcp.as_workunit()
 
     def get_report(self):
         return self.report
+
+
+def _get_entity_urn(entity_config: EntityConfig) -> Optional[str]:
+    """A return value of None represents an unsupported entity type."""
+    if entity_config.type == "dataset":
+        return make_dataset_urn_with_platform_instance(
+            platform=entity_config.platform,
+            name=entity_config.name,
+            env=entity_config.env,
+            platform_instance=entity_config.platform_instance,
+        )
+    return None
+
+
+def _get_lineage_mcp(
+    entity_node: EntityNodeConfig, preserve_upstream: bool
+) -> Optional[MetadataChangeProposalWrapper]:
+    new_upstreams: List[models.UpstreamClass] = []
+    # if this entity has upstream nodes defined, we'll want to do some work.
+    # if no upstream nodes are present, we don't emit an MCP for it.
+    if not entity_node.upstream:
+        return None
+
+    entity = entity_node.entity
+    logger.info(f"Upstream detected for {entity}. Extracting urn...")
+    entity_urn = _get_entity_urn(entity)
+    if not entity_urn:
+        logger.warning(
+            f"Entity type: {entity.type} is unsupported. "
+            f"Entity node {entity.name} and its upstream lineages will be skipped"
+        )
+        return None
+
+    # extract the old lineage and save it for the new mcp
+    if preserve_upstream:
+        old_upstream_lineage = get_aspects_for_entity(
+            entity_urn=entity_urn,
+            aspects=["upstreamLineage"],
+            typed=True,
+        ).get("upstreamLineage")
+        if old_upstream_lineage:
+            # Can't seem to get mypy to be happy about
+            # `Argument 1 to "list" has incompatible type "Optional[Any]";
+            # expected "Iterable[UpstreamClass]"`
+            new_upstreams.extend(old_upstream_lineage.get("upstreams"))  # type: ignore
+
+    for upstream_entity_node in entity_node.upstream:
+        upstream_entity = upstream_entity_node.entity
+        upstream_entity_urn = _get_entity_urn(upstream_entity)
+        if upstream_entity_urn:
+            new_upstreams.append(
+                models.UpstreamClass(
+                    dataset=upstream_entity_urn,
+                    type=models.DatasetLineageTypeClass.TRANSFORMED,
+                )
+            )
+        else:
+            logger.warning(
+                f"Entity type: {upstream_entity.type} is unsupported. "
+                f"Upstream lineage will be skipped for {upstream_entity.name}->{entity.name}"
+            )
+
+    return MetadataChangeProposalWrapper(
+        entityUrn=entity_urn,
+        aspect=models.UpstreamLineageClass(upstreams=new_upstreams),
+    )

--- a/metadata-ingestion/src/datahub/ingestion/source_config/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/csv_enricher.py
@@ -7,7 +7,7 @@ from datahub.configuration.common import ConfigModel, ConfigurationError
 
 class CSVEnricherConfig(ConfigModel):
     filename: str = pydantic.Field(
-        description="Path to CSV file to ingest. It can also be in the form of a URL."
+        description="File path or URL of CSV file to ingest."
     )
     write_semantics: str = pydantic.Field(
         default="PATCH",

--- a/metadata-ingestion/src/datahub/utilities/source_helpers.py
+++ b/metadata-ingestion/src/datahub/utilities/source_helpers.py
@@ -1,6 +1,7 @@
-from typing import Callable, Iterable, Optional, Set, Union
+from typing import Callable, Iterable, Optional, Set, TypeVar, Union
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import WorkUnit
 from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
@@ -103,10 +104,10 @@ def auto_stale_entity_removal(
     yield from stale_entity_removal_handler.gen_removed_entity_workunits()
 
 
-def auto_workunit_reporter(
-    report: SourceReport,
-    stream: Iterable[MetadataWorkUnit],
-) -> Iterable[MetadataWorkUnit]:
+T = TypeVar("T", bound=WorkUnit)
+
+
+def auto_workunit_reporter(report: SourceReport, stream: Iterable[T]) -> Iterable[T]:
     """
     Calls report.report_workunit() on each workunit.
     """

--- a/metadata-ingestion/tests/integration/remote/golden/remote_lineage_golden.json
+++ b/metadata-ingestion/tests/integration/remote/golden/remote_lineage_golden.json
@@ -9,16 +9,16 @@
             "upstreams": [
                 {
                     "auditStamp": {
-                        "time": 0,
-                        "actor": "urn:li:corpuser:unknown"
+                        "time": 1629795600000,
+                        "actor": "urn:li:corpUser:ingestion"
                     },
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:kafka,topic2,DEV)",
                     "type": "TRANSFORMED"
                 },
                 {
                     "auditStamp": {
-                        "time": 0,
-                        "actor": "urn:li:corpuser:unknown"
+                        "time": 1629795600000,
+                        "actor": "urn:li:corpUser:ingestion"
                     },
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:kafka,topic1,DEV)",
                     "type": "TRANSFORMED"
@@ -41,8 +41,8 @@
             "upstreams": [
                 {
                     "auditStamp": {
-                        "time": 0,
-                        "actor": "urn:li:corpuser:unknown"
+                        "time": 1629795600000,
+                        "actor": "urn:li:corpUser:ingestion"
                     },
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test.kafka.topic2,PROD)",
                     "type": "TRANSFORMED"

--- a/metadata-ingestion/tests/unit/test_file_lineage_source.py
+++ b/metadata-ingestion/tests/unit/test_file_lineage_source.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 
 from datahub.configuration.common import ConfigurationError
-from datahub.ingestion.source.metadata.lineage import LineageConfig, LineageFileSource
+from datahub.ingestion.source.metadata.lineage import LineageConfig, _get_lineage_mcp
 from datahub.metadata.schema_classes import UpstreamClass
 
 logger = logging.getLogger(__name__)
@@ -41,12 +41,7 @@ def basic_mcp():
         """
     config = yaml.safe_load(sample_lineage)
     lineage_config: LineageConfig = LineageConfig.parse_obj(config)
-    mcp = list(
-        LineageFileSource.get_lineage_metadata_change_event_proposal(
-            entities=lineage_config.lineage, preserve_upstream=False
-        )
-    )
-    return mcp
+    return _get_lineage_mcp(lineage_config.lineage[0], False)
 
 
 def unsupported_entity_type_mcp():
@@ -86,13 +81,7 @@ def unsupported_entity_type_mcp():
                   platform: kafka
         """
     config = yaml.safe_load(sample_lineage)
-    lineage_config: LineageConfig = LineageConfig.parse_obj(config)
-    mcp = list(
-        LineageFileSource.get_lineage_metadata_change_event_proposal(
-            entities=lineage_config.lineage, preserve_upstream=False
-        )
-    )
-    return mcp
+    return LineageConfig.parse_obj(config)
 
 
 def unsupported_upstream_entity_type_mcp():
@@ -116,13 +105,7 @@ def unsupported_upstream_entity_type_mcp():
                   platform: kafka
         """
     config = yaml.safe_load(sample_lineage)
-    lineage_config: LineageConfig = LineageConfig.parse_obj(config)
-    mcp = list(
-        LineageFileSource.get_lineage_metadata_change_event_proposal(
-            entities=lineage_config.lineage, preserve_upstream=False
-        )
-    )
-    return mcp
+    return LineageConfig.parse_obj(config)
 
 
 def unsupported_entity_env_mcp():
@@ -162,13 +145,7 @@ def unsupported_entity_env_mcp():
                   platform: kafka
         """
     config = yaml.safe_load(sample_lineage)
-    lineage_config: LineageConfig = LineageConfig.parse_obj(config)
-    mcp = list(
-        LineageFileSource.get_lineage_metadata_change_event_proposal(
-            entities=lineage_config.lineage, preserve_upstream=False
-        )
-    )
-    return mcp
+    return LineageConfig.parse_obj(config)
 
 
 def test_basic_lineage_entity_root_node_urn(basic_mcp):
@@ -177,8 +154,7 @@ def test_basic_lineage_entity_root_node_urn(basic_mcp):
     """
 
     assert (
-        basic_mcp[0].entityUrn
-        == "urn:li:dataset:(urn:li:dataPlatform:kafka,topic3,DEV)"
+        basic_mcp.entityUrn == "urn:li:dataset:(urn:li:dataPlatform:kafka,topic3,DEV)"
     )
 
 
@@ -186,7 +162,7 @@ def test_basic_lineage_upstream_urns(basic_mcp):
     """
     Checks to see if the upstream urns are correct for a basic_mcp example
     """
-    basic_mcp_upstreams: List[UpstreamClass] = basic_mcp[0].aspect.upstreams
+    basic_mcp_upstreams: List[UpstreamClass] = basic_mcp.aspect.upstreams
     assert (
         basic_mcp_upstreams[0].dataset
         == "urn:li:dataset:(urn:li:dataPlatform:kafka,topic1,DEV)"


### PR DESCRIPTION
A few followups to https://github.com/datahub-project/datahub/pull/7552, + some modernization of the sources, with `auto_workunit_reporter`.

Refactoring got the most complicated on the file lineage source but logic should still be the same, sorry if it's a difficult review.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
