### PR TITLE
refactor(ingest): Remove auto_workunit

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/source_helpers.py
+++ b/metadata-ingestion/src/datahub/utilities/source_helpers.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, Optional, Set, TypeVar, Union
+from typing import Callable, Iterable, Optional, Set, TypeVar
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import WorkUnit
@@ -16,18 +16,6 @@ from datahub.metadata.schema_classes import (
 from datahub.utilities.urns.tag_urn import TagUrn
 from datahub.utilities.urns.urn import guess_entity_type
 from datahub.utilities.urns.urn_iter import list_urns
-
-
-def auto_workunit(
-    stream: Iterable[Union[MetadataChangeEventClass, MetadataChangeProposalWrapper]]
-) -> Iterable[MetadataWorkUnit]:
-    """Convert a stream of MCEs and MCPs to a stream of :class:`MetadataWorkUnit`s."""
-
-    for item in stream:
-        if isinstance(item, MetadataChangeEventClass):
-            yield MetadataWorkUnit(id=f"{item.proposedSnapshot.urn}/mce", mce=item)
-        else:
-            yield item.as_workunit()
 
 
 def auto_status_aspect(
@@ -132,11 +120,11 @@ def auto_materialize_referenced_tags(
 
     for wu in stream:
         for urn in list_urns(wu.metadata):
-            if guess_entity_type(urn) == "tag":
+            if guess_entity_type(urn) == TagUrn.ENTITY_TYPE:
                 referenced_tags.add(urn)
 
         urn = wu.get_urn()
-        if guess_entity_type(urn) == "tag":
+        if guess_entity_type(urn) == TagUrn.ENTITY_TYPE:
             tags_with_aspects.add(urn)
 
         yield wu

--- a/metadata-ingestion/tests/unit/test_source_helpers.py
+++ b/metadata-ingestion/tests/unit/test_source_helpers.py
@@ -1,13 +1,10 @@
-from typing import List, Union
+from typing import List
 
 import datahub.metadata.schema_classes as models
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.utilities.source_helpers import auto_status_aspect, auto_workunit
+from datahub.utilities.source_helpers import auto_status_aspect
 
-_base_metadata: List[
-    Union[MetadataChangeProposalWrapper, models.MetadataChangeEventClass]
-] = [
+_base_metadata: List[MetadataChangeProposalWrapper] = [
     MetadataChangeProposalWrapper(
         entityUrn="urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
         aspect=models.ContainerPropertiesClass(
@@ -18,60 +15,32 @@ _base_metadata: List[
         entityUrn="urn:li:container:108e111aa1d250dd52e0fd5d4b307b12",
         aspect=models.StatusClass(removed=True),
     ),
-    models.MetadataChangeEventClass(
-        proposedSnapshot=models.DatasetSnapshotClass(
-            urn="urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.staffing,PROD)",
-            aspects=[
-                models.DatasetPropertiesClass(
-                    customProperties={
-                        "key": "value",
-                    },
-                ),
-            ],
+    MetadataChangeProposalWrapper(
+        entityUrn="urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.staffing,PROD)",
+        aspect=models.DatasetPropertiesClass(
+            customProperties={
+                "key": "value",
+            },
         ),
     ),
-    models.MetadataChangeEventClass(
-        proposedSnapshot=models.DatasetSnapshotClass(
-            urn="urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.hospital_beds,PROD)",
-            aspects=[
-                models.StatusClass(removed=True),
-            ],
-        ),
+    MetadataChangeProposalWrapper(
+        entityUrn="urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.hospital_beds,PROD)",
+        aspect=models.StatusClass(removed=True),
     ),
 ]
 
 
-def test_auto_workunit():
-    wu = list(auto_workunit(_base_metadata))
-    assert all(isinstance(w, MetadataWorkUnit) for w in wu)
-
-    ids = [w.id for w in wu]
-    assert ids == [
-        "urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a-containerProperties",
-        "urn:li:container:108e111aa1d250dd52e0fd5d4b307b12-status",
-        "urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.staffing,PROD)/mce",
-        "urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.hospital_beds,PROD)/mce",
-    ]
-
-
 def test_auto_status_aspect():
-    initial_wu = list(auto_workunit(_base_metadata))
-
+    initial_wu = [mcp.as_workunit() for mcp in _base_metadata]
     expected = [
         *initial_wu,
-        *list(
-            auto_workunit(
-                [
-                    MetadataChangeProposalWrapper(
-                        entityUrn="urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
-                        aspect=models.StatusClass(removed=False),
-                    ),
-                    MetadataChangeProposalWrapper(
-                        entityUrn="urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.staffing,PROD)",
-                        aspect=models.StatusClass(removed=False),
-                    ),
-                ]
-            )
-        ),
+        MetadataChangeProposalWrapper(
+            entityUrn="urn:li:container:008e111aa1d250dd52e0fd5d4b307b1a",
+            aspect=models.StatusClass(removed=False),
+        ).as_workunit(),
+        MetadataChangeProposalWrapper(
+            entityUrn="urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_aha.staffing,PROD)",
+            aspect=models.StatusClass(removed=False),
+        ).as_workunit(),
     ]
     assert list(auto_status_aspect(initial_wu)) == expected


### PR DESCRIPTION
Am looking at the `auto_` source helpers for the 0 usage stats aspect emission and saw this was unused. Removing if we can actually do that

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
