### PR TITLE
fix: move scattered guides under api section 

### DIFF
--- a/docs/api/tutorials/modifying-dataset-deprecation.md
+++ b/docs/api/tutorials/modifying-dataset-deprecation.md
@@ -9,7 +9,7 @@ Deprecation indicates the status of an entity. For datasets, keeping the depreca
 
 ### Goal Of This Guide
 
-This guide will show you how to read or update deprecation status of a dataset `fct_users_created`.
+This guide will show you how to read or update deprecation status of a dataset.
 
 ## Prerequisites
 
@@ -22,8 +22,7 @@ If you attempt to manipulate entities that do not exist, your operation will fai
 In this guide, we will be using data from a sample ingestion.
 :::
 
-
-## Read Deprecation 
+## Read Deprecation
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -79,7 +78,6 @@ Expected Response:
 }
 ```
 
-
 </TabItem>
 
 <TabItem value="python" label="Python">
@@ -88,9 +86,6 @@ Expected Response:
 
 </TabItem>
 </Tabs>
-
-
-
 
 ## Update Deprecation
 
@@ -147,7 +142,6 @@ Expected Response:
 { "data": { "removeTag": true }, "extensions": {} }
 ```
 
-
 </TabItem>
 
 <TabItem value="python" label="Python">
@@ -156,7 +150,6 @@ Expected Response:
 
 </TabItem>
 </Tabs>
-
 
 ### Expected Outcomes of Updating Deprecation
 

--- a/docs/api/tutorials/modifying-dataset-descriptions.md
+++ b/docs/api/tutorials/modifying-dataset-descriptions.md
@@ -9,9 +9,10 @@ Adding a description and related link to a dataset can provide important informa
 
 ### Goal Of This Guide
 
-This guide will show you how to 
-* Add dataset description: add a description and a link to dataset `fct_users_deleted`.
-* Add column description: add a description to `user_name `column of a dataset `fct_users_deleted`.
+This guide will show you how to
+
+- Add dataset description: add a description and a link to dataset.
+- Add column description: add a description to column of a dataset.
 
 ## Prerequisites
 
