### PR TITLE
fix(ui) Fix tags and terms columns on nested schema fields

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -100,10 +100,10 @@ export default function SchemaTable({
     const schemaTitleRenderer = useSchemaTitleRenderer(schemaMetadata, setSelectedFkFieldPath, filterText);
     const schemaBlameRenderer = useSchemaBlameRenderer(schemaFieldBlameList);
 
-    const onTagTermCell = (record: SchemaField, rowIndex: number | undefined) => ({
+    const onTagTermCell = (record: SchemaField) => ({
         onMouseEnter: () => {
             if (editMode) {
-                setTagHoveredIndex(`${record.fieldPath}-${rowIndex}`);
+                setTagHoveredIndex(record.fieldPath);
             }
         },
         onMouseLeave: () => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
@@ -21,7 +21,7 @@ export default function useTagsAndTermsRenderer(
         schemaRefetch?.();
     };
 
-    const tagAndTermRender = (tags: GlobalTags, record: SchemaField, rowIndex: number | undefined) => {
+    const tagAndTermRender = (tags: GlobalTags, record: SchemaField) => {
         const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
             (candidateEditableFieldInfo) => pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         );
@@ -35,8 +35,8 @@ export default function useTagsAndTermsRenderer(
                     editableGlossaryTerms={options.showTerms ? relevantEditableFieldInfo?.glossaryTerms : null}
                     canRemove
                     buttonProps={{ size: 'small' }}
-                    canAddTag={tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTags}
-                    canAddTerm={tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTerms}
+                    canAddTag={tagHoveredIndex === record.fieldPath && options.showTags}
+                    canAddTerm={tagHoveredIndex === record.fieldPath && options.showTerms}
                     onOpenModal={() => setTagHoveredIndex(undefined)}
                     entityUrn={urn}
                     entityType={EntityType.Dataset}


### PR DESCRIPTION
When we updated ant design, I believe they introduced a new bug where the `rowIndex` for nested table rows is inconsistent depending on the method you're using. The `onCell` function gives the overall index as if it were a flat list of rows while the `render` method gives the index of the row in the nested field context (this is not how it used to work).

Therefore, the `tagHoveredIndex` piece of state would never line up with the row and it would never think you're hovering over it so we would never show the option to add tags and terms. Since `fieldPath` is unique in a schema anyways, we don't need the `rowIndex` here so I simply remove it.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
