### PR TITLE
fix(deploy): add missing plugin files for mysql-client library in mysql-setup

### DIFF
--- a/docker/mysql-setup/Dockerfile
+++ b/docker/mysql-setup/Dockerfile
@@ -12,7 +12,7 @@ RUN go install github.com/jwilder/dockerize@$DOCKERIZE_VERSION
 FROM alpine:3
 COPY --from=binary /go/bin/dockerize /usr/local/bin
 
-RUN apk add --no-cache mysql-client bash
+RUN apk add --no-cache mysql-client bash mariadb-connector-c
 
 COPY docker/mysql-setup/init.sql /init.sql
 COPY docker/mysql-setup/init.sh /init.sh


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

### Bug Description 🐛 

This PR fixes a bug found when running the `datahub-mysql-setup` job within a kubernetes cluster that connects to a MySQL 8 database instance. It appears the current mysql-setup script uses the `mysql-client` alpine package that does not include files necessary to support the MySQL `caching_sha2_password` plugin. An additional package is required to get the setup script to work. 

### How to Reproduce

1. I am running a MySQL 8.0.32 instance in Azure with the `caching_sha2_password` plugin active (which occurs by default).

```sql
mysql> SELECT VERSION();
+-----------+
| VERSION() |
+-----------+
| 8.0.32    |
+-----------+
1 row in set (0.04 sec)
```

```sql
mysql> SELECT * FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'caching_sha2_password';
+-----------------------+----------------+---------------+----------------+---------------------+----------------+------------------------+--------------------+-----------------------------+----------------+-------------+
| PLUGIN_NAME           | PLUGIN_VERSION | PLUGIN_STATUS | PLUGIN_TYPE    | PLUGIN_TYPE_VERSION | PLUGIN_LIBRARY | PLUGIN_LIBRARY_VERSION | PLUGIN_AUTHOR      | PLUGIN_DESCRIPTION          | PLUGIN_LICENSE | LOAD_OPTION |
+-----------------------+----------------+---------------+----------------+---------------------+----------------+------------------------+--------------------+-----------------------------+----------------+-------------+
| caching_sha2_password | 1.0            | ACTIVE        | AUTHENTICATION | 2.1                 | NULL           | NULL                   | Oracle Corporation | Caching sha2 authentication | GPL            | FORCE       |
+-----------------------+----------------+---------------+----------------+---------------------+----------------+------------------------+--------------------+-----------------------------+----------------+-------------+
1 row in set (0.04 sec)
```

2. I configured my Kube cluster to connect to my MySQL instance instead of using the default Bitnami chart.

3. When running `helm upgrade datahub datahub/datahub --values values.yaml` the datahub-mysql-setup job fails on each run with the following error: 🐛 

```SQL
ERROR 1045 (28000): Plugin caching_sha2_password could not be loaded: Error loading shared library /usr/lib/mariadb/plugin/caching_sha2_password.so: No such file or directory
2023/04/25 23:09:18 Command exited with error: exit status 1
```

### The Core Issue 💡 

The MariaDB reference is notable as we are connecting to a MySQL instance. I believe this indicates that the mysql client used to execute the SQL DDL cannot find the proper plugin files in its local installation. Upon further investigation, it appears the [`mysql-client` package](https://github.com/datahub-project/datahub/blob/master/docker/mysql-setup/Dockerfile#L15) used in the mysql-setup script is a mariadb client and likely the source of the problem.

I confirmed this client is the source of the error by rebuilding the mysql-setup docker image using its [Dockerfile](https://github.com/datahub-project/datahub/blob/master/docker/mysql-setup/Dockerfile) and attempting to manually connect to the same database. And I received the same error.

### A Potential Solution 😃 

Based on [this thread](https://community.home-assistant.io/t/usr-lib-mariadb-plugin-caching-sha2-password-so-cannot-be-found/439973) this error has been seen before and the simple solution is to add the `mariadb-connector-c` package.  I added the package in my local container and I was able to connect to the database without error.

### Considerations 🤔 

- I would love feedback on my approach and I'm very open to alternative ideas! 🎉 
- Apologies if I've missed anything in the PR. This is my first contribution to DataHub!

