### PR TITLE
test(ingest/snowflake): Fix tests around host_port

### DIFF
--- a/metadata-ingestion/tests/unit/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_source.py
@@ -86,20 +86,6 @@ def test_snowflake_throws_error_on_encoded_oauth_private_key_missing_if_use_cert
         )
 
 
-def test_account_id_is_added_when_host_port_is_present():
-    config = SnowflakeV2Config.parse_obj(
-        {
-            "username": "user",
-            "password": "password",
-            "host_port": "acctname",
-            "database_pattern": {"allow": {"^demo$"}},
-            "warehouse": "COMPUTE_WH",
-            "role": "sysadmin",
-        }
-    )
-    assert config.account_id == "acctname"
-
-
 def test_account_id_with_snowflake_host_suffix():
     config = SnowflakeV2Config.parse_obj(
         {
@@ -178,7 +164,7 @@ def test_options_contain_connect_args():
         {
             "username": "user",
             "password": "password",
-            "host_port": "acctname",
+            "account_id": "acctname",
             "database_pattern": {"allow": {"^demo$"}},
             "warehouse": "COMPUTE_WH",
             "role": "sysadmin",
@@ -194,7 +180,7 @@ def test_snowflake_config_with_view_lineage_no_table_lineage_throws_error():
             {
                 "username": "user",
                 "password": "password",
-                "host_port": "acctname",
+                "account_id": "acctname",
                 "database_pattern": {"allow": {"^demo$"}},
                 "warehouse": "COMPUTE_WH",
                 "role": "sysadmin",
@@ -210,7 +196,7 @@ def test_snowflake_config_with_column_lineage_no_table_lineage_throws_error():
             {
                 "username": "user",
                 "password": "password",
-                "host_port": "acctname",
+                "account_id": "acctname",
                 "database_pattern": {"allow": {"^demo$"}},
                 "warehouse": "COMPUTE_WH",
                 "role": "sysadmin",
@@ -225,7 +211,7 @@ def test_snowflake_config_with_no_connect_args_returns_base_connect_args():
         {
             "username": "user",
             "password": "password",
-            "host_port": "acctname",
+            "account_id": "acctname",
             "database_pattern": {"allow": {"^demo$"}},
             "warehouse": "COMPUTE_WH",
             "role": "sysadmin",
@@ -253,7 +239,7 @@ def test_snowflake_config_with_connect_args_overrides_base_connect_args():
         {
             "username": "user",
             "password": "password",
-            "host_port": "acctname",
+            "account_id": "acctname",
             "database_pattern": {"allow": {"^demo$"}},
             "warehouse": "COMPUTE_WH",
             "role": "sysadmin",


### PR DESCRIPTION
Aims to fix CI, which has been failing since https://github.com/datahub-project/datahub/pull/7787. Not sure why, since https://github.com/datahub-project/datahub/pull/7717 is the change that seems to have induced the failure.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
