### PR TITLE
fix(docker-compose): make startup more robust with deterministic services' dependencies

### DIFF
--- a/docker/docker-compose-with-cassandra.yml
+++ b/docker/docker-compose-with-cassandra.yml
@@ -4,158 +4,203 @@
 
 # NOTE: This file does not build! No dockerfiles are set. See the README.md in this directory.
 ---
-version: '3.8'
+version: '3.9'
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.2
-    env_file: zookeeper/env/docker.env
-    hostname: zookeeper
-    container_name: zookeeper
+  datahub-frontend-react:
+    container_name: datahub-frontend-react
+    hostname: datahub-frontend-react
+    image: ${DATAHUB_FRONTEND_IMAGE:-linkedin/datahub-frontend-react}:${DATAHUB_VERSION:-head}
     ports:
-      - "2181:2181"
-    volumes:
-      - zkdata:/var/lib/zookeeper
-
-  broker:
-    image: confluentinc/cp-kafka:7.2.2
-    env_file: broker/env/docker.env
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
-    ports:
-      - "29092:29092"
-      - "9092:9092"
-    volumes:
-      - broker:/var/lib/kafka/data/
-
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.2
-    env_file: schema-registry/env/docker.env
-    hostname: schema-registry
-    container_name: schema-registry
-    depends_on:
-      - broker
-    ports:
-      - ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}:8081
-
-  elasticsearch:
-    image: elasticsearch:7.10.1
-    env_file: elasticsearch/env/docker.env
-    container_name: elasticsearch
-    hostname: elasticsearch
-    ports:
-      - "9200:9200"
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1"]
-      start_period: 2m
-      retries: 4
-
-  neo4j:
-    image: neo4j:4.0.6
-    env_file: neo4j/env/docker.env
-    hostname: neo4j
-    container_name: neo4j
-    ports:
-      - "7474:7474"
-      - "7687:7687"
-    volumes:
-      - neo4jdata:/data
-
-  # This "container" is a workaround to pre-create search indices
-  elasticsearch-setup:
+      - 9002:9002
     build:
       context: ../
-      dockerfile: docker/elasticsearch-setup/Dockerfile
-    image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
-    env_file: elasticsearch-setup/env/docker.env
-    hostname: elasticsearch-setup
-    container_name: elasticsearch-setup
+      dockerfile: docker/datahub-frontend/Dockerfile
+    env_file: datahub-frontend/env/docker.env
     depends_on:
-      - elasticsearch
-
-  cassandra:
-    container_name: cassandra
-    hostname: cassandra
-    image: cassandra:3.11
-    ports:
-      - '9042:9042'
-    healthcheck:
-      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
+      datahub-gms:
+        condition: service_healthy
     volumes:
-      - cassandradata:/var/lib/cassandra
-
+      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+  datahub-actions:
+    container_name: datahub-actions
+    hostname: actions
+    image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
+    env_file: datahub-actions/env/docker.env
+    depends_on:
+      datahub-gms:
+        condition: service_healthy
+  datahub-gms:
+    container_name: datahub-gms
+    hostname: datahub-gms
+    image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
+    ports:
+      - 8080:8080
+    build:
+        context: ../
+        dockerfile: docker/datahub-gms/Dockerfile
+    env_file: ./datahub-gms/env/docker.cassandra.env
+    healthcheck:
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      start_period: 20s
+      interval: 1s
+      retries: 20
+      timeout: 5s
+    depends_on:
+      datahub-upgrade:
+        condition: service_completed_successfully
+    volumes:
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+  datahub-upgrade:
+    container_name: datahub-upgrade
+    hostname: datahub-upgrade
+    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    command:
+    - -u
+    - SystemUpdate
+    build:
+      context: ../
+      dockerfile: docker/datahub-upgrade/Dockerfile
+    env_file: datahub-upgrade/env/docker-without-neo4j.env
+    depends_on:
+      cassandra-setup:
+        condition: service_completed_successfully
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      neo4j:
+        condition: service_healthy
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
   cassandra-setup:
     container_name: cassandra-setup
+    hostname: cassandra-setup
     image: cassandra:3.11
+    command: /bin/bash -c "cqlsh cassandra -f /init.cql"
     depends_on:
       cassandra:
         condition: service_healthy
     volumes:
       - ./cassandra/init.cql:/init.cql
-    command: /bin/bash -c "cqlsh cassandra -f /init.cql"
-
-  datahub-gms:
-    build:
-        context: ../
-        dockerfile: docker/datahub-gms/Dockerfile
-    image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
-    env_file: ./datahub-gms/env/docker.cassandra.env
-    hostname: datahub-gms
-    container_name: datahub-gms
-    ports:
-      - "8080:8080"
-    depends_on:
-      - neo4j
-
-  datahub-frontend-react:
+    labels:
+      datahub_setup_job: true
+  # This "container" is a workaround to pre-create search indices
+  elasticsearch-setup:
+    container_name: elasticsearch-setup
+    hostname: elasticsearch-setup
+    image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
     build:
       context: ../
-      dockerfile: docker/datahub-frontend/Dockerfile
-    image: ${DATAHUB_FRONTEND_IMAGE:-linkedin/datahub-frontend-react}:${DATAHUB_VERSION:-head}
-    env_file: datahub-frontend/env/docker.env
-    hostname: datahub-frontend-react
-    container_name: datahub-frontend-react
-    ports:
-      - "9002:9002"
+      dockerfile: docker/elasticsearch-setup/Dockerfile
+    env_file: elasticsearch-setup/env/docker.env
     depends_on:
-      - datahub-gms
+      elasticsearch:
+        condition: service_healthy
+    labels:
+      datahub_setup_job: true
+  cassandra:
+    container_name: cassandra
+    hostname: cassandra
+    image: cassandra:3.11
+    ports:
+      - 9042:9042
+    healthcheck:
+      test: cqlsh -u cassandra -p cassandra -e describe keyspaces
+      interval: 15s
+      timeout: 10s
+      retries: 10
     volumes:
-      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
-
-  datahub-actions:
-    image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
-    hostname: actions
-    env_file: datahub-actions/env/docker.env
-    restart: on-failure:5
+      - cassandradata:/var/lib/cassandra
+  elasticsearch:
+    container_name: elasticsearch
+    hostname: elasticsearch
+    image: elasticsearch:7.10.1
+    ports:
+      - 9200:9200
+    env_file: elasticsearch/env/docker.env
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    healthcheck:
+      test: curl -sS --fail http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=0s
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+  neo4j:
+    container_name: neo4j
+    hostname: neo4j
+    image: neo4j:4.0.6
+    ports:
+      - 7474:7474
+      - 7687:7687
+    env_file: neo4j/env/docker.env
+    healthcheck:
+      test: wget http://neo4j:7474
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - neo4jdata:/data
+  schema-registry:
+    container_name: schema-registry
+    hostname: schema-registry
+    image: confluentinc/cp-schema-registry:7.2.2
+    ports:
+      - ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}:8081
+    env_file: schema-registry/env/docker.env
+    healthcheck:
+      test: nc -z schema-registry 8081
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
     depends_on:
-      - datahub-gms
-
-  datahub-upgrade:
-    build:
-      context: ../
-      dockerfile: docker/datahub-upgrade/Dockerfile
-    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
-    env_file: datahub-upgrade/env/docker-without-neo4j.env
-    hostname: datahub-upgrade
-    container_name: datahub-upgrade
-    command: [ "-u", "SystemUpdate" ]
-
+      broker:
+        condition: service_healthy
+  broker:
+    container_name: broker
+    hostname: broker
+    image: confluentinc/cp-kafka:7.2.2
+    ports:
+      - 29092:29092
+      - 9092:9092
+    env_file: broker/env/docker.env
+    healthcheck:
+      test: nc -z broker 9092
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    volumes:
+      - broker:/var/lib/kafka/data/
+  zookeeper:
+    container_name: zookeeper
+    hostname: zookeeper
+    image: confluentinc/cp-zookeeper:7.2.2
+    ports:
+      - 2181:2181
+    env_file: zookeeper/env/docker.env
+    healthcheck:
+      test: echo srvr | nc zookeeper 2181
+      start_period: 2s
+      interval: 5s
+      retries: 5
+      timeout: 5s
+    volumes:
+      - zkdata:/var/lib/zookeeper
 networks:
   default:
     name: datahub_network
-
 volumes:
   cassandradata:
   esdata:
   neo4jdata:
-  zkdata:
   broker:
+  zkdata:

--- a/docker/docker-compose-without-neo4j.override.yml
+++ b/docker/docker-compose-without-neo4j.override.yml
@@ -1,54 +1,67 @@
 ---
