### PR TITLE
fix(ingest/delta-lake): Walk through directory structure with full path; reduce resource creation

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/delta_lake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/delta_lake_utils.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Optional
+from typing import Optional, Dict
 
 from deltalake import DeltaTable, PyDeltaTableError
 
@@ -7,47 +7,23 @@ from datahub.ingestion.source.delta_lake.config import DeltaLakeSourceConfig
 
 
 def read_delta_table(
-    path: str, delta_lake_config: DeltaLakeSourceConfig
+    path: str, opts: Dict[str, str], delta_lake_config: DeltaLakeSourceConfig
 ) -> Optional[DeltaTable]:
-    delta_table = None
-    try:
-        opts = {}
-        if delta_lake_config.is_s3:
-            if (
-                delta_lake_config.s3 is not None
-                and delta_lake_config.s3.aws_config is not None
-            ):
-                creds = delta_lake_config.s3.aws_config.get_credentials()
-                opts = {
-                    "AWS_ACCESS_KEY_ID": creds.get("aws_access_key_id") or "",
-                    "AWS_SECRET_ACCESS_KEY": creds.get("aws_secret_access_key") or "",
-                    "AWS_SESSION_TOKEN": creds.get("aws_session_token") or "",
-                    # Allow http connections, this is required for minio
-                    "AWS_STORAGE_ALLOW_HTTP": "true",
-                }
-                if delta_lake_config.s3.aws_config.aws_region:
-                    opts["AWS_REGION"] = delta_lake_config.s3.aws_config.aws_region
-                if delta_lake_config.s3.aws_config.aws_endpoint_url:
-                    opts[
-                        "AWS_ENDPOINT_URL"
-                    ] = delta_lake_config.s3.aws_config.aws_endpoint_url
-        else:
-            # Local file system
-            if not pathlib.Path(path).exists():
-                # The DeltaTable() constructor will create the path if it doesn't exist.
-                # Hence we need an extra, manual check here.
-                return None
+    if not delta_lake_config.is_s3 and not pathlib.Path(path).exists():
+        # The DeltaTable() constructor will create the path if it doesn't exist.
+        # Hence we need an extra, manual check here.
+        return None
 
