### PR TITLE
fix(metadata ingestion): fix incorrect dot interpretation

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -666,15 +666,17 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
             inspector, schema, table
         )
 
-        # Tablename might be different from the real table if we ran some normalisation ont it.
+        # Tablename might be different from the real table if we ran some normalisation on it.
         # Getting normalized table name from the dataset_name
-        # Table is the last item in the dataset name
+        # Table is the last item in the BigQuery dataset name
         normalised_table = table
-        splits = dataset_name.split(".")
-        if splits:
-            normalised_table = splits[-1]
-            if properties and normalised_table != table:
-                properties["original_table_name"] = table
+
+        if self.platform == "bigquery":
+            splits = dataset_name.split(".")
+            if splits:
+                normalised_table = splits[-1]
+                if properties and normalised_table != table:
+                    properties["original_table_name"] = table
 
         dataset_properties = DatasetPropertiesClass(
             name=normalised_table,


### PR DESCRIPTION
Bug: all dataset of all platforms were splitted by dots and the last element of a list was considered as an actual table name. Fix: add if-statement to check if platform instance is BigQuery, since PostgreSQL and some other DBMSs allow to use dots in table names. Not the cleanest solution for this behaviour, obviously, so feel free to provide me with an information on how to apply this change in a more consise way. Consider to move the normalization block to "bigquery_v2/bigquery.py", but I'm not able to test this using actual BQ table.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
