### PR TITLE
fix(ingest/bigquery): Raise report_failure threshold; add robustness around table parsing

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -426,7 +426,7 @@ class BigQueryDataDictionary:
             )
 
         for table in cur:
-            try:  # Calculating table.expires has failed -- too large to convert to int
+            try:
                 yield BigQueryDataDictionary._make_bigquery_table(
                     table, tables.get(table.table_name)
                 )
@@ -504,7 +504,7 @@ class BigQueryDataDictionary:
             )
 
         for table in cur:
-            try:  # Calculating table.expires has failed -- too large to convert to int
+            try:
                 yield BigQueryDataDictionary._make_bigquery_view(table)
             except Exception as e:
                 view_name = f"{project_id}.{dataset_name}.{table.table_name}"

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, Iterator, List, Optional
 
 from google.cloud import bigquery
 from google.cloud.bigquery.table import (
@@ -13,6 +13,7 @@ from google.cloud.bigquery.table import (
 )
 
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import BigqueryTableIdentifier
+from datahub.ingestion.source.bigquery_v2.bigquery_report import BigQueryV2Report
 from datahub.ingestion.source.sql.sql_generic import BaseColumn, BaseTable, BaseView
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -362,8 +363,6 @@ class BigQueryDataDictionary:
     def get_datasets_for_project_id(
         conn: bigquery.Client, project_id: str, maxResults: Optional[int] = None
     ) -> List[BigqueryDataset]:
-        # FIXME: Due to a bug in BigQuery's type annotations, we need to cast here.
-        maxResults = cast(int, maxResults)
         datasets = conn.list_datasets(project_id, max_results=maxResults)
         return [BigqueryDataset(name=d.dataset_id, labels=d.labels) for d in datasets]
 
@@ -399,7 +398,8 @@ class BigQueryDataDictionary:
         dataset_name: str,
         tables: Dict[str, TableListItem],
         with_data_read_permission: bool = False,
-    ) -> List[BigqueryTable]:
+        report: Optional[BigQueryV2Report] = None,
+    ) -> Iterator[BigqueryTable]:
         filter: str = ", ".join(f"'{table}'" for table in tables.keys())
 
         if with_data_read_permission:
@@ -424,42 +424,60 @@ class BigQueryDataDictionary:
                     table_filter=f" and t.table_name in ({filter})" if filter else "",
                 ),
             )
