### PR TITLE
refactor(ingest): Use sqlite.Row row_factory for FileBackedCollections

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -64,6 +64,7 @@ class ConnectionWrapper:
             filename = pathlib.Path(self._directory.name) / _DEFAULT_FILE_NAME
 
         self.conn = sqlite3.connect(filename, isolation_level=None)
+        self.conn.row_factory = sqlite3.Row
         self.filename = filename
 
         # These settings are optimized for performance.
@@ -314,7 +315,7 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT], Closeable):
         query: str,
         params: Tuple[Any, ...] = (),
         refs: Optional[List[Union["FileBackedList", "FileBackedDict"]]] = None,
-    ) -> List[Tuple[Any, ...]]:
+    ) -> List[sqlite3.Row]:
         return self._sql_query(query, params, refs).fetchall()
 
     def sql_query_iterator(
@@ -322,7 +323,7 @@ class FileBackedDict(MutableMapping[str, _VT], Generic[_VT], Closeable):
         query: str,
         params: Tuple[Any, ...] = (),
         refs: Optional[List[Union["FileBackedList", "FileBackedDict"]]] = None,
-    ) -> Iterator[Tuple[Any, ...]]:
+    ) -> Iterator[sqlite3.Row]:
         return self._sql_query(query, params, refs)
 
     def _sql_query(

--- a/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
+++ b/metadata-ingestion/tests/unit/utilities/test_file_backed_collections.py
@@ -257,21 +257,19 @@ def test_shared_connection() -> None:
             f"SELECT y, sum(x) FROM {cache2.tablename} GROUP BY y ORDER BY y"
         )
         assert type(iterator) == sqlite3.Cursor
-        assert list(iterator) == [("a", 15), ("b", 11)]
+        assert [tuple(r) for r in iterator] == [("a", 15), ("b", 11)]
 
         # Test joining between the two tables.
-        assert (
-            cache2.sql_query(
-                f"""
-                SELECT cache2.y, sum(cache2.x * cache1.v) FROM {cache2.tablename} cache2
-                LEFT JOIN {cache1.tablename} cache1 ON cache1.key = cache2.y
-                GROUP BY cache2.y
-                ORDER BY cache2.y
-                """,
-                refs=[cache1],
-            )
-            == [("a", 45), ("b", 55)]
+        rows = cache2.sql_query(
+            f"""
+                        SELECT cache2.y, sum(cache2.x * cache1.v) FROM {cache2.tablename} cache2
+                        LEFT JOIN {cache1.tablename} cache1 ON cache1.key = cache2.y
+                        GROUP BY cache2.y
+                        ORDER BY cache2.y
+                        """,
+            refs=[cache1],
         )
+        assert [tuple(row) for row in rows] == [("a", 45), ("b", 55)]
 
         assert list(cache2.items_snapshot('y = "a"')) == [
             ("ref-a-1", Pair(7, "a")),


### PR DESCRIPTION
@treff7es suggested accessing fields by name rather than as a tuple (by order) to avoid ugly bugs in the cross-project usage PR. To do that, we need to use a different row factory. This is ultimately a tradeoff between memory consumption and easy of use / code clarity. While we could make it an optional, per-cursor setting, I don't think this should add too much memory overhead, and it would require a decent refactor because right now we don't create any cursors -- we directly call `connection.execute(...)`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