-        delta_table = DeltaTable(
+    try:
+        return DeltaTable(
             path,
             storage_options=opts,
             without_files=not delta_lake_config.require_files,
         )
-
     except PyDeltaTableError as e:
         if "Not a Delta table" not in str(e):
             raise e
-    return delta_table
+    return None
 
 
 def get_file_count(delta_table: DeltaTable) -> int:

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/delta_lake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/delta_lake_utils.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from deltalake import DeltaTable, PyDeltaTableError
 

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -321,7 +321,7 @@ class DeltaLakeSource(Source):
         delta_table = read_delta_table(path, self.storage_options, self.source_config)
         if delta_table:
             logger.debug(f"Delta table found at: {path}")
-            for wu in self.ingest_table(delta_table, path):
+            for wu in self.ingest_table(delta_table, path.rstrip("/")):
                 yield wu
         else:
             for folder in self.get_folders(path):

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -306,7 +306,7 @@ class DeltaLakeSource(Source):
             opts = {
                 "AWS_ACCESS_KEY_ID": creds.get("aws_access_key_id") or "",
                 "AWS_SECRET_ACCESS_KEY": creds.get("aws_secret_access_key") or "",
-                "AWS_SESSION_TOKEN": creds.get("aws_session_token", ""),
+                "AWS_SESSION_TOKEN": creds.get("aws_session_token") or "",
                 # Allow http connections, this is required for minio
                 "AWS_STORAGE_ALLOW_HTTP": "true",
             }

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Dict, Iterable, List
 from urllib.parse import urlparse
 
-from cached_property import cached_property
 from deltalake import DeltaTable
 
 from datahub.emitter.mce_builder import (
@@ -98,6 +97,7 @@ class DeltaLakeSource(Source):
     report: DeltaLakeSourceReport
     profiling_times_taken: List[float]
     container_WU_creator: ContainerWUCreator
+    storage_options: Dict[str, str]
 
     def __init__(self, config: DeltaLakeSourceConfig, ctx: PipelineContext):
         super().__init__(ctx)
@@ -295,8 +295,7 @@ class DeltaLakeSource(Source):
 
         yield from self._create_operation_aspect_wu(delta_table, dataset_urn)
 
-    @cached_property
-    def storage_options(self) -> Dict[str, str]:
+    def get_storage_options(self) -> Dict[str, str]:
         if (
             self.source_config.is_s3
             and self.source_config.s3 is not None
@@ -358,6 +357,7 @@ class DeltaLakeSource(Source):
             self.source_config.platform_instance,
             self.source_config.env,
         )
+        self.storage_options = self.get_storage_options()
         yield from self.process_folder(self.source_config.complete_path)
 
     def get_report(self) -> SourceReport:

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -2,10 +2,10 @@ import logging
 import os
 import time
 from datetime import datetime
-from functools import cached_property
 from typing import Dict, Iterable, List
 from urllib.parse import urlparse
 
+from cached_property import cached_property
 from deltalake import DeltaTable
 
 from datahub.emitter.mce_builder import (

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -2,7 +2,9 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Callable, Iterable, List
+from functools import cached_property
+from typing import Callable, Iterable, List, Dict
+from urllib.parse import urlparse
 
 from deltalake import DeltaTable
 
@@ -101,12 +103,16 @@ class DeltaLakeSource(Source):
         super().__init__(ctx)
         self.source_config = config
         self.report = DeltaLakeSourceReport()
+        if self.source_config.is_s3:
+            if self.source_config.s3.aws_config is None:
+                raise ValueError("AWS Config must be provided for S3 base path.")
+            self.s3_client = self.source_config.s3.aws_config.get_s3_client()
+
         # self.profiling_times_taken = []
         config_report = {
             config_option: config.dict().get(config_option)
             for config_option in config_options_to_report
         }
-        config_report = config_report
 
         telemetry.telemetry_instance.ping(
             "delta_lake_config",
@@ -286,33 +292,62 @@ class DeltaLakeSource(Source):
 
         yield from self._create_operation_aspect_wu(delta_table, dataset_urn)
 
-    def process_folder(
-        self, path: str, get_folders: Callable[[str], Iterable[str]]
-    ) -> Iterable[MetadataWorkUnit]:
+    @cached_property
+    def storage_options(self) -> Dict[str, str]:
+        if (
+            self.source_config.is_s3
+            and self.source_config.s3 is not None
+            and self.source_config.s3.aws_config is not None
+        ):
+            aws_config = self.source_config.s3.aws_config
+            creds = aws_config.get_credentials()
+            opts = {
+                "AWS_ACCESS_KEY_ID": creds.get("aws_access_key_id", ""),
+                "AWS_SECRET_ACCESS_KEY": creds.get("aws_secret_access_key", ""),
+                "AWS_SESSION_TOKEN": creds.get("aws_session_token", ""),
+                # Allow http connections, this is required for minio
+                "AWS_STORAGE_ALLOW_HTTP": "true",
+            }
+            if self.source_config.s3.aws_config.aws_region:
+                opts["AWS_REGION"] = aws_config.aws_region
+            if self.source_config.s3.aws_config.aws_endpoint_url:
+                opts["AWS_ENDPOINT_URL"] = aws_config.aws_endpoint_url
+            return opts
+        else:
+            return {}
+
+    def process_folder(self, path: str) -> Iterable[MetadataWorkUnit]:
         logger.debug(f"Processing folder: {path}")
-        delta_table = read_delta_table(path, self.source_config)
+        delta_table = read_delta_table(path, self.storage_options, self.source_config)
         if delta_table:
             logger.debug(f"Delta table found at: {path}")
             for wu in self.ingest_table(delta_table, path):
                 yield wu
         else:
-            for folder in get_folders(path):
-                yield from self.process_folder(path + "/" + folder, get_folders)
+            for folder in self.get_folders(path):
+                yield from self.process_folder(folder)
+
+    def get_folders(self, path: str):
+        if self.source_config.is_s3:
+            return self.s3_get_folders(path)
+        else:
+            return self.local_get_folders(path)
 
     def s3_get_folders(self, path: str) -> Iterable[str]:
-        if self.source_config.s3 is not None:
-            yield from list_folders_path(path, self.source_config.s3.aws_config)
+        parse_result = urlparse(path)
+        for page in self.s3_client.get_paginator("list_objects_v2").paginate(
+            Bucket=parse_result.netloc, Prefix=parse_result.path[1:], Delimiter="/"
+        ):
+            for o in page.get("CommonPrefixes", []):
+                yield f"{parse_result.scheme}://{parse_result.netloc}/{o.get('Prefix')}"
 
     def local_get_folders(self, path: str) -> Iterable[str]:
         if not os.path.isdir(path):
             raise FileNotFoundError(
                 f"{path} does not exist or is not a directory. Please check base_path configuration."
             )
-        for _, folders, _ in os.walk(path):
-            for folder in folders:
-                yield folder
-            break
-        return
+        for folder in os.listdir(path):
+            yield os.path.join(path, folder)
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         self.container_WU_creator = ContainerWUCreator(
@@ -320,11 +355,7 @@ class DeltaLakeSource(Source):
             self.source_config.platform_instance,
             self.source_config.env,
         )
-        get_folders = (
-            self.s3_get_folders if self.source_config.is_s3 else self.local_get_folders
-        )
-        for wu in self.process_folder(self.source_config.complete_path, get_folders):
-            yield wu
+        yield from self.process_folder(self.source_config.complete_path)
 
     def get_report(self) -> SourceReport:
         return self.report

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -3,7 +3,7 @@ import os
 import time
 from datetime import datetime
 from functools import cached_property
-from typing import Callable, Dict, Iterable, List
+from typing import Dict, Iterable, List
 from urllib.parse import urlparse
 
 from deltalake import DeltaTable
@@ -24,7 +24,7 @@ from datahub.ingestion.api.decorators import (
 )
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.ingestion.source.aws.s3_boto_utils import get_s3_tags, list_folders_path
+from datahub.ingestion.source.aws.s3_boto_utils import get_s3_tags
 from datahub.ingestion.source.aws.s3_util import (
     get_bucket_name,
     get_key_prefix,
@@ -305,8 +305,8 @@ class DeltaLakeSource(Source):
             aws_config = self.source_config.s3.aws_config
             creds = aws_config.get_credentials()
             opts = {
-                "AWS_ACCESS_KEY_ID": creds.get("aws_access_key_id", ""),
-                "AWS_SECRET_ACCESS_KEY": creds.get("aws_secret_access_key", ""),
+                "AWS_ACCESS_KEY_ID": creds.get("aws_access_key_id") or "",
+                "AWS_SECRET_ACCESS_KEY": creds.get("aws_secret_access_key") or "",
                 "AWS_SESSION_TOKEN": creds.get("aws_session_token", ""),
                 # Allow http connections, this is required for minio
                 "AWS_STORAGE_ALLOW_HTTP": "true",


### PR DESCRIPTION
Main issue is https://github.com/datahub-project/datahub/issues/8049, which this fixes by yielding full paths in the `get_folders` method rather than piecing together paths.

Also does some refactoring to clean things up and fetch credentials / create clients less, pass fewer params, etc.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
