### PR TITLE
fix(cli): remove duplicate keys in docker-compose quickstart file

### DIFF
--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -95,8 +95,6 @@ services:
     volumes:
     - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   datahub-upgrade:
-    labels:
-      datahub_setup_job: true
     command:
     - -u
     - SystemUpdate
@@ -143,8 +141,6 @@ services:
     volumes:
     - esdata:/usr/share/elasticsearch/data
   elasticsearch-setup:
-    labels:
-      datahub_setup_job: true
     container_name: elasticsearch-setup
     depends_on:
     - elasticsearch
@@ -157,8 +153,6 @@ services:
     labels:
       datahub_setup_job: true
   kafka-setup:
-    labels:
-      datahub_setup_job: true
     container_name: kafka-setup
     depends_on:
     - broker
@@ -187,8 +181,6 @@ services:
     - ../mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
     - mysqldata:/var/lib/mysql
   mysql-setup:
-    labels:
-      datahub_setup_job: true
     container_name: mysql-setup
     depends_on:
     - mysql


### PR DESCRIPTION
This partially reverts 1d3339276129a7cb8385c07a958fcc93acda3b4e

That commit duplicated some `labels` keys, resulting in errors when running `datahub docker quickstart`:

![image](https://user-images.githubusercontent.com/8766565/233600362-e3e382e5-2b6e-41f8-9fe9-f4e181bfd944.png)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
