### PR TITLE
feat(timeseries): Support sorting timeseries aspects by non-timestampMillis field + fix operations resolver

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -289,6 +289,8 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.graph.SiblingGraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.filter.SortCriterion;
+import com.linkedin.metadata.query.filter.SortOrder;
 import com.linkedin.metadata.recommendation.RecommendationsService;
 import com.linkedin.metadata.secret.SecretService;
 import com.linkedin.metadata.service.QueryService;
@@ -1012,7 +1014,8 @@ public class GmsGraphQLEngine {
                         this.entityClient,
                         "dataset",
                         "operation",
-                        OperationMapper::map
+                        OperationMapper::map,
+                        new SortCriterion().setField(OPERATION_EVENT_TIME_FIELD_NAME).setOrder(SortOrder.DESCENDING)
                     )
                 )
                 .dataFetcher("usageStats", new DatasetUsageStatsResolver(this.usageClient))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolver.java
@@ -64,7 +64,6 @@ public class AssertionRunEventResolver implements DataFetcher<CompletableFuture<
             maybeStartTimeMillis,
             maybeEndTimeMillis,
             maybeLimit,
-            false,
             buildFilter(maybeFilters, maybeStatus),
             context.getAuthentication());
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardUsageStatsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardUsageStatsResolver.java
@@ -87,7 +87,7 @@ public class DashboardUsageStatsResolver implements DataFetcher<CompletableFutur
       List<EnvelopedAspect> aspects =
           timeseriesAspectService.getAspectValues(Urn.createFromString(dashboardUrn), Constants.DASHBOARD_ENTITY_NAME,
               Constants.DASHBOARD_USAGE_STATISTICS_ASPECT_NAME, maybeStartTimeMillis, maybeEndTimeMillis, maybeLimit,
-              null, filter);
+              filter);
       dashboardUsageMetrics = aspects.stream().map(DashboardUsageMetricMapper::map).collect(Collectors.toList());
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Invalid resource", e);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardUsageStatsUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardUsageStatsUtils.java
@@ -56,7 +56,6 @@ public class DashboardUsageStatsUtils {
         maybeStartTimeMillis,
         maybeEndTimeMillis,
         maybeLimit,
-        null,
         filter);
       dashboardUsageMetrics = aspects.stream().map(DashboardUsageMetricMapper::map).collect(Collectors.toList());
     } catch (URISyntaxException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/TimeSeriesAspectResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/TimeSeriesAspectResolver.java
@@ -14,6 +14,7 @@ import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
 import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -49,13 +50,27 @@ public class TimeSeriesAspectResolver implements DataFetcher<CompletableFuture<L
   private final String _entityName;
   private final String _aspectName;
   private final Function<EnvelopedAspect, TimeSeriesAspect> _aspectMapper;
+  private final SortCriterion _sort;
 
-  public TimeSeriesAspectResolver(final EntityClient client, final String entityName, final String aspectName,
+  public TimeSeriesAspectResolver(
+      final EntityClient client,
+      final String entityName,
+      final String aspectName,
       final Function<EnvelopedAspect, TimeSeriesAspect> aspectMapper) {
+    this(client, entityName, aspectName, aspectMapper, null);
+  }
+
+  public TimeSeriesAspectResolver(
+      final EntityClient client,
+      final String entityName,
+      final String aspectName,
+      final Function<EnvelopedAspect, TimeSeriesAspect> aspectMapper,
+      final SortCriterion sort) {
     _client = client;
     _entityName = entityName;
     _aspectName = aspectName;
     _aspectMapper = aspectMapper;
+    _sort = sort;
   }
 
   /**
@@ -90,12 +105,13 @@ public class TimeSeriesAspectResolver implements DataFetcher<CompletableFuture<L
       final FilterInput maybeFilters = environment.getArgument("filter") != null
           ? bindArgument(environment.getArgument("filter"), FilterInput.class)
           : null;
+      final SortCriterion maybeSort = _sort;
 
       try {
         // Step 1: Get aspects.
         List<EnvelopedAspect> aspects =
             _client.getTimeseriesAspectValues(urn, _entityName, _aspectName, maybeStartTimeMillis, maybeEndTimeMillis,
-                maybeLimit, null, buildFilters(maybeFilters), context.getAuthentication());
+                maybeLimit, buildFilters(maybeFilters), context.getAuthentication());
 
         // Step 2: Bind profiles into GraphQL strong types.
         return aspects.stream().map(_aspectMapper).collect(Collectors.toList());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/TimeSeriesAspectResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/TimeSeriesAspectResolver.java
@@ -111,7 +111,7 @@ public class TimeSeriesAspectResolver implements DataFetcher<CompletableFuture<L
         // Step 1: Get aspects.
         List<EnvelopedAspect> aspects =
             _client.getTimeseriesAspectValues(urn, _entityName, _aspectName, maybeStartTimeMillis, maybeEndTimeMillis,
-                maybeLimit, buildFilters(maybeFilters), context.getAuthentication());
+                maybeLimit, buildFilters(maybeFilters), maybeSort, context.getAuthentication());
 
         // Step 2: Bind profiles into GraphQL strong types.
         return aspects.stream().map(_aspectMapper).collect(Collectors.toList());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolverTest.java
@@ -50,7 +50,6 @@ public class AssertionRunEventResolverTest {
         Mockito.eq(0L),
         Mockito.eq(10L),
         Mockito.eq(5),
-        Mockito.eq(false),
         Mockito.eq(AssertionRunEventResolver.buildFilter(null, AssertionRunStatus.COMPLETE.toString())),
         Mockito.any(Authentication.class)
     )).thenReturn(
@@ -86,7 +85,6 @@ public class AssertionRunEventResolverTest {
         Mockito.eq(0L),
         Mockito.eq(10L),
         Mockito.eq(5),
-        Mockito.eq(false),
         Mockito.any(Filter.class),
         Mockito.any(Authentication.class)
     );

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardStatsSummaryTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardStatsSummaryTest.java
@@ -81,7 +81,6 @@ public class DashboardStatsSummaryTest {
         Mockito.eq(null),
         Mockito.eq(null),
         Mockito.eq(1),
-        Mockito.eq(null),
         Mockito.eq(filterForLatestStats)
     )).thenReturn(ImmutableList.of(newResult));
 
@@ -159,7 +158,6 @@ public class DashboardStatsSummaryTest {
         Mockito.eq(null),
         Mockito.eq(null),
         Mockito.eq(1),
-        Mockito.eq(null),
         Mockito.eq(filterForLatestStats)
     )).thenReturn(
         ImmutableList.of(envelopedLatestStats)

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -75,6 +75,7 @@ public class Constants {
   public static final String SUB_TYPES_ASPECT_NAME = "subTypes";
   public static final String DEPRECATION_ASPECT_NAME = "deprecation";
   public static final String OPERATION_ASPECT_NAME = "operation";
+  public static final String OPERATION_EVENT_TIME_FIELD_NAME = "lastUpdatedTimestamp"; // :(
   public static final String SIBLINGS_ASPECT_NAME = "siblings";
   public static final String ORIGIN_ASPECT_NAME = "origin";
   public static final String INPUT_FIELDS_ASPECT_NAME = "inputFields";

--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -3405,6 +3405,30 @@
     "systemMetadata":null
   },
   {
+    "auditHeader":null,
+    "entityType":"dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType":"UPSERT",
+    "aspectName":"operation",
+    "aspect":{
+      "value":"{\"timestampMillis\": 1629097200000, \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1629097200001 }",
+      "contentType":"application/json"
+    },
+    "systemMetadata":null
+  },
+  {
+    "auditHeader":null,
+    "entityType":"dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType":"UPSERT",
+    "aspectName":"operation",
+    "aspect":{
+      "value":"{\"timestampMillis\": 1629107200000, \"operationType\": \"UPDATE\", \"lastUpdatedTimestamp\": 1625097200000 }",
+      "contentType":"application/json"
+    },
+    "systemMetadata":null
+  },
+  {
     "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -459,7 +459,7 @@ public class JavaEntityClient implements EntityClient {
     @Override
     public List<EnvelopedAspect> getTimeseriesAspectValues(@Nonnull String urn, @Nonnull String entity,
         @Nonnull String aspect, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit,
-        @Nullable Boolean getLatestValue, @Nullable Filter filter, @Nonnull final Authentication authentication)
+        @Nullable Filter filter, @Nullable SortCriterion sort, @Nonnull final Authentication authentication)
         throws RemoteInvocationException {
       GetTimeseriesAspectValuesResponse response = new GetTimeseriesAspectValuesResponse();
       response.setEntityName(entity);
@@ -473,15 +473,12 @@ public class JavaEntityClient implements EntityClient {
       if (limit != null) {
         response.setLimit(limit);
       }
-      if (getLatestValue != null) {
-        response.setGetLatestValue(getLatestValue);
-      }
       if (filter != null) {
         response.setFilter(filter);
       }
       response.setValues(new EnvelopedAspectArray(
           _timeseriesAspectService.getAspectValues(Urn.createFromString(urn), entity, aspect, startTimeMillis,
-              endTimeMillis, limit, getLatestValue, filter)));
+              endTimeMillis, limit, filter, sort)));
       return response.getValues();
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/TimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/TimeseriesAspectService.java
@@ -21,6 +21,7 @@ public interface TimeseriesAspectService {
    */
   void configure();
 
+
   /**
    * Retrieve a list of Time-Series Aspects for an individual entity, matching a set of optional filters, sorted by the timestampMillis
    * field descending.
@@ -37,7 +38,37 @@ public interface TimeseriesAspectService {
    * @param startTimeMillis the start of a time window in milliseconds, compared against the standard timestampMillis field
    * @param endTimeMillis the end of a time window in milliseconds, compared against the standard timestampMillis field
    * @param limit the maximum number of results to retrieve
-   * @param getLatestValue whether to retrieve only the single latest value. This is actually a redundant parameter that should be removed.
+   * @param filter a set of additional secondary filters to apply when finding the aspects
+   * @return a list of {@link EnvelopedAspect} containing the Time-Series aspects that were found, or empty list if none were found.
+   */
+  @Nonnull
+  default List<EnvelopedAspect> getAspectValues(
+      @Nonnull final Urn urn,
+      @Nonnull final String entityName,
+      @Nonnull final String aspectName,
+      @Nullable final Long startTimeMillis,
+      @Nullable final Long endTimeMillis,
+      @Nullable final Integer limit,
+      @Nullable final Filter filter) {
+    return getAspectValues(urn, entityName, aspectName, startTimeMillis, endTimeMillis, limit, filter, null);
+  }
+
+  /**
+   * Retrieve a list of Time-Series Aspects for an individual entity, matching a set of optional filters, sorted by the timestampMillis
+   * field descending.
+   *
+   * This method allows you to optionally filter for events that fall into a particular time window based on the timestampMillis
+   * field of the aspect, or simply retrieve the latest aspects sorted by time.
+   *
+   * Note that this does not always indicate the event time, and is often used to reflect the reported
+   * time of a given event.
+   *
+   * @param urn the urn of the entity to retrieve aspects for
+   * @param entityName the name of the entity to retrieve aspects for
+   * @param aspectName the name of the timeseries aspect to retrieve for the entity
+   * @param startTimeMillis the start of a time window in milliseconds, compared against the standard timestampMillis field
+   * @param endTimeMillis the end of a time window in milliseconds, compared against the standard timestampMillis field
+   * @param limit the maximum number of results to retrieve
    * @param filter a set of additional secondary filters to apply when finding the aspects
    * @param sort the sort criterion for the result set. If not provided, defaults to sorting by timestampMillis descending.
    * @return a list of {@link EnvelopedAspect} containing the Time-Series aspects that were found, or empty list if none were found.
@@ -50,7 +81,6 @@ public interface TimeseriesAspectService {
       @Nullable final Long startTimeMillis,
       @Nullable final Long endTimeMillis,
       @Nullable final Integer limit,
-      @Nullable final Boolean getLatestValue,
       @Nullable final Filter filter,
       @Nullable final SortCriterion sort);
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/TimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/TimeseriesAspectService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.timeseries.AggregationSpec;
 import com.linkedin.timeseries.DeleteAspectValuesResult;
 import com.linkedin.timeseries.GenericTable;
@@ -15,38 +16,102 @@ import javax.annotation.Nullable;
 
 public interface TimeseriesAspectService {
 
+  /**
+   * Configure the Time-Series aspect service one time at boot-up.
+   */
   void configure();
 
-  void upsertDocument(@Nonnull String entityName, @Nonnull String aspectName, @Nonnull String docId,
-      @Nonnull JsonNode document);
-
-  List<EnvelopedAspect> getAspectValues(@Nonnull final Urn urn, @Nonnull String entityName, @Nonnull String aspectName,
-      @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit,
-      @Nullable Boolean getLatestValue, @Nullable Filter filter);
-
   /**
-   * Get the aggregated metrics for the given dataset or column from a time series aspect.
+   * Retrieve a list of Time-Series Aspects for an individual entity, matching a set of optional filters, sorted by the timestampMillis
+   * field descending.
+   *
+   * This method allows you to optionally filter for events that fall into a particular time window based on the timestampMillis
+   * field of the aspect, or simply retrieve the latest aspects sorted by time.
+   *
+   * Note that this does not always indicate the event time, and is often used to reflect the reported
+   * time of a given event.
+   *
+   * @param urn the urn of the entity to retrieve aspects for
+   * @param entityName the name of the entity to retrieve aspects for
+   * @param aspectName the name of the timeseries aspect to retrieve for the entity
+   * @param startTimeMillis the start of a time window in milliseconds, compared against the standard timestampMillis field
+   * @param endTimeMillis the end of a time window in milliseconds, compared against the standard timestampMillis field
+   * @param limit the maximum number of results to retrieve
+   * @param getLatestValue whether to retrieve only the single latest value. This is actually a redundant parameter that should be removed.
+   * @param filter a set of additional secondary filters to apply when finding the aspects
+   * @param sort the sort criterion for the result set. If not provided, defaults to sorting by timestampMillis descending.
+   * @return a list of {@link EnvelopedAspect} containing the Time-Series aspects that were found, or empty list if none were found.
    */
   @Nonnull
-  GenericTable getAggregatedStats(@Nonnull String entityName, @Nonnull String aspectName,
-      @Nonnull AggregationSpec[] aggregationSpecs, @Nullable Filter filter, @Nullable GroupingBucket[] groupingBuckets);
+  List<EnvelopedAspect> getAspectValues(
+      @Nonnull final Urn urn,
+      @Nonnull final String entityName,
+      @Nonnull final String aspectName,
+      @Nullable final Long startTimeMillis,
+      @Nullable final Long endTimeMillis,
+      @Nullable final Integer limit,
+      @Nullable final Boolean getLatestValue,
+      @Nullable final Filter filter,
+      @Nullable final SortCriterion sort);
 
   /**
-   * Generic filter based deletion for timseries aspects.
-   * @param entityName - The name of the entity.
-   * @param aspectName  - The name of the aspect.
-   * @param filter - The filter to be used for deletion of the documents on the index.
-   * @return - number of documents deleted.
+   * Perform a arbitrary aggregation query over a set of Time-Series aspects.
+   * This is used to answer arbitrary questions about the Time-Series aspects that we have.
+   *
+   * @param entityName the name of the entity associated with the Time-Series aspect.
+   * @param aspectName the name of the Time-Series aspect.
+   * @param aggregationSpecs a specification of the types of metric-value aggregations that should be performed
+   * @param filter an optional  filter that should be applied prior to performing the requested aggregations.
+   * @param groupingBuckets an optional set of buckets to group the aggregations on the timeline -- For example, by a particular date or
+   *                        string value.
+   * @return a "table" representation of the results of performing the aggregation, with a row per group.
    */
   @Nonnull
-  DeleteAspectValuesResult deleteAspectValues(@Nonnull String entityName, @Nonnull String aspectName,
-      @Nonnull Filter filter);
+  GenericTable getAggregatedStats(
+      @Nonnull final String entityName,
+      @Nonnull final String aspectName,
+      @Nonnull final AggregationSpec[] aggregationSpecs,
+      @Nullable final Filter filter,
+      @Nullable final GroupingBucket[] groupingBuckets);
 
   /**
-   * Rollback the timeseries aspects associated with a runId.
-   * @param runId The runId that needs to be rolledback.
-   * @return
+   * Generic filter based deletion for Time-Series Aspects.
+   *
+   * @param entityName The name of the entity.
+   * @param aspectName  The name of the aspect.
+   * @param filter A filter to be used for deletion of the documents on the index.
+   * @return a summary of the aspects which were deleted
    */
   @Nonnull
-  DeleteAspectValuesResult rollbackTimeseriesAspects(@Nonnull String runId);
+  DeleteAspectValuesResult deleteAspectValues(
+      @Nonnull final String entityName,
+      @Nonnull final String aspectName,
+      @Nonnull final Filter filter);
+
+  /**
+   * Rollback the Time-Series aspects associated with a particular runId. This is invoked as a part of an
+   * ingestion rollback process.
+   *
+   * @param runId The runId that needs to be rolled back.
+   * @return a summary of the aspects which were deleted
+   */
+  @Nonnull
+  DeleteAspectValuesResult rollbackTimeseriesAspects(@Nonnull final String runId);
+
+  /**
+   * Upsert a raw timeseries aspect into a timeseries index. Note that this is a bit of a hack, and leaks
+   * too much implementation detail around Elasticsearch.
+   *
+   * TODO: Make this more general purpose.
+   *
+   * @param entityName the name of the entity
+   * @param aspectName the name of an aspect
+   * @param docId the doc id for the elasticsearch document - this serves as the primary key for the document.
+   * @param document the raw document to insert.
+   */
+  void upsertDocument(
+      @Nonnull final String entityName,
+      @Nonnull final String aspectName,
+      @Nonnull final String docId,
+      @Nonnull final JsonNode document);
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -55,7 +55,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -150,7 +150,6 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
       @Nullable final Long startTimeMillis,
       @Nullable final Long endTimeMillis,
       @Nullable final Integer limit,
-      @Nullable final Boolean getLatestValue,
       @Nullable final Filter filter,
       @Nullable final SortCriterion sort) {
     final BoolQueryBuilder filterQueryBuilder = QueryBuilders.boolQuery().must(ESUtils.buildFilterQuery(filter, true));
@@ -171,12 +170,6 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
     }
     final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.query(filterQueryBuilder);
-    if (getLatestValue != null && getLatestValue) {
-      if (limit != null && limit > 1) {
-        log.warn(String.format("Changing limit from %s to 1, since getLatestValue is true", limit));
-      }
-      limit = 1;
-    }
     searchSourceBuilder.size(limit != null ? limit : DEFAULT_LIMIT);
 
     if (sort != null) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -15,6 +15,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.ReindexConfig;
 import com.linkedin.metadata.search.elasticsearch.update.ESBulkProcessor;
 import com.linkedin.metadata.search.utils.ESUtils;
@@ -54,6 +55,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 
@@ -141,9 +143,16 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
   }
 
   @Override
