### PR TITLE
fix(ui) Fix entity name styling to show deprecation and others properly

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
@@ -9,8 +9,6 @@ import { useGlossaryEntityData } from '../../../GlossaryEntityContext';
 
 const EntityTitle = styled(Typography.Title)`
     margin-right: 10px;
-    width: 90%;
-    max-width: 650px;
 
     &&& {
         margin-bottom: 0;


### PR DESCRIPTION
A very recent merge updated CSS on entity names that makes displaying deprecation, failing tests, failing assertions, etc (whatever is next to the name) look bad.

This reverts that change that was made so things look good again.

Before:
<img width="1114" alt="image" src="https://github.com/datahub-project/datahub/assets/28656603/fbbaa31c-30dd-4f5b-81b5-1df8baa62e55">

After:
<img width="1119" alt="image" src="https://github.com/datahub-project/datahub/assets/28656603/040bc377-de08-4a17-87ce-25d7c93d2463">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
