### PR TITLE
feat(tracking) Add tracking events to our chrome extension page

### DIFF
--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -64,6 +64,8 @@ export enum EventType {
     SelectAutoCompleteOption,
     SelectQuickFilterEvent,
     DeselectQuickFilterEvent,
+    ChromeExtensionProfileViewEvent,
+    ChromeExtensionViewInDataHubEvent,
 }
 
 /**
@@ -495,6 +497,18 @@ export interface DeselectQuickFilterEvent extends BaseEvent {
     quickFilterValue: string;
 }
 
+export interface ChromeExtensionProfileViewEvent extends BaseEvent {
+    type: EventType.ChromeExtensionProfileViewEvent;
+    entityType: string;
+    entityUrn: string;
+}
+
+export interface ChromeExtensionViewInDataHubEvent extends BaseEvent {
+    type: EventType.ChromeExtensionViewInDataHubEvent;
+    entityType: string;
+    entityUrn: string;
+}
+
 /**
  * Event consisting of a union of specific event types.
  */
@@ -557,4 +571,6 @@ export type Event =
     | DeleteQueryEvent
     | SelectAutoCompleteOption
     | SelectQuickFilterEvent
-    | DeselectQuickFilterEvent;
+    | DeselectQuickFilterEvent
+    | ChromeExtensionProfileViewEvent
+    | ChromeExtensionViewInDataHubEvent;

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -64,8 +64,8 @@ export enum EventType {
     SelectAutoCompleteOption,
     SelectQuickFilterEvent,
     DeselectQuickFilterEvent,
-    ChromeExtensionProfileViewEvent,
-    ChromeExtensionViewInDataHubEvent,
+    EmbedProfileViewEvent,
+    EmbedProfileViewInDataHubEvent,
 }
 
 /**
@@ -497,14 +497,14 @@ export interface DeselectQuickFilterEvent extends BaseEvent {
     quickFilterValue: string;
 }
 
-export interface ChromeExtensionProfileViewEvent extends BaseEvent {
-    type: EventType.ChromeExtensionProfileViewEvent;
+export interface EmbedProfileViewEvent extends BaseEvent {
+    type: EventType.EmbedProfileViewEvent;
     entityType: string;
     entityUrn: string;
 }
 
-export interface ChromeExtensionViewInDataHubEvent extends BaseEvent {
-    type: EventType.ChromeExtensionViewInDataHubEvent;
+export interface EmbedProfileViewInDataHubEvent extends BaseEvent {
+    type: EventType.EmbedProfileViewInDataHubEvent;
     entityType: string;
     entityUrn: string;
 }
@@ -572,5 +572,5 @@ export type Event =
     | SelectAutoCompleteOption
     | SelectQuickFilterEvent
     | DeselectQuickFilterEvent
-    | ChromeExtensionProfileViewEvent
-    | ChromeExtensionViewInDataHubEvent;
+    | EmbedProfileViewEvent
+    | EmbedProfileViewInDataHubEvent;

--- a/datahub-web-react/src/app/embed/EmbeddedPage.tsx
+++ b/datahub-web-react/src/app/embed/EmbeddedPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
 import styled from 'styled-components/macro';
 import { useGetGrantedPrivilegesQuery } from '../../graphql/policy.generated';
@@ -9,6 +9,8 @@ import { decodeUrn } from '../entity/shared/utils';
 import CompactContext from '../shared/CompactContext';
 import { useEntityRegistry } from '../useEntityRegistry';
 import { useGetAuthenticatedUserUrn } from '../useGetAuthenticatedUser';
+import analytics from '../analytics/analytics';
+import { EventType } from '../analytics';
 
 const EmbeddedPageWrapper = styled.div`
     max-height: 100%;
@@ -28,6 +30,14 @@ export default function EmbeddedPage({ entityType }: Props) {
     const entityRegistry = useEntityRegistry();
     const { urn: encodedUrn } = useParams<RouteParams>();
     const urn = decodeUrn(encodedUrn);
+
+    useEffect(() => {
+        analytics.event({
+            type: EventType.ChromeExtensionProfileViewEvent,
+            entityType,
+            entityUrn: urn,
+        });
+    }, [entityType, urn]);
 
     const authenticatedUserUrn = useGetAuthenticatedUserUrn();
     const { data } = useGetGrantedPrivilegesQuery({

--- a/datahub-web-react/src/app/embed/EmbeddedPage.tsx
+++ b/datahub-web-react/src/app/embed/EmbeddedPage.tsx
@@ -33,7 +33,7 @@ export default function EmbeddedPage({ entityType }: Props) {
 
     useEffect(() => {
         analytics.event({
-            type: EventType.ChromeExtensionProfileViewEvent,
+            type: EventType.EmbedProfileViewEvent,
             entityType,
             entityUrn: urn,
         });

--- a/datahub-web-react/src/app/entity/shared/embed/EmbeddedHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/embed/EmbeddedHeader.tsx
@@ -10,6 +10,8 @@ import { IconStyleType } from '../../Entity';
 import { useEntityData } from '../EntityContext';
 import { getDisplayedEntityType } from '../containers/profile/header/PlatformContent/PlatformContentContainer';
 import { ANTD_GRAY } from '../constants';
+import analytics from '../../../analytics/analytics';
+import { EventType } from '../../../analytics';
 
 const HeaderWrapper = styled.div`
     display: flex;
@@ -61,6 +63,14 @@ export default function EmbeddedHeader() {
     const appConfig = useAppConfig();
     const themeConfig = useTheme();
 
+    function trackClickViewInDataHub() {
+        analytics.event({
+            type: EventType.ChromeExtensionViewInDataHubEvent,
+            entityType,
+            entityUrn: entityData?.urn || '',
+        });
+    }
+
     const typeIcon = entityRegistry.getIcon(entityType, 12, IconStyleType.ACCENT, ANTD_GRAY[8]);
     const displayedEntityType = getDisplayedEntityType(entityData, entityRegistry, entityType);
     const entityName = entityRegistry.getDisplayName(entityType, entityData);
@@ -86,6 +96,7 @@ export default function EmbeddedHeader() {
                         href={`${window.location.origin}/${entityTypePathName}/${entityData?.urn}`}
                         target="_blank"
                         rel="noreferrer noopener"
+                        onClick={trackClickViewInDataHub}
                     >
                         view in DataHub <ArrowRightOutlined />
                     </StyledLink>

--- a/datahub-web-react/src/app/entity/shared/embed/EmbeddedHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/embed/EmbeddedHeader.tsx
@@ -65,7 +65,7 @@ export default function EmbeddedHeader() {
 
     function trackClickViewInDataHub() {
         analytics.event({
-            type: EventType.ChromeExtensionViewInDataHubEvent,
+            type: EventType.EmbedProfileViewInDataHubEvent,
             entityType,
             entityUrn: entityData?.urn || '',
         });

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -63,7 +63,9 @@ public enum DataHubUsageEventType {
   UPDATE_QUERY_EVENT("UpdateQueryEvent"),
   SELECT_AUTO_COMPLETE_OPTION("SelectAutoCompleteOption"),
   SELECT_QUICK_FILTER_EVENT("SelectQuickFilterEvent"),
-  DESELECT_QUICK_FILTER_EVENT("DeselectQuickFilterEvent");
+  DESELECT_QUICK_FILTER_EVENT("DeselectQuickFilterEvent"),
+  CHROME_EXTENSION_PROFILE_VIEW_EVENT("ChromeExtensionProfileViewEvent"),
+  CHROME_EXTENSION_VIEW_IN_DATAHUB_EVENT("ChromeExtensionViewInDataHubEvent");
 
   private final String type;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -64,8 +64,8 @@ public enum DataHubUsageEventType {
   SELECT_AUTO_COMPLETE_OPTION("SelectAutoCompleteOption"),
   SELECT_QUICK_FILTER_EVENT("SelectQuickFilterEvent"),
   DESELECT_QUICK_FILTER_EVENT("DeselectQuickFilterEvent"),
-  CHROME_EXTENSION_PROFILE_VIEW_EVENT("ChromeExtensionProfileViewEvent"),
-  CHROME_EXTENSION_VIEW_IN_DATAHUB_EVENT("ChromeExtensionViewInDataHubEvent");
+  EMBED_PROFILE_VIEW_EVENT("EmbedProfileViewEvent"),
+  EMBED_PROFILE_VIEW_IN_DATAHUB_EVENT("EmbedProfileViewInDataHubEvent");
 
   private final String type;
 


### PR DESCRIPTION
Adds two new tracking events for our chrome extension experience. The first `ChromeExtensionProfileViewEvent` happens when they open the drawer to see a profile page with the chrome extension. The second `ChromeExtensionViewInDataHubEvent` is called when they click "view in datahub" from the chrome extension drawer.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