-  public List<EnvelopedAspect> getAspectValues(@Nonnull final Urn urn, @Nonnull String entityName,
-      @Nonnull String aspectName, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit,
-      @Nullable Boolean getLatestValue, @Nullable Filter filter) {
+  public List<EnvelopedAspect> getAspectValues(
+      @Nonnull final Urn urn,
+      @Nonnull final String entityName,
+      @Nonnull final String aspectName,
+      @Nullable final Long startTimeMillis,
+      @Nullable final Long endTimeMillis,
+      @Nullable final Integer limit,
+      @Nullable final Boolean getLatestValue,
+      @Nullable final Filter filter,
+      @Nullable final SortCriterion sort) {
     final BoolQueryBuilder filterQueryBuilder = QueryBuilders.boolQuery().must(ESUtils.buildFilterQuery(filter, true));
     filterQueryBuilder.must(QueryBuilders.matchQuery("urn", urn.toString()));
     // NOTE: We are interested only in the un-exploded rows as only they carry the `event` payload.
@@ -169,7 +178,16 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
       limit = 1;
     }
     searchSourceBuilder.size(limit != null ? limit : DEFAULT_LIMIT);
-    searchSourceBuilder.sort(SortBuilders.fieldSort("@timestamp").order(SortOrder.DESC));
+
+    if (sort != null) {
+      final SortOrder esSortOrder =
+          (sort.getOrder() == com.linkedin.metadata.query.filter.SortOrder.ASCENDING) ? SortOrder.ASC
+              : SortOrder.DESC;
+      searchSourceBuilder.sort(SortBuilders.fieldSort(sort.getField()).order(esSortOrder));
+    } else {
+      // By default, sort by the timestampMillis descending.
+      searchSourceBuilder.sort(SortBuilders.fieldSort("@timestamp").order(SortOrder.DESC));
+    }
 
     final SearchRequest searchRequest = new SearchRequest();
     searchRequest.source(searchSourceBuilder);

--- a/metadata-io/src/test/java/com/linkedin/metadata/ESTestConfiguration.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/ESTestConfiguration.java
@@ -126,7 +126,7 @@ public class ESTestConfiguration {
     @Bean(name = "entityRegistry")
     public EntityRegistry entityRegistry() throws EntityRegistryException {
         ConfigEntityRegistry configEntityRegistry = new ConfigEntityRegistry(
-                ESTestConfiguration.class.getClassLoader().getResourceAsStream("entity-registry.yml"));
+                ESTestConfiguration.class.getClassLoader().getResourceAsStream("test-entity-registry.yml"));
         return new MergedEntityRegistry(SnapshotEntityRegistry.getInstance()).apply(configEntityRegistry);
     }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/ESTestConfiguration.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/ESTestConfiguration.java
@@ -126,7 +126,7 @@ public class ESTestConfiguration {
     @Bean(name = "entityRegistry")
     public EntityRegistry entityRegistry() throws EntityRegistryException {
         ConfigEntityRegistry configEntityRegistry = new ConfigEntityRegistry(
-                ESTestConfiguration.class.getClassLoader().getResourceAsStream("test-entity-registry.yml"));
+                ESTestConfiguration.class.getClassLoader().getResourceAsStream("entity-registry.yml"));
         return new MergedEntityRegistry(SnapshotEntityRegistry.getInstance()).apply(configEntityRegistry);
     }
 }