@@ -40,6 +41,7 @@ In this example, we will add a description to `user_name `column of a dataset `f
 ```python
 {{ inline /metadata-ingestion/examples/library/dataset_add_documentation.py show_path_as_comment }}
 ```
+
 </TabItem>
 </Tabs>
 
@@ -49,8 +51,7 @@ You can now see the description is added to `fct_users_deleted`.
 
 ![dataset-description-added](../../imgs/apis/tutorials/dataset-description-added.png)
 
-## Add Description on Column 
-
+## Add Description on Column
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -126,7 +127,7 @@ Expected Response:
 </TabItem>
 </Tabs>
 
-### Expected Outcomes of Adding Description on Column 
+### Expected Outcomes of Adding Description on Column
 
 You can now see column description is added to `user_name` column of `fct_users_deleted`.
 

--- a/docs/api/tutorials/modifying-dataset-domains.md
+++ b/docs/api/tutorials/modifying-dataset-domains.md
@@ -10,19 +10,19 @@ For more information about domains, refer to [About DataHub Domains](/docs/domai
 
 ### Goal Of This Guide
 
-This guide will show you how to 
-* create a domain named `Marketing`
-* read domains attached to a dataset `fct_users_created`.
-* add a dataset named `fct_users_created` to a domain named `Marketing`.
-* remove the domain `Marketing` from the `fct_users_created` dataset.
+This guide will show you how to
+
+- Create: create a domain.
+- Read : read domain attached to a dataset.
+- Add: add a domain to a dataset
+- Remove: remove a domain from a dataset.
 
 ## Prerequisites
 
 For this tutorial, you need to deploy DataHub Quickstart and ingest sample data.
 For detailed steps, please refer to [Datahub Quickstart Guide](/docs/quickstart.md).
 
-## Create Domain 
-
+## Create Domain
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -75,7 +75,6 @@ Expected Response:
 You can now see `Marketing` domain has been created under `Govern > Domains`.
 
 ![domain-created](../../imgs/apis/tutorials/domain-created.png)
-
 
 ## Read Domains
 
@@ -156,8 +155,7 @@ Expected Response:
 </TabItem>
 </Tabs>
 
-
-## Add Domains 
+## Add Domains
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -210,15 +208,13 @@ Please note that there are two available endpoints (`:8000`, `:9002`) to access 
 For more information about the differences between these endpoints, please refer to [DataHub Metadata Service](../../../metadata-service/README.md#graphql-api)
 :::
 
-### Expected Outcomes of Adding Domain 
+### Expected Outcomes of Adding Domain
 
 You can now see `CustomerAccount` domain has been added to `user_name` column.
 
 ![tag-added](../../imgs/apis/tutorials/tag-added.png)
 
-
-## Remove Domains 
-
+## Remove Domains
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -255,11 +251,10 @@ curl --location --request POST 'http://localhost:8080/api/graphql' \
 </TabItem>
 <TabItem value="python" label="Python">
 
-> Coming Soon! 
+> Coming Soon!
 
 </TabItem>
 </Tabs>
-
 
 ### Expected Outcomes of Removing Domain
 

--- a/docs/api/tutorials/modifying-dataset-lineage.md
+++ b/docs/api/tutorials/modifying-dataset-lineage.md
@@ -10,8 +10,9 @@ For more information about lineage, refer to [About DataHub Lineage](/docs/linea
 
 ### Goal Of This Guide
 
-This guide will show you how to 
-* Add: add lineage between two hive datasets named `fct_users_deleted` and `logging_events`.
+This guide will show you how to
+
+- Add: add lineage between two hive datasets.
 
 ## Prerequisites
 
@@ -24,8 +25,7 @@ If you attempt to manipulate entities that do not exist, your operation will fai
 In this guide, we will be using data from sample ingestion.
 :::
 
-## Add Lineage 
-
+## Add Lineage
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -82,6 +82,7 @@ If you see the following response, the operation was successful:
   "extensions": {}
 }
 ```
+
 </TabItem>
 <TabItem value="curl" label="Curl">
 
@@ -96,6 +97,7 @@ Expected Response:
 ```json
 { "data": { "updateLineage": true }, "extensions": {} }
 ```
+
 </TabItem>
 <TabItem value="python" label="Python">
 
@@ -105,7 +107,6 @@ Expected Response:
 
 </TabItem>
 </Tabs>
-
 
 ### Expected Outcomes of Adding Lineage
 

--- a/docs/api/tutorials/modifying-dataset-owners.md
+++ b/docs/api/tutorials/modifying-dataset-owners.md
@@ -11,11 +11,12 @@ This helps to avoid confusion or conflicts over who is responsible for specific 
 
 ### Goal Of This Guide
 
-This guide will show you how to 
-* Create: create or update users and groups.
-* Read: read owners attached to a dataset `SampleHiveDataset`.
-* Add: add user group `bfoo` as an owner to the `fct_users_created` datatset.
-* Remove: remove the owner `John Doe` from the `SampleHdfsDataset` datatset.
+This guide will show you how to
+
+- Create: create or update users and groups.
+- Read: read owners attached to a dataset.
+- Add: add user group as an owner to the dataset.
+- Remove: remove the owner from the dataset.
 
 ## Pre-requisites
 
@@ -69,6 +70,7 @@ Update succeeded for urn urn:li:corpuser:datahub.
 ```python
 {{ inline /metadata-ingestion/examples/library/upsert_user.py show_path_as_comment }}
 ```
+
 </TabItem>
 </Tabs>
 
@@ -108,6 +110,7 @@ If you see the following logs, the operation was successful:
 ```shell
 Update succeeded for group urn:li:corpGroup:foogroup@acryl.io.
 ```
+
 </TabItem>
 
 <TabItem value="python" label="Python">
