### PR TITLE
feat: set generateParameterizedFieldsResolvers to false to have parameterized queries be generated

### DIFF
--- a/datahub-graphql-core/build.gradle
+++ b/datahub-graphql-core/build.gradle
@@ -41,6 +41,7 @@ graphqlCodegen {
     outputDir = new File("$projectDir/src/mainGeneratedGraphQL/java")
     packageName = "com.linkedin.datahub.graphql.generated"
     generateApis = true
+    generateParameterizedFieldsResolvers = false
     modelValidationAnnotation = "@javax.annotation.Nonnull"
     customTypesMapping = [
             Long: "Long",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/view/CreateViewResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/view/CreateViewResolver.java
@@ -60,19 +60,21 @@ public class CreateViewResolver implements DataFetcher<CompletableFuture<DataHub
   }
 
   private DataHubView createView(@Nonnull final Urn urn, @Nonnull final CreateViewInput input) {
-    return new DataHubView(
-        urn.toString(),
-        com.linkedin.datahub.graphql.generated.EntityType.DATAHUB_VIEW,
-        input.getViewType(),
-        input.getName(),
-        input.getDescription(),
-        new DataHubViewDefinition(
+    return new DataHubView.Builder()
+        .setUrn(urn.toString())
+        .setType(com.linkedin.datahub.graphql.generated.EntityType.DATAHUB_VIEW)
+        .setViewType(input.getViewType())
+        .setName(input.getName())
+        .setDescription(input.getDescription())
+        .setDefinition(new DataHubViewDefinition(
             input.getDefinition().getEntityTypes(),
             new DataHubViewFilter(
                 input.getDefinition().getFilter().getOperator(),
                 input.getDefinition().getFilter().getFilters().stream().map(filterInput ->
-                    new FacetFilter(filterInput.getField(), filterInput.getCondition(), filterInput.getValues(),
-                        filterInput.getNegated()))
-                    .collect(Collectors.toList()))));
+                        new FacetFilter(filterInput.getField(), filterInput.getCondition(),
+                            filterInput.getValues(),
+                            filterInput.getNegated()))
+                    .collect(Collectors.toList()))))
+        .build();
   }
 }


### PR DESCRIPTION
The current graphql code gen does not generate as properties in the generated classes in `mainGeneratedGprahQL` for parameterized fields defined in graphql schema. As a result, fields like `schemaMetadata` is missing in generated `Dataset`, or `IngestionSourceExecutionRequests` is missing in `IngestionSource`.

According to the author of graphql-java-codegen, setting the option`generateParameterizedFieldsResolvers` to false in `build.gradle` will generate the parameterized queries as properties in the generated classes and he also suggested this flag should be set to `false` by default in `6.0.0` release in one of the issue raised [here](https://github.com/kobylynskyi/graphql-java-codegen/issues/676)

This PR sets the option `generateParameterizedFieldsResolvers` to `false` to have the parameterized queries generated as properties in the class. Since datahub doesn't use the generated resolver interfaces that come from when setting this to `true`. There's only one place to change in  `CreateViewResolver.java` because the constructor of DatahubView takes one more parameter with this change.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