-version: '3.8'
+version: '3.9'
 services:
+  datahub-gms:
+    env_file: datahub-gms/env/docker-without-neo4j.env
+    environment:
+      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
+      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
+    depends_on:
+      datahub-upgrade:
+        condition: service_completed_successfully
+    volumes:
+      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+  datahub-upgrade:
+    container_name: datahub-upgrade
+    hostname: datahub-upgrade
+    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    command:
+    - -u
+    - SystemUpdate
+    build:
+      context: ../
+      dockerfile: docker/datahub-upgrade/Dockerfile
+    env_file: datahub-upgrade/env/docker-without-neo4j.env
+    depends_on:
+      mysql-setup:
+        condition: service_completed_successfully
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+  mysql-setup:
+    container_name: mysql-setup
+    hostname: mysql-setup
+    image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
+    build:
+      context: ../
+      dockerfile: docker/mysql-setup/Dockerfile
+    env_file: mysql-setup/env/docker.env
+    depends_on:
+      mysql:
+        condition: service_healthy
+    labels:
+      datahub_setup_job: true
+  kafka-setup:
+    environment:
+      - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
   mysql:
     container_name: mysql
     hostname: mysql
     image: mysql:5.7
-    env_file: mysql/env/docker.env
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
     ports:
       - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    env_file: mysql/env/docker.env
+    restart: on-failure
+    healthcheck:
+      test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      start_period: 2s
+      interval: 1s
+      retries: 5
+      timeout: 5s
     volumes:
       - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - mysqldata:/var/lib/mysql
-
-  mysql-setup:
-    labels:
-      datahub_setup_job: true
-    build:
-      context: ../
-      dockerfile: docker/mysql-setup/Dockerfile
-    image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
-    env_file: mysql-setup/env/docker.env
-    hostname: mysql-setup
-    container_name: mysql-setup
-    depends_on:
-      - mysql
-
-  kafka-setup:
-    environment:
-      - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
-
-  datahub-gms:
-    env_file: datahub-gms/env/docker-without-neo4j.env
-    depends_on:
-      - mysql
-    environment:
-      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
-      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
-    volumes:
-      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
-
-  datahub-upgrade:
-    build:
-      context: ../
-      dockerfile: docker/datahub-upgrade/Dockerfile
-    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
-    env_file: datahub-upgrade/env/docker-without-neo4j.env
-    hostname: datahub-upgrade
-    container_name: datahub-upgrade
-    command: ["-u", "SystemUpdate"]
-
 volumes:
   mysqldata:

--- a/docker/docker-compose-without-neo4j.yml
+++ b/docker/docker-compose-without-neo4j.yml
@@ -4,135 +4,177 @@
 
 # NOTE: This file will cannot build! No dockerfiles are set. See the README.md in this directory.
 ---
-version: '3.8'
+version: '3.9'
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.2
-    env_file: zookeeper/env/docker.env
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
-    volumes:
-      - zkdata:/var/lib/zookeeper
-
-  broker:
-    image: confluentinc/cp-kafka:7.2.2
-    env_file: broker/env/docker.env
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
-    ports:
-      - ${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}:9092
-
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.2
-    env_file: schema-registry/env/docker.env
-    hostname: schema-registry
-    container_name: schema-registry
-    depends_on:
-      - broker
-    ports:
-      - ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}:8081
-
-  elasticsearch:
-    image: elasticsearch:7.10.1
-    env_file: elasticsearch/env/docker.env
-    container_name: elasticsearch
-    hostname: elasticsearch
-    ports:
-      - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
-    healthcheck:
-        test: ["CMD-SHELL", "curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1"]
-        start_period: 2m
-        retries: 4
-
-  # This "container" is a workaround to pre-create search indices
-  elasticsearch-setup:
-    labels:
-      datahub_setup_job: true
-    build:
-      context: ../
-      dockerfile: docker/elasticsearch-setup/Dockerfile
-    image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
-    env_file: elasticsearch-setup/env/docker.env
-    hostname: elasticsearch-setup
-    container_name: elasticsearch-setup
-    depends_on:
-      - elasticsearch
-
-  datahub-gms:
-    build:
-        context: ../
-        dockerfile: docker/datahub-gms/Dockerfile
-    image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
-    env_file: datahub-gms/env/docker-without-neo4j.env
-    hostname: datahub-gms
-    container_name: datahub-gms
-    ports:
-      - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
-    depends_on:
-      - mysql
-
   datahub-frontend-react:
+    container_name: datahub-frontend-react
+    hostname: datahub-frontend-react
+    image: ${DATAHUB_FRONTEND_IMAGE:-linkedin/datahub-frontend-react}:${DATAHUB_VERSION:-head}
+    ports:
+    - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
     build:
       context: ../
       dockerfile: docker/datahub-frontend/Dockerfile
-    image: ${DATAHUB_FRONTEND_IMAGE:-linkedin/datahub-frontend-react}:${DATAHUB_VERSION:-head}
     env_file: datahub-frontend/env/docker.env
-    hostname: datahub-frontend-react
-    container_name: datahub-frontend-react
-    ports:
-      - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
     depends_on:
-      - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     volumes:
-      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
 
   datahub-actions:
-    image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
+    container_name: datahub-actions
     hostname: actions
+    image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
     env_file: datahub-actions/env/docker.env
-    restart: on-failure:5
     depends_on:
-      - datahub-gms
-
-  kafka-setup:
-    labels:
-      datahub_setup_job: true
+      datahub-gms:
+        condition: service_healthy
+  datahub-gms:
+    container_name: datahub-gms
+    hostname: datahub-gms
+    image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
+    ports:
+    - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
     build:
-      dockerfile: ./docker/kafka-setup/Dockerfile
-      context: ../
-    image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
-    env_file: kafka-setup/env/docker.env
-    hostname: kafka-setup
-    container_name: kafka-setup
+        context: ../
+        dockerfile: docker/datahub-gms/Dockerfile
+    env_file: datahub-gms/env/docker-without-neo4j.env
+    healthcheck:
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      start_period: 20s
+      interval: 1s
+      retries: 20
+      timeout: 5s
     depends_on:
-      - broker
-      - schema-registry
-
+      datahub-upgrade:
+        condition: service_completed_successfully
+    volumes:
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   datahub-upgrade:
-    labels:
-      datahub_setup_job: true
+    container_name: datahub-upgrade
+    hostname: datahub-upgrade
+    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    command:
+    - -u
+    - SystemUpdate
     build:
       context: ../
       dockerfile: docker/datahub-upgrade/Dockerfile
-    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
     env_file: datahub-upgrade/env/docker-without-neo4j.env
-    hostname: datahub-upgrade
-    container_name: datahub-upgrade
-    command: ["-u", "SystemUpdate"]
-
+    depends_on:
+      mysql-setup:
+        condition: service_completed_successfully
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+    labels:
+      datahub_setup_job: true
+  # This "container" is a workaround to pre-create search indices
+  elasticsearch-setup:
+    container_name: elasticsearch-setup
+    hostname: elasticsearch-setup
+    image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
+    build:
+      context: ../
+      dockerfile: docker/elasticsearch-setup/Dockerfile
+    env_file: elasticsearch-setup/env/docker.env
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    labels:
+      datahub_setup_job: true
+  kafka-setup:
+    container_name: kafka-setup
+    hostname: kafka-setup
+    image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
+    build:
+      dockerfile: ./docker/kafka-setup/Dockerfile
+      context: ../
+    env_file: kafka-setup/env/docker.env
+    depends_on:
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
+    labels:
+      datahub_setup_job: true
+  elasticsearch:
+    container_name: elasticsearch
+    hostname: elasticsearch
+    image: elasticsearch:7.10.1
+    ports:
+    - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
+    env_file: elasticsearch/env/docker.env
+    environment:
+    - discovery.type=single-node
+    - xpack.security.enabled=false
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    healthcheck:
+      test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    volumes:
+    - esdata:/usr/share/elasticsearch/data
+  schema-registry:
+    container_name: schema-registry
+    hostname: schema-registry
+    image: confluentinc/cp-schema-registry:7.2.2
+    ports:
+    - ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}:8081
+    env_file: schema-registry/env/docker.env
+    healthcheck:
+      test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    depends_on:
+      broker:
+        condition: service_healthy
+  broker:
+    container_name: broker
+    hostname: broker
+    image: confluentinc/cp-kafka:7.2.2
+    ports:
+    - ${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}:9092
+    env_file: broker/env/docker.env
+    healthcheck:
+      test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    volumes:
+    - broker:/var/lib/kafka/data/
+  zookeeper:
+    container_name: zookeeper
+    hostname: zookeeper
+    image: confluentinc/cp-zookeeper:7.2.2
+    ports:
+    - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
+    env_file: zookeeper/env/docker.env
+    healthcheck:
+      test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
+      start_period: 2s
+      interval: 5s
+      retries: 5
+      timeout: 5s
+    volumes:
+    - zkdata:/var/lib/zookeeper
 networks:
   default:
     name: datahub_network
