### PR TITLE
feat(search): support only searching by quick filter

### DIFF
--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -157,9 +157,8 @@ export const HomePageHeader = () => {
     }, [suggestionsData]);
 
     const onSearch = (query: string, type?: EntityType, filters?: FacetFilterInput[]) => {
-        if (!query || query.trim().length === 0) {
-            return;
-        }
+        if (!query.trim() && !selectedQuickFilter) return;
+
         analytics.event({
             type: EventType.HomePageSearchEvent,
             query,

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -71,9 +71,8 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
     }, [suggestionsData]);
 
     const search = (query: string, type?: EntityType, quickFilters?: FacetFilterInput[]) => {
-        if (!query || query.trim().length === 0) {
-            return;
-        }
+        if (!query.trim() && !selectedQuickFilter) return;
+
         analytics.event({
             type: EventType.SearchEvent,
             query,

--- a/datahub-web-react/src/app/search/ViewAllSearchItem.tsx
+++ b/datahub-web-react/src/app/search/ViewAllSearchItem.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components/macro';
+import { Typography } from 'antd';
+import { SearchOutlined } from '@ant-design/icons';
+
+const ExploreForEntity = styled.span`
+    font-weight: light;
+    font-size: 16px;
+    padding: 5px 0;
+`;
+
+const ExploreForEntityText = styled.span`
+    margin-left: 10px;
+`;
+
+const ViewAllContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+`;
+
+const ReturnKey = styled(Typography.Text)`
+    & kbd {
+        border: none;
+    }
+    font-size: 12px;
+`;
+
+function ViewAllSearchItem({ searchTarget: searchText }: { searchTarget?: string }) {
+    return (
+        <ViewAllContainer>
+            <ExploreForEntity>
+                <SearchOutlined />
+                <ExploreForEntityText>
+                    View all results for <Typography.Text strong>{searchText}</Typography.Text>
+                </ExploreForEntityText>
+            </ExploreForEntity>
+            <ReturnKey keyboard disabled>
+                ⮐ return
+            </ReturnKey>
+        </ViewAllContainer>
+    );
+}
+
+export default ViewAllSearchItem;


### PR DESCRIPTION
Adds support for searching via a quick filter without entering any text in the autocomplete. Handles both home page and search results page autocompletes. Also adds a little "return key" component to the right per the figma designs.

With just quick filter
<img width="1065" alt="Screenshot 2023-05-09 at 11 45 50 AM" src="https://github.com/datahub-project/datahub/assets/2107911/0576bac0-48eb-4b72-b8c9-231229535972">

With data
<img width="1168" alt="Screenshot 2023-05-09 at 11 45 43 AM" src="https://github.com/datahub-project/datahub/assets/2107911/15f41994-4915-4689-9815-515c0fa5cf57">

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
