### PR TITLE
fix(search): enter key with no query should search all

### DIFF
--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -157,8 +157,6 @@ export const HomePageHeader = () => {
     }, [suggestionsData]);
 
     const onSearch = (query: string, type?: EntityType, filters?: FacetFilterInput[]) => {
-        if (!query.trim() && !selectedQuickFilter) return;
-
         analytics.event({
             type: EventType.HomePageSearchEvent,
             query,

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -71,8 +71,6 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
     }, [suggestionsData]);
 
     const search = (query: string, type?: EntityType, quickFilters?: FacetFilterInput[]) => {
-        if (!query.trim() && !selectedQuickFilter) return;
-
         analytics.event({
             type: EventType.SearchEvent,
             query,


### PR DESCRIPTION
This did end up being as simple as removing the checks (oops). I figured out what I was hung up on earlier. There's another unrelated bug where the selectedQuickFilter is not persisted from home->results and is also cleared out after toggling quick filters on the results page and searching. I'll file another bug for that but this should provide an improvement without breaking other functionality.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