--- a/metadata-service/restli-api/src/main/idl/com.linkedin.entity.aspects.restspec.json
+++ b/metadata-service/restli-api/src/main/idl/com.linkedin.entity.aspects.restspec.json
@@ -65,6 +65,10 @@
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.filter.Filter",
         "optional" : true
+      }, {
+        "name" : "sort",
+        "type" : "com.linkedin.metadata.query.filter.SortCriterion",
+        "optional" : true
       } ],
       "returns" : "com.linkedin.aspect.GetTimeseriesAspectValuesResponse"
     }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -867,18 +867,7 @@
                 }
               }
             },
-            "doc" : "Urn of the applied tag",
-            "Relationship" : {
-              "entityTypes" : [ "tag" ],
-              "name" : "TaggedWith"
-            },
-            "Searchable" : {
-              "addToFilters" : true,
-              "fieldName" : "tags",
-              "fieldType" : "URN",
-              "filterNameOverride" : "Tag",
-              "hasValuesFieldName" : "hasTags"
-            }
+            "doc" : "Urn of the applied tag"
           }, {
             "name" : "context",
             "type" : "string",
@@ -888,12 +877,20 @@
         }
       },
       "doc" : "Tags associated with a given entity",
+      "Relationship" : {
+        "/*/tag" : {
+          "entityTypes" : [ "tag" ],
+          "name" : "TaggedWith"
+        }
+      },
       "Searchable" : {
         "/*/tag" : {
           "addToFilters" : true,
           "boostScore" : 0.5,
           "fieldName" : "tags",
           "fieldType" : "URN",
+          "filterNameOverride" : "Tag",
+          "hasValuesFieldName" : "hasTags",
           "queryByDefault" : true
         }
       }
