### PR TITLE
fix(ingest/postgres): Allow specification of initial engine database; set default database to postgres

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
@@ -125,7 +125,7 @@ class BasicSQLAlchemyConfig(SQLAlchemyConfig):
             self.username,
             self.password.get_secret_value() if self.password is not None else None,
             self.host_port,
-            self.database or database,
+            database or self.database,
             uri_opts=uri_opts,
         )
 

--- a/metadata-ingestion/tests/integration/postgres/postgres_all_db_to_file_with_db_estimate_row_count.yml
+++ b/metadata-ingestion/tests/integration/postgres/postgres_all_db_to_file_with_db_estimate_row_count.yml
@@ -4,6 +4,7 @@ source:
   type: postgres
   config:
     host_port: 'localhost:5432'
+    database: 'postgrestest'
     username: 'postgres'
     password: 'example'
     include_view_lineage: True

--- a/metadata-ingestion/tests/integration/postgres/postgres_to_file_with_db_estimate_row_count.yml
+++ b/metadata-ingestion/tests/integration/postgres/postgres_to_file_with_db_estimate_row_count.yml
@@ -7,6 +7,7 @@ source:
     database: 'postgrestest'
     username: 'postgres'
     password: 'example'
+    ingest_multiple_databases: false
     profiling:
       enabled: true
       profile_table_level_only: true

--- a/metadata-ingestion/tests/unit/test_postgres_source.py
+++ b/metadata-ingestion/tests/unit/test_postgres_source.py
@@ -1,11 +1,49 @@
 from unittest import mock
 
+import pytest
+
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.sql.postgres import PostgresConfig, PostgresSource
 
 
 def _base_config():
     return {"username": "user", "password": "password", "host_port": "host:1521"}
+
+
+def test_default_database():
+    config = PostgresConfig.parse_obj(_base_config())
+    assert config.database == "postgres"
+
+    config = PostgresConfig.parse_obj({**_base_config(), "database": "my_database"})
+    assert config.database == "my_database"
+
+
+def test_ingest_multiple_databases_with_sqlachemy_uri():
+    config = PostgresConfig.parse_obj(
+        {
+            **_base_config(),
+            "ingest_multiple_databases": True,
+        }
+    )
+    assert config.ingest_multiple_databases is True
+
+    config = PostgresConfig.parse_obj(
+        {
+            **_base_config(),
+            "sqlalchemy_uri": "postgresql://user:password@host:1521/postgres",
+            "ingest_multiple_databases": False,
+        }
+    )
+    assert config.sqlalchemy_uri == "postgresql://user:password@host:1521/postgres"
+
+    with pytest.raises(ValueError):
+        PostgresConfig.parse_obj(
+            {
+                **_base_config(),
+                "ingest_multiple_databases": True,
+                "sqlachemy_uri": "postgresql://user:password@host:1521/postgres",
+            }
+        )
 
 
 def test_database_alias_takes_precendence():


### PR DESCRIPTION
As per discussion on https://datahubspace.slack.com/archives/CUMUWQU66/p1682617946632919, by "overwriting" the `database` config param to use it for determining whether to ingest multiple databases, we no longer allow users to specify the database of the original engine (that scans for databases). This changes that determination to a new config option, `ingest_multiple_databases`, default True. Also per request, sets the default database to `"postgres"`, which seems preferable to postgres' default, which is the username of the user making the connection.

@jinlintt for awareness

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
