### PR TITLE
fix(ingest/nifi): allow nifi site url with context path

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/nifi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/nifi.py
@@ -9,6 +9,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
+from cached_property import cached_property
 from dateutil import parser
 from packaging import version
 from pydantic import root_validator, validator
@@ -387,8 +388,9 @@ class NifiSource(Source):
         if self.config.ca_file is not None:
             self.session.verify = self.config.ca_file
 
-        # remove trailing "nifi/" and replace with "nifi-api/"
-        self.rest_api_base_url = self.config.site_url[:-5] + "nifi-api/"
+    @cached_property
+    def rest_api_base_url(self):
+        return self.config.site_url[: -len("nifi/")] + "nifi-api/"
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "Source":


### PR DESCRIPTION
The connector earlier assumed the nifi is hosted at root level. e.g. `https://domain-name/nifi/`

However for hosted nifi solutions this may not be the case. This PR adds support to nifi with context. e,g. `https://domain-name/context-path/nifi`

Also includes some refractors to use pydantic validators.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