@@ -2743,6 +2740,7 @@
               "type" : "com.linkedin.dataset.SchemaFieldPath",
               "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
               "Searchable" : {
+                "boostScore" : 5.0,
                 "fieldName" : "fieldPaths",
                 "fieldType" : "TEXT"
               }
@@ -3863,7 +3861,30 @@
       "name" : "version",
       "type" : "long"
     } ]
-  }, "com.linkedin.metadata.key.ChartKey", "com.linkedin.metadata.key.CorpGroupKey", "com.linkedin.metadata.key.CorpUserKey", "com.linkedin.metadata.key.DashboardKey", "com.linkedin.metadata.key.DataFlowKey", "com.linkedin.metadata.key.DataJobKey", "com.linkedin.metadata.key.GlossaryNodeKey", "com.linkedin.metadata.key.GlossaryTermKey", "com.linkedin.metadata.key.MLFeatureKey", "com.linkedin.metadata.key.MLModelKey", "com.linkedin.metadata.key.TagKey", "com.linkedin.metadata.query.filter.Condition", "com.linkedin.metadata.query.filter.ConjunctiveCriterion", "com.linkedin.metadata.query.filter.Criterion", "com.linkedin.metadata.query.filter.Filter", "com.linkedin.ml.metadata.BaseData", "com.linkedin.ml.metadata.CaveatDetails", "com.linkedin.ml.metadata.CaveatsAndRecommendations", "com.linkedin.ml.metadata.EthicalConsiderations", "com.linkedin.ml.metadata.EvaluationData", "com.linkedin.ml.metadata.HyperParameterValueType", "com.linkedin.ml.metadata.IntendedUse", "com.linkedin.ml.metadata.IntendedUserType", "com.linkedin.ml.metadata.MLFeatureProperties", "com.linkedin.ml.metadata.MLHyperParam", "com.linkedin.ml.metadata.MLMetric", "com.linkedin.ml.metadata.MLModelFactorPrompts", "com.linkedin.ml.metadata.MLModelFactors", "com.linkedin.ml.metadata.MLModelProperties", "com.linkedin.ml.metadata.Metrics", "com.linkedin.ml.metadata.QuantitativeAnalyses", "com.linkedin.ml.metadata.ResultsType", "com.linkedin.ml.metadata.SourceCode", "com.linkedin.ml.metadata.SourceCodeUrl", "com.linkedin.ml.metadata.SourceCodeUrlType", "com.linkedin.ml.metadata.TrainingData", "com.linkedin.mxe.GenericAspect", {
+  }, "com.linkedin.metadata.key.ChartKey", "com.linkedin.metadata.key.CorpGroupKey", "com.linkedin.metadata.key.CorpUserKey", "com.linkedin.metadata.key.DashboardKey", "com.linkedin.metadata.key.DataFlowKey", "com.linkedin.metadata.key.DataJobKey", "com.linkedin.metadata.key.GlossaryNodeKey", "com.linkedin.metadata.key.GlossaryTermKey", "com.linkedin.metadata.key.MLFeatureKey", "com.linkedin.metadata.key.MLModelKey", "com.linkedin.metadata.key.TagKey", "com.linkedin.metadata.query.filter.Condition", "com.linkedin.metadata.query.filter.ConjunctiveCriterion", "com.linkedin.metadata.query.filter.Criterion", "com.linkedin.metadata.query.filter.Filter", {
+    "type" : "record",
+    "name" : "SortCriterion",
+    "namespace" : "com.linkedin.metadata.query.filter",
+    "doc" : "Sort order along with the field to sort it on, to be applied to the results.",
+    "fields" : [ {
+      "name" : "field",
+      "type" : "string",
+      "doc" : "The name of the field that sorting has to be applied to"
+    }, {
+      "name" : "order",
+      "type" : {
+        "type" : "enum",
+        "name" : "SortOrder",
+        "doc" : "The order used to sort the results",
+        "symbols" : [ "ASCENDING", "DESCENDING" ],
+        "symbolDocs" : {
+          "ASCENDING" : "If results need to be sorted in ascending order",
+          "DESCENDING" : "If results need to be sorted in descending order"
+        }
+      },
+      "doc" : "The order to sort the results i.e. ASCENDING or DESCENDING"
+    } ]
+  }, "com.linkedin.metadata.query.filter.SortOrder", "com.linkedin.ml.metadata.BaseData", "com.linkedin.ml.metadata.CaveatDetails", "com.linkedin.ml.metadata.CaveatsAndRecommendations", "com.linkedin.ml.metadata.EthicalConsiderations", "com.linkedin.ml.metadata.EvaluationData", "com.linkedin.ml.metadata.HyperParameterValueType", "com.linkedin.ml.metadata.IntendedUse", "com.linkedin.ml.metadata.IntendedUserType", "com.linkedin.ml.metadata.MLFeatureProperties", "com.linkedin.ml.metadata.MLHyperParam", "com.linkedin.ml.metadata.MLMetric", "com.linkedin.ml.metadata.MLModelFactorPrompts", "com.linkedin.ml.metadata.MLModelFactors", "com.linkedin.ml.metadata.MLModelProperties", "com.linkedin.ml.metadata.Metrics", "com.linkedin.ml.metadata.QuantitativeAnalyses", "com.linkedin.ml.metadata.ResultsType", "com.linkedin.ml.metadata.SourceCode", "com.linkedin.ml.metadata.SourceCodeUrl", "com.linkedin.ml.metadata.SourceCodeUrlType", "com.linkedin.ml.metadata.TrainingData", "com.linkedin.mxe.GenericAspect", {
     "type" : "record",
     "name" : "MetadataChangeProposal",
     "namespace" : "com.linkedin.mxe",
@@ -3974,6 +3995,10 @@
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.filter.Filter",
+          "optional" : true
+        }, {
+          "name" : "sort",
+          "type" : "com.linkedin.metadata.query.filter.SortCriterion",
           "optional" : true
         } ],
         "returns" : "com.linkedin.aspect.GetTimeseriesAspectValuesResponse"

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -842,18 +842,7 @@
                 }
               }
             },
