### PR TITLE
fix(ui) Fix 404 page routing bug

### DIFF
--- a/datahub-web-react/src/app/SearchRoutes.tsx
+++ b/datahub-web-react/src/app/SearchRoutes.tsx
@@ -41,7 +41,7 @@ export const SearchRoutes = (): JSX.Element => {
                 <Route path={PageRoutes.DOMAINS} render={() => <ManageDomainsPage />} />
                 <Route path={PageRoutes.INGESTION} render={() => <ManageIngestionPage />} />
                 <Route path={PageRoutes.SETTINGS} render={() => <SettingsPage />} />
-                <GlossaryRoutes />
+                <Route path={`${PageRoutes.GLOSSARY}*`} render={() => <GlossaryRoutes />} />
                 <Route component={NoPageFound} />
             </Switch>
         </SearchablePage>


### PR DESCRIPTION
There's a routing bug in the app right now where if a user goes to a route that doesn't exist, instead of showing them our 404 page, we show them an empty business glossary page. This is because routes were getting caught in the `GlossaryRoutes` component and never making it past it to show the `NoPageFound` component.

This PR fixes that by adding a real route that anything that starts with `glossary` will render the `GlossaryRoutes` component. So now a broken link will actually render our 404 page.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
