### PR TITLE
fix(search): enable search relevancy by adding _ in the main_tokenizer

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
@@ -297,7 +297,7 @@ public class SettingsBuilder {
     tokenizers.put(MAIN_TOKENIZER,
             ImmutableMap.<String, Object>builder()
                     .put(TYPE, PATTERN)
-                    .put(PATTERN, "[(),./:]")
+                    .put(PATTERN, "[(),./:_]")
                     .build());
 
     return tokenizers.build();


### PR DESCRIPTION
Currently, in the following example. A user should expect the search for 'core dataset' to appear at the top as an exact match. However due to the existing search configurations, the results for a matching id/name/urn are all scored the same which may result in irrelevant entities being pushed to the top. (this is evident in our instance as there are easily tens of entities with very similar/extended names). 

![image](https://github.com/datahub-project/datahub/assets/10681923/27e7369a-c30c-436f-99fb-93fb7a63a840)

Elasticsearch references the score using 'length of the field' / 'average length of the field' (this is a heavily simplified explanation, see [more](https://www.elastic.co/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables)). Since the main_tokenizer does not tokenize underscores, the 'length of the field' always results to 3 in this case:  `[my_platform, my_schema, core_dataset]`. Thus resulting in all the results to get the same score.

This small MR aims to tokenize underscores so that the length of the field calculates as 6, which is lesser than the other results (the 'irrelevant' one should return 9), increasing the score and pushing the result to the top.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
