### PR TITLE
fix(ui) Fix selecting columns in Lineage tab for CLL

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Lineage/ColumnLineageSelect.tsx
@@ -8,6 +8,7 @@ import { ImpactAnalysisIcon } from '../Dataset/Schema/components/MenuColumn';
 import updateQueryParams from '../../../../shared/updateQueryParams';
 import { downgradeV2FieldPath } from '../../../dataset/profile/schema/utils/utils';
 import { useEntityData } from '../../EntityContext';
+import { useGetEntityWithSchema } from '../Dataset/Schema/useGetEntitySchema';
 
 const StyledSelect = styled(Select)`
     margin-right: 5px;
@@ -50,6 +51,7 @@ export default function ColumnsLineageSelect({
     const { entityData } = useEntityData();
     const location = useLocation();
     const history = useHistory();
+    const { entityWithSchema } = useGetEntityWithSchema();
 
     function selectColumn(column: any) {
         updateQueryParams({ column }, location, history);
@@ -68,7 +70,7 @@ export default function ColumnsLineageSelect({
                     allowClear
                     placeholder="Select column"
                 >
-                    {entityData?.schemaMetadata?.fields.map((field) => {
+                    {entityWithSchema?.schemaMetadata?.fields.map((field) => {
                         const fieldPath = downgradeV2FieldPath(field.fieldPath);
                         return (
                             <Select.Option value={field.fieldPath}>


### PR DESCRIPTION
We recently made a change to fetch schemas separately from the main dataset fetch (for performance reasons) so the schema info was no longer in `entityData`. This uses that nice hook that only fetches schemas when we need to and will render that in the dropdown now for CLL impact analysis. Things still work the same and are all good for charts/dashboards and inputFields.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
