### PR TITLE
feat(cli): Modifies ingest-sample-data command to use DataHub url & token based on config

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -20,7 +20,7 @@ import requests
 from expandvars import expandvars
 from requests_file import FileAdapter
 
-from datahub.cli.cli_utils import DATAHUB_ROOT_FOLDER
+from datahub.cli.cli_utils import DATAHUB_ROOT_FOLDER, get_url_and_token
 from datahub.cli.docker_check import (
     DATAHUB_COMPOSE_LEGACY_VOLUME_FILTERS,
     DATAHUB_COMPOSE_PROJECT_FILTER,
@@ -924,6 +924,8 @@ def ingest_sample_data(path: Optional[str], token: Optional[str]) -> None:
             footer="Try running `datahub docker quickstart` first.",
         )
 
+    gms_host, gms_token = get_url_and_token()
+
     # Run ingestion.
     click.echo("Starting ingestion...")
     recipe: dict = {
@@ -935,7 +937,10 @@ def ingest_sample_data(path: Optional[str], token: Optional[str]) -> None:
         },
         "sink": {
             "type": "datahub-rest",
-            "config": {"server": "http://localhost:8080"},
+            "config": {
+                "server": gms_host,
+                "token": gms_token,
+            },
         },
     }
 


### PR DESCRIPTION
Updates `datahub docker ingest-sample-data` to bootstrap whatever DataHub server is configured in `~/.datahubenv`

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
