### PR TITLE
fix(ui) Show Entities first on Domain pages again

### DIFF
--- a/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
@@ -72,12 +72,12 @@ export class DomainEntity implements Entity<Domain> {
             isNameEditable
             tabs={[
                 {
-                    name: 'Documentation',
-                    component: DocumentationTab,
-                },
-                {
                     name: 'Entities',
                     component: DomainEntitiesTab,
+                },
+                {
+                    name: 'Documentation',
+                    component: DocumentationTab,
                 },
                 {
                     name: 'Data Products',


### PR DESCRIPTION
Revert a recent change to show Entities instead of documentation tab first on Domain pages again.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
