### PR TITLE
feat(system-update): remove the need for datahub-update for live sche…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ buildscript {
   ext.slf4jVersion = '1.7.36'
   ext.logbackClassic = '1.2.12'
   ext.hadoop3Version = '3.3.5'
+  ext.kafkaVersion = '2.3.0'
+  ext.kafkaAvroVersion = '5.5.1'
 
   ext.docker_registry = 'linkedin'
 
@@ -133,9 +135,9 @@ project.ext.externalDependency = [
     'junitJupiterParams': "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion",
     'junitJupiterEngine': "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion",
     // avro-serde includes dependencies for `kafka-avro-serializer` `kafka-schema-registry-client` and `avro`
-    'kafkaAvroSerde': 'io.confluent:kafka-streams-avro-serde:5.5.1',
-    'kafkaAvroSerializer': 'io.confluent:kafka-avro-serializer:5.1.4',
-    'kafkaClients': 'org.apache.kafka:kafka-clients:2.3.0',
+    'kafkaAvroSerde': "io.confluent:kafka-streams-avro-serde:$kafkaAvroVersion",
+    'kafkaAvroSerializer': "io.confluent:kafka-avro-serializer:$kafkaAvroVersion",
+    'kafkaClients': "org.apache.kafka:kafka-clients:$kafkaVersion",
     'logbackClassic': "ch.qos.logback:logback-classic:$logbackClassic",
     'slf4jApi': "org.slf4j:slf4j-api:$slf4jVersion",
     'log4jCore': "org.apache.logging.log4j:log4j-core:$log4jVersion",

--- a/datahub-upgrade/build.gradle
+++ b/datahub-upgrade/build.gradle
@@ -40,6 +40,12 @@ dependencies {
     }
   }
 
+
+  // mock internal schema registry
+  implementation externalDependency.kafkaAvroSerde
+  implementation externalDependency.kafkaAvroSerializer
+  implementation "org.apache.kafka:kafka_2.12:$kafkaVersion"
+
   implementation externalDependency.slf4jApi
   compileOnly externalDependency.lombok
   compile externalDependency.picocli

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNoSchemaRegistryTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNoSchemaRegistryTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.datahub.upgrade;
+
+import com.linkedin.datahub.upgrade.system.SystemUpdate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+import javax.inject.Named;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+@ActiveProfiles("test")
+@SpringBootTest(classes = {UpgradeCliApplication.class, UpgradeCliApplicationTestConfiguration.class},
+        properties = {
+                "kafka.schemaRegistry.type=INTERNAL",
+                "kafka.schemaRegistry.systemUpdate=true",
+                "spring.kafka.properties.auto.register.schemas=false",
+                "spring.kafka.properties.use.latest.version=true"
+        })
+public class DatahubUpgradeNoSchemaRegistryTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired
+    @Named("systemUpdate")
+    private SystemUpdate systemUpdate;
+
+    @Test
+    public void testSystemUpdateInit() {
+       assertNotNull(systemUpdate);
+    }
+
+    @Test
+    public void testSystemUpdateSend() {
+        UpgradeStepResult.Result result = systemUpdate.steps().stream()
+                .filter(s -> s.id().equals("DataHubStartupStep"))
+                .findFirst().get()
+                .executable().apply(new UpgradeContext() {
+                    @Override
+                    public Upgrade upgrade() {
+                        return null;
+                    }
+
+                    @Override
+                    public List<UpgradeStepResult> stepResults() {
+                        return null;
+                    }
+
+                    @Override
+                    public UpgradeReport report() {
+                        return null;
+                    }
+
+                    @Override
+                    public List<String> args() {
+                        return null;
+                    }
+
+                    @Override
+                    public Map<String, Optional<String>> parsedArgs() {
+                        return null;
+                    }
+                }).result();
+        assertEquals("SUCCEEDED", result.toString());
+    }
+
+}