@@ -119,12 +122,10 @@ Update succeeded for group urn:li:corpGroup:foogroup@acryl.io.
 </TabItem>
 </Tabs>
 
-
 ### Expected Outcomes of Upserting Group
 
 You can see the group `Foo Group` has been created under `Settings > Access > Users & Groups`
 ![group-upserted](../../imgs/apis/tutorials/group-upserted.png)
-
 
 ## Read Owners
 
@@ -207,6 +208,7 @@ Expected Response:
   "extensions": {}
 }
 ```
+
 </TabItem>
 <TabItem value="python" label="Python">
 
@@ -214,8 +216,6 @@ Expected Response:
 
 </TabItem>
 </Tabs>
-
-
 
 ## Add Owners
 
@@ -249,7 +249,6 @@ Expected Response:
 </TabItem>
 <TabItem value="curl" label="Curl">
 
-
 ```shell
 curl --location --request POST 'http://localhost:8080/api/graphql' \
 --header 'Authorization: Bearer <my-access-token>' \
@@ -273,9 +272,7 @@ You can now see `bfoo` has been added as an owner to the `fct_users_created` dat
 
 ![ownership-added](../../imgs/apis/tutorials/owner-added.png)
 
-
-
-## Remove Owners 
+## Remove Owners
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -334,7 +331,6 @@ curl --location --request POST 'http://localhost:8080/api/graphql' \
 
 </TabItem>
 </Tabs>
-
 
 ### Expected Outcomes of Removing Owners
 

--- a/docs/api/tutorials/modifying-dataset-tags.md
+++ b/docs/api/tutorials/modifying-dataset-tags.md
@@ -11,10 +11,12 @@ For more information about tags, refer to [About DataHub Tags](/docs/tags.md).
 ### Goal Of This Guide
 
 This guide will show you how to
-- Create: create a tag named `Deprecated`
-- Read: read tags attached to a dataset `SampleHiveDataset`
-- Add: add a `CustomerAccount` tag to the `user_name` column of a dataset called `fct_users_created`.
-- Remove: remove a `Legacy` from the `shipment_info` column of a dataset called `SampleHdfsDataset`.
+
+- Create: create a tag.
+- Read : read tags attached to a dataset.
+- Add: add a tag to a column of a dataset or a dataset itself.
+- Remove: remove a tag from a dataset.
+-
 
 ## Prerequisites
 
@@ -105,9 +107,7 @@ datahub get --urn "urn:li:tag:deprecated" --aspect tagProperties
 }
 ```
 
-
-## Read Tags 
-
+## Read Tags
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -161,7 +161,6 @@ If you see the following response, the operation was successful:
 </TabItem>
 <TabItem value="curl" label="Curl">
 
-
 ```shell
 curl --location --request POST 'http://localhost:8080/api/graphql' \
 --header 'Authorization: Bearer <my-access-token>' \
@@ -203,8 +202,9 @@ Expected Response:
 </TabItem>
 </Tabs>
 
-
 ## Add Tags
+
+### Add Tags to a dataset
 
 The following code shows you how can add tags to a dataset.
 In the following code, we add a tag `Deprecated` to a dataset named `fct_users_created`.
@@ -220,19 +220,6 @@ mutation addTags {
         resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)",
       }
     )
-}
-```
-
-Note that you can also add a tag on a column of a dataset if you specify `subResourceType` and `subResource`.
-
-```json
-mutation addTags {
-    addTags(
-      input: {
-        tagUrns: ["urn:li:tag:deprecated"],
-        resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)",
-        subResourceType:DATASET_FIELD,
-        subResource:"user_name"})
 }
 ```
 
@@ -268,6 +255,48 @@ Expected Response:
 
 ```python
 {{ inline /metadata-ingestion/examples/library/create_tag.py show_path_as_comment }}
