### PR TITLE
refactor(ingest): simplify stateful ingestion provider interface

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/common.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Dict, Generic, Iterable, Optional, Tuple, Type
 
 from datahub.emitter.mce_builder import set_dataset_urn_to_lower
 from datahub.ingestion.api.committable import Committable
-from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.graph.client import DataHubGraph
 
 if TYPE_CHECKING:
     from datahub.ingestion.run.pipeline import PipelineConfig
@@ -43,22 +43,19 @@ class PipelineContext:
     def __init__(
         self,
         run_id: str,
-        datahub_api: Optional["DatahubClientConfig"] = None,
+        graph: Optional[DataHubGraph] = None,
         pipeline_name: Optional[str] = None,
         dry_run: bool = False,
         preview_mode: bool = False,
         pipeline_config: Optional["PipelineConfig"] = None,
     ) -> None:
         self.pipeline_config = pipeline_config
+        self.graph = graph
         self.run_id = run_id
         self.pipeline_name = pipeline_name
         self.dry_run_mode = dry_run
         self.preview_mode = preview_mode
         self.checkpointers: Dict[str, Committable] = {}
-        try:
-            self.graph = DataHubGraph(datahub_api) if datahub_api is not None else None
-        except Exception as e:
-            raise Exception(f"Failed to connect to DataHub: {e}") from e
 
         self._set_dataset_urn_to_lower_if_needed()
 

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -27,6 +27,7 @@ from datahub.ingestion.api.sink import Sink, SinkReport, WriteCallback
 from datahub.ingestion.api.source import Extractor, Source
 from datahub.ingestion.api.transform import Transformer
 from datahub.ingestion.extractor.extractor_registry import extractor_registry
+from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.reporting.reporting_provider_registry import (
     reporting_provider_registry,
 )
@@ -183,10 +184,15 @@ class Pipeline:
         self.last_time_printed = int(time.time())
         self.cli_report = CliReport()
 
