### PR TITLE
fix(docs): Adding relationship types section to Business Glossary docs

### DIFF
--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -94,6 +94,33 @@ To manage your glossary using Git, you can define it within a file and then use 
 it into DataHub whenever a change is made (e.g. on a `git commit` hook). For detailed information about the format of
 the glossary file, and how to ingest it into DataHub, check out the [Business Glossary](../generated/ingestion/sources/business-glossary.md) source guide.
 
+## About Glossary Term Relationships
+
+DataHub supports 2 different kinds of relationships _between_ individual Glossary Terms: **Inherits From** and **Contains**. 
+
+**Contains** can be used to relate two Glossary Terms when one may be a superset of another. 
+For example:
+
+**Address** Term _Contains_ **Zip Code** Term, **Street** Term, **City** Term (_Has-A_ style relationship)
+
+**Inherits** can be used to relate two Glossary Terms when one is be a sub-type or sub-category of another. 
+
+For example:
+
+**Email** Term _Inherits From_  **PII** Term (_Is-A_ style relationship)
+
+These relationship types allow you to map the concepts existing within your organization, enabling you to
+change the mapping between concepts behind the scenes, without needing to change the Glossary Terms
+that are attached to individual Data Assets and Columns. 
+
+For example, you can define a very specific, concrete Glossary Term like `Email Address` to represent a physical
+data type, and then associate this with a higher-level `PII` Glossary Term via an `Inheritance` relationship. 
+This allows you to easily maintain a set of all Data Assets that contain or process `PII`, while keeping it easy to add 
+and remove new Terms from the `PII` Classification, e.g. without requiring re-annotation of individual Data Assets or Columns.
+
+
+
+
 ## Demo
 
 Check out [our demo site](https://demo.datahubproject.io/glossary) to see an example Glossary and how it works!

--- a/docs/glossary/business-glossary.md
+++ b/docs/glossary/business-glossary.md
@@ -98,16 +98,11 @@ the glossary file, and how to ingest it into DataHub, check out the [Business Gl
 
 DataHub supports 2 different kinds of relationships _between_ individual Glossary Terms: **Inherits From** and **Contains**. 
 
-**Contains** can be used to relate two Glossary Terms when one may be a superset of another. 
-For example:
+**Contains** can be used to relate two Glossary Terms when one is a _superset_ of or _consists_ of another.
+For example: **Address** Term _Contains_ **Zip Code** Term, **Street** Term, & **City** Term (_Has-A_ style relationship)
 
-**Address** Term _Contains_ **Zip Code** Term, **Street** Term, **City** Term (_Has-A_ style relationship)
-
-**Inherits** can be used to relate two Glossary Terms when one is be a sub-type or sub-category of another. 
-
-For example:
-
-**Email** Term _Inherits From_  **PII** Term (_Is-A_ style relationship)
+**Inherits** can be used to relate two Glossary Terms when one is a _sub-type_ or _sub-category_ of another.
+For example: **Email** Term _Inherits From_  **PII** Term (_Is-A_ style relationship)
 
 These relationship types allow you to map the concepts existing within your organization, enabling you to
 change the mapping between concepts behind the scenes, without needing to change the Glossary Terms


### PR DESCRIPTION
## Summary

In this PR I extend the Business Glossary docs to contain examples of each type of supported relationship. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
