### PR TITLE
feat: datahub-upgrade.sh to support old versions

### DIFF
--- a/docker/datahub-upgrade/datahub-upgrade.sh
+++ b/docker/datahub-upgrade/datahub-upgrade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-read -p "Desired datahub version, for example 'v0.10.1' (defaults to newest): " VERSION
-VERSION=${VERSION:-head}
+# read -p "Desired datahub version, for example 'v0.10.1' (defaults to newest): " VERSION
+VERSION=${DATAHUB_VERSION:-head}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-IMAGE=acryldata/datahub-upgrade:$VERSION
+IMAGE=acryldata/datahub-upgrade:$DATAHUB_VERSION
 cd $DIR && docker pull ${IMAGE} && docker run --env-file ./env/docker.env --network="datahub_network" ${IMAGE} "$@"

--- a/docker/datahub-upgrade/datahub-upgrade.sh
+++ b/docker/datahub-upgrade/datahub-upgrade.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+read -p "Desired datahub version, for example 'v0.10.1' (defaults to newest): " VERSION
+VERSION=${VERSION:-head}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-IMAGE=acryldata/datahub-upgrade:head
+IMAGE=acryldata/datahub-upgrade:$VERSION
 cd $DIR && docker pull ${IMAGE} && docker run --env-file ./env/docker.env --network="datahub_network" ${IMAGE} "$@"


### PR DESCRIPTION
Currently shell script fetches newest image. When using `SystemUpdate` and target system is lower level, the indexes are fixed due to newest version and this causes problems.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