-            "doc" : "Urn of the applied tag",
-            "Relationship" : {
-              "entityTypes" : [ "tag" ],
-              "name" : "TaggedWith"
-            },
-            "Searchable" : {
-              "addToFilters" : true,
-              "fieldName" : "tags",
-              "fieldType" : "URN",
-              "filterNameOverride" : "Tag",
-              "hasValuesFieldName" : "hasTags"
-            }
+            "doc" : "Urn of the applied tag"
           }, {
             "name" : "context",
             "type" : "string",
@@ -863,12 +852,20 @@
         }
       },
       "doc" : "Tags associated with a given entity",
+      "Relationship" : {
+        "/*/tag" : {
+          "entityTypes" : [ "tag" ],
+          "name" : "TaggedWith"
+        }
+      },
       "Searchable" : {
         "/*/tag" : {
           "addToFilters" : true,
           "boostScore" : 0.5,
           "fieldName" : "tags",
           "fieldType" : "URN",
+          "filterNameOverride" : "Tag",
+          "hasValuesFieldName" : "hasTags",
           "queryByDefault" : true
         }
       }
@@ -3104,6 +3101,7 @@
                           "type" : "com.linkedin.dataset.SchemaFieldPath",
                           "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
                           "Searchable" : {
+                            "boostScore" : 5.0,
                             "fieldName" : "fieldPaths",
                             "fieldType" : "TEXT"
                           }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -621,18 +621,7 @@
                 }
               }
             },
