### PR TITLE
feat(ingest/bigquery): Add BigQuery Views lineage extraction from Google Data Catalog API

### DIFF
--- a/docker/datahub-ingestion-base/base-requirements.txt
+++ b/docker/datahub-ingestion-base/base-requirements.txt
@@ -109,7 +109,7 @@ google-cloud-audit-log==0.2.5
 google-cloud-bigquery==3.9.0
 google-cloud-bigquery-storage==2.19.1
 google-cloud-core==2.3.2
-google-cloud-datacatalog-lineage==0.2.0
+google-cloud-datacatalog-lineage==0.2.2
 google-cloud-logging==3.5.0
 google-crc32c==1.5.0
 google-resumable-media==2.4.1

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -279,7 +279,7 @@ plugins: Dict[str, Set[str]] = {
         *sqllineage_lib,
         "sql_metadata",
         "sqlalchemy-bigquery>=1.4.1",
-        "google-cloud-datacatalog-lineage==0.2.0",
+        "google-cloud-datacatalog-lineage==0.2.2",
     },
     "bigquery-beta": sql_common
     | bigquery_common

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -159,12 +159,6 @@ timestamp < "{end_time}"
             of upstream tables identifiers.
         """
         logger.info("Populating lineage info via Catalog Data Linage API")
-        #  Data Catalog API version 0.2.0 don't export views lineage, but future versions can cover it
-        #  NOTE: Users can enable to parse views DDL to build views lineage
-        if self.config.include_views:
-            logger.warning(
-                "It's not possible to extract views lineage from Catalog API. Views will be ignored."
-            )
 
         # Regions to search for BigQuery tables: projects/{project_id}/locations/{region}
         enabled_regions: List[str] = ["US", "EU"]
@@ -176,12 +170,12 @@ timestamp < "{end_time}"
             datasets = list(bigquery_client.list_datasets(project_id))
             project_tables = []
             for dataset in datasets:
-                # Enables only tables where type is TABLE (removes VIEWS)
+                # Enables only tables where type is TABLE, VIEW or MATERIALIZED_VIEW (not EXTERNAL)
                 project_tables.extend(
                     [
                         table
                         for table in bigquery_client.list_tables(dataset.dataset_id)
-                        if table.table_type == "TABLE"
+                        if table.table_type in ["TABLE", "VIEW", "MATERIALIZED_VIEW"]
                     ]
                 )
 
@@ -564,7 +558,7 @@ timestamp < "{end_time}"
     def _compute_bigquery_lineage(self, project_id: str) -> Dict[str, Set[LineageEdge]]:
         lineage_metadata: Dict[str, Set[LineageEdge]]
         try:
-            if self.config.extract_lineage_from_catalog and self.config.include_tables:
+            if self.config.extract_lineage_from_catalog:
                 lineage_metadata = self.lineage_via_catalog_lineage_api(project_id)
             else:
                 events = self._get_parsed_audit_log_events(project_id)

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -193,7 +193,7 @@ timestamp < "{end_time}"
             curr_date = datetime.now()
             for table in project_tables:
                 logger.info("Creating lineage map for table %s", table)
-                upstreams = []
+                upstreams = set()
                 downstream_table = lineage_v1.EntityReference()
                 # fully_qualified_name in format: "bigquery:<project_id>.<dataset_id>.<table_id>"
                 downstream_table.fully_qualified_name = f"bigquery:{table}"
@@ -204,7 +204,7 @@ timestamp < "{end_time}"
                         parent=f"projects/{project_id}/locations/{region.lower()}",
                     )
                     response = lineage_client.search_links(request=location_request)
-                    upstreams.extend(
+                    upstreams.update(
                         [
                             str(lineage.source.fully_qualified_name).replace(
                                 "bigquery:", ""


### PR DESCRIPTION
# Adds BigQuery Views' lineage extraction from Google Data Catalog API

This Pull Request makes extracting Lineage from Google Data Catalog API possible. https://github.com/datahub-project/datahub/pull/7137 first introduced this feature, but there were some limitations on the API at the time, making the API not return Lineage metadata for Views. However, now it's possible to retrieve this information, and it's much faster than parsing all Views SQL.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