--- a/metadata-events/mxe-utils-avro-1.7/src/main/java/com/linkedin/metadata/EventUtils.java
+++ b/metadata-events/mxe-utils-avro-1.7/src/main/java/com/linkedin/metadata/EventUtils.java
@@ -66,7 +66,7 @@ public class EventUtils {
   private static final Schema ORIGINAL_PE_AVRO_SCHEMA =
       getAvroSchemaFromResource("avro/com/linkedin/mxe/PlatformEvent.avsc");
 
-  private static final Schema ORIGINAL_DUHE_AVRO_SCHEMA =
+  public static final Schema ORIGINAL_DUHE_AVRO_SCHEMA =
       getAvroSchemaFromResource("avro/com/linkedin/mxe/DataHubUpgradeHistoryEvent.avsc");
 
   private static final Schema RENAMED_MCE_AVRO_SCHEMA = com.linkedin.pegasus2avro.mxe.MetadataChangeEvent.SCHEMA$;

--- a/metadata-io/src/main/java/com/linkedin/metadata/config/kafka/SchemaRegistryConfiguration.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/config/kafka/SchemaRegistryConfiguration.java
@@ -8,4 +8,6 @@ public class SchemaRegistryConfiguration {
   private String type;
 
   private String url;
+
+  private boolean systemUpdate;
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/InternalSchemaRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/InternalSchemaRegistryFactory.java
@@ -39,8 +39,12 @@ public class InternalSchemaRegistryFactory {
     props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, kafkaConfiguration
         .getSchemaRegistry().getUrl());
 
-    log.info("Creating internal registry configuration for url {}", kafkaConfiguration.getSchemaRegistry().getUrl());
-    return new SchemaRegistryConfig(KafkaAvroSerializer.class, KafkaAvroDeserializer.class, props);
+    if (kafkaConfiguration.getSchemaRegistry().isSystemUpdate()) {
+      return new SchemaRegistryConfig(MockDUHESerializer.class, KafkaAvroDeserializer.class, props);
+    } else {
+      log.info("Creating internal registry configuration for url {}", kafkaConfiguration.getSchemaRegistry().getUrl());
+      return new SchemaRegistryConfig(KafkaAvroSerializer.class, KafkaAvroDeserializer.class, props);
+    }
   }
 
   @Bean(name = "schemaRegistryService")

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/MockDUHESerializer.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/kafka/schemaregistry/MockDUHESerializer.java
@@ -1,0 +1,44 @@
+package com.linkedin.gms.factory.kafka.schemaregistry;
+
+import com.linkedin.metadata.EventUtils;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Used for early bootstrap to avoid contact with not yet existing schema registry
+ */
+@Slf4j
+public class MockDUHESerializer extends KafkaAvroSerializer {
+
+    private static final String DATAHUB_UPGRADE_HISTORY_EVENT_SUBJECT = "DataHubUpgradeHistory_v1-value";
+
+    public MockDUHESerializer() {
+        buildMockSchemaRegistryClient();
+    }
+
+    public MockDUHESerializer(SchemaRegistryClient client) {
+        buildMockSchemaRegistryClient();
+    }
+
+    public MockDUHESerializer(SchemaRegistryClient client, Map<String, ?> props) {
+        super(client, props);
+        buildMockSchemaRegistryClient();
+    }
+
+    private void buildMockSchemaRegistryClient() {
+        this.schemaRegistry = new MockSchemaRegistryClient();
+        try {
+            this.schemaRegistry.register(DATAHUB_UPGRADE_HISTORY_EVENT_SUBJECT,
+                    new AvroSchema(EventUtils.ORIGINAL_DUHE_AVRO_SCHEMA));
+        } catch (IOException | RestClientException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -222,6 +222,7 @@ kafka:
     #awsGlue:
     #  region: ${AWS_GLUE_SCHEMA_REGISTRY_REGION:us-east-1}
     #  registryName: ${AWS_GLUE_SCHEMA_REGISTRY_NAME:#{null}}
+    systemUpdate: ${SCHEMA_REGISTRY_SYSTEM_UPDATE:false}
   schema:
     registry:
       security:


### PR DESCRIPTION
When running DataHub without confluent schema registry, the datahub system-update process must function. These changes allow a mock schema registry client to remove this requirement.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
