### PR TITLE
feat(sqllineage): Bump sqllineage to 1.4.5 for python>3.7

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -126,12 +126,14 @@ sql_common = {
 }
 
 sqllineage_lib = {
-    "sqllineage==1.3.6",
+    "sqllineage==1.4.5 ;  python_version >= '3.8'",
+
+    "sqllineage==1.3.6 ;  python_version < '3.8'",
     # We don't have a direct dependency on sqlparse but it is a dependency of sqllineage.
     # As per https://github.com/reata/sqllineage/issues/361
     # and https://github.com/reata/sqllineage/pull/360
     # sqllineage has compat issues with sqlparse 0.4.4.
-    "sqlparse==0.4.3",
+    "sqlparse==0.4.3 ;  python_version < '3.8'",
 }
 
 sqlglot_lib = {


### PR DESCRIPTION
Bumping sqllineage library to "sqllineage==1.4.5" for python versions after 3.7. (For older python versions including the 3.7, the behaviour should not change and we can continue using the version of sqllineage supporting old pythons.)

The reason for the change is to catch up with the improvements on the dependency. The upgraded version parses some queries using `with` statements correctly while the older versions cannot. 

I'm also removing the fixed version of the sqlparse which was a transitive dependency of sqllineage since the mentioned issue in the comments have been fixed.