### PR TITLE
fix(dep): add sqllineage dependency for tableau

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -353,7 +353,7 @@ plugins: Dict[str, Set[str]] = {
         "great_expectations",
         "greenlet",
     },
-    "tableau": {"tableauserverclient>=0.17.0"},
+    "tableau": {"tableauserverclient>=0.17.0", sqllineage_lib},
     "trino": sql_common | trino,
     "starburst-trino-usage": sql_common | usage_common | trino,
     "nifi": {"requests", "packaging"},


### PR DESCRIPTION
Issue: 
```
pip uninstall sqllineage
pip install 'acryl-datahub[tableau]==v0.10.1.2rc6'
datahub check plugins
```
tableau plugin is still disabled.
`tableau        (disabled)          ModuleNotFoundError("No module named 'sqllineage'")`

Root Cause:
Due to this [PR](https://github.com/datahub-project/datahub/pull/7561), tableau source now requires `sqllineage` as dependency.

Solution:
Add sqllineage as dependency for tableau plugin to setup.py 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
