### PR TITLE
feat(opensearch): Rollover usage events at a file size rather than time-based manner

### DIFF
--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
@@ -10,7 +10,7 @@
         "actions": [
           {
             "rollover": {
-              "max_size": "5gb",
+              "min_size": "5gb",
               "min_index_age": "1d"
             }
           }

--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
@@ -3,13 +3,14 @@
     "policy_id": "PREFIXdatahub_usage_event_policy",
     "description": "Datahub Usage Event Policy",
     "default_state": "Rollover",
-    "schema_version": 1,
+    "schema_version": 2,
     "states": [
       {
         "name": "Rollover",
         "actions": [
           {
             "rollover": {
+              "max_size": "5gb",
               "min_index_age": "1d"
             }
           }


### PR DESCRIPTION
According to the ES documentation, this is a best practice as it results in fewer small files: https://www.elastic.co/guide/en/elasticsearch/reference/7.14/index-rollover.html

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
