### PR TITLE
docs(csv-enricher): add example csv file & recipe

### DIFF
--- a/metadata-ingestion/docs/sources/csv/csv-enricher_recipe.yml
+++ b/metadata-ingestion/docs/sources/csv/csv-enricher_recipe.yml
@@ -1,0 +1,8 @@
+source:
+  type: csv-enricher 
+  config:
+    # relative path to your csv file to ingest
+    filename: ./path/to/your/file.csv
+
+# Default sink is datahub-rest and doesn't need to be configured
+# See https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for customization options

--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -98,19 +98,21 @@ class CSVEnricherReport(SourceReport):
 @support_status(SupportStatus.INCUBATING)
 class CSVEnricherSource(Source):
     """
-    This plugin is used to apply glossary terms, tags, owners and domain at the entity level. It can also be used to apply tags
-    and glossary terms at the column level. These values are read from a CSV file and can be used to either overwrite
+    This plugin is used to bulk upload metadata to Datahub.
+    This plugin can apply glossary terms, tags, decription, owners and domain at the entity level. It can also be used to apply tags,
+    glossary terms, and documentation at the column level. These values are read from a CSV file and can be used to either overwrite
     or append the above aspects to entities.
 
-    The format of the CSV must be like so, with a few example rows.
+    The format of the CSV must be like so, with a few example rows. Note that the header is required and that URNs should be surrounded by quotes when they contains commas themselves.
 
-    |resource                                                        |subresource|glossary_terms                      |tags               |owners                                             |ownership_type |description    |domain                     |
-    |----------------------------------------------------------------|-----------|------------------------------------|-------------------|---------------------------------------------------|---------------|---------------|---------------------------|
-    |urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)|           |[urn:li:glossaryTerm:AccountBalance]|[urn:li:tag:Legacy]|[urn:li:corpuser:datahub&#124;urn:li:corpuser:jdoe]|TECHNICAL_OWNER|new description|urn:li:domain:Engineering  |
-    |urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)|field_foo  |[urn:li:glossaryTerm:AccountBalance]|                   |                                                   |               |field_foo!     |                           |
-    |urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)|field_bar  |                                    |[urn:li:tag:Legacy]|                                                   |               |field_bar?     |                           |
+    ```
+    resource,subresource,glossary_terms,tags,owners,ownership_type,description,domain
+    "urn:li:dataset:(urn:li:dataPlatform:snowflake,datahub.growth.users,PROD",,[urn:li:glossaryTerm:Users],[urn:li:tag:HighQuality],[urn:li:corpuser:lfoe;urn:li:corpuser:jdoe],TECHNICAL_OWNER,"description for users table",urn:li:domain:Engineering
+    "urn:li:dataset:(urn:li:dataPlatform:hive,datahub.growth.users,PROD",first_name,[urn:li:glossaryTerm:FirstName],,,,"first_name description"
+    "urn:li:dataset:(urn:li:dataPlatform:hive,datahub.growth.users,PROD",last_name,[urn:li:glossaryTerm:LastName],,,,"last_name description"
+    ```
 
-    Note that the first row does not have a subresource populated. That means any glossary terms, tags, and owners will
+    See that the first row does not have a subresource populated. That means any glossary terms, tags, and owners will
     be applied at the entity field. If a subresource IS populated (as it is for the second and third rows), glossary
     terms and tags will be applied on the subresource. Every row MUST have a resource. Also note that owners can only
     be applied at the resource level and will be ignored if populated for a row with a subresource.

--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -99,11 +99,11 @@ class CSVEnricherReport(SourceReport):
 class CSVEnricherSource(Source):
     """
     This plugin is used to bulk upload metadata to Datahub.
-    This plugin can apply glossary terms, tags, decription, owners and domain at the entity level. It can also be used to apply tags,
-    glossary terms, and documentation at the column level. These values are read from a CSV file and can be used to either overwrite
-    or append the above aspects to entities.
+    It will apply glossary terms, tags, decription, owners and domain at the entity level. It can also be used to apply tags,
+    glossary terms, and documentation at the column level. These values are read from a CSV file. You have the option to either overwrite
+    or append existing values.
 
-    The format of the CSV must be like so, with a few example rows. Note that the header is required and that URNs should be surrounded by quotes when they contains commas themselves.
+    The format of the CSV is demonstrated below. The header is required and URNs should be surrounded by quotes when they contains commas (most URNs contains commas).
 
     ```
     resource,subresource,glossary_terms,tags,owners,ownership_type,description,domain
@@ -112,10 +112,10 @@ class CSVEnricherSource(Source):
     "urn:li:dataset:(urn:li:dataPlatform:hive,datahub.growth.users,PROD",last_name,[urn:li:glossaryTerm:LastName],,,,"last_name description"
     ```
 
-    See that the first row does not have a subresource populated. That means any glossary terms, tags, and owners will
-    be applied at the entity field. If a subresource IS populated (as it is for the second and third rows), glossary
-    terms and tags will be applied on the subresource. Every row MUST have a resource. Also note that owners can only
-    be applied at the resource level and will be ignored if populated for a row with a subresource.
+    Note that the first row does not have a subresource populated. That means any glossary terms, tags, and owners will
+    be applied at the entity field. If a subresource is populated (as it is for the second and third rows), glossary
+    terms and tags will be applied on the column. Every row MUST have a resource. Also note that owners can only
+    be applied at the resource level.
 
     :::note
     This source will not work on very large csv files that do not fit in memory.


### PR DESCRIPTION
The example we gave is hard to reference since it doesn't indicate the exact format. Users will be creating `.csv` files, so for simplicity I replace the table with an example csv file. Also adds an example recipe & rephrases the documentation for concise-ness.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
