### PR TITLE
docs(readme): adds PITS Global Data Recovery Services to the adopters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Here are the companies that have officially adopted DataHub. Please feel free to
 - [N26](https://n26brasil.com/)
 - [Optum](https://www.optum.com/)
 - [Peloton](https://www.onepeloton.com)
+- [PITS Global Data Recovery Services](https://www.pitsdatarecovery.net/)
 - [Razer](https://www.razer.com)
 - [Saxo Bank](https://www.home.saxo)
 - [Showroomprive](https://www.showroomprive.com/)


### PR DESCRIPTION
This pull request adds PITS Global Data Recovery Services to the adopters list in README.md file's adopters section.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