-        # Some property we want to capture only available from the TableListItem we get from an earlier query of
-        # the list of tables.
-        return [
-            BigqueryTable(
-                name=table.table_name,
-                created=table.created,
-                last_altered=datetime.fromtimestamp(
-                    table.get("last_altered") / 1000, tz=timezone.utc
+
+        for table in cur:
+            try:  # Calculating table.expires has failed -- too large to convert to int
+                yield BigQueryDataDictionary._make_bigquery_table(
+                    table, tables.get(table.table_name)
                 )
-                if table.get("last_altered") is not None
-                else table.created,
-                size_in_bytes=table.get("bytes"),
-                rows_count=table.get("row_count"),
-                comment=table.comment,
-                ddl=table.ddl,
-                expires=tables[table.table_name].expires if tables else None,
-                labels=tables[table.table_name].labels if tables else None,
-                partition_info=PartitionInfo.from_table_info(tables[table.table_name])
-                if tables
-                else None,
-                clustering_fields=tables[table.table_name].clustering_fields
-                if tables
-                else None,
-                max_partition_id=table.get("max_partition_id"),
-                max_shard_id=BigqueryTableIdentifier.get_table_and_shard(
-                    table.table_name
-                )[1]
-                if len(BigqueryTableIdentifier.get_table_and_shard(table.table_name))
-                == 2
-                else None,
-                num_partitions=table.get("num_partitions"),
-                active_billable_bytes=table.get("active_billable_bytes"),
-                long_term_billable_bytes=table.get("long_term_billable_bytes"),
+            except Exception as e:
+                table_name = f"{project_id}.{dataset_name}.{table.table_name}"
+                logger.warning(
+                    f"Error while processing table {table_name}",
+                    exc_info=True,
+                )
+                if report:
+                    report.report_warning(
+                        "metadata-extraction",
+                        f"Failed to get table {table_name}: {e}",
+                    )
+
+    @staticmethod
+    def _make_bigquery_table(
+        table: bigquery.Row, table_basic: Optional[TableListItem]
+    ) -> BigqueryTable:
+        # Some properties we want to capture are only available from the TableListItem
+        # we get from an earlier query of the list of tables.
+        try:
+            expiration = getattr(table_basic, "expires", None)
+        except OverflowError:
+            expiration = None
+
+        _, shard = BigqueryTableIdentifier.get_table_and_shard(table.table_name)
+        return BigqueryTable(
+            name=table.table_name,
+            created=table.created,
+            last_altered=datetime.fromtimestamp(
+                table.get("last_altered") / 1000, tz=timezone.utc
             )
-            for table in cur
-        ]
+            if table.get("last_altered") is not None
+            else table.created,
+            size_in_bytes=table.get("bytes"),
+            rows_count=table.get("row_count"),
+            comment=table.comment,
+            ddl=table.ddl,
+            expires=expiration,
+            labels=table_basic.labels if table_basic else None,
+            partition_info=PartitionInfo.from_table_info(table_basic)
+            if table_basic
+            else None,
+            clustering_fields=table_basic.clustering_fields if table_basic else None,
+            max_partition_id=table.get("max_partition_id"),
+            max_shard_id=shard,
+            num_partitions=table.get("num_partitions"),
+            active_billable_bytes=table.get("active_billable_bytes"),
+            long_term_billable_bytes=table.get("long_term_billable_bytes"),
+        )
 
     @staticmethod
     def get_views_for_dataset(
@@ -467,7 +485,8 @@ class BigQueryDataDictionary:
         project_id: str,
         dataset_name: str,
         has_data_read: bool,
-    ) -> List[BigqueryView]:
+        report: Optional[BigQueryV2Report] = None,
+    ) -> Iterator[BigqueryView]:
         if has_data_read:
             cur = BigQueryDataDictionary.get_query_result(
                 conn,
@@ -483,21 +502,35 @@ class BigQueryDataDictionary:
                 ),
             )
 