+```
+
+</TabItem>
+</Tabs>
+
+### Add Tags to a Column of a dataset
+
+<Tabs>
+<TabItem value="graphql" label="GraphQL">
+
+```json
+mutation addTags {
+    addTags(
+      input: {
+        tagUrns: ["urn:li:tag:deprecated"],
+        resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)",
+        subResourceType:DATASET_FIELD,
+        subResource:"user_name"})
+}
+```
+
+</TabItem>
+<TabItem value="curl" label="Curl">
+
+```shell
+curl --location --request POST 'http://localhost:8080/api/graphql' \
+--header 'Authorization: Bearer <my-access-token>' \
+--header 'Content-Type: application/json' \
+--data-raw '{ "query": "mutation addTags { addTags(input: { tagUrns: [\"urn:li:tag:deprecated\"], resourceUrn: \"urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)\", subResourceType: DATASET_FIELD, subResource: \"user_name\" }) }", "variables":{}}'
+```
+
+Expected Response:
+
+```json
+{ "data": { "addTags": true }, "extensions": {} }
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+{{ inline /metadata-ingestion/examples/library/dataset_add_column_tag.py show_path_as_comment }}
 ```
 
 </TabItem>

--- a/docs/api/tutorials/modifying-dataset-terms.md
+++ b/docs/api/tutorials/modifying-dataset-terms.md
@@ -11,11 +11,12 @@ For more information about terms, refer to [About DataHub Business Glossary](/do
 
 ### Goal Of This Guide
 
-This guide will show you how to 
-- Create: create a term named `Rate of Return`.
-- Read : read terms attached to a dataset `SampleHiveDataset`.
-- Add: add a `CustomerAccount` term to `user_name` column of a dataset named `fct_users_created`.
-- Remove: remove a term `CustomerAccount` from the `user_name` column of a dataset called `fct_users_created`.
+This guide will show you how to
+
+- Create: create a term.
+- Read : read terms attached to a dataset.
+- Add: add a term to a column of a dataset or a dataset itself.
+- Remove: remove a term from a dataset.
 
 ## Prerequisites
 
@@ -110,7 +111,7 @@ datahub get --urn "urn:li:glossaryTerm:rateofreturn" --aspect glossaryTermInfo
 }
 ```
 
-## Read Terms 
+## Read Terms
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
@@ -161,7 +162,6 @@ If you see the following response, the operation was successful:
 </TabItem>
 <TabItem value="curl" label="Curl">
 
