### PR TITLE
fix(auto-complete) Pass in views to auto-complete endpoint for filtering

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -688,7 +688,7 @@ public class GmsGraphQLEngine {
             .dataFetcher("searchAcrossLineage", new SearchAcrossLineageResolver(this.entityClient))
             .dataFetcher("scrollAcrossLineage", new ScrollAcrossLineageResolver(this.entityClient))
             .dataFetcher("autoComplete", new AutoCompleteResolver(searchableTypes))
-            .dataFetcher("autoCompleteForMultiple", new AutoCompleteForMultipleResolver(searchableTypes))
+            .dataFetcher("autoCompleteForMultiple", new AutoCompleteForMultipleResolver(searchableTypes, this.viewService))
             .dataFetcher("browse", new BrowseResolver(browsableTypes))
             .dataFetcher("browsePaths", new BrowsePathsResolver(browsableTypes))
             .dataFetcher("dataset", getResolver(datasetType))

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -718,6 +718,11 @@ input AutoCompleteMultipleInput {
   A list of disjunctive criterion for the filter. (or operation to combine filters)
   """
   orFilters: [AndFilterInput!]
+
+  """
+  Optional - A View to apply when generating results
+  """
+  viewUrn: String
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolverTest.java
@@ -32,8 +32,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.List;
-
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 
 public class AutoCompleteForMultipleResolverTest {
@@ -135,7 +133,15 @@ public class AutoCompleteForMultipleResolverTest {
           .setEntities(new AutoCompleteEntityArray())
           .setSuggestions(new StringArray())
     );
-    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DATASET_ENTITY_NAME, EntityType.DATASET, new DatasetType(mockClient), TEST_VIEW_URN, viewInfo.getDefinition().getFilter());
+    testAutoCompleteResolverSuccess(
+        mockClient,
+        viewService,
+        Constants.DATASET_ENTITY_NAME,
+        EntityType.DATASET,
+        new DatasetType(mockClient),
+        TEST_VIEW_URN,
+        viewInfo.getDefinition().getFilter()
+    );
   }
 
   // test entity type filters with a given view
@@ -158,7 +164,15 @@ public class AutoCompleteForMultipleResolverTest {
     );
 
     // ensure we do hit the entity client for dashboards since dashboards are in our view
-    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DASHBOARD_ENTITY_NAME, EntityType.DASHBOARD, new DashboardType(mockClient), TEST_VIEW_URN, viewInfo.getDefinition().getFilter());
+    testAutoCompleteResolverSuccess(
+        mockClient,
+        viewService,
+        Constants.DASHBOARD_ENTITY_NAME,
+        EntityType.DASHBOARD,
+        new DashboardType(mockClient),
+        TEST_VIEW_URN,
+        viewInfo.getDefinition().getFilter()
+    );
 
     // if the view has only dashboards, we should not make an auto-complete request on other entity types
     Mockito.verify(mockClient, Mockito.times(0))

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolverTest.java
@@ -2,6 +2,9 @@ package com.linkedin.datahub.graphql.resolvers.search;
 
 import com.datahub.authentication.Authentication;
 import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.ValidationException;
@@ -15,25 +18,41 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.query.AutoCompleteEntityArray;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.service.ViewService;
+import com.linkedin.view.DataHubViewDefinition;
+import com.linkedin.view.DataHubViewInfo;
+import com.linkedin.view.DataHubViewType;
 import graphql.schema.DataFetchingEnvironment;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 
 public class AutoCompleteForMultipleResolverTest {
+
+  private static final Urn TEST_VIEW_URN = UrnUtils.getUrn("urn:li:dataHubView:test");
+  private static final Urn TEST_USER_URN = UrnUtils.getUrn("urn:li:corpuser:test");
 
   private AutoCompleteForMultipleResolverTest() { }
 
   public static void testAutoCompleteResolverSuccess(
       EntityClient mockClient,
+      ViewService viewService,
       String entityName,
       EntityType entityType,
-      SearchableEntityType<?, ?> entity
+      SearchableEntityType<?, ?> entity,
+      Urn viewUrn,
+      Filter filter
   ) throws Exception {
-    final AutoCompleteForMultipleResolver resolver = new AutoCompleteForMultipleResolver(ImmutableList.of(entity));
+    final AutoCompleteForMultipleResolver resolver = new AutoCompleteForMultipleResolver(ImmutableList.of(entity), viewService);
 
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     QueryContext mockContext = getMockAllowContext();
@@ -41,6 +60,9 @@ public class AutoCompleteForMultipleResolverTest {
     input.setQuery("test");
     input.setTypes(ImmutableList.of(entityType));
     input.setLimit(10);
+    if (viewUrn != null) {
+      input.setViewUrn(viewUrn.toString());
+    }
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -49,7 +71,7 @@ public class AutoCompleteForMultipleResolverTest {
         mockClient,
         entityName,
         "test",
-        null,
+        filter,
         10
     );
   }
@@ -57,6 +79,7 @@ public class AutoCompleteForMultipleResolverTest {
   // test our main entity types
   @Test
   public static void testAutoCompleteResolverSuccessForDifferentEntities() throws Exception {
+    ViewService viewService = initMockViewService(null, null);
     // Daatasets
     EntityClient mockClient = initMockEntityClient(
       Constants.DATASET_ENTITY_NAME,
@@ -68,7 +91,7 @@ public class AutoCompleteForMultipleResolverTest {
           .setEntities(new AutoCompleteEntityArray())
           .setSuggestions(new StringArray())
     );
-    testAutoCompleteResolverSuccess(mockClient, Constants.DATASET_ENTITY_NAME, EntityType.DATASET, new DatasetType(mockClient));
+    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DATASET_ENTITY_NAME, EntityType.DATASET, new DatasetType(mockClient), null, null);
 
     // Dashboards
     mockClient = initMockEntityClient(
@@ -81,7 +104,7 @@ public class AutoCompleteForMultipleResolverTest {
           .setEntities(new AutoCompleteEntityArray())
           .setSuggestions(new StringArray())
     );
-    testAutoCompleteResolverSuccess(mockClient, Constants.DASHBOARD_ENTITY_NAME, EntityType.DASHBOARD, new DashboardType(mockClient));
+    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DASHBOARD_ENTITY_NAME, EntityType.DASHBOARD, new DashboardType(mockClient), null, null);
 
     //DataFlows
     mockClient = initMockEntityClient(
@@ -94,13 +117,65 @@ public class AutoCompleteForMultipleResolverTest {
           .setEntities(new AutoCompleteEntityArray())
           .setSuggestions(new StringArray())
     );
-    testAutoCompleteResolverSuccess(mockClient, Constants.DATA_FLOW_ENTITY_NAME, EntityType.DATA_FLOW, new DataFlowType(mockClient));
+    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DATA_FLOW_ENTITY_NAME, EntityType.DATA_FLOW, new DataFlowType(mockClient), null, null);
+  }
+
+  // test filters with a given view
+  @Test
+  public static void testAutoCompleteResolverWithViewFilter() throws Exception {
+    DataHubViewInfo viewInfo = createViewInfo(new StringArray());
+    ViewService viewService = initMockViewService(TEST_VIEW_URN, viewInfo);
+    EntityClient mockClient = initMockEntityClient(
+      Constants.DATASET_ENTITY_NAME,
+      "test",
+      null,
+      10,
+      new AutoCompleteResult()
+          .setQuery("test")
+          .setEntities(new AutoCompleteEntityArray())
+          .setSuggestions(new StringArray())
+    );
+    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DATASET_ENTITY_NAME, EntityType.DATASET, new DatasetType(mockClient), TEST_VIEW_URN, viewInfo.getDefinition().getFilter());
+  }
+
+  // test entity type filters with a given view
+  @Test
+  public static void testAutoCompleteResolverWithViewEntityFilter() throws Exception {
+    // have view be a filter to only get dashboards
+    StringArray entityNames = new StringArray();
+    entityNames.add(Constants.DASHBOARD_ENTITY_NAME);
+    DataHubViewInfo viewInfo = createViewInfo(entityNames);
+    ViewService viewService = initMockViewService(TEST_VIEW_URN, viewInfo);
+    EntityClient mockClient = initMockEntityClient(
+      Constants.DASHBOARD_ENTITY_NAME,
+      "test",
+      null,
+      10,
+      new AutoCompleteResult()
+          .setQuery("test")
+          .setEntities(new AutoCompleteEntityArray())
+          .setSuggestions(new StringArray())
+    );
+
+    // ensure we do hit the entity client for dashboards since dashboards are in our view
+    testAutoCompleteResolverSuccess(mockClient, viewService, Constants.DASHBOARD_ENTITY_NAME, EntityType.DASHBOARD, new DashboardType(mockClient), TEST_VIEW_URN, viewInfo.getDefinition().getFilter());
+
+    // if the view has only dashboards, we should not make an auto-complete request on other entity types
+    Mockito.verify(mockClient, Mockito.times(0))
+        .autoComplete(
+            Mockito.eq(Constants.DATASET_ENTITY_NAME),
+            Mockito.eq("test"),
+            Mockito.eq(viewInfo.getDefinition().getFilter()),
+            Mockito.eq(10),
+            Mockito.any(Authentication.class)
+        );
   }
 
   @Test
   public static void testAutoCompleteResolverFailNoQuery() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    final AutoCompleteForMultipleResolver resolver = new AutoCompleteForMultipleResolver(ImmutableList.of(new DatasetType(mockClient)));
+    ViewService viewService = initMockViewService(null, null);
+    final AutoCompleteForMultipleResolver resolver = new AutoCompleteForMultipleResolver(ImmutableList.of(new DatasetType(mockClient)), viewService);
 
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     QueryContext mockContext = getMockAllowContext();
@@ -132,6 +207,20 @@ public class AutoCompleteForMultipleResolverTest {
     return client;
   }
 
+  private static ViewService initMockViewService(
+      Urn viewUrn,
+      DataHubViewInfo viewInfo
+  ) {
+    ViewService service = Mockito.mock(ViewService.class);
+    Mockito.when(service.getViewInfo(
+        Mockito.eq(viewUrn),
+        Mockito.any(Authentication.class)
+    )).thenReturn(
+        viewInfo
+    );
+    return service;
+  }
+  
   private static void verifyMockEntityClient(
       EntityClient mockClient,
       String entityName,
@@ -147,5 +236,29 @@ public class AutoCompleteForMultipleResolverTest {
             Mockito.eq(limit),
             Mockito.any(Authentication.class)
         );
+  }
+
+  private static DataHubViewInfo createViewInfo(StringArray entityNames) {
+    Filter viewFilter = new Filter()
+        .setOr(new ConjunctiveCriterionArray(
+            new ConjunctiveCriterion().setAnd(
+                new CriterionArray(ImmutableList.of(
+                    new Criterion()
+                        .setField("field")
+                        .setValue("test")
+                        .setValues(new StringArray(ImmutableList.of("test")))
+                ))
+            )));
+
+    DataHubViewInfo info = new DataHubViewInfo();
+    info.setName("test");
+    info.setType(DataHubViewType.GLOBAL);
+    info.setCreated(new AuditStamp().setTime(0L).setActor(TEST_USER_URN));
+    info.setLastModified(new AuditStamp().setTime(0L).setActor(TEST_USER_URN));
+    info.setDefinition(new DataHubViewDefinition()
+        .setEntityTypes(entityNames)
+        .setFilter(viewFilter)
+    );
+    return info;
   }
 }

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/editor/extensions/mentions/MentionsComponent.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/editor/extensions/mentions/MentionsComponent.tsx
@@ -7,6 +7,7 @@ import { Positioner, selectionPositioner } from 'remirror/extensions';
 import { useGetAutoCompleteMultipleResultsLazyQuery } from '../../../../../../../../../graphql/search.generated';
 import { MentionsDropdown } from './MentionsDropdown';
 import { useDataHubMentions } from './useDataHubMentions';
+import { useUserContext } from '../../../../../../../../context/useUserContext';
 
 const Container = styled.div`
     position: relative;
@@ -19,15 +20,17 @@ const StyledEmpty = styled(Empty)`
 `;
 
 export const MentionsComponent = () => {
+    const userContext = useUserContext();
     const [getAutoComplete, { data: autocompleteData, loading }] = useGetAutoCompleteMultipleResultsLazyQuery();
     const { active, range, filter: query } = useDataHubMentions({});
     const [suggestions, setSuggestions] = useState<any[]>([]);
+    const viewUrn = userContext.localState?.selectedViewUrn;
 
     useEffect(() => {
         if (query) {
-            getAutoComplete({ variables: { input: { query } } });
+            getAutoComplete({ variables: { input: { query, viewUrn } } });
         }
-    }, [getAutoComplete, query]);
+    }, [getAutoComplete, query, viewUrn]);
     useDebounce(() => setSuggestions(autocompleteData?.autoCompleteForMultiple?.suggestions || []), 250, [
         autocompleteData,
     ]);

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -142,11 +142,13 @@ export const HomePageHeader = () => {
     const history = useHistory();
     const entityRegistry = useEntityRegistry();
     const [getAutoCompleteResultsForMultiple, { data: suggestionsData }] = useGetAutoCompleteMultipleResultsLazyQuery();
-    const user = useUserContext()?.user;
+    const userContext = useUserContext();
     const themeConfig = useTheme();
     const appConfig = useAppConfig();
     const [newSuggestionData, setNewSuggestionData] = useState<GetAutoCompleteMultipleResultsQuery | undefined>();
     const { selectedQuickFilter } = useQuickFiltersContext();
+    const { user } = userContext;
+    const viewUrn = userContext.localState?.selectedViewUrn;
 
     useEffect(() => {
         if (suggestionsData !== undefined) {
@@ -180,6 +182,7 @@ export const HomePageHeader = () => {
                     input: {
                         query,
                         limit: 10,
+                        viewUrn,
                         ...getAutoCompleteInputFromQuickFilter(selectedQuickFilter),
                     },
                 },
@@ -207,6 +210,7 @@ export const HomePageHeader = () => {
                 count: 6,
                 filters: [],
                 orFilters: [],
+                viewUrn,
             },
         },
     });

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -59,8 +59,10 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
     const { selectedQuickFilter } = useQuickFiltersContext();
 
     const [getAutoCompleteResults, { data: suggestionsData }] = useGetAutoCompleteMultipleResultsLazyQuery();
-    const user = useUserContext()?.user;
+    const userContext = useUserContext();
     const [newSuggestionData, setNewSuggestionData] = useState<GetAutoCompleteMultipleResultsQuery | undefined>();
+    const { user } = userContext;
+    const viewUrn = userContext.localState?.selectedViewUrn;
 
     useEffect(() => {
         if (suggestionsData !== undefined) {
@@ -97,6 +99,7 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
                 variables: {
                     input: {
                         query,
+                        viewUrn,
                         ...getAutoCompleteInputFromQuickFilter(selectedQuickFilter),
                     },
                 },
@@ -111,11 +114,12 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
                 variables: {
                     input: {
                         query: currentQuery,
+                        viewUrn,
                     },
                 },
             });
         }
-    }, [currentQuery, getAutoCompleteResults]);
+    }, [currentQuery, getAutoCompleteResults, viewUrn]);
 
     return (
         <>

--- a/datahub-web-react/src/app/search/autoComplete/quickFilters/QuickFilters.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/quickFilters/QuickFilters.tsx
@@ -16,7 +16,7 @@ export default function QuickFilters() {
     return (
         <QuickFiltersWrapper>
             {quickFilters?.map((quickFilter) => (
-                <QuickFilter quickFilter={quickFilter} />
+                <QuickFilter key={quickFilter.value} quickFilter={quickFilter} />
             ))}
         </QuickFiltersWrapper>
     );

--- a/datahub-web-react/src/providers/QuickFiltersProvider.tsx
+++ b/datahub-web-react/src/providers/QuickFiltersProvider.tsx
@@ -2,9 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { QuickFiltersContext } from './QuickFiltersContext';
 import { QuickFilter } from '../types.generated';
 import { useGetQuickFiltersQuery } from '../graphql/quickFilters.generated';
+import { useUserContext } from '../app/context/useUserContext';
 
 export default function QuickFiltersProvider({ children }: { children: React.ReactNode }) {
-    const { data } = useGetQuickFiltersQuery({ variables: { input: {} } });
+    const userContext = useUserContext();
+    const viewUrn = userContext.localState?.selectedViewUrn;
+
+    const { data, refetch } = useGetQuickFiltersQuery({ variables: { input: { viewUrn } } });
     const [quickFilters, setQuickFilters] = useState<QuickFilter[] | null>(null);
     const [selectedQuickFilter, setSelectedQuickFilter] = useState<QuickFilter | null>(null);
 
@@ -13,6 +17,15 @@ export default function QuickFiltersProvider({ children }: { children: React.Rea
             setQuickFilters(data.getQuickFilters.quickFilters as QuickFilter[]);
         }
     }, [data, quickFilters]);
+
+    // refetch and update quick filters whenever viewUrn changes
+    useEffect(() => {
+        refetch({ input: { viewUrn } }).then((result) => {
+            if (result.data.getQuickFilters?.quickFilters) {
+                setQuickFilters(result.data.getQuickFilters.quickFilters as QuickFilter[]);
+            }
+        });
+    }, [viewUrn, refetch]);
 
     return (
         <QuickFiltersContext.Provider


### PR DESCRIPTION
We should be filtering auto-complete results by a view but we weren't before. This adds a new optional `viewUrn` param to the auto-complete endpoint and does mostly the same logic for combining entity types and filters as we do in the search endpoint. The difference here is that we don't pass in entity types as a filter, but get the actual entity class and call `autocomplete` on each of them. So here we just filter those out based on what's passed in the view combined with what's passed into the input.

This also passes in a viewUrn from the FE to quick filters. The backend was already built to accept this, it was just missed on implementation.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
