### PR TITLE
fix(ingest/bigquery): Fix lineage / usage table ref checks

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -793,7 +793,9 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             return
 
         if self.config.include_table_lineage or self.config.include_usage_statistics:
-            self.table_refs.add(str(BigQueryTableRef(table_identifier)))
+            self.table_refs.add(
+                str(BigQueryTableRef(table_identifier).get_sanitized_table_ref())
+            )
         table.column_count = len(columns)
 
         # We only collect profile ignore list if profiling is enabled and profile_table_level_only is false
@@ -839,8 +841,10 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             self.report.report_dropped(table_identifier.raw_table_name())
             return
 
-        if self.config.include_table_lineage:
-            table_ref = str(BigQueryTableRef(table_identifier))
+        if self.config.include_table_lineage or self.config.include_usage_statistics:
+            table_ref = str(
+                BigQueryTableRef(table_identifier).get_sanitized_table_ref()
+            )
             self.table_refs.add(table_ref)
             if self.config.lineage_parse_view_ddl:
                 upstream_tables = self.lineage_extractor.parse_view_lineage(

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/usage.py
@@ -444,8 +444,9 @@ class BigQueryUsageExtractor:
         ):
             resource = event.read_event.resource
             if str(resource) not in table_refs:
-                logger.debug(f"Skipping non-existent {resource} from usage")
+                logger.info(f"Skipping non-existent {resource} from usage")
                 self.report.num_usage_resources_dropped += 1
+                self.report.report_dropped(str(resource))
                 return False
             elif resource.is_temporary_table([self.config.temp_table_dataset_prefix]):
                 logger.debug(f"Dropping temporary table {resource}")


### PR DESCRIPTION
Need to sanitize the refs to remove shard information, to match what we do when parsing events from the audit log. Also generate view table refs when usage but not lineage is enabled.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