-
 volumes:
   esdata:
+  broker:
   zkdata:

--- a/docker/docker-compose.consumers-without-neo4j.yml
+++ b/docker/docker-compose.consumers-without-neo4j.yml
@@ -1,32 +1,30 @@
 # Service definitions for standalone Kafka consumer containers.
-version: '3.8'
+version: '3.9'
 services:
   datahub-gms:
     environment:
-      - MAE_CONSUMER_ENABLED=false
-      - MCE_CONSUMER_ENABLED=false
-
+    - MAE_CONSUMER_ENABLED=false
+    - MCE_CONSUMER_ENABLED=false
   datahub-mae-consumer:
+    container_name: datahub-mae-consumer
+    hostname: datahub-mae-consumer
+    image: ${DATAHUB_MAE_CONSUMER_IMAGE:-linkedin/datahub-mae-consumer}:${DATAHUB_VERSION:-head}
+    ports:
+    - 9091:9091
     build:
       context: ../
       dockerfile: docker/datahub-mae-consumer/Dockerfile
-    image: ${DATAHUB_MAE_CONSUMER_IMAGE:-linkedin/datahub-mae-consumer}:${DATAHUB_VERSION:-head}
     env_file: datahub-mae-consumer/env/docker-without-neo4j.env
-    hostname: datahub-mae-consumer
-    container_name: datahub-mae-consumer
-    ports:
-      - "9091:9091"
-
   datahub-mce-consumer:
+    container_name: datahub-mce-consumer
+    hostname: datahub-mce-consumer
+    image: ${DATAHUB_MCE_CONSUMER_IMAGE:-linkedin/datahub-mce-consumer}:${DATAHUB_VERSION:-head}
+    ports:
+    - 9090:9090
     build:
       context: ../
       dockerfile: docker/datahub-mce-consumer/Dockerfile
-    image: ${DATAHUB_MCE_CONSUMER_IMAGE:-linkedin/datahub-mce-consumer}:${DATAHUB_VERSION:-head}
     env_file: datahub-mce-consumer/env/docker-without-neo4j.env
-    hostname: datahub-mce-consumer
-    container_name: datahub-mce-consumer
     environment:
-      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
-      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
-    ports:
-      - "9090:9090"
+    - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
+    - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}

--- a/docker/docker-compose.consumers.dev.yml
+++ b/docker/docker-compose.consumers.dev.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.9'
 services:
   datahub-mae-consumer:
     image: linkedin/datahub-mae-consumer:debug
@@ -8,11 +8,10 @@ services:
       args:
         APP_ENV: dev
     volumes:
-      - ./datahub-mae-consumer/start.sh:/datahub/datahub-mae-consumer/scripts/start.sh
-      - ../metadata-models/src/main/resources/:/datahub/datahub-mae-consumer/resources
-      - ../metadata-jobs/mae-consumer-job/build/libs/:/datahub/datahub-mae-consumer/bin/
-      - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-mae-consumer/scripts/prometheus-config.yaml
-
+    - ./datahub-mae-consumer/start.sh:/datahub/datahub-mae-consumer/scripts/start.sh
+    - ../metadata-models/src/main/resources/:/datahub/datahub-mae-consumer/resources
+    - ../metadata-jobs/mae-consumer-job/build/libs/:/datahub/datahub-mae-consumer/bin/
+    - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-mae-consumer/scripts/prometheus-config.yaml
   datahub-mce-consumer:
     image: linkedin/datahub-mce-consumer:debug
     build:
@@ -21,6 +20,6 @@ services:
       args:
         APP_ENV: dev
     volumes:
-      - ./datahub-mce-consumer/start.sh:/datahub/datahub-mce-consumer/scripts/start.sh
-      - ../metadata-jobs/mce-consumer-job/build/libs/:/datahub/datahub-mce-consumer/bin
-      - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-mce-consumer/scripts/prometheus-config.yaml
+    - ./datahub-mce-consumer/start.sh:/datahub/datahub-mce-consumer/scripts/start.sh
+    - ../metadata-jobs/mce-consumer-job/build/libs/:/datahub/datahub-mce-consumer/bin
+    - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-mce-consumer/scripts/prometheus-config.yaml

--- a/docker/docker-compose.consumers.yml
+++ b/docker/docker-compose.consumers.yml
@@ -1,41 +1,41 @@
 # Service definitions for standalone Kafka consumer containers.
-version: '3.8'
+version: '3.9'
 services:
   datahub-gms:
     environment:
-      - MAE_CONSUMER_ENABLED=false
-      - MCE_CONSUMER_ENABLED=false
-
+    - MAE_CONSUMER_ENABLED=false
+    - MCE_CONSUMER_ENABLED=false
   datahub-mae-consumer:
+    container_name: datahub-mae-consumer
+    hostname: datahub-mae-consumer
+    image: ${DATAHUB_MAE_CONSUMER_IMAGE:-linkedin/datahub-mae-consumer}:${DATAHUB_VERSION:-head}
+    ports:
+    - 9091:9091
     build:
       context: ../
       dockerfile: docker/datahub-mae-consumer/Dockerfile
-    image: ${DATAHUB_MAE_CONSUMER_IMAGE:-linkedin/datahub-mae-consumer}:${DATAHUB_VERSION:-head}
     env_file: datahub-mae-consumer/env/docker.env
-    hostname: datahub-mae-consumer
-    container_name: datahub-mae-consumer
-    ports:
-      - "9091:9091"
     depends_on:
-      - neo4j
-
+      neo4j:
+        condition: service_healthy
   datahub-mce-consumer:
+    container_name: datahub-mce-consumer
+    hostname: datahub-mce-consumer
+    image: ${DATAHUB_MCE_CONSUMER_IMAGE:-linkedin/datahub-mce-consumer}:${DATAHUB_VERSION:-head}
+    ports:
+    - 9090:9090
     build:
       context: ../
       dockerfile: docker/datahub-mce-consumer/Dockerfile
-    image: ${DATAHUB_MCE_CONSUMER_IMAGE:-linkedin/datahub-mce-consumer}:${DATAHUB_VERSION:-head}
     env_file: datahub-mce-consumer/env/docker.env
-    hostname: datahub-mce-consumer
-    container_name: datahub-mce-consumer
     environment:
-      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
-      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
-      - NEO4J_HOST=http://neo4j:7474
-      - NEO4J_URI=bolt://neo4j
-      - NEO4J_USERNAME=neo4j
-      - NEO4J_PASSWORD=datahub
-      - GRAPH_SERVICE_IMPL=neo4j
-    ports:
-      - "9090:9090"
+    - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
+    - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
+    - NEO4J_HOST=http://neo4j:7474
+    - NEO4J_URI=bolt://neo4j
+    - NEO4J_USERNAME=neo4j
+    - NEO4J_PASSWORD=datahub
+    - GRAPH_SERVICE_IMPL=neo4j
     depends_on:
-      - neo4j
+      neo4j:
+        condition: service_healthy

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,8 +8,64 @@
 # To make a JVM app debuggable via IntelliJ, go to its env file and add JVM debug flags, and then add the JVM debug
 # port to this file.
 ---
-version: '3.8'
+version: '3.9'
 services:
+  datahub-frontend-react:
+    image: linkedin/datahub-frontend-react:debug
+    ports:
+    - ${DATAHUB_MAPPED_FRONTEND_DEBUG_PORT:-5002}:5002
+    - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
+    build:
+      context: ../
+      dockerfile: docker/datahub-frontend/Dockerfile
+      args:
+        APP_ENV: dev
+    environment:
+    - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5002
+    - DATAHUB_ANALYTICS_ENABLED=${DATAHUB_ANALYTICS_ENABLED:-true}
+    volumes:
+    - ../datahub-frontend/build/stage/playBinary:/datahub-frontend
+  datahub-gms:
+    image: linkedin/datahub-gms:debug
+    ports:
+    - ${DATAHUB_MAPPED_GMS_DEBUG_PORT:-5001}:5001
+    - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
+    build:
+      context: datahub-gms
+      dockerfile: Dockerfile
+      args:
+        APP_ENV: dev
+    environment:
+    - SKIP_ELASTICSEARCH_CHECK=false
+    - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-dev}
+    - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
+    - METADATA_SERVICE_AUTH_ENABLED=false
+    - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5001
+    - BOOTSTRAP_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE=false
+    - SEARCH_SERVICE_ENABLE_CACHE=false
+    - LINEAGE_SEARCH_CACHE_ENABLED=false
+    volumes:
+    - ./datahub-gms/start.sh:/datahub/datahub-gms/scripts/start.sh
+    - ./datahub-gms/jetty.xml:/datahub/datahub-gms/scripts/jetty.xml
+    - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-gms/scripts/prometheus-config.yaml
+    - ../metadata-models/src/main/resources/:/datahub/datahub-gms/resources
+    - ../metadata-service/war/build/libs/:/datahub/datahub-gms/bin
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+  datahub-upgrade:
+    image: acryldata/datahub-upgrade:debug
+    build:
+      context: datahub-upgrade
+      dockerfile: Dockerfile
+      args:
+        APP_ENV: dev
+    environment:
+    - SKIP_ELASTICSEARCH_CHECK=false
+    - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-dev}
+    - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
+    volumes:
+    - ../datahub-upgrade/build/libs/:/datahub/datahub-upgrade/bin/
+    - ../metadata-models/src/main/resources/:/datahub/datahub-gms/resources
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   # Pre-creates the search indices using local mapping/settings.json
   elasticsearch-setup:
     image: linkedin/datahub-elasticsearch-setup:debug
@@ -19,66 +75,8 @@ services:
       args:
         APP_ENV: dev
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     volumes:
-      - ./elasticsearch-setup/create-indices.sh:/create-indices.sh
-      - ../metadata-service/restli-servlet-impl/src/main/resources/index/:/index
-
-  datahub-gms:
-    image: linkedin/datahub-gms:debug
-    build:
-      context: datahub-gms
-      dockerfile: Dockerfile
-      args:
-        APP_ENV: dev
-    ports:
-      - ${DATAHUB_MAPPED_GMS_DEBUG_PORT:-5001}:5001
-      - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
-    environment:
-      - SKIP_ELASTICSEARCH_CHECK=false
-      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-dev}
-      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
-      - METADATA_SERVICE_AUTH_ENABLED=false
-      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5001
-      - BOOTSTRAP_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE=false
-      - SEARCH_SERVICE_ENABLE_CACHE=false
-      - LINEAGE_SEARCH_CACHE_ENABLED=false
-    volumes:
-      - ./datahub-gms/start.sh:/datahub/datahub-gms/scripts/start.sh
-      - ./datahub-gms/jetty.xml:/datahub/datahub-gms/scripts/jetty.xml
-      - ./monitoring/client-prometheus-config.yaml:/datahub/datahub-gms/scripts/prometheus-config.yaml
-      - ../metadata-models/src/main/resources/:/datahub/datahub-gms/resources
-      - ../metadata-service/war/build/libs/:/datahub/datahub-gms/bin
-      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
-
-  datahub-frontend-react:
-    image: linkedin/datahub-frontend-react:debug
-    build:
-      context: ../
-      dockerfile: docker/datahub-frontend/Dockerfile
-      args:
-        APP_ENV: dev
-    ports:
-      - ${DATAHUB_MAPPED_FRONTEND_DEBUG_PORT:-5002}:5002
-      - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
-    environment:
-      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5002
-      - DATAHUB_ANALYTICS_ENABLED=${DATAHUB_ANALYTICS_ENABLED:-true}
-    volumes:
-      - ../datahub-frontend/build/stage/playBinary:/datahub-frontend
-
-  datahub-upgrade:
-    image: acryldata/datahub-upgrade:debug
-    build:
-      context: datahub-upgrade
-      dockerfile: Dockerfile
-      args:
-        APP_ENV: dev
-    environment:
-      - SKIP_ELASTICSEARCH_CHECK=false
-      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-dev}
-      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
-    volumes:
-      - ../datahub-upgrade/build/libs/:/datahub/datahub-upgrade/bin/
-      - ../metadata-models/src/main/resources/:/datahub/datahub-gms/resources
-      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+    - ./elasticsearch-setup/create-indices.sh:/create-indices.sh
+    - ../metadata-service/restli-servlet-impl/src/main/resources/index/:/index

--- a/docker/docker-compose.kafka-setup.yml
+++ b/docker/docker-compose.kafka-setup.yml
@@ -1,4 +1,3 @@
 # Empty docker compose for kafka-setup as we have moved kafka-setup back into the main compose
-version: '3.8'
+version: '3.9'
 services:
-

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,46 +1,47 @@
 # Default override to use MySQL as a backing store for datahub-gms (same as docker-compose.mysql.yml).
 ---
-version: '3.8'
+version: '3.9'
 services:
+  datahub-gms:
+    env_file: datahub-gms/env/docker.env
+    environment:
+    - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
+    - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
+    volumes:
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+  mysql-setup:
+    container_name: mysql-setup
+    hostname: mysql-setup
+    image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
+    build:
+      context: ../
+      dockerfile: docker/mysql-setup/Dockerfile
+    env_file: mysql-setup/env/docker.env
+    depends_on:
+      mysql:
+        condition: service_healthy
+    labels:
+      datahub_setup_job: true
+  kafka-setup:
+    environment:
+    - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
   mysql:
     container_name: mysql
     hostname: mysql
     image: mysql:5.7
-    env_file: mysql/env/docker.env
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --default-authentication-plugin=mysql_native_password
     ports:
-      - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    env_file: mysql/env/docker.env
+    restart: on-failure
+    healthcheck:
+      test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      start_period: 2s
+      interval: 1s
+      retries: 5
+      timeout: 5s
     volumes:
-      - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - mysqldata:/var/lib/mysql
-
-  mysql-setup:
-    labels:
-      datahub_setup_job: true
-    build:
-      context: ../
-      dockerfile: docker/mysql-setup/Dockerfile
-    image: ${DATAHUB_MYSQL_SETUP_IMAGE:-acryldata/datahub-mysql-setup}:${DATAHUB_VERSION:-head}
-    env_file: mysql-setup/env/docker.env
-    hostname: mysql-setup
-    container_name: mysql-setup
-    depends_on:
-      - mysql
-
-  datahub-gms:
-    env_file: datahub-gms/env/docker.env
-    depends_on:
-      - mysql
-    environment:
-      - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
-      - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
-    volumes:
-      - ${HOME}/.datahub/plugins/:/etc/datahub/plugins
-      - ${HOME}/.datahub/plugins/auth/resources/:/etc/datahub/plugins/auth/resources
-
-  kafka-setup:
-    environment:
-      - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
-
+    - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    - mysqldata:/var/lib/mysql
 volumes:
   mysqldata:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,153 +4,197 @@
 
 # NOTE: This file does not build! No dockerfiles are set. See the README.md in this directory.
 ---
-version: '3.8'
+version: '3.9'
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.2.2
-    env_file: zookeeper/env/docker.env
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
-    volumes:
-      - zkdata:/var/lib/zookeeper
-
-  broker:
-    image: confluentinc/cp-kafka:7.2.2
-    env_file: broker/env/docker.env
-    hostname: broker
-    container_name: broker
-    depends_on:
-      - zookeeper
-    ports:
-      - ${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}:9092
-    volumes:
-      - broker:/var/lib/kafka/data/
-
-  schema-registry:
-    image: confluentinc/cp-schema-registry:7.2.2
-    env_file: schema-registry/env/docker.env
-    hostname: schema-registry
-    container_name: schema-registry
-    depends_on:
-      - broker
-    ports:
-      - ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}:8081
-
-  elasticsearch:
-    image: elasticsearch:7.10.1
-    env_file: elasticsearch/env/docker.env
-    container_name: elasticsearch
-    hostname: elasticsearch
-    ports:
-      - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
-    environment:
-      - discovery.type=single-node
-      - xpack.security.enabled=false
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
-    healthcheck:
-        test: ["CMD-SHELL", "curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1"]
-        start_period: 2m
-        retries: 4
-
-  neo4j:
-    image: neo4j:4.4.9-community
-    env_file: neo4j/env/docker.env
-    hostname: neo4j
-    container_name: neo4j
-    ports:
-      - ${DATAHUB_MAPPED_NEO4J_HTTP_PORT:-7474}:7474
-      - ${DATAHUB_MAPPED_NEO4J_BOLT_PORT:-7687}:7687
-    volumes:
-      - neo4jdata:/data
-
-  # This "container" is a workaround to pre-create search indices
-  elasticsearch-setup:
-    labels:
-      datahub_setup_job: true
-    build:
-      context: ../
-      dockerfile: docker/elasticsearch-setup/Dockerfile
-    image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
-    env_file: elasticsearch-setup/env/docker.env
-    hostname: elasticsearch-setup
-    container_name: elasticsearch-setup
-    depends_on:
-      - elasticsearch
-
-  datahub-gms:
-    build:
-        context: ../
-        dockerfile: docker/datahub-gms/Dockerfile
-    image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
-    hostname: datahub-gms
-    container_name: datahub-gms
-    ports:
-      - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
-    depends_on:
-      - mysql
-      - neo4j
-
   datahub-frontend-react:
+    container_name: datahub-frontend-react
+    hostname: datahub-frontend-react
+    image: ${DATAHUB_FRONTEND_IMAGE:-linkedin/datahub-frontend-react}:${DATAHUB_VERSION:-head}
+    ports:
+    - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
     build:
       context: ../
       dockerfile: docker/datahub-frontend/Dockerfile
-    image: ${DATAHUB_FRONTEND_IMAGE:-linkedin/datahub-frontend-react}:${DATAHUB_VERSION:-head}
     env_file: datahub-frontend/env/docker.env
-    hostname: datahub-frontend-react
-    container_name: datahub-frontend-react
-    ports:
-      - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
     depends_on:
-      - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     volumes:
-      - ${HOME}/.datahub/plugins:/etc/datahub/plugins
-
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   datahub-actions:
-    image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
+    container_name: datahub-actions
     hostname: actions
+    image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
     env_file: datahub-actions/env/docker.env
-    restart: on-failure:5
     depends_on:
-      - datahub-gms
-
+      datahub-gms:
+        condition: service_healthy
+  datahub-gms:
+    container_name: datahub-gms
+    hostname: datahub-gms
+    image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
+    ports:
+    - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
+    build:
+        context: ../
+        dockerfile: docker/datahub-gms/Dockerfile
+    healthcheck:
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      start_period: 20s
+      interval: 1s
+      retries: 20
+      timeout: 5s
+    depends_on:
+      datahub-upgrade:
+        condition: service_completed_successfully
+    volumes:
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
+  datahub-upgrade:
+    container_name: datahub-upgrade
+    hostname: datahub-upgrade
+    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
+    command:
+    - -u
+    - SystemUpdate
+    build:
+      context: ../
+      dockerfile: docker/datahub-upgrade/Dockerfile
+    env_file: datahub-upgrade/env/docker-without-neo4j.env
+    labels:
+      datahub_setup_job: true
+    depends_on:
+      mysql-setup:
+        condition: service_completed_successfully
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+      neo4j:
+        condition: service_healthy
+  # This "container" is a workaround to pre-create search indices
+  elasticsearch-setup:
+    container_name: elasticsearch-setup
+    hostname: elasticsearch-setup
+    image: ${DATAHUB_ELASTIC_SETUP_IMAGE:-linkedin/datahub-elasticsearch-setup}:${DATAHUB_VERSION:-head}
+    build:
+      context: ../
+      dockerfile: docker/elasticsearch-setup/Dockerfile
+    env_file: elasticsearch-setup/env/docker.env
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    labels:
+      datahub_setup_job: true
   # This "container" is a workaround to pre-create topics.
   # This is not required in most cases, kept here for backwards compatibility with older clients that
   # explicitly wait for this container
   kafka-setup:
-    labels:
-      datahub_setup_job: true
+    container_name: kafka-setup
+    hostname: kafka-setup
+    image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
     build:
       dockerfile: ./docker/kafka-setup/Dockerfile
       context: ../
-    image: ${DATAHUB_KAFKA_SETUP_IMAGE:-linkedin/datahub-kafka-setup}:${DATAHUB_VERSION:-head}
     env_file: kafka-setup/env/docker.env
-    hostname: kafka-setup
-    container_name: kafka-setup
     depends_on:
-      - broker
-      - schema-registry
-
-  datahub-upgrade:
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
     labels:
       datahub_setup_job: true
-    build:
-      context: ../
-      dockerfile: docker/datahub-upgrade/Dockerfile
-    image: ${DATAHUB_UPGRADE_IMAGE:-acryldata/datahub-upgrade}:${DATAHUB_VERSION:-head}
-    env_file: datahub-upgrade/env/docker-without-neo4j.env
-    hostname: datahub-upgrade
-    container_name: datahub-upgrade
-    command: ["-u", "SystemUpdate"]
-
+  elasticsearch:
+    container_name: elasticsearch
+    hostname: elasticsearch
+    image: elasticsearch:7.10.1
+    ports:
+    - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
+    env_file: elasticsearch/env/docker.env
+    environment:
+    - discovery.type=single-node
+    - xpack.security.enabled=false
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    healthcheck:
+      test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    volumes:
+    - esdata:/usr/share/elasticsearch/data
+  neo4j:
+    container_name: neo4j
+    hostname: neo4j
+    image: neo4j:4.4.9-community
+    ports:
+    - ${DATAHUB_MAPPED_NEO4J_HTTP_PORT:-7474}:7474
+    - ${DATAHUB_MAPPED_NEO4J_BOLT_PORT:-7687}:7687
+    env_file: neo4j/env/docker.env
+    healthcheck:
+      test: wget http://neo4j:$${DATAHUB_MAPPED_NEO4J_HTTP_PORT:-7474}
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    volumes:
+    - neo4jdata:/data
+  schema-registry:
+    container_name: schema-registry
+    hostname: schema-registry
+    image: confluentinc/cp-schema-registry:7.2.2
+    ports:
+    - ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}:8081
+    env_file: schema-registry/env/docker.env
+    healthcheck:
+      test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    depends_on:
+      broker:
+        condition: service_healthy
+  broker:
+    container_name: broker
+    hostname: broker
+    image: confluentinc/cp-kafka:7.2.2
+    ports:
+    - ${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}:9092
+    env_file: broker/env/docker.env
+    healthcheck:
+      test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
+      start_period: 5s
+      interval: 1s
+      retries: 5
+      timeout: 5s
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    volumes:
+    - broker:/var/lib/kafka/data/
+  zookeeper:
+    container_name: zookeeper
+    hostname: zookeeper
+    image: confluentinc/cp-zookeeper:7.2.2
+    ports:
+    - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
+    env_file: zookeeper/env/docker.env
+    healthcheck:
+      test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
+      start_period: 2s
+      interval: 5s
+      retries: 5
+      timeout: 5s
+    volumes:
+    - zkdata:/var/lib/zookeeper
 networks:
   default:
     name: datahub_network
-
 volumes:
   esdata:
   neo4jdata:
-  zkdata:
   broker:
+  zkdata:

--- a/docker/monitoring/docker-compose.monitoring.yml
+++ b/docker/monitoring/docker-compose.monitoring.yml
@@ -1,17 +1,6 @@
 ---
-version: '3.8'
+version: '3.9'
 services:
-  datahub-gms:
-    environment:
-      - ENABLE_PROMETHEUS=true
-      - ENABLE_OTEL=true
-      - OTEL_TRACES_EXPORTER=jaeger
-      - OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger-all-in-one:14250
-      - OTEL_METRICS_EXPORTER=none
-      - OTEL_SERVICE_NAME=datahub-gms
-    ports:
-      - "4318"
-
   datahub-frontend-react:
     environment:
       - ENABLE_PROMETHEUS=true
@@ -21,34 +10,39 @@ services:
       - OTEL_METRICS_EXPORTER=none
       - OTEL_SERVICE_NAME=datahub-gms
     ports:
-      - "4318"
-
-  # Jaeger
-  jaeger-all-in-one:
-    image: jaegertracing/all-in-one:latest
+      - '4318'
+  datahub-gms:
+    environment:
+      - ENABLE_PROMETHEUS=true
+      - ENABLE_OTEL=true
+      - OTEL_TRACES_EXPORTER=jaeger
+      - OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger-all-in-one:14250
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_SERVICE_NAME=datahub-gms
     ports:
-      - "16686:16686"
-      - "14268"
-      - "14250"
-
-  prometheus:
-    container_name: prometheus
-    image: prom/prometheus:latest
-    volumes:
-      - ./monitoring/prometheus.yaml:/etc/prometheus/prometheus.yml
-    ports:
-      - "9089:9090"
-
+      - '4318'
   grafana:
     image: grafana/grafana:9.1.4
     ports:
-      - "3001:3000"
+      - 3001:3000
     volumes:
       - grafana-storage:/var/lib/grafana
       - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources
       - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
     depends_on:
       - prometheus
