### PR TITLE
feat(cli): improve quickstart stability

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_check.py
+++ b/metadata-ingestion/src/datahub/cli/docker_check.py
@@ -137,6 +137,17 @@ class QuickstartStatus:
     def is_ok(self) -> bool:
         return not self.errors()
 
+    def needs_up(self) -> bool:
+        return any(
+            container.status
+            in {
+                ContainerStatus.EXITED_WITH_FAILURE,
+                ContainerStatus.DIED,
+                ContainerStatus.MISSING,
+            }
+            for container in self.containers
+        )
+
     def to_exception(
         self, header: str, footer: Optional[str] = None
     ) -> QuickstartError:


### PR DESCRIPTION
- Increase quickstart timeout from 8 to 10 minutes.
- Only run `docker compose up` when required, instead of wasting compute by running it every 30 seconds.

Hopefully this will reduce quickstart errors in OSS and in CI.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