-            "doc" : "Urn of the applied tag",
-            "Relationship" : {
-              "entityTypes" : [ "tag" ],
-              "name" : "TaggedWith"
-            },
-            "Searchable" : {
-              "addToFilters" : true,
-              "fieldName" : "tags",
-              "fieldType" : "URN",
-              "filterNameOverride" : "Tag",
-              "hasValuesFieldName" : "hasTags"
-            }
+            "doc" : "Urn of the applied tag"
           }, {
             "name" : "context",
             "type" : "string",
@@ -642,12 +631,20 @@
         }
       },
       "doc" : "Tags associated with a given entity",
+      "Relationship" : {
+        "/*/tag" : {
+          "entityTypes" : [ "tag" ],
+          "name" : "TaggedWith"
+        }
+      },
       "Searchable" : {
         "/*/tag" : {
           "addToFilters" : true,
           "boostScore" : 0.5,
           "fieldName" : "tags",
           "fieldType" : "URN",
+          "filterNameOverride" : "Tag",
+          "hasValuesFieldName" : "hasTags",
           "queryByDefault" : true
         }
       }
@@ -2489,6 +2486,7 @@
               "type" : "com.linkedin.dataset.SchemaFieldPath",
               "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
               "Searchable" : {
+                "boostScore" : 5.0,
                 "fieldName" : "fieldPaths",
                 "fieldType" : "TEXT"
               }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -842,18 +842,7 @@
                 }
               }
             },
