### PR TITLE
fix(ingest/bigquery) - Lineage edges use datetime with timezone

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -4,7 +4,7 @@ import os
 import re
 import traceback
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Type, Union, cast
 
 from google.cloud import bigquery
@@ -684,7 +684,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                 lineage[view] = {
                     LineageEdge(
                         table=table,
-                        auditStamp=datetime.now(),
+                        auditStamp=datetime.now(timezone.utc),
                         type=DatasetLineageTypeClass.VIEW,
                     )
                     for table in upstream_tables

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -487,7 +487,11 @@ class BigQueryDataDictionary:
             BigqueryView(
                 name=table.table_name,
                 created=table.created,
-                last_altered=table.get("last_altered", table.created),
+                last_altered=datetime.fromtimestamp(
+                    table.get("last_altered") / 1000, tz=timezone.utc
+                )
+                if table.get("last_altered") is not None
+                else table.created,
                 comment=table.comment,
                 view_definition=table.view_definition,
                 materialized=table.table_type == BigqueryTableType.MATERIALIZED_VIEW,

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -2,7 +2,7 @@ import collections
 import logging
 import textwrap
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import humanfriendly
@@ -330,7 +330,6 @@ timestamp < "{end_time}"
     def _get_exported_bigquery_audit_metadata(
         self, bigquery_client: BigQueryClient, limit: Optional[int] = None
     ) -> Iterable[BigQueryAuditMetadata]:
-
         if self.config.bigquery_audit_metadata_datasets is None:
             self.error(
                 logger, "audit-metadata", "bigquery_audit_metadata_datasets not set"
@@ -458,7 +457,9 @@ timestamp < "{end_time}"
                     lineage_map[destination_table_str].add(
                         LineageEdge(
                             table=str(ref_table),
-                            auditStamp=e.end_time if e.end_time else datetime.now(),
+                            auditStamp=e.end_time
+                            if e.end_time
+                            else datetime.now(tz=timezone.utc),
                         )
                     )
                     has_table = True
@@ -468,7 +469,9 @@ timestamp < "{end_time}"
                     lineage_map[destination_table_str].add(
                         LineageEdge(
                             table=str(ref_view),
-                            auditStamp=e.end_time if e.end_time else datetime.now(),
+                            auditStamp=e.end_time
+                            if e.end_time
+                            else datetime.now(tz=timezone.utc),
                         )
                     )
                     has_view = True

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -1,5 +1,4 @@
 import datetime
-from time import timezone
 from typing import Dict, List
 
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import (

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -1,9 +1,17 @@
 import datetime
+from typing import List, Dict
 
+from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
+    BigQueryTableRef,
+    QueryEvent,
+)
 from datahub.ingestion.source.bigquery_v2.bigquery_config import BigQueryV2Config
 from datahub.ingestion.source.bigquery_v2.bigquery_report import BigQueryV2Report
 from datahub.ingestion.source.bigquery_v2.bigquery_schema import BigqueryView
-from datahub.ingestion.source.bigquery_v2.lineage import BigqueryLineageExtractor
+from datahub.ingestion.source.bigquery_v2.lineage import (
+    BigqueryLineageExtractor,
+    LineageEdge,
+)
 
 
 def test_parse_view_lineage():
@@ -90,3 +98,79 @@ def test_create_statement_with_multiple_table():
     assert 2 == len(tables)
     assert "my_project_2.my_dataset_2.sometable" == tables[0].get_table_name()
     assert "my_project_2.my_dataset_2.sometable2" == tables[1].get_table_name()
+
+
+def test_lineage_tables():
+    config = BigQueryV2Config()
+    report = BigQueryV2Report()
+    extractor: BigqueryLineageExtractor = BigqueryLineageExtractor(config, report)
+    lineage_entries: List[QueryEvent] = [
+        QueryEvent(
+            timestamp=datetime.datetime.now(),
+            actor_email="bla@bla.com",
+            query="testQuery",
+            statementType="SELECT",
+            project_id="proj_12344",
+            end_time=None,
+            referencedTables=[
+                BigQueryTableRef.from_string_name(
+                    "projects/my_project/datasets/my_dataset/tables/my_source_table1"
+                ),
+                BigQueryTableRef.from_string_name(
+                    "projects/my_project/datasets/my_dataset/tables/my_source_table2"
+                ),
+            ],
+            destinationTable=BigQueryTableRef.from_string_name(
+                "projects/my_project/datasets/my_dataset/tables/my_table"
+            ),
+        ),
+        QueryEvent(
+            timestamp=datetime.datetime.now(),
+            actor_email="bla@bla.com",
+            query="testQuery",
+            statementType="SELECT",
+            project_id="proj_12344",
+            end_time=datetime.datetime.fromtimestamp(
+                1617295943.17321, tz=datetime.timezone.utc
+            ),
+            referencedTables=[
+                BigQueryTableRef.from_string_name(
+                    "projects/my_project/datasets/my_dataset/tables/my_source_table3"
+                ),
+            ],
+            destinationTable=BigQueryTableRef.from_string_name(
+                "projects/my_project/datasets/my_dataset/tables/my_table"
+            ),
+        ),
+        QueryEvent(
+            timestamp=datetime.datetime.now(),
+            actor_email="bla@bla.com",
+            query="testQuery",
+            statementType="SELECT",
+            project_id="proj_12344",
+            referencedViews=[
+                BigQueryTableRef.from_string_name(
+                    "projects/my_project/datasets/my_dataset/tables/my_source_view1"
+                ),
+            ],
+            destinationTable=BigQueryTableRef.from_string_name(
+                "projects/my_project/datasets/my_dataset/tables/my_table"
+            ),
+        ),
+    ]
+
+    bq_table = BigQueryTableRef.from_string_name(
+        "projects/my_project/datasets/my_dataset/tables/my_table"
+    )
+
+    lineage_map: Dict[str, set[LineageEdge]] = extractor._create_lineage_map(
+        iter(lineage_entries)
+    )
+
+    upstream_lineage = extractor.get_lineage_for_table(
+        bq_table=bq_table,
+        lineage_metadata=lineage_map,
+        platform="bigquery",
+    )
+    assert upstream_lineage
+    assert len(upstream_lineage[0].upstreams) == 4

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -1,4 +1,5 @@
 import datetime
+from time import timezone
 from typing import Dict, List
 
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
@@ -29,8 +30,8 @@ FROM
 """
     view = BigqueryView(
         name="test",
-        created=datetime.datetime.now(),
-        last_altered=datetime.datetime.now(),
+        created=datetime.datetime.now(tz=datetime.timezone.utc),
+        last_altered=datetime.datetime.now(tz=datetime.timezone.utc),
         comment="",
         view_definition=ddl,
     )
@@ -48,8 +49,8 @@ def test_parse_view_lineage_with_two_part_table_name():
     ddl = "CREATE VIEW my_view as select * from some_dataset.sometable as a"
     view = BigqueryView(
         name="test",
-        created=datetime.datetime.now(),
-        last_altered=datetime.datetime.now(),
+        created=datetime.datetime.now(tz=datetime.timezone.utc),
+        last_altered=datetime.datetime.now(tz=datetime.timezone.utc),
         comment="",
         view_definition=ddl,
     )
@@ -67,8 +68,8 @@ def test_one_part_table():
     ddl = "CREATE VIEW my_view as select * from sometable as a"
     view = BigqueryView(
         name="test",
-        created=datetime.datetime.now(),
-        last_altered=datetime.datetime.now(),
+        created=datetime.datetime.now(tz=datetime.timezone.utc),
+        last_altered=datetime.datetime.now(tz=datetime.timezone.utc),
         comment="",
         view_definition=ddl,
     )
@@ -100,13 +101,13 @@ def test_create_statement_with_multiple_table():
     assert "my_project_2.my_dataset_2.sometable2" == tables[1].get_table_name()
 
 
-def test_lineage_tables():
+def test_lineage_with_timestamps():
     config = BigQueryV2Config()
     report = BigQueryV2Report()
     extractor: BigqueryLineageExtractor = BigqueryLineageExtractor(config, report)
     lineage_entries: List[QueryEvent] = [
         QueryEvent(
-            timestamp=datetime.datetime.now(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             actor_email="bla@bla.com",
             query="testQuery",
             statementType="SELECT",
@@ -125,7 +126,7 @@ def test_lineage_tables():
             ),
         ),
         QueryEvent(
-            timestamp=datetime.datetime.now(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             actor_email="bla@bla.com",
             query="testQuery",
             statementType="SELECT",
@@ -143,7 +144,7 @@ def test_lineage_tables():
             ),
         ),
         QueryEvent(
-            timestamp=datetime.datetime.now(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
             actor_email="bla@bla.com",
             query="testQuery",
             statementType="SELECT",

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Dict
+from typing import Dict, List
 
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
     BigQueryTableRef,

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Dict, List
+from typing import Dict, List, Set
 
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
     BigQueryTableRef,
@@ -163,7 +163,7 @@ def test_lineage_with_timestamps():
         "projects/my_project/datasets/my_dataset/tables/my_table"
     )
 
-    lineage_map: Dict[str, set[LineageEdge]] = extractor._create_lineage_map(
+    lineage_map: Dict[str, Set[LineageEdge]] = extractor._create_lineage_map(
         iter(lineage_entries)
     )
 

--- a/metadata-ingestion/tests/unit/test_bigquery_source.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_source.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Dict, Optional, cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from google.cloud.bigquery.table import Row, TableListItem
@@ -424,7 +424,7 @@ def create_row(d: Dict[str, Any]) -> Row:
 
 
 @pytest.fixture
-def bigquery_view_1():
+def bigquery_view_1() -> BigqueryView:
     now = datetime.now(tz=timezone.utc)
     return BigqueryView(
         name="table1",
@@ -437,7 +437,7 @@ def bigquery_view_1():
 
 
 @pytest.fixture
-def bigquery_view_2():
+def bigquery_view_2() -> BigqueryView:
     now = datetime.now(tz=timezone.utc)
     return BigqueryView(
         name="table2",
@@ -454,8 +454,11 @@ def bigquery_view_2():
 )
 @patch("google.cloud.bigquery.client.Client")
 def test_get_views_for_dataset(
-    client_mock, query_mock, bigquery_view_1, bigquery_view_2
-):
+    client_mock: Mock,
+    query_mock: Mock,
+    bigquery_view_1: BigqueryView,
+    bigquery_view_2: BigqueryView,
+) -> None:
     row1 = create_row(
         dict(
             table_name=bigquery_view_1.name,


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
