### PR TITLE
fix(ui) Fix Tag Details button to use url encoding

### DIFF
--- a/datahub-web-react/src/app/shared/tags/TagProfileDrawer.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagProfileDrawer.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import { InfoCircleOutlined } from '@ant-design/icons';
 
 import TagStyleEntity from '../TagStyleEntity';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { EntityType } from '../../../types.generated';
 
 type Props = {
     closeTagProfileDrawer?: () => void;
@@ -17,6 +19,7 @@ const DetailsLayout = styled.div`
 `;
 
 export const TagProfileDrawer = ({ closeTagProfileDrawer, tagProfileDrawerVisible, urn }: Props) => {
+    const entityRegistry = useEntityRegistry();
     return (
         <>
             <Drawer
@@ -33,7 +36,7 @@ export const TagProfileDrawer = ({ closeTagProfileDrawer, tagProfileDrawerVisibl
                             </Button>
                         </Space>
                         <Space>
-                            <Button href={`/tag/${urn}`}>
+                            <Button href={entityRegistry.getEntityUrl(EntityType.Tag, urn)}>
                                 <InfoCircleOutlined /> Tag Details
                             </Button>
                         </Space>


### PR DESCRIPTION
The Tag Details button was sending users directly to a link with the `urn` in it - but that urn needs to be encoded. So let's use our handy entity registry method which handles this stuff for us.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
