### PR TITLE
fix(ui): Open mailto link in new tab

### DIFF
--- a/datahub-web-react/src/app/shared/share/items/EmailMenuItem.tsx
+++ b/datahub-web-react/src/app/shared/share/items/EmailMenuItem.tsx
@@ -44,7 +44,7 @@ export default function EmailMenuItem({ urn, name, type, key }: EmailMenuItemPro
                     <Tooltip title={`Share this ${type} via email`}>
                         {isClicked ? <CheckOutlined /> : <MailOutlined />}
                         <TextSpan>
-                            <a href={link} style={{ color: 'inherit' }}>
+                            <a href={link} target="_blank" rel="noreferrer" style={{ color: 'inherit' }}>
                                 <b>Email</b>
                             </a>
                         </TextSpan>


### PR DESCRIPTION
<img width="220" alt="email" src="https://user-images.githubusercontent.com/99757211/236581912-0181f3b1-6d4b-406b-b321-c62f785eaa91.png">


Description: 

Some Apple/Chrome users have Chrome set to handle `mailto` links by opening them in a specific webmail client (e.g. gmail). In this situation, when DataHub's "email" link is clicked, the current DataHub page is replaced with a gmail-compose page, which then disappears once the message is sent.

The fix here is adding `target="_blank"` to the anchor tag. I tried out this change and verified that behavior is what we'd want for both situations:
1. When Chrome is set to handle `mailto` links, they open in a new tab
2. When that's not the case, an external client is opened as usual, without opening an extra tab

Other browsers:
- Safari has this capability but only with installing an extension. I did not test this.
- [Firefox ignores `target="_blank"` for `mailto` links.](https://bugzilla.mozilla.org/show_bug.cgi?id=646552) If we'd like to fix this for Firefox, we can do it in javascript with `window.open` but that's a rabbit hole. I don't think we should worry about it, [considering its relative low
usage](https://en.wikipedia.org/wiki/Usage_share_of_web_browsers#toc-Summary_tables-sublist), but happy to work on it if we think it's necessary.

To test this out:
1. Open Apple mail settings and set "Default email reader" to Google Chrome
2. Open up gmail in chrome, and click the double-diamonds on the right side of the address bar
3. If the double diamonds don't appear, remove `mail.google.com` from `chrome://settings/handlers` and reload the gmail page

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