-
 ```shell
 curl --location --request POST 'http://localhost:8080/api/graphql' \
 --header 'Authorization: Bearer <my-access-token>' \
@@ -183,28 +183,15 @@ Expected Response:
 </TabItem>
 </Tabs>
 
-
-
 ## Add Terms
 
+### Add Terms to a dataset
+
 The following code shows you how can add terms to a dataset.
-In the following code, we add a term `Legacy` to a dataset named `fct_users_created`.
+In the following code, we add a term `Rate of Return` to a dataset named `fct_users_created`.
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>
-
-```python
-mutation addTerms {
-    addTerms(
-      input: {
-        termUrns: ["urn:li:glossaryTerm:rateofreturn"],
-        resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)",
-        subResourceType:DATASET_FIELD,
-        subResource:"user_name"})
-}
-```
-
-Note that you can also add a term on a dataset if you don't specify `subResourceType` and `subResource`.
 
 ```json
 mutation addTerms {
@@ -254,16 +241,58 @@ Expected Response:
 </TabItem>
 </Tabs>
 
+### Add Terms to a Column of a Dataset
+
+<Tabs>
+<TabItem value="graphql" label="GraphQL">
+
+```json
+mutation addTerms {
+    addTerms(
+      input: {
+        termUrns: ["urn:li:glossaryTerm:rateofreturn"],
+        resourceUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)",
+        subResourceType:DATASET_FIELD,
+        subResource:"user_name"})
+}
+```
+
+</TabItem>
+<TabItem value="curl" label="Curl">
+
+```shell
+curl --location --request POST 'http://localhost:8080/api/graphql' \
+--header 'Authorization: Bearer <my-access-token>' \
+--header 'Content-Type: application/json' \
+--data-raw '{ "query": "mutation addTerms { addTerms(input: { termUrns: [\"urn:li:glossaryTerm:rateofreturn\"], resourceUrn: \"urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)\", subResourceType: DATASET_FIELD, subResource: \"user_name\" }) }", "variables":{}}'
+```
+
+Expected Response:
+
+```json
+{ "data": { "addTerms": true }, "extensions": {} }
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+{{ inline /metadata-ingestion/examples/library/dataset_add_column_term.py show_path_as_comment }}
+```
+
+</TabItem>
+</Tabs>
+
 ### Expected Outcome of Adding Terms
 
-You can now see `Legacy` term has been added to `user_name` column.
+You can now see `Rate of Return` term has been added to `user_name` column.
 
 ![term-added](../../imgs/apis/tutorials/term-added.png)
 
 ## Remove Terms
 
 The following code remove a term from a dataset.
-After running this code, `Legacy` term will be removed from a `user_name` column.
+After running this code, `Rate of Return` term will be removed from a `user_name` column.
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL" default>

--- a/docs/api/tutorials/modifying-datasets.md
+++ b/docs/api/tutorials/modifying-datasets.md
@@ -10,14 +10,17 @@ For more information about datasets, refer to [Dataset](/docs/generated/metamode
 
 ### Goal Of This Guide
 
-This guide will show you how to 
-* Create: create a dataset named `realestate_db.sales` with three columns.
-* Delete: delete a dataset named `fct_user_deleted`.
+This guide will show you how to
+
+- Create: create a dataset named `realestate_db.sales` with three columns.
+- Delete: delete a dataset named `fct_user_deleted`.
 
 ## Prerequisites
 
 For this tutorial, you need to deploy DataHub Quickstart and ingest sample data.
 For detailed steps, please refer to [Datahub Quickstart Guide](/docs/quickstart.md).
+
+## Create Dataset
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL">
@@ -31,9 +34,9 @@ For detailed steps, please refer to [Datahub Quickstart Guide](/docs/quickstart.
 ```python
 {{ inline /metadata-ingestion/examples/library/dataset_schema.py show_path_as_comment }}
 ```
+
 </TabItem>
 </Tabs>
-
 
 ### Expected Outcomes of Creating Dataset
 
@@ -51,7 +54,6 @@ There are two methods of deletion: soft delete and hard delete.
 **Hard delete** physically deletes all rows for all aspects of the entity.
 
 For more information about soft delete and hard delete, please refer to [Removing Metadata from DataHub](/docs/how/delete-metadata.md#delete-by-urn).
-
 
 <Tabs>
 <TabItem value="graphql" label="GraphQL">
@@ -100,6 +102,7 @@ Expected Response:
 ```python
 {{ inline /metadata-ingestion/examples/library/delete_dataset.py show_path_as_comment }}
 ```
+
 </TabItem>
 </Tabs>
 

--- a/metadata-ingestion/examples/library/dataset_add_column_term.py
+++ b/metadata-ingestion/examples/library/dataset_add_column_term.py
@@ -97,7 +97,7 @@ if need_write:
         aspect=current_editable_schema_metadata,
     )
     graph.emit(event)
-    log.info(f"Tag {term_to_add} added to column {column} of dataset {dataset_urn}")
+    log.info(f"Term {term_to_add} added to column {column} of dataset {dataset_urn}")
 
 else:
-    log.info(f"Tag {term_to_add} already attached to column {column}, omitting write")
+    log.info(f"Term {term_to_add} already attached to column {column}, omitting write")

--- a/metadata-models/docs/entities/dataset.md
+++ b/metadata-models/docs/entities/dataset.md
@@ -40,15 +40,7 @@ Taking a simple nested schema as described below:
 
 Understanding field paths is important, because they are the identifiers through which tags, terms, documentation on fields are expressed. Besides the type and name of the field, schemas also contain descriptions attached to the individual fields, as well as information about primary and foreign keys.
 
-The following code snippet shows you how to add a Schema containing 3 fields to a dataset.
-<details>
-<summary>Python SDK: Add a schema to a dataset</summary>
-
-```python
-{{ inline /metadata-ingestion/examples/library/dataset_schema.py show_path_as_comment }}
-```
-</details>
-
+For more information on how to add a schema to a dataset, please refer to our API guides on [Creating Dataset via Python SDK](/docs/api/tutorials/modifying-datasets.md#create-dataset).
 
 ### Tags and Glossary Terms
 
@@ -58,48 +50,19 @@ Datasets can have Tags or Terms attached to them. Read [this blog](https://blog.
 
 At the top-level, tags are added to datasets using the `globalTags` aspect, while terms are added using the `glossaryTerms` aspect.
 
-Here is an example for how to add a tag to a dataset. Note that this involves reading the currently set tags on the dataset and then adding a new one if needed.
-
-<details>
-<summary>Python SDK: Add a tag to a dataset at the top-level</summary>
-
-```python
-{{ inline /metadata-ingestion/examples/library/dataset_add_tag.py show_path_as_comment }}
-```
-</details>
-
-Here is an example of adding a term to a dataset. Note that this involves reading the currently set terms on the dataset and then adding a new one if needed.
-<details>
-<summary>Python SDK: Add a term to a dataset at the top-level</summary>
-
-```python
-{{ inline /metadata-ingestion/examples/library/dataset_add_term.py show_path_as_comment }}
-```
-</details>
+Refer to the following guides for more information. 
+* [Adding Tags to a dataset](/docs/api/tutorials/modifying-dataset-tags.md#add-tags-to-a-dataset)
+* [Adding Terms to a dataset](/docs/api/tutorials/modifying-dataset-terms.md#add-terms-to-a-dataset)
 
 #### Adding Tags or Glossary Terms to columns / fields of a dataset
 
 Tags and Terms can also be attached to an individual column (field) of a dataset. These attachments are done via the `schemaMetadata` aspect by ingestion connectors / transformers and via the `editableSchemaMetadata` aspect by the UI.
 This separation allows the writes from the replication of metadata from the source system to be isolated from the edits made in the UI.
 
-Here is an example of how you can add a tag to a field in a dataset using the low-level Python SDK.
+Refer to the following guides for more information. 
+* [Adding Tags to a column of a dataset](/docs/api/tutorials/modifying-dataset-tags.md#add-tags-to-a-column-of-a-dataset)
+* [Adding Terms to a column of a dataset](/docs/api/tutorials/modifying-dataset-terms.md#add-terms-to-a-column-of-a-dataset)
 
-<details>
-<summary>Python SDK: Add a tag to a column (field) of a dataset</summary>
-
-```python
-{{ inline /metadata-ingestion/examples/library/dataset_add_column_term.py show_path_as_comment }}
-```
-</details>
-
-Similarly, here is an example of how you would add a term to a field in a dataset using the low-level Python SDK. 
-<details>
-<summary>Python SDK: Add a term to a column (field) of a dataset</summary>
-
-```python
-{{ inline /metadata-ingestion/examples/library/dataset_add_column_term.py show_path_as_comment }}
-```
-</details>
 
 ### Ownership
 
@@ -107,15 +70,8 @@ Ownership is associated to a dataset using the `ownership` aspect. Owners can be
 
 #### Adding Owners
 
-The following script shows you how to add an owner to a dataset using the low-level Python SDK.
-
-<details>
-<summary>Python SDK: Add an owner to a dataset</summary>
-
-```python
-{{ inline /metadata-ingestion/examples/library/dataset_add_owner.py show_path_as_comment }}
-```
-</details>
+Refer to the following guides for more information. 
+* [Adding Owners to a dataset](/docs/api/tutorials/modifying-dataset-owners.md#add-owners)
 
 ### Fine-grained lineage
 Fine-grained lineage at field level can be associated to a dataset in two ways - either directly attached to the `upstreamLineage` aspect of a dataset, or captured as part of the `dataJobInputOutput` aspect of a dataJob.


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


