### PR TITLE
fix(es) Fix browseV2 index mappings

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
@@ -51,6 +51,8 @@ public class SettingsBuilder {
   public static final String TOKENIZER = "tokenizer";
   public static final String TYPE = "type";
   public static final String TYPE_TABLE = "type_table";
+  public static final String DELIMITER = "delimiter";
+  public static final String UNIT_SEPARATOR_DELIMITER = "␟";
 
   // Analyzers
   public static final String BROWSE_PATH_HIERARCHY_ANALYZER = "browse_path_hierarchy";
@@ -104,6 +106,7 @@ public class SettingsBuilder {
   public static final String MAIN_TOKENIZER = "main_tokenizer";
   public static final String PATH_HIERARCHY_TOKENIZER = "path_hierarchy";
   public static final String SLASH_TOKENIZER = "slash_tokenizer";
+  public static final String UNIT_SEPARATOR_PATH_TOKENIZER = "unit_separator_path_tokenizer";
   public static final String UNIT_SEPARATOR_TOKENIZER = "unit_separator_tokenizer";
   // Do not remove the space, needed for multi-term synonyms
   public static final List<String> ALPHANUM_SPACE_PATTERNS = ImmutableList.of(
@@ -293,6 +296,12 @@ public class SettingsBuilder {
                 .put(PATTERN, "[␟]")
                 .build());
 
+    tokenizers.put(UNIT_SEPARATOR_PATH_TOKENIZER,
+        ImmutableMap.<String, Object>builder()
+                .put(TYPE, PATH_HIERARCHY_TOKENIZER)
+                .put(DELIMITER, "␟")
+                .build());
+
     // Tokenize by whitespace and most special chars
     tokenizers.put(MAIN_TOKENIZER,
             ImmutableMap.<String, Object>builder()
@@ -336,7 +345,7 @@ public class SettingsBuilder {
 
     // Analyzer for matching browse path v2
     analyzers.put(BROWSE_PATH_V2_HIERARCHY_ANALYZER, ImmutableMap.<String, Object>builder()
-            .put(TOKENIZER, PATH_HIERARCHY_TOKENIZER)
+            .put(TOKENIZER, UNIT_SEPARATOR_PATH_TOKENIZER)
             .build());
 
     // Analyzer for case-insensitive exact matching - Only used when building queries


### PR DESCRIPTION
We were not able to do the types of queries on the new `browsePathV2` field in elastic search that we expected due to some unexpected defaults from elasticsearch itself. This updates mappings so that we have a path_hierarchy tokenizer using our desired delimiter (instead of forward slash which is default for elastic) on our `BROWSE_PATH_V2_HIERARCHY_ANALYZER`. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
