### PR TITLE
fix(ci): Fixing broken Domains Test 

### DIFF
--- a/datahub-web-react/src/app/domain/CreateDomainModal.tsx
+++ b/datahub-web-react/src/app/domain/CreateDomainModal.tsx
@@ -82,7 +82,12 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
                     <Button onClick={onClose} type="text">
                         Cancel
                     </Button>
-                    <Button id="createDomainButton" onClick={onCreateDomain} disabled={!createButtonEnabled}>
+                    <Button
+                        id="createDomainButton"
+                        data-testid="create-domain-button"
+                        onClick={onCreateDomain}
+                        disabled={!createButtonEnabled}
+                    >
                         Create
                     </Button>
                 </>
@@ -110,7 +115,7 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
                         ]}
                         hasFeedback
                     >
-                        <Input placeholder="A name for your domain" />
+                        <Input data-testid="create-domain-name" placeholder="A name for your domain" />
                     </Form.Item>
                     <SuggestedNamesGroup>
                         {SUGGESTED_DOMAIN_NAMES.map((name) => {
@@ -164,7 +169,7 @@ export default function CreateDomainModal({ onClose, onCreate }: Props) {
                                     }),
                                 ]}
                             >
-                                <Input placeholder="engineering" />
+                                <Input data-testid="create-domain-id" placeholder="engineering" />
                             </Form.Item>
                         </Form.Item>
                     </Collapse.Panel>

--- a/smoke-test/tests/cypress/cypress.config.js
+++ b/smoke-test/tests/cypress/cypress.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('./cypress/plugins/index.js')(on, config)
     },
-    baseUrl: 'http://localhost:9002/',
+    baseUrl: 'http://localhost:3000/',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
     experimentalStudio: true,
   },

--- a/smoke-test/tests/cypress/cypress.config.js
+++ b/smoke-test/tests/cypress/cypress.config.js
@@ -17,7 +17,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('./cypress/plugins/index.js')(on, config)
     },
-    baseUrl: 'http://localhost:3000/',
+    baseUrl: 'http://localhost:9002/',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
     experimentalStudio: true,
   },

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
@@ -1,19 +1,19 @@
-const test_domain = "CypressDomainTest";
-let domain_created_urn = ""
+const test_domain_id = Math.floor(Math.random() * 100000);
+const test_domain = `CypressDomainTest ${test_domain_id}`
+const test_domain_urn = `urn:li:domain:${test_domain_id}`
+
 
 describe("add remove domain", () => {
     it("create domain", () => {
         cy.login();
         cy.goToDomainList();
         cy.clickOptionWithText("New Domain");
-        cy.addViaModal(test_domain, "Create new Domain")
-        cy.waitTextVisible("Created domain!")
+        cy.waitTextVisible("Create new Domain");
+        cy.get('[data-testid="create-domain-name"]').click().type(test_domain)
+        cy.clickOptionWithText('Advanced')
+        cy.get('[data-testid="create-domain-id"]').click().type(test_domain_id)
+        cy.get('[data-testid="create-domain-button"]').click()
         cy.waitTextVisible(test_domain)
-            .parents("[data-testid^='urn:li:domain:']")
-            .invoke('attr', 'data-testid')
-            .then((data_test_id) => {
-                domain_created_urn = data_test_id;
-            })
     })
 
     it("add entities to domain", () => {
@@ -23,8 +23,8 @@ describe("add remove domain", () => {
         cy.waitTextVisible("Add assets")
         cy.clickOptionWithText("Add assets")     
         cy.get(".ant-modal-content").within(() => {
-            cy.get('[data-testid="search-input"]').click().type("jaffle_shop")
-            cy.waitTextVisible("jaffle_shop")
+            cy.get('[data-testid="search-input"]').click().invoke("val", "cypress_project.jaffle_shop.").type("customer")
+            cy.contains("customers")
             cy.get(".ant-checkbox-input").first().click()
             cy.get("#continueButton").click()
         })
@@ -35,8 +35,8 @@ describe("add remove domain", () => {
         cy.login();
         cy.goToStarSearchList()
         cy.waitTextVisible(test_domain)
-        cy.get('[data-testid="facet-domains-' + domain_created_urn + '"]').click()
-        cy.waitTextVisible("jaffle_shop")
+        cy.get('[data-testid="facet-domains-' + test_domain_urn + '"]').click()
+        cy.waitTextVisible("customers")
     })
 
     it("remove entity from domain", () => {
@@ -45,14 +45,14 @@ describe("add remove domain", () => {
         cy.removeDomainFromDataset(
             "urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.customers,PROD)",
             "customers",
-            domain_created_urn
+            test_domain_urn
         )
     })
 
     it("delete a domain and ensure dangling reference is deleted on entities", () => {
         cy.login();
         cy.goToDomainList();
-        cy.get('[data-testid="dropdown-menu-' + domain_created_urn + '"]').click();
+        cy.get('[data-testid="dropdown-menu-' + test_domain_urn + '"]').click();
         cy.clickOptionWithText("Delete");
         cy.clickOptionWithText("Yes");
         cy.ensureTextNotPresent(test_domain)

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/domains.js
@@ -24,7 +24,7 @@ describe("add remove domain", () => {
         cy.clickOptionWithText("Add assets")     
         cy.get(".ant-modal-content").within(() => {
             cy.get('[data-testid="search-input"]').click().invoke("val", "cypress_project.jaffle_shop.").type("customer")
-            cy.contains("customers")
+            cy.contains("BigQuery")
             cy.get(".ant-checkbox-input").first().click()
             cy.get("#continueButton").click()
         })
@@ -58,7 +58,7 @@ describe("add remove domain", () => {
         cy.ensureTextNotPresent(test_domain)
         
         cy.goToContainer("urn:li:container:348c96555971d3f5c1ffd7dd2e7446cb")
-        cy.waitTextVisible("jaffle_shop")
+        cy.waitTextVisible("customers")
         cy.ensureTextNotPresent(test_domain)
     })
 });


### PR DESCRIPTION
## Summary

The domains test was flaky due to changes in how search ranking is performed. This change addresses the issue. It also makes the test more resilient to re-runs by generating a unique urn on each run. 

## Status

Ready for review


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
