### PR TITLE
test(sdk): move cli tests into the unit dir

### DIFF
--- a/metadata-ingestion/.gitignore
+++ b/metadata-ingestion/.gitignore
@@ -6,6 +6,7 @@ pvenv36/
 /venv*/
 bq_credentials.json
 junit.*.xml
+tests/integrations/delta_lake/minio/minio
 /tmp
 *.bak
 

--- a/metadata-ingestion/tests/unit/cli/test_quickstart_version_mapping.py
+++ b/metadata-ingestion/tests/unit/cli/test_quickstart_version_mapping.py
@@ -8,7 +8,7 @@ example_version_mapper = QuickstartVersionMappingConfig.parse_obj(
         "quickstart_version_map": {
             "default": {"composefile_git_ref": "master", "docker_tag": "latest"},
             "v0.9.6": {
-                "composefile_git_ref": "v0.9.6.1",  # this will be overwritten by the cli
+                "composefile_git_ref": "v0.9.6.1",
                 "docker_tag": "v0.9.6.1",
             },
             "v2.0.0": {"composefile_git_ref": "v2.0.1", "docker_tag": "v2.0.0"},
@@ -82,6 +82,6 @@ def test_quickstart_get_older_version():
     execution_plan = example_version_mapper.get_quickstart_execution_plan("v0.9.6")
     expected = QuickstartExecutionPlan(
         docker_tag="v0.9.6.1",
-        composefile_git_ref="1d3339276129a7cb8385c07a958fcc93acda3b4e",
+        composefile_git_ref="v0.9.6.1",
     )
     assert execution_plan == expected


### PR DESCRIPTION
Our gradle tests were previously not running the tests/cli directory so we were just missing these tests entirely.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
