### PR TITLE
feat(models): Make assets searchable by their external URLs

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/common/ExternalReference.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/ExternalReference.pdl
@@ -7,5 +7,8 @@ record ExternalReference {
   /**
    * URL where the reference exist
    */
+  @Searchable = {
+    "fieldType": "KEYWORD"
+  }
   externalUrl: optional Url
 }


### PR DESCRIPTION
## Summary
In this PR we add the https://github.com/searchable annotation to the externalUrl field shared across entities! This enables us to find unique assets based on their unique URL, for use within the Chrome extension :)

Tested using this search input
```
{
 "input": {"types": ["DATASET"], "query": "*", "start": 0, "count": 10, "orFilters": [ { "and": [ { "field": "externalUrl", "values": ["https://www.google.com/"] } ] } ] }
}
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
