### PR TITLE
fix(ingest): Fix modeldocgen; bump feast to relax pyarrow constraint

### DIFF
--- a/metadata-ingestion/scripts/modeldocgen.py
+++ b/metadata-ingestion/scripts/modeldocgen.py
@@ -605,7 +605,7 @@ def generate(
             ]
 
     relationship_graph = RelationshipGraph()
-    mcps = generate_stitched_record(relationship_graph)
+    mcps = list(generate_stitched_record(relationship_graph))
 
     shutil.rmtree(f"{generated_docs_dir}/entities", ignore_errors=True)
     entity_names = [(x, entity_registry[x]) for x in generated_documentation]

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -189,8 +189,7 @@ snowflake_common = {
     # because it may break Airflow users that need SQLAlchemy 1.3.x.
     "SQLAlchemy<1.4.42",
     # See https://github.com/snowflakedb/snowflake-connector-python/pull/1348 for why 2.8.2 is blocked
-    # Cannot upgrade to 3.0.0 because of dependency on pyarrow>=10.0.1, conflicts with feast
-    "snowflake-connector-python!=2.8.2, <3.0.0",
+    "snowflake-connector-python!=2.8.2",
     "pandas",
     "cryptography",
     "msal",
@@ -302,7 +301,7 @@ plugins: Dict[str, Set[str]] = {
     # https://github.com/elastic/elasticsearch-py/issues/1639#issuecomment-883587433
     "elasticsearch": {"elasticsearch==7.13.4"},
     "feast": {
-        "feast~=0.29.0",
+        "feast>=0.30.2",
         "flask-openid>=1.3.0",
         # typeguard 3.x, released on 2023-03-14, seems to cause issues with Feast.
         "typeguard<3",

--- a/metadata-ingestion/tests/integration/feast/feature_store/feature_store.yaml
+++ b/metadata-ingestion/tests/integration/feast/feature_store/feature_store.yaml
@@ -6,3 +6,4 @@ online_store:
 offline_store:
   type: file
 entity_key_serialization_version: 2
+registry: "data/registry.db"


### PR DESCRIPTION
Bumped feast so that I could generate docs locally on M2 machine

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
