### PR TITLE
fix(ui): Fix subtle initial redirect bug

### DIFF
--- a/datahub-web-react/src/app/context/useInitialRedirect.ts
+++ b/datahub-web-react/src/app/context/useInitialRedirect.ts
@@ -10,21 +10,19 @@ export function useInitialRedirect(state, localState, setState, setLocalState) {
      * Route to the most recently visited path once on first load of home page, if present in local storage.
      */
     useEffect(() => {
-        if (
-            location.pathname === PageRoutes.ROOT &&
-            !state.loadedInitialPath &&
-            localState.selectedPath !== location.pathname
-        ) {
+        if (!state.loadedInitialPath) {
+            if (location.pathname === PageRoutes.ROOT && localState.selectedPath !== location.pathname) {
+                if (localState.selectedPath && !localState.selectedPath.includes(PageRoutes.EMBED)) {
+                    history.replace({
+                        pathname: localState.selectedPath,
+                        search: localState.selectedSearch || '',
+                    });
+                }
+            }
             setState({
                 ...state,
                 loadedInitialPath: true,
             });
-            if (localState.selectedPath && !localState.selectedPath.includes(PageRoutes.EMBED)) {
-                history.replace({
-                    pathname: localState.selectedPath,
-                    search: localState.selectedSearch || '',
-                });
-            }
         }
     }, [
         localState.selectedPath,


### PR DESCRIPTION
## Summary

Due to these composite condition, we only mark the initial path as "bootstrapped" once we've hit the HOME page. However, this causes a subtle bug wherein if you link directly to a particular page that is not the home page, clicking to go home will result in a one-time redirect. This in turn marks the "bootstrap" process as completed. 

In this fix, we always mark the initial path as bootstrapped after the initial page load. If you go to the home page, this may involve a redirect to the previous page that you were on. If you go directly to a url that is not the home page, we will skip the redirect process altogether as the user is showing intent to navigate to the page directly. 

## Status

Ready for review 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
