### PR TITLE
fix(ingest/tableau): Add a try catch to LineageRunner parser

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -1371,27 +1371,36 @@ class TableauSource(StatefulIngestionSourceBase):
             and tableau_constant.CONNECTION_TYPE in database
         ):
             upstream_tables = []
-            parser = LineageRunner(csql.get(tableau_constant.QUERY))
+            query = csql.get(tableau_constant.QUERY)
+            parser = LineageRunner(query)
 
-            for table in parser.source_tables:
-                split_table = str(table).split(".")
-                if len(split_table) == 2:
-                    datset = make_table_urn(
-                        env=self.config.env,
-                        upstream_db=database.get(tableau_constant.NAME),
-                        connection_type=database.get(
-                            tableau_constant.CONNECTION_TYPE, ""
-                        ),
-                        schema=split_table[0],
-                        full_name=split_table[1],
-                        platform_instance_map=self.config.platform_instance_map,
-                        lineage_overrides=self.config.lineage_overrides,
-                    )
-                    upstream_tables.append(
-                        UpstreamClass(
-                            type=DatasetLineageType.TRANSFORMED, dataset=datset
+            try:
+                for table in parser.source_tables:
+                    split_table = str(table).split(".")
+                    if len(split_table) == 2:
+                        datset = make_table_urn(
+                            env=self.config.env,
+                            upstream_db=database.get(tableau_constant.NAME),
+                            connection_type=database.get(
+                                tableau_constant.CONNECTION_TYPE, ""
+                            ),
+                            schema=split_table[0],
+                            full_name=split_table[1],
+                            platform_instance_map=self.config.platform_instance_map,
+                            lineage_overrides=self.config.lineage_overrides,
                         )
-                    )
+                        upstream_tables.append(
+                            UpstreamClass(
+                                type=DatasetLineageType.TRANSFORMED, dataset=datset
+                            )
+                        )
+            except Exception as e:
+                self.report.report_failure(
+                    key="mode-query",
+                    reason=f"Unable to retrieve lineage from query. "
+                    f"Query: {query} "
+                    f"Reason: {str(e)} ",
+                )
             upstream_lineage = UpstreamLineage(upstreams=upstream_tables)
             yield self.get_metadata_change_proposal(
                 csql_urn,

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -1395,8 +1395,8 @@ class TableauSource(StatefulIngestionSourceBase):
                             )
                         )
             except Exception as e:
-                self.report.report_failure(
-                    key="mode-query",
+                self.report.report_warning(
+                    key="csql-lineage",
                     reason=f"Unable to retrieve lineage from query. "
                     f"Query: {query} "
                     f"Reason: {str(e)} ",


### PR DESCRIPTION
We have found that sometimes LineageRunner parser throws exceptions when dealing with some queries. 

We are handling the exception same way as we do for example here https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/src/datahub/ingestion/source/metabase.py#L462-L491

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