-
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - 16686:16686
+      - '14268'
+      - '14250'
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    volumes:
+      - ./monitoring/prometheus.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - 9089:9090
 volumes:
   grafana-storage:

--- a/docker/quickstart/docker-compose-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-m1.quickstart.yml
@@ -5,7 +5,8 @@ services:
   broker:
     container_name: broker
     depends_on:
-    - zookeeper
+      zookeeper:
+        condition: service_healthy
     environment:
     - KAFKA_BROKER_ID=1
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
@@ -15,6 +16,12 @@ services:
     - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
     - KAFKA_HEAP_OPTS=-Xms256m -Xmx256m
     - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
+      timeout: 5s
     hostname: broker
     image: confluentinc/cp-kafka:7.2.2
     ports:
@@ -22,8 +29,10 @@ services:
     volumes:
     - broker:/var/lib/kafka/data/
   datahub-actions:
+    container_name: datahub-actions
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -37,11 +46,11 @@ services:
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     hostname: actions
     image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
-    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -62,8 +71,8 @@ services:
   datahub-gms:
     container_name: datahub-gms
     depends_on:
-    - mysql
-    - neo4j
+      datahub-upgrade:
+        condition: service_completed_successfully
     environment:
     - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
     - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
@@ -94,18 +103,32 @@ services:
     - PE_CONSUMER_ENABLED=true
     - UI_INGESTION_ENABLED=true
     - METADATA_SERVICE_AUTH_ENABLED=false
+    healthcheck:
+      interval: 1s
+      retries: 20
+      start_period: 20s
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      timeout: 5s
     hostname: datahub-gms
     image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
     ports:
     - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
     volumes:
-    - ${HOME}/.datahub/plugins/:/etc/datahub/plugins
-    - ${HOME}/.datahub/plugins/auth/resources/:/etc/datahub/plugins/auth/resources
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   datahub-upgrade:
     command:
     - -u
     - SystemUpdate
     container_name: datahub-upgrade
+    depends_on:
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+      mysql-setup:
+        condition: service_completed_successfully
+      neo4j:
+        condition: service_healthy
     environment:
     - EBEAN_DATASOURCE_USERNAME=datahub
     - EBEAN_DATASOURCE_PASSWORD=datahub
@@ -129,19 +152,22 @@ services:
       datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     environment:
     - discovery.type=single-node
     - xpack.security.enabled=false
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
-      retries: 4
-      start_period: 2m
-      test:
-      - CMD-SHELL
-      - curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
+      timeout: 5s
     hostname: elasticsearch
     image: elasticsearch:7.10.1
-    mem_limit: 1g
     ports:
     - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     volumes:
@@ -149,7 +175,8 @@ services:
   elasticsearch-setup:
     container_name: elasticsearch-setup
     depends_on:
-    - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     environment:
     - ELASTICSEARCH_HOST=elasticsearch
     - ELASTICSEARCH_PORT=9200
@@ -161,8 +188,10 @@ services:
   kafka-setup:
     container_name: kafka-setup
     depends_on:
-    - broker
-    - schema-registry
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
     environment:
     - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
     - KAFKA_BOOTSTRAP_SERVER=broker:29092
@@ -180,17 +209,25 @@ services:
     - MYSQL_USER=datahub
     - MYSQL_PASSWORD=datahub
     - MYSQL_ROOT_PASSWORD=datahub
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 2s
+      test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      timeout: 5s
     hostname: mysql
     image: mariadb:10.5.8
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    restart: on-failure
     volumes:
     - ../mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
     - mysqldata:/var/lib/mysql
   mysql-setup:
     container_name: mysql-setup
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
     environment:
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
@@ -207,6 +244,12 @@ services:
     - NEO4J_AUTH=neo4j/datahub
     - NEO4J_dbms_default__database=graph.db
     - NEO4J_dbms_allow__upgrade=true
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: wget http://neo4j:$${DATAHUB_MAPPED_NEO4J_HTTP_PORT:-7474}
+      timeout: 5s
     hostname: neo4j
     image: neo4j/neo4j-arm64-experimental:4.0.6-arm64
     ports:
@@ -217,11 +260,18 @@ services:
   schema-registry:
     container_name: schema-registry
     depends_on:
-    - broker
+      broker:
+        condition: service_healthy
     environment:
     - SCHEMA_REGISTRY_HOST_NAME=schemaregistry
     - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=PLAINTEXT
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
+      timeout: 5s
     hostname: schema-registry
     image: confluentinc/cp-schema-registry:7.2.2
     ports:
@@ -231,13 +281,19 @@ services:
     environment:
     - ZOOKEEPER_CLIENT_PORT=2181
     - ZOOKEEPER_TICK_TIME=2000
+    healthcheck:
+      interval: 5s
+      retries: 5
+      start_period: 2s
+      test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
+      timeout: 5s
     hostname: zookeeper
     image: confluentinc/cp-zookeeper:7.2.2
     ports:
     - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
     volumes:
     - zkdata:/var/lib/zookeeper
-version: '2.3'
+version: '3.9'
 volumes:
   broker: null
   esdata: null

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -5,7 +5,8 @@ services:
   broker:
     container_name: broker
     depends_on:
-    - zookeeper
+      zookeeper:
+        condition: service_healthy
     environment:
     - KAFKA_BROKER_ID=1
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
@@ -15,13 +16,23 @@ services:
     - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
     - KAFKA_HEAP_OPTS=-Xms256m -Xmx256m
     - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
+      timeout: 5s
     hostname: broker
     image: confluentinc/cp-kafka:7.2.2
     ports:
     - ${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}:9092
+    volumes:
+    - broker:/var/lib/kafka/data/
   datahub-actions:
+    container_name: datahub-actions
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -35,11 +46,11 @@ services:
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     hostname: actions
     image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
-    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -60,7 +71,8 @@ services:
   datahub-gms:
     container_name: datahub-gms
     depends_on:
-    - mysql
+      datahub-upgrade:
+        condition: service_completed_successfully
     environment:
     - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
     - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
@@ -86,6 +98,12 @@ services:
     - MCE_CONSUMER_ENABLED=true
     - PE_CONSUMER_ENABLED=true
     - UI_INGESTION_ENABLED=true
+    healthcheck:
+      interval: 1s
+      retries: 20
+      start_period: 20s
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      timeout: 5s
     hostname: datahub-gms
     image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
     ports:
@@ -97,6 +115,13 @@ services:
     - -u
     - SystemUpdate
     container_name: datahub-upgrade
+    depends_on:
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+      mysql-setup:
+        condition: service_completed_successfully
     environment:
     - EBEAN_DATASOURCE_USERNAME=datahub
     - EBEAN_DATASOURCE_PASSWORD=datahub
@@ -120,19 +145,22 @@ services:
       datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     environment:
     - discovery.type=single-node
     - xpack.security.enabled=false
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
-      retries: 4
-      start_period: 2m
-      test:
-      - CMD-SHELL
-      - curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
+      timeout: 5s
     hostname: elasticsearch
     image: elasticsearch:7.10.1
-    mem_limit: 1g
     ports:
     - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     volumes:
@@ -140,7 +168,8 @@ services:
   elasticsearch-setup:
     container_name: elasticsearch-setup
     depends_on:
-    - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     environment:
     - ELASTICSEARCH_HOST=elasticsearch
     - ELASTICSEARCH_PORT=9200
@@ -152,8 +181,10 @@ services:
   kafka-setup:
     container_name: kafka-setup
     depends_on:
-    - broker
-    - schema-registry
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
     environment:
     - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
     - KAFKA_BOOTSTRAP_SERVER=broker:29092
@@ -171,17 +202,25 @@ services:
     - MYSQL_USER=datahub
     - MYSQL_PASSWORD=datahub
     - MYSQL_ROOT_PASSWORD=datahub
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 2s
+      test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      timeout: 5s
     hostname: mysql
     image: mariadb:10.5.8
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    restart: on-failure
     volumes:
     - ../mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
     - mysqldata:/var/lib/mysql
   mysql-setup:
     container_name: mysql-setup
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
     environment:
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
@@ -195,11 +234,18 @@ services:
   schema-registry:
     container_name: schema-registry
     depends_on:
-    - broker
+      broker:
+        condition: service_healthy
     environment:
     - SCHEMA_REGISTRY_HOST_NAME=schemaregistry
     - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=PLAINTEXT
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
+      timeout: 5s
     hostname: schema-registry
     image: confluentinc/cp-schema-registry:7.2.2
     ports:
