### PR TITLE
ci: prevent qodana from using all of our cache

### DIFF
--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -20,3 +20,4 @@ jobs:
       - uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+          cache-default-branch-only: true


### PR DESCRIPTION
We're currently using 74GB of our allowed 10 GB - https://github.com/datahub-project/datahub/actions/caches


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