-        return [
-            BigqueryView(
-                name=table.table_name,
-                created=table.created,
-                last_altered=datetime.fromtimestamp(
-                    table.get("last_altered") / 1000, tz=timezone.utc
+        for table in cur:
+            try:  # Calculating table.expires has failed -- too large to convert to int
+                yield BigQueryDataDictionary._make_bigquery_view(table)
+            except Exception as e:
+                view_name = f"{project_id}.{dataset_name}.{table.table_name}"
+                logger.warning(
+                    f"Error while processing view {view_name}",
+                    exc_info=True,
                 )
-                if table.get("last_altered") is not None
-                else table.created,
-                comment=table.comment,
-                view_definition=table.view_definition,
-                materialized=table.table_type == BigqueryTableType.MATERIALIZED_VIEW,
+                if report:
+                    report.report_warning(
+                        "metadata-extraction",
+                        f"Failed to get view {view_name}: {e}",
+                    )
+
+    @staticmethod
+    def _make_bigquery_view(view: bigquery.Row) -> BigqueryView:
+        return BigqueryView(
+            name=view.table_name,
+            created=view.created,
+            last_altered=datetime.fromtimestamp(
+                view.get("last_altered") / 1000, tz=timezone.utc
             )
-            for table in cur
-        ]
+            if view.get("last_altered") is not None
+            else view.created,
+            comment=view.comment,
+            view_definition=view.view_definition,
+            materialized=view.table_type == BigqueryTableType.MATERIALIZED_VIEW,
+        )
 
     @staticmethod
     def get_columns_for_dataset(
@@ -577,7 +610,6 @@ class BigQueryDataDictionary:
                     logger.warning(
                         f"{table_identifier.project_id}.{table_identifier.dataset}.{column.table_name} contains more than {column_limit} columns, only processing {column_limit} columns"
                     )
-                    last_seen_table = column.table_name
             else:
                 columns.append(
                     BigqueryColumn(

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -449,7 +449,7 @@ class BigQueryDataDictionary:
         # Some properties we want to capture are only available from the TableListItem
         # we get from an earlier query of the list of tables.
         try:
-            expiration = getattr(table_basic, "expires", None)
+            expiration = table_basic.expires if table_basic else None
         except OverflowError:
             expiration = None
 

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -451,6 +451,7 @@ class BigQueryDataDictionary:
         try:
             expiration = table_basic.expires if table_basic else None
         except OverflowError:
+            logger.info(f"Invalid expiration time for table {table.table_name}.")
             expiration = None
 
         _, shard = BigqueryTableIdentifier.get_table_and_shard(table.table_name)

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -90,7 +90,7 @@ timestamp < "{end_time}"
         self.report = report
 
     def error(self, log: logging.Logger, key: str, reason: str) -> None:
-        self.report.report_failure(key, reason)
+        self.report.report_warning(key, reason)
         log.error(f"{key} => {reason}")
 
     @staticmethod

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/usage.py
@@ -245,7 +245,7 @@ class BigQueryUsageExtractor:
             logger.warning(
                 f"Encountered exception retrieving AuditLogEntries for project {client.project} - {e}"
             )
-            self.report.report_failure(
+            self.report.report_warning(
                 "lineage-extraction",
                 f"{client.project} - unable to retrieve log entries {e}",
             )
@@ -346,7 +346,7 @@ class BigQueryUsageExtractor:
             logger.warning(
                 f"Encountered exception retrieving AuditLogEntires for project {client.project} - {e}"
             )
-            self.report.report_failure(
+            self.report.report_warning(
                 "usage-extraction",
                 f"{client.project} - unable to retrive log entrires {e}",
             )

--- a/metadata-ingestion/tests/unit/test_bigquery_source.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_source.py
@@ -330,7 +330,7 @@ def test_table_processing_logic(client_mock, data_dictionary_mock):
 
     source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
 
-    list(
+    _ = list(
         source.get_tables_for_dataset(
             conn=client_mock, project_id="test-project", dataset_name="test-dataset"
         )
@@ -402,7 +402,7 @@ def test_table_processing_logic_date_named_tables(client_mock, data_dictionary_m
 
     source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
 
-    list(
+    _ = list(
         source.get_tables_for_dataset(
             conn=client_mock, project_id="test-project", dataset_name="test-dataset"
         )

--- a/metadata-ingestion/tests/unit/test_bigquery_source.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_source.py
@@ -330,8 +330,10 @@ def test_table_processing_logic(client_mock, data_dictionary_mock):
 
     source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
 
-    _ = source.get_tables_for_dataset(
-        conn=client_mock, project_id="test-project", dataset_name="test-dataset"
+    list(
+        source.get_tables_for_dataset(
+            conn=client_mock, project_id="test-project", dataset_name="test-dataset"
+        )
     )
 
     assert data_dictionary_mock.call_count == 1
@@ -400,8 +402,10 @@ def test_table_processing_logic_date_named_tables(client_mock, data_dictionary_m
 
     source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
 
-    _ = source.get_tables_for_dataset(
-        conn=client_mock, project_id="test-project", dataset_name="test-dataset"
+    list(
+        source.get_tables_for_dataset(
+            conn=client_mock, project_id="test-project", dataset_name="test-dataset"
+        )
     )
 
     assert data_dictionary_mock.call_count == 1
@@ -487,7 +491,7 @@ def test_get_views_for_dataset(
         dataset_name="test-dataset",
         has_data_read=False,
     )
-    assert views == [bigquery_view_1, bigquery_view_2]
+    assert list(views) == [bigquery_view_1, bigquery_view_2]
 
 
 @patch.object(BigqueryV2Source, "gen_dataset_workunits", lambda *args, **kwargs: [])


### PR DESCRIPTION
Converted getting views and tables to iterators. Even though this is slightly less clean for usage, I think we should try to generate iterators as a default for memory efficiency

Fixes bug around expiration time being impossible to represent in python because it's too far in the future

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
