### PR TITLE
fix(ui) Disable cache on Domain and Glossary Related Entities pages

### DIFF
--- a/datahub-web-react/src/app/entity/domain/DomainEntitiesTab.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntitiesTab.tsx
@@ -24,6 +24,7 @@ export const DomainEntitiesTab = () => {
             }}
             emptySearchQuery="*"
             placeholderText="Filter domain entities..."
+            skipCache
         />
     );
 };

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryRelatedEntity.tsx
@@ -46,6 +46,7 @@ export default function GlossaryRelatedEntity() {
             }}
             emptySearchQuery="*"
             placeholderText="Filter entities..."
+            skipCache
         />
     );
 }

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -1,7 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { ApolloError } from '@apollo/client';
-import { EntityType, FacetFilterInput, FacetMetadata } from '../../../../../../types.generated';
+import {
+    EntityType,
+    FacetFilterInput,
+    FacetMetadata,
+    SearchAcrossEntitiesInput,
+} from '../../../../../../types.generated';
 import { ENTITY_FILTER_NAME, UnionType } from '../../../../../search/utils/constants';
 import { SearchCfg } from '../../../../../../conf';
 import { EmbeddedListSearchResults } from './EmbeddedListSearchResults';
@@ -73,6 +78,7 @@ type Props = {
     defaultFilters?: Array<FacetFilterInput>;
     searchBarStyle?: any;
     searchBarInputStyle?: any;
+    skipCache?: boolean;
     useGetSearchResults?: (params: GetSearchResultsParams) => {
         data: SearchResultsInterface | undefined | null;
         loading: boolean;
@@ -100,6 +106,7 @@ export const EmbeddedListSearch = ({
     defaultFilters,
     searchBarStyle,
     searchBarInputStyle,
+    skipCache,
     useGetSearchResults = useWrappedSearchResults,
     shouldRefetch,
     resetShouldRefetch,
@@ -146,13 +153,16 @@ export const EmbeddedListSearch = ({
         return refetchForDownload(variables).then((res) => res.data.scrollAcrossEntities);
     };
 
-    const searchInput = {
+    let searchInput: SearchAcrossEntitiesInput = {
         types: entityFilters,
         query: finalQuery,
         start: (page - 1) * numResultsPerPage,
         count: numResultsPerPage,
         orFilters: finalFilters,
     };
+    if (skipCache) {
+        searchInput = { ...searchInput, searchFlags: { skipCache: true } };
+    }
 
     const { data, loading, error, refetch } = useGetSearchResults({
         variables: {

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchSection.tsx
@@ -31,6 +31,7 @@ type Props = {
     defaultFilters?: Array<FacetFilterInput>;
     searchBarStyle?: any;
     searchBarInputStyle?: any;
+    skipCache?: boolean;
     useGetSearchResults?: (params: GetSearchResultsParams) => {
         data: SearchResultsInterface | undefined | null;
         loading: boolean;
@@ -50,6 +51,7 @@ export const EmbeddedListSearchSection = ({
     defaultFilters,
     searchBarStyle,
     searchBarInputStyle,
+    skipCache,
     useGetSearchResults,
     shouldRefetch,
     resetShouldRefetch,
@@ -133,6 +135,7 @@ export const EmbeddedListSearchSection = ({
             defaultFilters={defaultFilters}
             searchBarStyle={searchBarStyle}
             searchBarInputStyle={searchBarInputStyle}
+            skipCache={skipCache}
             useGetSearchResults={useGetSearchResults}
             shouldRefetch={shouldRefetch}
             resetShouldRefetch={resetShouldRefetch}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -82,6 +82,7 @@ const ContentContainer = styled.div`
     height: auto;
     min-height: 100%;
     flex: 1;
+    min-width: 0;
 `;
 
 const HeaderAndTabs = styled.div`

--- a/datahub-web-react/src/app/glossary/GlossaryRoutes.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryRoutes.tsx
@@ -13,6 +13,7 @@ import { useEntityRegistry } from '../useEntityRegistry';
 const ContentWrapper = styled.div`
     display: flex;
     flex: 1;
+    overflow: hidden;
 `;
 
 export default function GlossaryRoutes() {


### PR DESCRIPTION
User's were experiencing bugs with the cache after adding Glossary Terms and Domains to entities and their Related Entities pages not updating. This skips the cache for those two specific pages all the time.

This also fixes a fe UX overflow scrolling issues that I noticed while working on this ticket.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
