### PR TITLE
fix(ingest/salesforce): support JSON web token auth

### DIFF
--- a/metadata-ingestion/docs/sources/salesforce/salesforce_pre.md
+++ b/metadata-ingestion/docs/sources/salesforce/salesforce_pre.md
@@ -1,8 +1,9 @@
 ### Prerequisites
 
-In order to ingest metadata from Salesforce, you will need:
+In order to ingest metadata from Salesforce, you will need one of:
 
-- Salesforce username, password, [security token](https://developer.Salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_concepts_security.htm) OR 
+- Salesforce username, password, [security token](https://developer.Salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_concepts_security.htm)
+- Salesforce username, consumer key and private key for [JSON web token access](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_jwt_flow.htm&type=5)
 - Salesforce instance url and access token/session id (suitable for one-shot ingestion only, as access token typically expires after 2 hours of inactivity)
 
 The account used to access Salesforce requires the following permissions for this integration to work:


### PR DESCRIPTION
Enable authorisation to Salesforce with JSON web tokens, by a direct passthrough to the Simple Salesforce authorisation.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