-            "doc" : "Urn of the applied tag",
-            "Relationship" : {
-              "entityTypes" : [ "tag" ],
-              "name" : "TaggedWith"
-            },
-            "Searchable" : {
-              "addToFilters" : true,
-              "fieldName" : "tags",
-              "fieldType" : "URN",
-              "filterNameOverride" : "Tag",
-              "hasValuesFieldName" : "hasTags"
-            }
+            "doc" : "Urn of the applied tag"
           }, {
             "name" : "context",
             "type" : "string",
@@ -863,12 +852,20 @@
         }
       },
       "doc" : "Tags associated with a given entity",
+      "Relationship" : {
+        "/*/tag" : {
+          "entityTypes" : [ "tag" ],
+          "name" : "TaggedWith"
+        }
+      },
       "Searchable" : {
         "/*/tag" : {
           "addToFilters" : true,
           "boostScore" : 0.5,
           "fieldName" : "tags",
           "fieldType" : "URN",
+          "filterNameOverride" : "Tag",
+          "hasValuesFieldName" : "hasTags",
           "queryByDefault" : true
         }
       }
@@ -3098,6 +3095,7 @@
                           "type" : "com.linkedin.dataset.SchemaFieldPath",
                           "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
                           "Searchable" : {
+                            "boostScore" : 5.0,
                             "fieldName" : "fieldPaths",
                             "fieldType" : "TEXT"
                           }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -357,9 +357,25 @@ public interface EntityClient {
   public VersionedAspect getAspectOrNull(@Nonnull String urn, @Nonnull String aspect, @Nonnull Long version,
       @Nonnull Authentication authentication) throws RemoteInvocationException;
 
+  default List<EnvelopedAspect> getTimeseriesAspectValues(@Nonnull String urn, @Nonnull String entity,
+      @Nonnull String aspect, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit,
+      @Nullable Filter filter, @Nonnull Authentication authentication)
+      throws RemoteInvocationException {
+    return getTimeseriesAspectValues(
+        urn,
+        entity,
+        aspect,
+        startTimeMillis,
+        endTimeMillis,
+        limit,
+        filter,
+        null,
+        authentication);
+  }
+
   public List<EnvelopedAspect> getTimeseriesAspectValues(@Nonnull String urn, @Nonnull String entity,
       @Nonnull String aspect, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit,
-      @Nullable Boolean getLatestValue, @Nullable Filter filter, @Nonnull Authentication authentication)
+      @Nullable Filter filter, @Nullable SortCriterion sort, @Nonnull Authentication authentication)
       throws RemoteInvocationException;
 
   @Deprecated

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -714,15 +714,14 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   @Nonnull
   public List<EnvelopedAspect> getTimeseriesAspectValues(@Nonnull String urn, @Nonnull String entity,
       @Nonnull String aspect, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit,
-      @Nullable Boolean getLatestValue, @Nullable Filter filter, @Nonnull final Authentication authentication)
+      @Nullable Filter filter, @Nullable SortCriterion sort, @Nonnull final Authentication authentication)
       throws RemoteInvocationException {
 
     AspectsDoGetTimeseriesAspectValuesRequestBuilder requestBuilder =
         ASPECTS_REQUEST_BUILDERS.actionGetTimeseriesAspectValues()
             .urnParam(urn)
             .entityParam(entity)
-            .aspectParam(aspect)
-            .latestValueParam(getLatestValue);
+            .aspectParam(aspect);
 
     if (startTimeMillis != null) {
       requestBuilder.startTimeMillisParam(startTimeMillis);
@@ -736,13 +735,13 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.limitParam(limit);
     }
 
-    if (getLatestValue != null) {
-      requestBuilder.latestValueParam(getLatestValue);
-    }
-
     if (filter != null) {
       requestBuilder.filterParam(filter);
     }
+
+    // if (sort != null) {
+    //   requestBuilder.sortParam(sort);
+    // }
 
     return sendClientRequest(requestBuilder, authentication).getEntity().getValues();
   }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -739,9 +739,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       requestBuilder.filterParam(filter);
     }
 
