### PR TITLE
feat(ingest/snowflake): Deprecate legacy lineage and optimize query history joins

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -91,7 +91,7 @@ class SnowflakeV2Config(
     )
 
     use_legacy_lineage_method: bool = Field(
-        default=True,
+        default=False,
         description="Whether to use the legacy lineage computation method. If set to False, ingestion uses new optimised lineage extraction method that requires less ingestion process memory.",
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -325,7 +325,11 @@ class SnowflakeQuery:
         FROM
             snowflake.account_usage.access_history access_history
         LEFT JOIN
-            snowflake.account_usage.query_history query_history
+            (
+                SELECT * FROM snowflake.account_usage.query_history
+                WHERE query_history.start_time >= to_timestamp_ltz({start_time_millis}, 3)
+                    AND query_history.start_time < to_timestamp_ltz({end_time_millis}, 3)
+            ) query_history
             ON access_history.query_id = query_history.query_id
         LEFT JOIN
             snowflake.account_usage.users users
@@ -652,9 +656,13 @@ class SnowflakeQuery:
                 count(distinct(access_history.query_id)) AS total_queries
             FROM
                 object_access_history access_history
-                LEFT JOIN
-                    snowflake.account_usage.query_history query_history
-                    ON access_history.query_id = query_history.query_id
+            LEFT JOIN
+                (
+                    SELECT * FROM snowflake.account_usage.query_history
+                    WHERE query_history.start_time >= to_timestamp_ltz({start_time_millis}, 3)
+                        AND query_history.start_time < to_timestamp_ltz({end_time_millis}, 3)
+                ) query_history
+                ON access_history.query_id = query_history.query_id
             GROUP BY
                 bucket_start_time,
                 object_name,


### PR DESCRIPTION
Optimized lineage seems stable enough to make default.
Also optimizes query history joins, limiting to specified time range, based on John's work for observability.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