@@ -209,14 +255,21 @@ services:
     environment:
     - ZOOKEEPER_CLIENT_PORT=2181
     - ZOOKEEPER_TICK_TIME=2000
+    healthcheck:
+      interval: 5s
+      retries: 5
+      start_period: 2s
+      test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
+      timeout: 5s
     hostname: zookeeper
     image: confluentinc/cp-zookeeper:7.2.2
     ports:
     - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
     volumes:
     - zkdata:/var/lib/zookeeper
-version: '2.3'
+version: '3.9'
 volumes:
+  broker: null
   esdata: null
   mysqldata: null
   zkdata: null

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -5,7 +5,8 @@ services:
   broker:
     container_name: broker
     depends_on:
-    - zookeeper
+      zookeeper:
+        condition: service_healthy
     environment:
     - KAFKA_BROKER_ID=1
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
@@ -15,13 +16,23 @@ services:
     - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
     - KAFKA_HEAP_OPTS=-Xms256m -Xmx256m
     - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
+      timeout: 5s
     hostname: broker
     image: confluentinc/cp-kafka:7.2.2
     ports:
     - ${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}:9092
+    volumes:
+    - broker:/var/lib/kafka/data/
   datahub-actions:
+    container_name: datahub-actions
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -35,11 +46,11 @@ services:
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     hostname: actions
     image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
-    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -60,7 +71,8 @@ services:
   datahub-gms:
     container_name: datahub-gms
     depends_on:
-    - mysql
+      datahub-upgrade:
+        condition: service_completed_successfully
     environment:
     - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
     - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
@@ -86,6 +98,12 @@ services:
     - MCE_CONSUMER_ENABLED=true
     - PE_CONSUMER_ENABLED=true
     - UI_INGESTION_ENABLED=true
+    healthcheck:
+      interval: 1s
+      retries: 20
+      start_period: 20s
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      timeout: 5s
     hostname: datahub-gms
     image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
     ports:
@@ -97,6 +115,13 @@ services:
     - -u
     - SystemUpdate
     container_name: datahub-upgrade
+    depends_on:
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+      mysql-setup:
+        condition: service_completed_successfully
     environment:
     - EBEAN_DATASOURCE_USERNAME=datahub
     - EBEAN_DATASOURCE_PASSWORD=datahub
@@ -120,19 +145,22 @@ services:
       datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     environment:
     - discovery.type=single-node
     - xpack.security.enabled=false
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
-      retries: 4
-      start_period: 2m
-      test:
-      - CMD-SHELL
-      - curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
+      timeout: 5s
     hostname: elasticsearch
     image: elasticsearch:7.10.1
-    mem_limit: 1g
     ports:
     - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     volumes:
@@ -140,7 +168,8 @@ services:
   elasticsearch-setup:
     container_name: elasticsearch-setup
     depends_on:
-    - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     environment:
     - ELASTICSEARCH_HOST=elasticsearch
     - ELASTICSEARCH_PORT=9200
@@ -152,8 +181,10 @@ services:
   kafka-setup:
     container_name: kafka-setup
     depends_on:
-    - broker
-    - schema-registry
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
     environment:
     - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
     - KAFKA_BOOTSTRAP_SERVER=broker:29092
@@ -171,17 +202,25 @@ services:
     - MYSQL_USER=datahub
     - MYSQL_PASSWORD=datahub
     - MYSQL_ROOT_PASSWORD=datahub
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 2s
+      test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      timeout: 5s
     hostname: mysql
     image: mysql:5.7
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    restart: on-failure
     volumes:
     - ../mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
     - mysqldata:/var/lib/mysql
   mysql-setup:
     container_name: mysql-setup
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
     environment:
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
@@ -195,11 +234,18 @@ services:
   schema-registry:
     container_name: schema-registry
     depends_on:
-    - broker
+      broker:
+        condition: service_healthy
     environment:
     - SCHEMA_REGISTRY_HOST_NAME=schemaregistry
     - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=PLAINTEXT
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
+      timeout: 5s
     hostname: schema-registry
     image: confluentinc/cp-schema-registry:7.2.2
     ports:
@@ -209,14 +255,21 @@ services:
     environment:
     - ZOOKEEPER_CLIENT_PORT=2181
     - ZOOKEEPER_TICK_TIME=2000
+    healthcheck:
+      interval: 5s
+      retries: 5
+      start_period: 2s
+      test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
+      timeout: 5s
     hostname: zookeeper
     image: confluentinc/cp-zookeeper:7.2.2
     ports:
     - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
     volumes:
     - zkdata:/var/lib/zookeeper
-version: '2.3'
+version: '3.9'
 volumes:
+  broker: null
   esdata: null
   mysqldata: null
   zkdata: null

--- a/docker/quickstart/docker-compose.consumers-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose.consumers-without-neo4j.quickstart.yml
@@ -53,4 +53,4 @@ services:
     image: ${DATAHUB_MCE_CONSUMER_IMAGE:-linkedin/datahub-mce-consumer}:${DATAHUB_VERSION:-head}
     ports:
     - 9090:9090
-version: '2.3'
+version: '3.9'

--- a/docker/quickstart/docker-compose.consumers.quickstart.yml
+++ b/docker/quickstart/docker-compose.consumers.quickstart.yml
@@ -6,7 +6,8 @@ services:
   datahub-mae-consumer:
     container_name: datahub-mae-consumer
     depends_on:
-    - neo4j
+      neo4j:
+        condition: service_healthy
     environment:
     - DATAHUB_UPGRADE_HISTORY_KAFKA_CONSUMER_GROUP_ID=generic-duhe-consumer-job-client-mcl
     - DATAHUB_GMS_HOST=datahub-gms
@@ -31,7 +32,8 @@ services:
   datahub-mce-consumer:
     container_name: datahub-mce-consumer
     depends_on:
-    - neo4j
+      neo4j:
+        condition: service_healthy
     environment:
     - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
     - DATAHUB_SYSTEM_CLIENT_ID=__datahub_system
@@ -65,4 +67,4 @@ services:
     image: ${DATAHUB_MCE_CONSUMER_IMAGE:-linkedin/datahub-mce-consumer}:${DATAHUB_VERSION:-head}
     ports:
     - 9090:9090
-version: '2.3'
+version: '3.9'

--- a/docker/quickstart/docker-compose.kafka-setup.quickstart.yml
+++ b/docker/quickstart/docker-compose.kafka-setup.quickstart.yml
@@ -1,2 +1,2 @@
 services: {}
-version: '2.3'
+version: '3.9'

--- a/docker/quickstart/docker-compose.monitoring.quickstart.yml
+++ b/docker/quickstart/docker-compose.monitoring.quickstart.yml
@@ -42,6 +42,6 @@ services:
     - 9089:9090
     volumes:
     - ../monitoring/prometheus.yaml:/etc/prometheus/prometheus.yml
-version: '2.3'
+version: '3.9'
 volumes:
   grafana-storage: null

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -5,7 +5,8 @@ services:
   broker:
     container_name: broker
     depends_on:
-    - zookeeper
+      zookeeper:
+        condition: service_healthy
     environment:
     - KAFKA_BROKER_ID=1
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
@@ -15,6 +16,12 @@ services:
     - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
     - KAFKA_HEAP_OPTS=-Xms256m -Xmx256m
     - KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE=false
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
+      timeout: 5s
     hostname: broker
     image: confluentinc/cp-kafka:7.2.2
     ports:
@@ -22,8 +29,10 @@ services:
     volumes:
     - broker:/var/lib/kafka/data/
   datahub-actions:
+    container_name: datahub-actions
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -37,11 +46,11 @@ services:
     - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     hostname: actions
     image: acryldata/datahub-actions:${ACTIONS_VERSION:-head}
-    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:
-    - datahub-gms
+      datahub-gms:
+        condition: service_healthy
     environment:
     - DATAHUB_GMS_HOST=datahub-gms
     - DATAHUB_GMS_PORT=8080
@@ -62,8 +71,8 @@ services:
   datahub-gms:
     container_name: datahub-gms
     depends_on:
-    - mysql
-    - neo4j
+      datahub-upgrade:
+        condition: service_completed_successfully
     environment:
     - DATAHUB_SERVER_TYPE=${DATAHUB_SERVER_TYPE:-quickstart}
     - DATAHUB_TELEMETRY_ENABLED=${DATAHUB_TELEMETRY_ENABLED:-true}
@@ -94,18 +103,32 @@ services:
     - PE_CONSUMER_ENABLED=true
     - UI_INGESTION_ENABLED=true
     - METADATA_SERVICE_AUTH_ENABLED=false
