### PR TITLE
fix(ui) Fix displaying column level lineage for sibling nodes

### DIFF
--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -132,6 +132,7 @@ export default class EntityRegistry {
     getLineageVizConfig<T>(type: EntityType, data: T): FetchedEntity | undefined {
         const entity = validatedGet(type, this.entityTypeToEntity);
         const genericEntityProperties = this.getGenericEntityProperties(type, data);
+        // combine fineGrainedLineages from this node as well as its siblings
         const fineGrainedLineages = getFineGrainedLineageWithSiblings(
             genericEntityProperties,
             (t: EntityType, d: EntityInterface) => this.getGenericEntityProperties(t, d),

--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -3,7 +3,7 @@ import { FetchedEntity } from '../lineage/types';
 import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from './Entity';
 import { GLOSSARY_ENTITY_TYPES } from './shared/constants';
 import { GenericEntityProperties } from './shared/types';
-import { dictToQueryStringParams, urlEncodeUrn } from './shared/utils';
+import { dictToQueryStringParams, getFineGrainedLineageWithSiblings, urlEncodeUrn } from './shared/utils';
 
 function validatedGet<K, V>(key: K, map: Map<K, V>): V {
     if (map.has(key)) {
@@ -132,6 +132,10 @@ export default class EntityRegistry {
     getLineageVizConfig<T>(type: EntityType, data: T): FetchedEntity | undefined {
         const entity = validatedGet(type, this.entityTypeToEntity);
         const genericEntityProperties = this.getGenericEntityProperties(type, data);
+        const fineGrainedLineages = getFineGrainedLineageWithSiblings(
+            genericEntityProperties,
+            (t: EntityType, d: EntityInterface) => this.getGenericEntityProperties(t, d),
+        );
         return (
             ({
                 ...entity.getLineageVizConfig?.(data),
@@ -161,7 +165,8 @@ export default class EntityRegistry {
                     (genericEntityProperties?.upstream?.filtered || 0),
                 status: genericEntityProperties?.status,
                 siblingPlatforms: genericEntityProperties?.siblingPlatforms,
-                fineGrainedLineages: genericEntityProperties?.fineGrainedLineages,
+                fineGrainedLineages,
+                siblings: genericEntityProperties?.siblings,
                 schemaMetadata: genericEntityProperties?.schemaMetadata,
                 inputFields: genericEntityProperties?.inputFields,
                 canEditLineage: genericEntityProperties?.privileges?.canEditLineage,

--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -147,6 +147,7 @@ export const handleBatchError = (urns, e, defaultMessage) => {
     return defaultMessage;
 };
 
+// put all of the fineGrainedLineages for a given entity and its siblings into one array so we have all of it in one place
 export function getFineGrainedLineageWithSiblings(
     entityData: GenericEntityProperties | null,
     getGenericEntityProperties: (type: EntityType, data: Entity) => GenericEntityProperties | null,

--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -1,6 +1,6 @@
 import * as QueryString from 'query-string';
 
-import { MatchedField } from '../../../types.generated';
+import { Entity, EntityType, MatchedField } from '../../../types.generated';
 import { capitalizeFirstLetterOnly } from '../../shared/textUtil';
 import { FIELDS_TO_HIGHLIGHT } from '../dataset/search/highlights';
 import { GenericEntityProperties } from './types';
@@ -146,3 +146,19 @@ export const handleBatchError = (urns, e, defaultMessage) => {
     }
     return defaultMessage;
 };
+
+export function getFineGrainedLineageWithSiblings(
+    entityData: GenericEntityProperties | null,
+    getGenericEntityProperties: (type: EntityType, data: Entity) => GenericEntityProperties | null,
+) {
+    const fineGrainedLineages = [...(entityData?.fineGrainedLineages || [])];
+    entityData?.siblings?.siblings?.forEach((sibling) => {
+        if (sibling) {
+            const genericSiblingProps = getGenericEntityProperties(sibling.type, sibling);
+            if (genericSiblingProps && genericSiblingProps.fineGrainedLineages) {
+                fineGrainedLineages.push(...genericSiblingProps.fineGrainedLineages);
+            }
+        }
+    });
+    return fineGrainedLineages;
+}

--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -58,6 +58,7 @@ export default function LineageExplorer({ urn, type }: Props) {
     const previousUrn = usePrevious(urn);
     const history = useHistory();
     const [fineGrainedMap] = useState<any>({ forward: {}, reverse: {} });
+    const [fineGrainedMapForSiblings] = useState<any>({});
 
     const entityRegistry = useEntityRegistry();
     const isHideSiblingMode = useIsSeparateSiblingsMode();
@@ -100,6 +101,7 @@ export default function LineageExplorer({ urn, type }: Props) {
                 // record that we have added this entity
                 let newAsyncEntities = extendAsyncEntities(
                     fineGrainedMap,
+                    fineGrainedMapForSiblings,
                     asyncEntities,
                     entityRegistry,
                     entityAndType,
@@ -110,6 +112,7 @@ export default function LineageExplorer({ urn, type }: Props) {
                 config?.downstreamChildren?.forEach((downstream) => {
                     newAsyncEntities = extendAsyncEntities(
                         fineGrainedMap,
+                        fineGrainedMapForSiblings,
                         newAsyncEntities,
                         entityRegistry,
                         downstream,
@@ -119,6 +122,7 @@ export default function LineageExplorer({ urn, type }: Props) {
                 config?.upstreamChildren?.forEach((downstream) => {
                     newAsyncEntities = extendAsyncEntities(
                         fineGrainedMap,
+                        fineGrainedMapForSiblings,
                         newAsyncEntities,
                         entityRegistry,
                         downstream,
@@ -128,7 +132,7 @@ export default function LineageExplorer({ urn, type }: Props) {
                 setAsyncEntities(newAsyncEntities);
             }
         },
-        [asyncEntities, setAsyncEntities, entityRegistry, fineGrainedMap],
+        [asyncEntities, setAsyncEntities, entityRegistry, fineGrainedMap, fineGrainedMapForSiblings],
     );
 
     // set asyncEntity to have fullyFetched: false so we can update it in maybeAddAsyncLoadedEntity

--- a/datahub-web-react/src/app/lineage/__tests__/LineageTree.test.tsx
+++ b/datahub-web-react/src/app/lineage/__tests__/LineageTree.test.tsx
@@ -44,6 +44,7 @@ describe('LineageTree', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: EntityType.Dataset },

--- a/datahub-web-react/src/app/lineage/__tests__/adjustVXTreeLayout.test.tsx
+++ b/datahub-web-react/src/app/lineage/__tests__/adjustVXTreeLayout.test.tsx
@@ -31,6 +31,7 @@ describe('adjustVXTreeLayout', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: EntityType.Dataset },
@@ -80,6 +81,7 @@ describe('adjustVXTreeLayout', () => {
         const mockFetchedEntities = fetchedEntities.reduce(
             (acc, entry) =>
                 extendAsyncEntities(
+                    {},
                     {},
                     acc,
                     testEntityRegistry,
@@ -136,6 +138,7 @@ describe('adjustVXTreeLayout', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: EntityType.Dataset },
@@ -180,6 +183,7 @@ describe('adjustVXTreeLayout', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: EntityType.Dataset },
@@ -223,6 +227,7 @@ describe('adjustVXTreeLayout', () => {
         const mockFetchedEntities = fetchedEntities.reduce(
             (acc, entry) =>
                 extendAsyncEntities(
+                    {},
                     {},
                     acc,
                     testEntityRegistry,

--- a/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
+++ b/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
@@ -55,6 +55,7 @@ describe('constructTree', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: EntityType.Dataset },
@@ -105,6 +106,7 @@ describe('constructTree', () => {
         const mockFetchedEntities = fetchedEntities.reduce(
             (acc, entry) =>
                 extendAsyncEntities(
+                    {},
                     {},
                     acc,
                     testEntityRegistry,
@@ -157,6 +159,7 @@ describe('constructTree', () => {
         const mockFetchedEntities = fetchedEntities.reduce(
             (acc, entry) =>
                 extendAsyncEntities(
+                    {},
                     {},
                     acc,
                     testEntityRegistry,
@@ -252,6 +255,7 @@ describe('constructTree', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: EntityType.Dataset },
@@ -281,6 +285,7 @@ describe('constructTree', () => {
         const mockFetchedEntities = fetchedEntities.reduce(
             (acc, entry) =>
                 extendAsyncEntities(
+                    {},
                     {},
                     acc,
                     testEntityRegistry,
@@ -368,6 +373,7 @@ describe('constructTree', () => {
             (acc, entry) =>
                 extendAsyncEntities(
                     {},
+                    {},
                     acc,
                     testEntityRegistry,
                     { entity: entry.entity, type: entry.entity.type },
@@ -421,6 +427,7 @@ describe('constructTree', () => {
         const mockFetchedEntities = fetchedEntities.reduce(
             (acc, entry) =>
                 extendAsyncEntities(
+                    {},
                     {},
                     acc,
                     testEntityRegistry,

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -18,6 +18,7 @@ import {
     InputFields,
     Entity,
     LineageRelationship,
+    SiblingProperties,
 } from '../../types.generated';
 
 export type EntitySelectParams = {
@@ -51,6 +52,7 @@ export type FetchedEntity = {
     status?: Maybe<Status>;
     siblingPlatforms?: Maybe<DataPlatform[]>;
     fineGrainedLineages?: [FineGrainedLineage];
+    siblings?: Maybe<SiblingProperties>;
     schemaMetadata?: SchemaMetadata;
     inputFields?: InputFields;
     canEditLineage?: boolean;

--- a/datahub-web-react/src/app/lineage/utils/constructTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructTree.ts
@@ -73,6 +73,7 @@ export default function constructTree(
             if (!(entity.urn in updatedFetchedEntities)) {
                 updatedFetchedEntities = extendAsyncEntities(
                     {},
+                    {},
                     updatedFetchedEntities,
                     entityRegistry,
                     createEntityAndType(entity),

--- a/datahub-web-react/src/app/lineage/utils/extendAsyncEntities.ts
+++ b/datahub-web-react/src/app/lineage/utils/extendAsyncEntities.ts
@@ -23,7 +23,7 @@ function updateFineGrainedMap(
 ) {
     const mapForUrn = fineGrainedMap.forward[upstreamEntityUrn] || {};
     const mapForField = mapForUrn[upstreamField] || {};
-    const listForDownstream = mapForField[downstreamEntityUrn] || [];
+    const listForDownstream = [...(mapForField[downstreamEntityUrn] || [])];
     listForDownstream.push(downstreamField);
 
     // eslint-disable-next-line no-param-reassign
@@ -33,7 +33,7 @@ function updateFineGrainedMap(
 
     const mapForUrnReverse = fineGrainedMap.reverse[downstreamEntityUrn] || {};
     const mapForFieldReverse = mapForUrnReverse[downstreamField] || {};
-    const listForDownstreamReverse = mapForFieldReverse[upstreamEntityUrn] || [];
+    const listForDownstreamReverse = [...(mapForFieldReverse[upstreamEntityUrn] || [])];
     listForDownstreamReverse.push(upstreamField);
 
     // eslint-disable-next-line no-param-reassign
@@ -42,24 +42,78 @@ function updateFineGrainedMap(
     mapForFieldReverse[upstreamEntityUrn] = listForDownstreamReverse;
 }
 
-function extendColumnLineage(lineageVizConfig: FetchedEntity, fineGrainedMap: any) {
+function extendColumnLineage(
+    lineageVizConfig: FetchedEntity,
+    fineGrainedMap: any,
+    fineGrainedMapForSiblings: any,
+    fetchedEntities: FetchedEntities,
+) {
     if (lineageVizConfig.fineGrainedLineages && lineageVizConfig.fineGrainedLineages.length > 0) {
         lineageVizConfig.fineGrainedLineages.forEach((fineGrainedLineage) => {
             fineGrainedLineage.upstreams?.forEach((upstream) => {
                 const [upstreamEntityUrn, upstreamField] = breakFieldUrn(upstream);
                 fineGrainedLineage.downstreams?.forEach((downstream) => {
-                    const [downstreamEntityUrn, downstreamField] = breakFieldUrn(downstream);
+                    const downstreamField = breakFieldUrn(downstream)[1];
+                    // fineGrainedLineage always belongs on the downstream urn with upstreams pointing to another entity
+                    // pass in the visualized node's urn and not the urn from the schema field as the downstream urn,
+                    // as they will either be the same or if they are different, it belongs to a "hidden" sibling
                     updateFineGrainedMap(
                         fineGrainedMap,
                         upstreamEntityUrn,
                         upstreamField,
-                        downstreamEntityUrn,
+                        lineageVizConfig.urn,
                         downstreamField,
                     );
+
+                    // upstreamEntityUrn could belong to a sibling we don't "render", so store its inputs to updateFineGrainedMap
+                    // and update the fine grained map later when we see the entity with these siblings
+                    // eslint-disable-next-line no-param-reassign
+                    fineGrainedMapForSiblings[upstreamEntityUrn] = [
+                        ...(fineGrainedMapForSiblings[upstreamEntityUrn] || []),
+                        {
+                            upstreamField,
+                            downstreamEntityUrn: lineageVizConfig.urn,
+                            downstreamField,
+                        },
+                    ];
+
+                    // if this upstreamEntityUrn is a sibling of one of the already rendered nodes,
+                    // update the fine grained map with the rendered node instead of its sibling
+                    Object.keys(fetchedEntities).forEach((urn) => {
+                        fetchedEntities[urn].siblings?.siblings?.forEach((sibling) => {
+                            if (sibling && sibling.urn === upstreamEntityUrn) {
+                                updateFineGrainedMap(
+                                    fineGrainedMap,
+                                    urn,
+                                    upstreamField,
+                                    lineageVizConfig.urn,
+                                    downstreamField,
+                                );
+                            }
+                        });
+                    });
                 });
             });
         });
     }
+
+    // if we've seen fineGrainedMappings for this current entity's siblings, update the
+    // fine grained map with the rendered urn instead of the "hidden" sibling urn
+    lineageVizConfig.siblings?.siblings?.forEach((sibling) => {
+        if (sibling && fineGrainedMapForSiblings[sibling.urn]) {
+            fineGrainedMapForSiblings[sibling.urn].forEach((entry) => {
+                updateFineGrainedMap(
+                    fineGrainedMap,
+                    lineageVizConfig.urn,
+                    entry.upstreamField,
+                    entry.downstreamEntityUrn,
+                    entry.downstreamField,
+                );
+            });
+        }
+    });
+
+    // below is to update the fineGrainedMap for Data Jobs
     if (lineageVizConfig.inputFields?.fields && lineageVizConfig.inputFields.fields.length > 0) {
         lineageVizConfig.inputFields.fields.forEach((inputField) => {
             if (inputField?.schemaFieldUrn && inputField.schemaField) {
@@ -80,6 +134,7 @@ function extendColumnLineage(lineageVizConfig: FetchedEntity, fineGrainedMap: an
 
 export default function extendAsyncEntities(
     fineGrainedMap: any,
+    fineGrainedMapForSiblings: any,
     fetchedEntities: FetchedEntities,
     entityRegistry: EntityRegistry,
     entityAndType: EntityAndType,
@@ -93,7 +148,7 @@ export default function extendAsyncEntities(
 
     if (!lineageVizConfig) return fetchedEntities;
 
-    extendColumnLineage(lineageVizConfig, fineGrainedMap);
+    extendColumnLineage(lineageVizConfig, fineGrainedMap, fineGrainedMapForSiblings, fetchedEntities);
 
     return {
         ...fetchedEntities,


### PR DESCRIPTION
We had an issue where we sometimes were not displaying column level lineage properly for nodes that have siblings. This was happening because we had one "main" node that we display and if that node didn't have CLL, then we wouldn't show it. But one of its siblings may have CLL and we should be showing that if so.

This fixes that by creating a mapping of urns to inputs so we can create this `fineGrainedMap` (that's used to draw the lines between columns) and we check through each entity's siblings against this new mapping and update this `fineGrainedMap` to account for siblings and show CLL on the "visible" sibling node.

This ultimately this combines CLL between siblings and shows it as if it were one node.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
