### PR TITLE
feat(ui) Show documentation on Domain pages first

### DIFF
--- a/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
@@ -72,12 +72,12 @@ export class DomainEntity implements Entity<Domain> {
             isNameEditable
             tabs={[
                 {
-                    name: 'Entities',
-                    component: DomainEntitiesTab,
-                },
-                {
                     name: 'Documentation',
                     component: DocumentationTab,
+                },
+                {
+                    name: 'Entities',
+                    component: DomainEntitiesTab,
                 },
                 {
                     name: 'Data Products',

--- a/smoke-test/tests/cypress/cypress/e2e/domains/domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/domains.js
@@ -1,7 +1,7 @@
 describe("domains", () => {
   it("can see elements inside the domain", () => {
     cy.login();
-    cy.goToDomain("urn:li:domain:marketing");
+    cy.goToDomain("urn:li:domain:marketing/Entities");
 
     cy.contains("Marketing");
     cy.contains("SampleCypressKafkaDataset");


### PR DESCRIPTION
It's been requested to show the documentation page for Domains first and foremost. This does that.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
