### PR TITLE
ci(ingest/clickhouse): don't use kernel ephemeral ports

### DIFF
--- a/metadata-ingestion/tests/integration/clickhouse/clickhouse_to_file.yml
+++ b/metadata-ingestion/tests/integration/clickhouse/clickhouse_to_file.yml
@@ -6,7 +6,7 @@ source:
     username: clickhouseuser
     password: clickhousepass
     database: clickhousedb
-    host_port: localhost:58123
+    host_port: localhost:28123
     platform_instance: clickhousetestserver
     schema_pattern:
       allow:

--- a/metadata-ingestion/tests/integration/clickhouse/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/clickhouse/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       CLICKHOUSE_PASSWORD: clickhousepass
       CLICKHOUSE_DB: clickhousedb
     ports:
-      - "58123:8123"
-      - "59000:9000"
+      - "28123:8123"
     volumes:
       - ./setup:/docker-entrypoint-initdb.d

--- a/metadata-ingestion/tests/integration/clickhouse/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/clickhouse/docker-compose.yml
@@ -9,5 +9,6 @@ services:
       CLICKHOUSE_DB: clickhousedb
     ports:
       - "28123:8123"
+      - "9000"
     volumes:
       - ./setup:/docker-entrypoint-initdb.d


### PR DESCRIPTION
Avoid "port in use" failures like this one https://github.com/datahub-project/datahub/actions/runs/4955237788/jobs/8864458075


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
