### PR TITLE
refactor(ingest/unity): Use databricks-sdk over databricks-cli for usage query

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -245,7 +245,6 @@ databricks_cli = {
     "databricks-sdk>=0.1.1",
     "pyspark",
     "requests",
-    "backoff",
 }
 
 # Note: for all of these, framework_common will be added.

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -240,7 +240,13 @@ usage_common = {
     "sqlparse",
 }
 
-databricks_cli = {"databricks-cli==0.17.3", "pyspark", "requests"}
+databricks_cli = {
+    "databricks-cli>=0.17.3",
+    "databricks-sdk>=0.1.1",
+    "pyspark",
+    "requests",
+    "backoff",
+}
 
 # Note: for all of these, framework_common will be added.
 plugins: Dict[str, Set[str]] = {

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -5,10 +5,8 @@ import dataclasses
 import logging
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
-from unittest.mock import patch
 
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.core import ApiClient
 from databricks.sdk.service.sql import (
     QueryFilter,
     QueryInfo,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy_types.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy_types.py
@@ -2,8 +2,9 @@
 # https://api-docs.databricks.com/rest/latest/unity-catalog-api-specification-2-1.html?_ga=2.151019001.1795147704.1666247755-2119235717.1666247755
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from typing import Dict, List, Optional
+
+from databricks.sdk.service.sql import QueryStatementType
 
 from datahub.metadata.schema_classes import (
     ArrayTypeClass,
@@ -42,46 +43,21 @@ DATA_TYPE_REGISTRY: dict = {
 }
 
 
-class StatementType(str, Enum):
-    OTHER = "OTHER"
-    ALTER = "ALTER"
-    ANALYZE = "ANALYZE"
-    COPY = "COPY"
-    CREATE = "CREATE"
-    DELETE = "DELETE"
-    DESCRIBE = "DESCRIBE"
-    DROP = "DROP"
-    EXPLAIN = "EXPLAIN"
-    GRANT = "GRANT"
-    INSERT = "INSERT"
-    MERGE = "MERGE"
-    OPTIMIZE = "OPTIMIZE"
-    REFRESH = "REFRESH"
-    REPLACE = "REPLACE"
-    REVOKE = "REVOKE"
-    SELECT = "SELECT"
-    SET = "SET"
-    SHOW = "SHOW"
-    TRUNCATE = "TRUNCATE"
-    UPDATE = "UPDATE"
-    USE = "USE"
-
-
 # Does not parse other statement types, besides SELECT
 OPERATION_STATEMENT_TYPES = {
-    StatementType.INSERT: OperationTypeClass.INSERT,
-    StatementType.COPY: OperationTypeClass.INSERT,
-    StatementType.UPDATE: OperationTypeClass.UPDATE,
-    StatementType.MERGE: OperationTypeClass.UPDATE,
-    StatementType.DELETE: OperationTypeClass.DELETE,
-    StatementType.TRUNCATE: OperationTypeClass.DELETE,
-    StatementType.CREATE: OperationTypeClass.CREATE,
-    StatementType.REPLACE: OperationTypeClass.CREATE,
-    StatementType.ALTER: OperationTypeClass.ALTER,
-    StatementType.DROP: OperationTypeClass.DROP,
-    StatementType.OTHER: OperationTypeClass.UNKNOWN,
+    QueryStatementType.INSERT: OperationTypeClass.INSERT,
+    QueryStatementType.COPY: OperationTypeClass.INSERT,
+    QueryStatementType.UPDATE: OperationTypeClass.UPDATE,
+    QueryStatementType.MERGE: OperationTypeClass.UPDATE,
+    QueryStatementType.DELETE: OperationTypeClass.DELETE,
+    QueryStatementType.TRUNCATE: OperationTypeClass.DELETE,
+    QueryStatementType.CREATE: OperationTypeClass.CREATE,
+    QueryStatementType.REPLACE: OperationTypeClass.CREATE,
+    QueryStatementType.ALTER: OperationTypeClass.ALTER,
+    QueryStatementType.DROP: OperationTypeClass.DROP,
+    QueryStatementType.OTHER: OperationTypeClass.UNKNOWN,
 }
-ALLOWED_STATEMENT_TYPES = {*OPERATION_STATEMENT_TYPES.keys(), StatementType.SELECT}
+ALLOWED_STATEMENT_TYPES = {*OPERATION_STATEMENT_TYPES.keys(), QueryStatementType.SELECT}
 
 
 @dataclass
@@ -185,24 +161,16 @@ class Table(CommonProperty):
         self.ref = TableReference.create(self)
 
 
-class QueryStatus(str, Enum):
-    FINISHED = "FINISHED"
-    RUNNING = "RUNNING"
-    QUEUED = "QUEUED"
-    FAILED = "FAILED"
-    CANCELED = "CANCELED"
-
-
 @dataclass
 class Query:
     query_id: str
     query_text: str
-    statement_type: StatementType
+    statement_type: QueryStatementType
     start_time: datetime
     end_time: datetime
     # User who ran the query
-    user_id: str
+    user_id: int
     user_name: str  # Email or username
     # User whose credentials were used to run the query
-    executed_as_user_id: str
+    executed_as_user_id: int
     executed_as_user_name: str

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Generic, Iterable, List, Optional, Set, TypeVar
 
 import pyspark
+from databricks.sdk.service.sql import QueryStatementType
 from sqllineage.runner import LineageRunner
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -15,7 +16,6 @@ from datahub.ingestion.source.unity.proxy import UnityCatalogApiProxy
 from datahub.ingestion.source.unity.proxy_types import (
     OPERATION_STATEMENT_TYPES,
     Query,
-    StatementType,
     TableReference,
 )
 from datahub.ingestion.source.unity.report import UnityCatalogReport
@@ -133,7 +133,7 @@ class UnityCatalogUsageExtractor:
         self, query: Query, table_map: TableMap
     ) -> Optional[QueryTableInfo]:
         table_info = self._parse_query_via_lineage_runner(query.query_text)
-        if table_info is None and query.statement_type == StatementType.SELECT:
+        if table_info is None and query.statement_type == QueryStatementType.SELECT:
             table_info = self._parse_query_via_spark_sql_plan(query.query_text)
 
         if table_info is None:


### PR DESCRIPTION
Introduces https://github.com/databricks/databricks-sdk-py, which seems like a more developed library for the databricks API. Using it should provide better error logging around the usage query.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
