### PR TITLE
fix(upgrade): removes sleep from bootstrap process

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/UpgradeStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/UpgradeStep.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public abstract class UpgradeStep implements BootstrapStep {
-  private static final Integer SLEEP_SECONDS = 120;
 
   protected final EntityService _entityService;
   private final String _version;
@@ -37,18 +36,11 @@ public abstract class UpgradeStep implements BootstrapStep {
 
   @Override
   public void execute() throws Exception {
-    String upgradeStepName = name();
-
-    log.info(String.format("Attempting to run %s Upgrade Step..", upgradeStepName));
-    log.info(String.format("Waiting %s seconds..", SLEEP_SECONDS));
 
     if (hasUpgradeRan()) {
       log.info(String.format("%s has run before for version %s. Skipping..", _upgradeId, _version));
       return;
     }
-
-    // Sleep to ensure deployment process finishes.
-    Thread.sleep(SLEEP_SECONDS * 1000);
 
     try {
       ingestUpgradeRequestAspect();


### PR DESCRIPTION
This sleep got moved into this abstract class during a refactor when it was only ever intended to execute once per start up, it instead executes with every upgrade step. With other robustness improvements around the start up process this shouldn't be needed.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
