### PR TITLE
fix(ingest/tableau): don't use unsupported sql condition field

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -263,7 +263,6 @@ custom_sql_graphql_query = """
       id
       name
       query
-      isUnsupportedCustomSql
       columns {
         id
         name
@@ -624,7 +623,9 @@ def get_unique_custom_sql(custom_sql_list: List[dict]) -> List[dict]:
         unique_csql = {
             "id": custom_sql.get("id"),
             "name": custom_sql.get("name"),
-            "isUnsupportedCustomSql": custom_sql.get("isUnsupportedCustomSql"),
+            # We assume that this is unsupported custom sql if "actual tables that this query references"
+            # are missing from api result.
+            "isUnsupportedCustomSql": True if not custom_sql.get("tables") else False,
             "query": custom_sql.get("query"),
             "columns": custom_sql.get("columns"),
             "tables": custom_sql.get("tables"),


### PR DESCRIPTION
This restores backwards compatibility w/ old versions

Tableau connector compatibility  for versions <2022.x and >2021.1.10 has broken due to this [PR](https://github.com/datahub-project/datahub/pull/7561)

This PR attempts to fix that.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
