### PR TITLE
fix(ui): Fix tags display name + color in UI for autocomplete, search preview, entity profile

### DIFF
--- a/datahub-web-react/src/app/entity/tag/Tag.tsx
+++ b/datahub-web-react/src/app/entity/tag/Tag.tsx
@@ -56,7 +56,7 @@ export class TagEntity implements Entity<Tag> {
     renderPreview = (_: PreviewType, data: Tag) => (
         <DefaultPreviewCard
             description={data.description || ''}
-            name={data.name}
+            name={this.displayName(data)}
             urn={data.urn}
             url={`/${this.getPathName()}/${urlEncodeUrn(data.urn)}`}
             logoComponent={<PreviewTagIcon />}

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -6,6 +6,7 @@ fragment globalTagsFields on GlobalTags {
             name
             description
             properties {
+                name
                 colorHex
             }
         }

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -856,15 +856,7 @@ query getSearchResultsForMultiple($input: SearchAcrossEntitiesInput!) {
     }
 }
 
-<<<<<<< HEAD
 query searchAcrossLineage($input: SearchAcrossLineageInput!, $includeAssertions: Boolean = false) {
-=======
-query searchAcrossLineage(
-    $input: SearchAcrossLineageInput!
-    $includeAssertions: Boolean = false
-    $includeIncidents: Boolean = false
-) {
->>>>>>> 48e6501a76... Fix tag display name
     searchAcrossLineage(input: $input) {
         ...searchAcrossRelationshipResults
     }

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -140,6 +140,7 @@ fragment autoCompleteFields on Entity {
         name
         properties {
             name
+            colorHex
         }
     }
     ... on MLFeatureTable {
@@ -699,6 +700,7 @@ fragment searchResultFields on Entity {
         name
         properties {
             name
+            colorHex
         }
         description
     }
@@ -719,6 +721,7 @@ fragment facetFields on FacetMetadata {
             ... on Tag {
                 name
                 properties {
+                    name
                     colorHex
                 }
             }
@@ -853,7 +856,15 @@ query getSearchResultsForMultiple($input: SearchAcrossEntitiesInput!) {
     }
 }
 
+<<<<<<< HEAD
 query searchAcrossLineage($input: SearchAcrossLineageInput!, $includeAssertions: Boolean = false) {
+=======
+query searchAcrossLineage(
+    $input: SearchAcrossLineageInput!
+    $includeAssertions: Boolean = false
+    $includeIncidents: Boolean = false
+) {
+>>>>>>> 48e6501a76... Fix tag display name
     searchAcrossLineage(input: $input) {
         ...searchAcrossRelationshipResults
     }


### PR DESCRIPTION
## Summary

Previously, we were using the urn-derived "name" field in some cases to render the name of a Tag. In this PR, we change to use the correct "name" field of the properties aspect, which can be changed once the Tag has been created.

This fixes a few different scenarios:

1. search preview
2. autocomplete dropdown
3. entity profile tags section

## Status

Ready for review 

## Screenshots
Before (notice the URN derived name): 
![Screenshot 2023-04-10 at 12 20 33 PM](https://user-images.githubusercontent.com/17549204/230980140-8cf405d2-17bd-4442-8180-e162d94bce4e.png)

![Screenshot 2023-04-10 at 12 22 34 PM](https://user-images.githubusercontent.com/17549204/230980144-2c22219f-d231-4b19-874d-960f535770b7.png)

(Fixed color in autocomplete) 
![Screenshot 2023-04-10 at 12 23 16 PM](https://user-images.githubusercontent.com/17549204/230980261-698f049f-f960-42bc-a31a-b369a67b886b.png)

![Screenshot 2023-04-10 at 12 24 37 PM](https://user-images.githubusercontent.com/17549204/230980431-fa7d838e-6994-427d-9dcb-5c4968486cde.png)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