-    // if (sort != null) {
-    //   requestBuilder.sortParam(sort);
-    // }
+    if (sort != null) {
+      requestBuilder.sortParam(sort);
+    }
 
     return sendClientRequest(requestBuilder, authentication).getEntity().getValues();
   }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
 import com.linkedin.metadata.entity.validation.ValidationException;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.restli.RestliUtil;
 import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
@@ -127,8 +128,9 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       @ActionParam(PARAM_START_TIME_MILLIS) @Optional @Nullable Long startTimeMillis,
       @ActionParam(PARAM_END_TIME_MILLIS) @Optional @Nullable Long endTimeMillis,
       @ActionParam(PARAM_LIMIT) @Optional("10000") int limit,
-      @ActionParam(PARAM_LATEST_VALUE) @Optional("false") boolean latestValue,
-      @ActionParam(PARAM_FILTER) @Optional @Nullable Filter filter) throws URISyntaxException {
+      @ActionParam(PARAM_LATEST_VALUE) @Optional("false") boolean latestValue, // This field is deprecated.
+      @ActionParam(PARAM_FILTER) @Optional @Nullable Filter filter,
+      @ActionParam(PARAM_SORT) @Optional @Nullable SortCriterion sort) throws URISyntaxException {
     log.info(
         "Get Timeseries Aspect values for aspect {} for entity {} with startTimeMillis {}, endTimeMillis {} and limit {}.",
         aspectName, entityName, startTimeMillis, endTimeMillis, limit);
@@ -149,10 +151,13 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       if (endTimeMillis != null) {
         response.setEndTimeMillis(endTimeMillis);
       }
-      response.setLimit(limit);
+      if (latestValue) {
+        response.setLimit(1);
+      } else {
+        response.setLimit(limit);
+      }
       response.setValues(new EnvelopedAspectArray(
-          _timeseriesAspectService.getAspectValues(urn, entityName, aspectName, startTimeMillis, endTimeMillis, limit,
-              latestValue, filter)));
+          _timeseriesAspectService.getAspectValues(urn, entityName, aspectName, startTimeMillis, endTimeMillis, limit, filter, sort)));
       return response;
     }, MetricRegistry.name(this.getClass(), "getTimeseriesAspectValues"));
   }


### PR DESCRIPTION
## Summary

Currently, we have a bug where the Operations for a dataset should be sorted descending with respect to time by the "lastUpdatedTimestamp" field of the aspect, which represents the actual time of the Operation. This was previously not possible because when fetching time-series aspects, there was no way to provide a custom sort-order (other than the default of sorting by timestampMillis field descending). 

In this PR, we add the ability to sort by non-timestampMillis fields for any Time-Series Aspects. Additionally, we make a small change to the resolution of Dataset "operations" to sort by the "lastUpdatedTimestamp" by default.

Included other misc refactoring and javadocs, nothing major. Specifically:

1. Remove the "getLatestValue" parameter of the TimeseriesAspectService getAspectValues method. Why? This is a duplicative argument that was already implied by the "limit" parameter of the API. This is to maintain logical consistency and simplicity in the API. 

2. Added test to validate that sorting by the non-timestampMillis field works as expected

3. Misc javadocs added to interface TimeseriesAspectService.java as well as other files. 

4. Misc annotation improvements -> Nonnull, final, etc. 

5. Added bootstrap data - add examples of operation.pdl to bootstrap_mce.pdl 

## Status

Ready for review

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