+        self.graph = None
+        with _add_init_error_context("connect to DataHub"):
+            if self.config.datahub_api:
+                self.graph = DataHubGraph(self.config.datahub_api)
+
         with _add_init_error_context("set up framework context"):
             self.ctx = PipelineContext(
                 run_id=self.config.run_id,
-                datahub_api=self.config.datahub_api,
+                graph=self.graph,
                 pipeline_name=self.config.pipeline_name,
                 dry_run=dry_run,
                 preview_mode=preview_mode,

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from enum import auto
 from threading import BoundedSemaphore
-from typing import Union, cast
+from typing import Union
 
 from datahub.cli.cli_utils import set_env_variables_override_config
 from datahub.configuration.common import (
@@ -123,8 +123,7 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
 
     def handle_work_unit_start(self, workunit: WorkUnit) -> None:
         if isinstance(workunit, MetadataWorkUnit):
-            mwu: MetadataWorkUnit = cast(MetadataWorkUnit, workunit)
-            self.treat_errors_as_warnings = mwu.treat_errors_as_warnings
+            self.treat_errors_as_warnings = workunit.treat_errors_as_warnings
 
     def handle_work_unit_end(self, workunit: WorkUnit) -> None:
         pass

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -1343,6 +1343,3 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
 
     def get_report(self) -> SourceReport:
         return self.reporter
-
-    def close(self):
-        self.prepare_for_commit()

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
@@ -2168,6 +2168,3 @@ class LookMLSource(StatefulIngestionSourceBase):
 
     def get_report(self):
         return self.reporter
-
-    def close(self):
-        self.prepare_for_commit()

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -1228,7 +1228,7 @@ class PowerBiDashboardSource(StatefulIngestionSourceBase):
                     # Because job_id is used as dictionary key, we have to set a new job_id
                     # Refer to https://github.com/datahub-project/datahub/blob/master/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py#L390
                     self.stale_entity_removal_handler.set_job_id(workspace.id)
-                    self.register_stateful_ingestion_usecase_handler(
+                    self.state_provider.register_stateful_ingestion_usecase_handler(
                         self.stale_entity_removal_handler
                     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
@@ -1335,6 +1335,3 @@ class VerticaSource(SQLAlchemySource):
                 return each["owner_name"]
 
         return None
-
-    def close(self):
-        self.prepare_for_commit()

--- a/metadata-ingestion/src/datahub/ingestion/source/state/entity_removal_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/entity_removal_state.py
@@ -85,10 +85,6 @@ class GenericCheckpointState(StaleEntityCheckpointStateBase["GenericCheckpointSt
         self.urns = deduplicate_list(self.urns)
         self._urns_set = set(self.urns)
 
-    @classmethod
-    def get_supported_types(cls) -> List[str]:
-        return ["*"]
-
     def add_checkpoint_urn(self, type: str, urn: str) -> None:
         if urn not in self._urns_set:
             self.urns.append(urn)
@@ -100,6 +96,7 @@ class GenericCheckpointState(StaleEntityCheckpointStateBase["GenericCheckpointSt
         diff = set(self.urns) - set(other_checkpoint_state.urns)
 
         # To maintain backwards compatibility, we provide this filtering mechanism.
+        # TODO: This is only used in tests and should be removed.
         if type == "*":
             yield from diff
         elif type == "topic":

--- a/metadata-ingestion/src/datahub/ingestion/source/state/entity_removal_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/entity_removal_state.py
@@ -1,11 +1,9 @@
-from typing import Any, Dict, Iterable, List, Type
+from typing import Any, Dict, Iterable, List, Tuple, Type
 
 import pydantic
 
 from datahub.emitter.mce_builder import make_assertion_urn, make_container_urn
-from datahub.ingestion.source.state.stale_entity_removal_handler import (
-    StaleEntityCheckpointStateBase,
-)
+from datahub.ingestion.source.state.checkpoint import CheckpointStateBase
 from datahub.utilities.checkpoint_state_util import CheckpointStateUtil
 from datahub.utilities.dedup_list import deduplicate_list
 from datahub.utilities.urns.urn import guess_entity_type
@@ -56,7 +54,7 @@ def pydantic_state_migrator(mapping: Dict[str, str]) -> classmethod:
     return pydantic.root_validator(pre=True, allow_reuse=True)(_validate_field_rename)
 
 
-class GenericCheckpointState(StaleEntityCheckpointStateBase["GenericCheckpointState"]):
+class GenericCheckpointState(CheckpointStateBase):
     urns: List[str] = pydantic.Field(default_factory=list)
 
     # We store a bit of extra internal-only state so that we can keep the urns list deduplicated.
@@ -86,6 +84,14 @@ class GenericCheckpointState(StaleEntityCheckpointStateBase["GenericCheckpointSt
         self._urns_set = set(self.urns)
 
     def add_checkpoint_urn(self, type: str, urn: str) -> None:
+        """
+        Adds an urn into the list used for tracking the type.
+
+        :param type: Deprecated parameter, has no effect.
+        :param urn: The urn string
+        """
+
+        # TODO: Deprecate the `type` parameter and remove it.
         if urn not in self._urns_set:
             self.urns.append(urn)
             self._urns_set.add(urn)
@@ -93,10 +99,18 @@ class GenericCheckpointState(StaleEntityCheckpointStateBase["GenericCheckpointSt
     def get_urns_not_in(
         self, type: str, other_checkpoint_state: "GenericCheckpointState"
     ) -> Iterable[str]:
+        """
+        Gets the urns present in this checkpoint but not the other_checkpoint for the given type.
+
+        :param type: Deprecated. Set to "*".
+        :param other_checkpoint_state: the checkpoint state to compute the urn set difference against.
+        :return: an iterable to the set of urns present in this checkpoint state but not in the other_checkpoint.
+        """
+
         diff = set(self.urns) - set(other_checkpoint_state.urns)
 
         # To maintain backwards compatibility, we provide this filtering mechanism.
-        # TODO: This is only used in tests and should be removed.
+        # TODO: Deprecate the `type` parameter and remove it.
         if type == "*":
             yield from diff
         elif type == "topic":
@@ -107,6 +121,36 @@ class GenericCheckpointState(StaleEntityCheckpointStateBase["GenericCheckpointSt
     def get_percent_entities_changed(
         self, old_checkpoint_state: "GenericCheckpointState"
     ) -> float:
-        return StaleEntityCheckpointStateBase.compute_percent_entities_changed(
+        """
+        Returns the percentage of entities that have changed relative to `old_checkpoint_state`.
+
+        :param old_checkpoint_state: the old checkpoint state to compute the relative change percent against.
+        :return: (1-|intersection(self, old_checkpoint_state)| / |old_checkpoint_state|) * 100.0
+        """
+        return compute_percent_entities_changed(
             [(self.urns, old_checkpoint_state.urns)]
         )
+
+
+def compute_percent_entities_changed(
+    new_old_entity_list: List[Tuple[List[str], List[str]]]
+) -> float:
+    old_count_all = 0
+    overlap_count_all = 0
+    for new_entities, old_entities in new_old_entity_list:
+        (overlap_count, old_count, _,) = get_entity_overlap_and_cardinalities(
+            new_entities=new_entities, old_entities=old_entities
+        )
+        overlap_count_all += overlap_count
+        old_count_all += old_count
+    if old_count_all:
+        return (1 - overlap_count_all / old_count_all) * 100.0
+    return 0.0
+
+
+def get_entity_overlap_and_cardinalities(
+    new_entities: List[str], old_entities: List[str]
+) -> Tuple[int, int, int]:
+    new_set = set(new_entities)
+    old_set = set(old_entities)
+    return len(new_set.intersection(old_set)), len(old_set), len(new_set)

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -183,16 +183,6 @@ class StatefulIngestionSourceBase(Source):
         self.state_provider.prepare_for_commit()
         super().close()
 
-    # TODO: The below proxy methods should be removed.
-
-    def get_current_checkpoint(self, job_id: JobId) -> Optional[Checkpoint]:
-        return self.state_provider.get_current_checkpoint(job_id)
-
-    def get_last_checkpoint(
-        self, job_id: JobId, checkpoint_state_class: Type[StateType]
-    ) -> Optional[Checkpoint]:
-        return self.state_provider.get_last_checkpoint(job_id, checkpoint_state_class)
-
 
 class StateProviderWrapper:
     def __init__(

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -185,17 +185,6 @@ class StatefulIngestionSourceBase(Source):
 
     # TODO: The below proxy methods should be removed.
 
-    def register_stateful_ingestion_usecase_handler(
-        self, usecase_handler: StatefulIngestionUsecaseHandlerBase
-    ) -> None:
-        self.state_provider.register_stateful_ingestion_usecase_handler(usecase_handler)
-
-    def is_stateful_ingestion_configured(self) -> bool:
-        return self.state_provider.is_stateful_ingestion_configured()
-
-    def is_checkpointing_enabled(self, job_id: JobId) -> bool:
-        return self.state_provider.is_checkpointing_enabled(job_id)
-
     def get_current_checkpoint(self, job_id: JobId) -> Optional[Checkpoint]:
         return self.state_provider.get_current_checkpoint(job_id)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -169,7 +169,7 @@ class StatefulIngestionSourceBase(Source):
     ) -> None:
         super().__init__(ctx)
         self.report: StatefulIngestionReport = StatefulIngestionReport()
-        self.state_provider = StateProviderWrapper(config, ctx)
+        self.state_provider = StateProviderWrapper(config.stateful_ingestion, ctx)
 
     def warn(self, log: logging.Logger, key: str, reason: str) -> None:
         self.report.report_warning(key, reason)
@@ -187,13 +187,12 @@ class StatefulIngestionSourceBase(Source):
 class StateProviderWrapper:
     def __init__(
         self,
-        config: StatefulIngestionConfigBase[StatefulIngestionConfig],
+        config: Optional[StatefulIngestionConfig],
         ctx: PipelineContext,
     ) -> None:
-        # self.config = config
         self.ctx = ctx
+        self.stateful_ingestion_config = config
 
-        self.stateful_ingestion_config = config.stateful_ingestion
         self.last_checkpoints: Dict[JobId, Optional[Checkpoint]] = {}
         self.cur_checkpoints: Dict[JobId, Optional[Checkpoint]] = {}
         self.report: StatefulIngestionReport = StatefulIngestionReport()

--- a/metadata-ingestion/tests/integration/azure_ad/test_azure_ad.py
+++ b/metadata-ingestion/tests/integration/azure_ad/test_azure_ad.py
@@ -1,17 +1,16 @@
 import json
 import pathlib
 from functools import partial
-from typing import List, Optional, cast
+from typing import List
 from unittest.mock import patch
 
 from freezegun import freeze_time
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.identity.azure_ad import AzureADConfig, AzureADSource
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
+from datahub.ingestion.source.identity.azure_ad import AzureADConfig
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -325,15 +324,6 @@ def test_azure_source_ingestion_disabled(pytestconfig, mock_datahub_graph, tmp_p
         pytestconfig,
         output_path=f"{tmp_path}/{output_file_name}",
         golden_path=test_resources_dir / "azure_ad_mces_golden_ingestion_disabled.json",
-    )
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    azure_ad_source = cast(AzureADSource, pipeline.source)
-    return azure_ad_source.get_current_checkpoint(
-        azure_ad_source.stale_entity_removal_handler.job_id
     )
 
 

--- a/metadata-ingestion/tests/integration/iceberg/test_iceberg.py
+++ b/metadata-ingestion/tests/integration/iceberg/test_iceberg.py
@@ -1,5 +1,5 @@
 from pathlib import PosixPath
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Union
 from unittest.mock import patch
 
 import pytest
@@ -8,11 +8,9 @@ from iceberg.core.filesystem.file_status import FileStatus
 from iceberg.core.filesystem.local_filesystem import LocalFileSystem
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.iceberg.iceberg import IcebergSource
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     run_and_get_pipeline,
     validate_all_providers_have_committed_successfully,
 )
@@ -20,15 +18,6 @@ from tests.test_helpers.state_helpers import (
 FROZEN_TIME = "2020-04-14 07:00:00"
 GMS_PORT = 8080
 GMS_SERVER = f"http://localhost:{GMS_PORT}"
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    iceberg_source = cast(IcebergSource, pipeline.source)
-    return iceberg_source.get_current_checkpoint(
-        iceberg_source.stale_entity_removal_handler.job_id
-    )
 
 
 @freeze_time(FROZEN_TIME)

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -1,6 +1,6 @@
 import subprocess
 import time
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, cast
 from unittest import mock
 
 import pytest
@@ -8,12 +8,12 @@ import requests
 from freezegun import freeze_time
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.state.checkpoint import Checkpoint
 from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -489,14 +489,3 @@ def test_kafka_connect_ingest_stateful(
         "urn:li:dataJob:(urn:li:dataFlow:(kafka-connect,connect-instance-1.mysql_source2,PROD),librarydb.member)",
     ]
     assert sorted(deleted_job_urns) == sorted(difference_job_urns)
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint]:
-    from datahub.ingestion.source.kafka_connect import KafkaConnectSource
-
-    kafka_connect_source = cast(KafkaConnectSource, pipeline.source)
-    return kafka_connect_source.get_current_checkpoint(
-        kafka_connect_source.stale_entity_removal_handler.job_id
-    )

--- a/metadata-ingestion/tests/integration/kafka/test_kafka_state.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka_state.py
@@ -1,17 +1,14 @@
 import time
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List
 from unittest.mock import patch
 
 import pytest
 from confluent_kafka.admin import AdminClient, NewTopic
 from freezegun import freeze_time
 
-from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.kafka import KafkaSource
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers.docker_helpers import wait_for_port
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     run_and_get_pipeline,
     validate_all_providers_have_committed_successfully,
 )
@@ -79,15 +76,6 @@ class KafkaTopicsCxtManager:
 
     def __exit__(self, exc_type, exc, traceback):
         self.delete_kafka_topics(self.topics)
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    kafka_source = cast(KafkaSource, pipeline.source)
-    return kafka_source.get_current_checkpoint(
-        kafka_source.stale_entity_removal_handler.job_id
-    )
 
 
 @freeze_time(FROZEN_TIME)

--- a/metadata-ingestion/tests/integration/ldap/test_ldap_stateful.py
+++ b/metadata-ingestion/tests/integration/ldap/test_ldap_stateful.py
@@ -1,18 +1,15 @@
 import pathlib
 import time
-from typing import Optional, cast
 from unittest import mock
 
 import pytest
 from freezegun import freeze_time
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.ldap import LDAPSource
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.docker_helpers import wait_for_port
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -88,15 +85,6 @@ def ldap_ingest_common(
                 ignore_paths=mce_helpers.IGNORE_PATH_TIMESTAMPS,
             )
             return pipeline
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    ldap_source = cast(LDAPSource, pipeline.source)
-    return ldap_source.get_current_checkpoint(
-        ldap_source.stale_entity_removal_handler.job_id
-    )
 
 
 @freeze_time(FROZEN_TIME)

--- a/metadata-ingestion/tests/integration/looker/test_looker.py
+++ b/metadata-ingestion/tests/integration/looker/test_looker.py
@@ -27,11 +27,10 @@ from datahub.ingestion.source.looker.looker_query_model import (
     LookViewField,
     UserViewField,
 )
-from datahub.ingestion.source.looker.looker_source import LookerDashboardSource
-from datahub.ingestion.source.state.checkpoint import Checkpoint
 from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -719,12 +718,3 @@ def test_looker_ingest_stateful(pytestconfig, tmp_path, mock_time, mock_datahub_
     assert len(difference_dashboard_urns) == 1
     deleted_dashboard_urns = ["urn:li:dashboard:(looker,dashboards.11)"]
     assert sorted(deleted_dashboard_urns) == sorted(difference_dashboard_urns)
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint]:
-    dbt_source = cast(LookerDashboardSource, pipeline.source)
-    return dbt_source.get_current_checkpoint(
-        dbt_source.stale_entity_removal_handler.job_id
-    )

--- a/metadata-ingestion/tests/integration/lookml/test_lookml.py
+++ b/metadata-ingestion/tests/integration/lookml/test_lookml.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, cast
 from unittest import mock
 
 import pydantic
@@ -15,10 +15,8 @@ from datahub.ingestion.source.file import read_metadata_file
 from datahub.ingestion.source.looker.lookml_source import (
     LookerModel,
     LookerRefinementResolver,
-    LookMLSource,
     LookMLSourceConfig,
 )
-from datahub.ingestion.source.state.checkpoint import Checkpoint
 from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from datahub.metadata.schema_classes import (
     DatasetSnapshotClass,
@@ -27,6 +25,7 @@ from datahub.metadata.schema_classes import (
 )
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -845,15 +844,6 @@ def test_lookml_ingest_stateful(pytestconfig, tmp_path, mock_time, mock_datahub_
         "urn:li:dataset:(urn:li:dataPlatform:looker,lkml_samples.view.flights,PROD)",
     ]
     assert sorted(deleted_dataset_urns) == sorted(difference_dataset_urns)
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint]:
-    dbt_source = cast(LookMLSource, pipeline.source)
-    return dbt_source.get_current_checkpoint(
-        dbt_source.stale_entity_removal_handler.job_id
-    )
 
 
 def test_lookml_base_folder():

--- a/metadata-ingestion/tests/integration/okta/test_okta.py
+++ b/metadata-ingestion/tests/integration/okta/test_okta.py
@@ -1,7 +1,6 @@
 import asyncio
 import pathlib
 from functools import partial
-from typing import Optional, cast
 from unittest.mock import Mock, patch
 
 import jsonpickle
@@ -10,11 +9,10 @@ from freezegun import freeze_time
 from okta.models import Group, User
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.identity.okta import OktaConfig, OktaSource
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
+from datahub.ingestion.source.identity.okta import OktaConfig
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -200,15 +198,6 @@ def test_okta_source_custom_user_name_regex(pytestconfig, mock_datahub_graph, tm
         pytestconfig,
         output_path=output_file_path,
         golden_path=f"{test_resources_dir}/okta_mces_golden_custom_user_name_regex.json",
-    )
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    azure_ad_source = cast(OktaSource, pipeline.source)
-    return azure_ad_source.get_current_checkpoint(
-        azure_ad_source.stale_entity_removal_handler.job_id
     )
 
 

--- a/metadata-ingestion/tests/integration/powerbi/test_stateful_ingestion.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_stateful_ingestion.py
@@ -216,7 +216,7 @@ def get_current_checkpoint_from_pipeline(
 ) -> Dict[JobId, Optional[Checkpoint[Any]]]:
     powerbi_source = cast(PowerBiDashboardSource, pipeline.source)
     checkpoints = {}
-    for job_id in powerbi_source._usecase_handlers.keys():
+    for job_id in powerbi_source.state_provider._usecase_handlers.keys():
         # for multi-workspace checkpoint, every good checkpoint will have an unique workspaceid suffix
         checkpoints[job_id] = powerbi_source.get_current_checkpoint(job_id)
     return checkpoints

--- a/metadata-ingestion/tests/integration/powerbi/test_stateful_ingestion.py
+++ b/metadata-ingestion/tests/integration/powerbi/test_stateful_ingestion.py
@@ -218,7 +218,9 @@ def get_current_checkpoint_from_pipeline(
     checkpoints = {}
     for job_id in powerbi_source.state_provider._usecase_handlers.keys():
         # for multi-workspace checkpoint, every good checkpoint will have an unique workspaceid suffix
-        checkpoints[job_id] = powerbi_source.get_current_checkpoint(job_id)
+        checkpoints[job_id] = powerbi_source.state_provider.get_current_checkpoint(
+            job_id
+        )
     return checkpoints
 
 

--- a/metadata-ingestion/tests/integration/superset/test_superset.py
+++ b/metadata-ingestion/tests/integration/superset/test_superset.py
@@ -1,15 +1,13 @@
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest
 from freezegun import freeze_time
 
 from datahub.ingestion.run.pipeline import Pipeline
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
-from datahub.ingestion.source.superset import SupersetSource
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     run_and_get_pipeline,
     validate_all_providers_have_committed_successfully,
 )
@@ -17,15 +15,6 @@ from tests.test_helpers.state_helpers import (
 FROZEN_TIME = "2020-04-14 07:00:00"
 GMS_PORT = 8080
 GMS_SERVER = f"http://localhost:{GMS_PORT}"
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    superset_source = cast(SupersetSource, pipeline.source)
-    return superset_source.get_current_checkpoint(
-        superset_source.stale_entity_removal_handler.job_id
-    )
 
 
 def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:

--- a/metadata-ingestion/tests/integration/tableau/test_tableau_ingest.py
+++ b/metadata-ingestion/tests/integration/tableau/test_tableau_ingest.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pathlib
 import sys
-from typing import Optional, cast
+from typing import cast
 from unittest import mock
 
 import pytest
@@ -17,8 +17,6 @@ from tableauserverclient.models import (
 
 from datahub.configuration.source_common import DEFAULT_ENV
 from datahub.ingestion.run.pipeline import Pipeline, PipelineContext
-from datahub.ingestion.source.state.checkpoint import Checkpoint
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from datahub.ingestion.source.tableau import TableauConfig, TableauSource
 from datahub.ingestion.source.tableau_common import (
     TableauLineageOverrides,
@@ -31,6 +29,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
 from datahub.metadata.schema_classes import MetadataChangeProposalClass, UpstreamClass
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     validate_all_providers_have_committed_successfully,
 )
 
@@ -251,15 +250,6 @@ def tableau_ingest_common(
                 ignore_paths=mce_helpers.IGNORE_PATH_TIMESTAMPS,
             )
             return pipeline
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint[GenericCheckpointState]]:
-    tableau_source = cast(TableauSource, pipeline.source)
-    return tableau_source.get_current_checkpoint(
-        tableau_source.stale_entity_removal_handler.job_id
-    )
 
 
 @freeze_time(FROZEN_TIME)

--- a/metadata-ingestion/tests/test_helpers/state_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/state_helpers.py
@@ -11,6 +11,14 @@ from datahub.ingestion.api.ingestion_job_checkpointing_provider_base import (
 )
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.run.pipeline import Pipeline
+from datahub.ingestion.source.state.checkpoint import Checkpoint
+from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
+from datahub.ingestion.source.state.stale_entity_removal_handler import (
+    StaleEntityRemovalHandler,
+)
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    StatefulIngestionSourceBase,
+)
 
 
 def validate_all_providers_have_committed_successfully(
@@ -91,3 +99,15 @@ def mock_datahub_graph():
 
     mock_datahub_graph_ctx = MockDataHubGraphContext()
     return mock_datahub_graph_ctx.mock_graph
+
+
+def get_current_checkpoint_from_pipeline(
+    pipeline: Pipeline,
+) -> Optional[Checkpoint[GenericCheckpointState]]:
+    # TODO: This only works for stale entity removal. We need to generalize this.
+
+    stateful_source = cast(StatefulIngestionSourceBase, pipeline.source)
+    stale_entity_removal_handler: StaleEntityRemovalHandler = stateful_source.stale_entity_removal_handler  # type: ignore
+    return stateful_source.state_provider.get_current_checkpoint(
+        stale_entity_removal_handler.job_id
+    )

--- a/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stale_entity_removal_handler.py
+++ b/metadata-ingestion/tests/unit/stateful_ingestion/state/test_stale_entity_removal_handler.py
@@ -2,8 +2,8 @@ from typing import Dict, List, Tuple
 
 import pytest
 
-from datahub.ingestion.source.state.stale_entity_removal_handler import (
-    StaleEntityCheckpointStateBase,
+from datahub.ingestion.source.state.entity_removal_state import (
+    compute_percent_entities_changed,
 )
 
 OldNewEntLists = List[Tuple[List[str], List[str]]]
@@ -43,9 +43,5 @@ old_new_ent_tests: Dict[str, Tuple[OldNewEntLists, float]] = {
 def test_change_percent(
     new_old_entity_list: OldNewEntLists, expected_percent_change: float
 ) -> None:
-    actual_percent_change = (
-        StaleEntityCheckpointStateBase.compute_percent_entities_changed(
-            new_old_entity_list
-        )
-    )
+    actual_percent_change = compute_percent_entities_changed(new_old_entity_list)
     assert actual_percent_change == expected_percent_change

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -10,10 +10,8 @@ from freezegun import freeze_time
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.extractor.schema_util import avro_schema_to_mce_fields
-from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.sink.file import write_metadata_file
 from datahub.ingestion.source.aws.glue import GlueSource, GlueSourceConfig
-from datahub.ingestion.source.state.checkpoint import Checkpoint
 from datahub.ingestion.source.state.sql_common_state import (
     BaseSQLAlchemyCheckpointState,
 )
@@ -26,6 +24,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
 from datahub.utilities.hive_schema_to_avro import get_avro_schema_for_hive_column
 from tests.test_helpers import mce_helpers
 from tests.test_helpers.state_helpers import (
+    get_current_checkpoint_from_pipeline,
     run_and_get_pipeline,
     validate_all_providers_have_committed_successfully,
 )
@@ -238,15 +237,6 @@ def test_config_without_platform():
         config=GlueSourceConfig(aws_region="us-west-2"),
     )
     assert source.platform == "glue"
-
-
-def get_current_checkpoint_from_pipeline(
-    pipeline: Pipeline,
-) -> Optional[Checkpoint]:
-    glue_source = cast(GlueSource, pipeline.source)
-    return glue_source.get_current_checkpoint(
-        glue_source.stale_entity_removal_handler.job_id
-    )
 
 
 @freeze_time(FROZEN_TIME)

--- a/smoke-test/tests/test_stateful_ingestion.py
+++ b/smoke-test/tests/test_stateful_ingestion.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, Optional, cast
 
-from sqlalchemy import create_engine
-from sqlalchemy.sql import text
-
 from datahub.ingestion.api.committable import StatefulCommittable
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.source.sql.mysql import MySQLConfig, MySQLSource
-from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
 from datahub.ingestion.source.state.checkpoint import Checkpoint
+from datahub.ingestion.source.state.entity_removal_state import GenericCheckpointState
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text
+
 from tests.utils import (
     get_gms_url,
     get_mysql_password,
@@ -49,8 +49,9 @@ def test_stateful_ingestion(wait_for_healthchecks):
     def get_current_checkpoint_from_pipeline(
         pipeline: Pipeline,
     ) -> Optional[Checkpoint[GenericCheckpointState]]:
+        # TODO: Refactor to use the helper method in the metadata-ingestion tests, instead of copying it here.
         mysql_source = cast(MySQLSource, pipeline.source)
-        return mysql_source.get_current_checkpoint(
+        return mysql_source.state_provider.get_current_checkpoint(
             mysql_source.stale_entity_removal_handler.job_id
         )
 


### PR DESCRIPTION
The main goal here is to decouple the source from the stateful ingestion provider logic. This also fully replaces `StaleEntityCheckpointStateBase` with `GenericCheckpointState` and adds a helper method to our stateful ingestion tests.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