+    healthcheck:
+      interval: 1s
+      retries: 20
+      start_period: 20s
+      test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
+      timeout: 5s
     hostname: datahub-gms
     image: ${DATAHUB_GMS_IMAGE:-linkedin/datahub-gms}:${DATAHUB_VERSION:-head}
     ports:
     - ${DATAHUB_MAPPED_GMS_PORT:-8080}:8080
     volumes:
-    - ${HOME}/.datahub/plugins/:/etc/datahub/plugins
-    - ${HOME}/.datahub/plugins/auth/resources/:/etc/datahub/plugins/auth/resources
+    - ${HOME}/.datahub/plugins:/etc/datahub/plugins
   datahub-upgrade:
     command:
     - -u
     - SystemUpdate
     container_name: datahub-upgrade
+    depends_on:
+      elasticsearch-setup:
+        condition: service_completed_successfully
+      kafka-setup:
+        condition: service_completed_successfully
+      mysql-setup:
+        condition: service_completed_successfully
+      neo4j:
+        condition: service_healthy
     environment:
     - EBEAN_DATASOURCE_USERNAME=datahub
     - EBEAN_DATASOURCE_PASSWORD=datahub
@@ -129,19 +152,22 @@ services:
       datahub_setup_job: true
   elasticsearch:
     container_name: elasticsearch
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     environment:
     - discovery.type=single-node
     - xpack.security.enabled=false
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
-      retries: 4
-      start_period: 2m
-      test:
-      - CMD-SHELL
-      - curl -sS --fail 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=0s' || exit 1
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
+      timeout: 5s
     hostname: elasticsearch
     image: elasticsearch:7.10.1
-    mem_limit: 1g
     ports:
     - ${DATAHUB_MAPPED_ELASTIC_PORT:-9200}:9200
     volumes:
@@ -149,7 +175,8 @@ services:
   elasticsearch-setup:
     container_name: elasticsearch-setup
     depends_on:
-    - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     environment:
     - ELASTICSEARCH_HOST=elasticsearch
     - ELASTICSEARCH_PORT=9200
@@ -161,8 +188,10 @@ services:
   kafka-setup:
     container_name: kafka-setup
     depends_on:
-    - broker
-    - schema-registry
+      broker:
+        condition: service_healthy
+      schema-registry:
+        condition: service_healthy
     environment:
     - DATAHUB_PRECREATE_TOPICS=${DATAHUB_PRECREATE_TOPICS:-false}
     - KAFKA_BOOTSTRAP_SERVER=broker:29092
@@ -180,17 +209,25 @@ services:
     - MYSQL_USER=datahub
     - MYSQL_PASSWORD=datahub
     - MYSQL_ROOT_PASSWORD=datahub
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 2s
+      test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      timeout: 5s
     hostname: mysql
     image: mysql:5.7
     ports:
     - ${DATAHUB_MAPPED_MYSQL_PORT:-3306}:3306
+    restart: on-failure
     volumes:
     - ../mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
     - mysqldata:/var/lib/mysql
   mysql-setup:
     container_name: mysql-setup
     depends_on:
-    - mysql
+      mysql:
+        condition: service_healthy
     environment:
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
@@ -207,6 +244,12 @@ services:
     - NEO4J_AUTH=neo4j/datahub
     - NEO4J_dbms_default__database=graph.db
     - NEO4J_dbms_allow__upgrade=true
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: wget http://neo4j:$${DATAHUB_MAPPED_NEO4J_HTTP_PORT:-7474}
+      timeout: 5s
     hostname: neo4j
     image: neo4j:4.4.9-community
     ports:
@@ -217,11 +260,18 @@ services:
   schema-registry:
     container_name: schema-registry
     depends_on:
-    - broker
+      broker:
+        condition: service_healthy
     environment:
     - SCHEMA_REGISTRY_HOST_NAME=schemaregistry
     - SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL=PLAINTEXT
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
+    healthcheck:
+      interval: 1s
+      retries: 5
+      start_period: 5s
+      test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
+      timeout: 5s
     hostname: schema-registry
     image: confluentinc/cp-schema-registry:7.2.2
     ports:
@@ -231,13 +281,19 @@ services:
     environment:
     - ZOOKEEPER_CLIENT_PORT=2181
     - ZOOKEEPER_TICK_TIME=2000
+    healthcheck:
+      interval: 5s
+      retries: 5
+      start_period: 2s
+      test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
+      timeout: 5s
     hostname: zookeeper
     image: confluentinc/cp-zookeeper:7.2.2
     ports:
     - ${DATAHUB_MAPPED_ZK_PORT:-2181}:2181
     volumes:
     - zkdata:/var/lib/zookeeper
-version: '2.3'
+version: '3.9'
 volumes:
   broker: null
   esdata: null

--- a/docker/quickstart/generate_docker_quickstart.py
+++ b/docker/quickstart/generate_docker_quickstart.py
@@ -52,7 +52,7 @@ omitted_services = [
 # Note that these are upper bounds on memory usage. Once exceeded, the container is killed.
 # Each service will be configured to use much less Java heap space than allocated here.
 mem_limits = {
-    "elasticsearch": "1g",
+    "elasticsearch": "1G",
 }
 
 
@@ -108,7 +108,7 @@ def modify_docker_config(base_path, docker_yaml_config):
 
         # 8. Set memory limits
         if name in mem_limits:
-            service["mem_limit"] = mem_limits[name]
+            service["deploy"] = {"resources":{"limits":{"memory":mem_limits[name]}}}
 
         # 9. Correct relative paths for volume mounts
         if "volumes" in service:
@@ -120,10 +120,10 @@ def modify_docker_config(base_path, docker_yaml_config):
                 elif volumes[i].startswith("./"):
                     volumes[i] = "." + volumes[i]
 
-    # 10. Set docker compose version to 2.
+    # 10. Set docker compose version to 3.
     # We need at least this version, since we use features like start_period for
-    # healthchecks and shell-like variable interpolation.
-    docker_yaml_config["version"] = "2.3"
+    # healthchecks (with services dependencies based on them) and shell-like variable interpolation.
+    docker_yaml_config["version"] = "3.9"
 
 
 def dedup_env_vars(merged_docker_config):


### PR DESCRIPTION
# Purpose

Several unstable behaviours of the startup through `docker compose` were noticed ; often requiring to `down` and `up` again, after a first unsuccesful `up`, whether it was just after containers' creation or restart of Docker / host machine.
This PR brings several improvements in corresponding `docker-compose*.yml` files (esp. `/quickstart` ones but then more extensively, trying to be consistent as much as possible), especially by:
- using more services' [`healthcheck` definitions](https://docs.docker.com/compose/compose-file/05-services/#healthcheck) (in `/quickstart` ones, only `elasticsearch` had one)
- making dependency of `service-A` on `service-B` more robust by relying on those `healthcheck`･s, thanks to [the `depends_on`'s _long syntax_](https://docs.docker.com/compose/compose-file/05-services/#long-syntax-1)
  ```yaml
    service-A:
      ...
      depends_on:
        service-B:
          condition: service_healthy | service_completed_successfully
  ```
  to ensure that `service-A` is started not only after `service-B` is started (which is what [_short syntax_](https://docs.docker.com/compose/compose-file/05-services/#short-syntax-1) only ensures), but also after `service-B` is a:
  - either `service_healthy` which means that its initialization (which can takes some time) completed, it's now running fine and therefore is **actually** ready to serve requests.
  - or `service_completed_successfully`, which is particularly useful in the DataHub's context of `*-setup` services/containers
- introducing many more such dependencies compared to what existed before.

Which somehow leads to such a dependency graph, e.g. with one of full "quickstart" examples:
```
                 datahub-frontend-react   datahub-actions
                                    \     /
                                datahub-gms (healthy)
                                       |
                                datahub-upgrade (completed)
            /--------------------/   |   \   \------------------------------------------------\
           /                         |    \-------------------\                                \
mysql-setup (completed)  elasticsearch-setup (completed)  kafka-setup (completed)  (if apply) neo4j (healthy)
    |                           |                          /         \
  mysql (healthy)         elasticsearch (healthy)   broker (healthy)  schema-registry (healthy)
                                                      |
                                                  zookeeper (healthy)
``` 
Hence the re-ordering in the `docker-compose*.yml` files to somehow reflect this dependencies' ordering.

This also enables to remove several `restart: on-failure` occurrences, that were poor workarounds compared to such more robust and deterministic solution (only kept the occurrences for `mysql`/`mariadb` that appears to sometimes still fail just once at the very beginning when trying to create a socket, but not due to `docker-compose*.yml` structure).


# Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
