### PR TITLE
fix(stats): display consistent query count on stats tab

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/stats/stats/DatasetStatsSummarySubHeader.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/stats/stats/DatasetStatsSummarySubHeader.tsx
@@ -18,6 +18,7 @@ export const DatasetStatsSummarySubHeader = () => {
     const rowCount = maybeLastProfile?.rowCount;
     const columnCount = maybeLastProfile?.columnCount;
     const sizeInBytes = maybeLastProfile?.sizeInBytes;
+    const totalSqlQueries = dataset?.usageStats?.aggregations?.totalSqlQueries;
     const queryCountLast30Days = maybeStatsSummary?.queryCountLast30Days;
     const uniqueUserCountLast30Days = maybeStatsSummary?.uniqueUserCountLast30Days;
     const lastUpdatedMs = maybeLastOperation?.lastUpdatedTimestamp;
@@ -27,6 +28,7 @@ export const DatasetStatsSummarySubHeader = () => {
             rowCount={rowCount}
             columnCount={columnCount}
             sizeInBytes={sizeInBytes}
+            totalSqlQueries={totalSqlQueries}
             queryCountLast30Days={queryCountLast30Days}
             uniqueUserCountLast30Days={uniqueUserCountLast30Days}
             lastUpdatedMs={lastUpdatedMs}

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -20,6 +20,7 @@ type Props = {
     rowCount?: number | null;
     columnCount?: number | null;
     sizeInBytes?: number | null;
+    totalSqlQueries?: number | null;
     queryCountLast30Days?: number | null;
     uniqueUserCountLast30Days?: number | null;
     lastUpdatedMs?: number | null;
@@ -30,6 +31,7 @@ export const DatasetStatsSummary = ({
     rowCount,
     columnCount,
     sizeInBytes,
+    totalSqlQueries,
     queryCountLast30Days,
     uniqueUserCountLast30Days,
     lastUpdatedMs,
@@ -55,10 +57,11 @@ export const DatasetStatsSummary = ({
                 <FormattedBytesStat bytes={sizeInBytes} />
             </StatText>
         ),
-        !!queryCountLast30Days && (
+        (!!queryCountLast30Days || !!totalSqlQueries) && (
             <StatText color={displayedColor}>
                 <ConsoleSqlOutlined style={{ marginRight: 8, color: displayedColor }} />
-                <b>{formatNumberWithoutAbbreviation(queryCountLast30Days)}</b> queries last month
+                <b>{formatNumberWithoutAbbreviation(queryCountLast30Days || totalSqlQueries)}</b>{' '}
+                {queryCountLast30Days ? <>queries last month</> : <>monthly queries</>}
             </StatText>
         ),
         !!uniqueUserCountLast30Days && (

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/StatsTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/StatsTab.tsx
@@ -51,6 +51,9 @@ export default function StatsTab() {
             latestProfile?.timestampMillis,
         )}`;
 
+    const totalSqlQueries = usageStats?.aggregations?.totalSqlQueries;
+    const queryCountLast30Days = baseEntity.dataset?.statsSummary?.queryCountLast30Days;
+
     const statsHeader = (
         <StatsHeader
             viewType={viewType}
@@ -66,7 +69,7 @@ export default function StatsTab() {
             <TableStats
                 rowCount={latestProfile?.rowCount || undefined}
                 columnCount={latestProfile?.columnCount || undefined}
-                queryCount={usageStats?.aggregations?.totalSqlQueries || undefined}
+                queryCount={queryCountLast30Days || totalSqlQueries || undefined}
                 users={usageStats?.aggregations?.users || undefined}
                 lastUpdatedTime={lastUpdatedTime || undefined}
                 lastReportedTime={lastReportedTime || undefined}


### PR DESCRIPTION
Show statsSummary query count consistently and fallback to usageStats if it was missing.