### PR TITLE
Add combined health check endpoint which can check multiple components

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/config/ConfigurationProvider.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/config/ConfigurationProvider.java
@@ -78,4 +78,9 @@ public class ConfigurationProvider {
    * Configuration for caching
    */
   private CacheConfiguration cache;
+
+  /**
+   * Configuration for the health check server
+   */
+  private HealthCheckConfiguration healthCheck;
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/config/HealthCheckConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/config/HealthCheckConfiguration.java
@@ -1,0 +1,9 @@
+package com.linkedin.gms.factory.config;
+
+import lombok.Data;
+
+
+@Data
+public class HealthCheckConfiguration {
+  private int cacheDurationSeconds;
+}

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -272,6 +272,9 @@ systemUpdate:
   backOffFactor: ${BOOTSTRAP_SYSTEM_UPDATE_BACK_OFF_FACTOR:2} # Multiplicative factor for back off, default values will result in waiting 5min 15s
   waitForSystemUpdate: ${BOOTSTRAP_SYSTEM_UPDATE_WAIT_FOR_SYSTEM_UPDATE:true}
 
+healthCheck:
+  cacheDurationSeconds: ${HEALTH_CHECK_CACHE_DURATION_SECONDS:5}
+
 featureFlags:
   showSimplifiedHomepageByDefault: ${SHOW_SIMPLIFIED_HOMEPAGE_BY_DEFAULT:false} # shows a simplified homepage with just datasets, charts and dashboards by default to users. this can be configured in user settings
   lineageSearchCacheEnabled: ${LINEAGE_SEARCH_CACHE_ENABLED:true} # Enables in-memory cache for searchAcrossLineage query

--- a/metadata-service/health-servlet/src/main/java/com/datahub/health/controller/HealthCheckController.java
+++ b/metadata-service/health-servlet/src/main/java/com/datahub/health/controller/HealthCheckController.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/metadata-service/health-servlet/src/main/java/com/datahub/health/controller/HealthCheckController.java
+++ b/metadata-service/health-servlet/src/main/java/com/datahub/health/controller/HealthCheckController.java
@@ -62,7 +62,7 @@ public class HealthCheckController {
     for (String check : componentsToCheck) {
       componentHealth.put(check,
           healthChecks.getOrDefault(check,
-              () -> ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Unrecognized component " + check))
+              () -> ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body("Unrecognized component " + check))
               .get());
     }
 
@@ -71,7 +71,7 @@ public class HealthCheckController {
     if (isHealthy) {
       return ResponseEntity.ok(componentHealth);
     }
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(componentHealth);
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(componentHealth);
   }
 
   /**
@@ -104,6 +104,6 @@ public class HealthCheckController {
         responseString = e.getMessage();
       }
     }
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseString);
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(responseString);
   }
 }


### PR DESCRIPTION
So far, only checks ElasticSearch client, the first one we implemented

Example response on quickstart for URL: http://localhost:8080/health/check/combined

200 response with body
```
{"elastic":{"headers":{},"body":"{\"cluster_name\":\"docker-cluster\",\"status\":\"yellow\",\"timed_out\":false,\"number_of_nodes\":1,\"number_of_data_nodes\":1,\"active_primary_shards\":65,\"active_shards\":65,\"relocating_shards\":0,\"initializing_shards\":0,\"unassigned_shards\":62,\"delayed_unassigned_shards\":0,\"number_of_pending_tasks\":0,\"number_of_in_flight_fetch\":0,\"task_max_waiting_in_queue_millis\":0,\"active_shards_percent_as_number\":51.181102362204726}","statusCodeValue":200,"statusCode":"OK"}}
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
