### PR TITLE
feat(ingest): Create zero usage aspects

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/workunit.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/workunit.py
@@ -12,6 +12,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
 from datahub.metadata.schema_classes import UsageAggregationClass, _Aspect
 
 T_Aspect = TypeVar("T_Aspect", bound=_Aspect)
+A = TypeVar("A", bound=_Aspect)
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -153,6 +153,10 @@ def cleanup(config: BigQueryV2Config) -> None:
 @capability(SourceCapability.DESCRIPTIONS, "Enabled by default")
 @capability(SourceCapability.LINEAGE_COARSE, "Optionally enabled via configuration")
 @capability(
+    SourceCapability.USAGE_STATS,
+    "Enabled by default, can be disabled via configuration `include_usage_stats`",
+)
+@capability(
     SourceCapability.DELETION_DETECTION,
     "Optionally enabled via `stateful_ingestion.remove_stale_metadata`",
     supported=True,
@@ -216,7 +220,9 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
         # For database, schema, tables, views, etc
         self.lineage_extractor = BigqueryLineageExtractor(config, self.report)
-        self.usage_extractor = BigQueryUsageExtractor(config, self.report)
+        self.usage_extractor = BigQueryUsageExtractor(
+            config, self.report, dataset_urn_builder=self.gen_dataset_urn_from_ref
+        )
 
         self.domain_registry: Optional[DomainRegistry] = None
         if self.config.domain:
@@ -328,7 +334,9 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         project_ids: List[str],
         report: BigQueryV2Report,
     ) -> CapabilityReport:
-        usage_extractor = BigQueryUsageExtractor(connection_conf, report)
+        usage_extractor = BigQueryUsageExtractor(
+            connection_conf, report, lambda ref: ""
+        )
         for project_id in project_ids:
             try:
                 logger.info(f"Usage capability test for project {project_id}")
@@ -475,7 +483,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             yield from self._process_project(conn, project_id)
 
         if self._should_ingest_usage():
-            yield from self.usage_extractor.run(
+            yield from self.usage_extractor.get_usage_workunits(
                 [p.id for p in projects], self.table_refs
             )
 
@@ -1044,12 +1052,18 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
     def gen_dataset_urn(self, project_id: str, dataset_name: str, table: str) -> str:
         datahub_dataset_name = BigqueryTableIdentifier(project_id, dataset_name, table)
-        dataset_urn = make_dataset_urn(
+        return make_dataset_urn(
             self.platform,
             str(datahub_dataset_name),
             self.config.env,
         )
-        return dataset_urn
+
+    def gen_dataset_urn_from_ref(self, ref: BigQueryTableRef) -> str:
+        return self.gen_dataset_urn(
+            ref.table_identifier.project_id,
+            ref.table_identifier.dataset,
+            ref.table_identifier.table,
+        )
 
     def gen_schema_fields(self, columns: List[BigqueryColumn]) -> List[SchemaField]:
         schema_fields: List[SchemaField] = []

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -108,7 +108,10 @@ logger: logging.Logger = logging.getLogger(__name__)
 @capability(SourceCapability.DATA_PROFILING, "Optionally enabled via configuration")
 @capability(SourceCapability.DESCRIPTIONS, "Enabled by default")
 @capability(SourceCapability.LINEAGE_COARSE, "Optionally enabled via configuration")
-@capability(SourceCapability.USAGE_STATS, "Optionally enabled via configuration")
+@capability(
+    SourceCapability.USAGE_STATS,
+    "Enabled by default, can be disabled via configuration `include_usage_stats`",
+)
 @capability(SourceCapability.DELETION_DETECTION, "Enabled via stateful ingestion")
 class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
     """
@@ -593,7 +596,6 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             database=database,
             schema=table.schema,
             sub_type=DatasetSubTypes.TABLE,
-            tags_to_add=[],
             custom_properties=custom_properties,
         )
 
@@ -609,17 +611,11 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             database=get_db_name(self.config),
             schema=schema,
             sub_type=DatasetSubTypes.VIEW,
-            tags_to_add=[],
             custom_properties={},
         )
 
         datahub_dataset_name = f"{database}.{schema}.{view.name}"
-        dataset_urn = make_dataset_urn_with_platform_instance(
-            platform=self.platform,
-            name=datahub_dataset_name,
-            platform_instance=self.config.platform_instance,
-            env=self.config.env,
-        )
+        dataset_urn = self.gen_dataset_urn(datahub_dataset_name)
         if view.ddl:
             view_properties_aspect = ViewProperties(
                 materialized=view.type == "VIEW_MATERIALIZED",
@@ -683,6 +679,14 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             entityUrn=dataset_urn, aspect=schema_metadata
         ).as_workunit()
 
+    def gen_dataset_urn(self, datahub_dataset_name: str) -> str:
+        return make_dataset_urn_with_platform_instance(
+            platform=self.platform,
+            name=datahub_dataset_name,
+            platform_instance=self.config.platform_instance,
+            env=self.config.env,
+        )
+
     # TODO: Move to common
     def gen_dataset_workunits(
         self,
@@ -690,16 +694,10 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         database: str,
         schema: str,
         sub_type: str,
-        tags_to_add: Optional[List[str]] = None,
         custom_properties: Optional[Dict[str, str]] = None,
     ) -> Iterable[MetadataWorkUnit]:
         datahub_dataset_name = f"{database}.{schema}.{table.name}"
-        dataset_urn = make_dataset_urn_with_platform_instance(
-            platform=self.platform,
-            name=datahub_dataset_name,
-            platform_instance=self.config.platform_instance,
-            env=self.config.env,
-        )
+        dataset_urn = self.gen_dataset_urn(datahub_dataset_name)
 
         yield from self.gen_schema_metadata(
             dataset_urn, table, str(datahub_dataset_name)
@@ -857,12 +855,12 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             return
 
         with PerfTimer() as timer:
-            usage_extractor = RedshiftUsageExtractor(
+            yield from RedshiftUsageExtractor(
                 config=self.config,
                 connection=connection,
                 report=self.report,
-            )
-            yield from usage_extractor.generate_usage(all_tables=all_tables)
+                dataset_urn_builder=self.gen_dataset_urn,
+            ).get_usage_workunits(all_tables=all_tables)
 
             self.report.usage_extraction_sec[database] = round(
                 timer.elapsed_seconds(), 2
@@ -917,12 +915,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
                     )
                     continue
                 datahub_dataset_name = f"{database}.{schema}.{table.name}"
-                dataset_urn = make_dataset_urn_with_platform_instance(
-                    platform=self.platform,
-                    name=datahub_dataset_name,
-                    platform_instance=self.config.platform_instance,
-                    env=self.config.env,
-                )
+                dataset_urn = self.gen_dataset_urn(datahub_dataset_name)
 
                 lineage_info = self.lineage_extractor.get_lineage(
                     table,
@@ -937,12 +930,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         for schema in self.db_views[database]:
             for view in self.db_views[database][schema]:
                 datahub_dataset_name = f"{database}.{schema}.{view.name}"
-                dataset_urn = make_dataset_urn_with_platform_instance(
-                    platform=self.platform,
-                    name=datahub_dataset_name,
-                    platform_instance=self.config.platform_instance,
-                    env=self.config.env,
-                )
+                dataset_urn = self.gen_dataset_urn(datahub_dataset_name)
                 lineage_info = self.lineage_extractor.get_lineage(
                     view,
                     dataset_urn,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_usage_v2.py
@@ -2,16 +2,14 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import pydantic
 from snowflake.connector import SnowflakeConnection
 
-from datahub.emitter.mce_builder import (
-    make_dataset_urn_with_platform_instance,
-    make_user_urn,
-)
+from datahub.emitter.mce_builder import make_user_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.source_helpers import auto_empty_dataset_usage_statistics
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.snowflake.constants import SnowflakeEdition
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
@@ -104,13 +102,19 @@ class SnowflakeJoinedAccessEvent(PermissiveModel):
 class SnowflakeUsageExtractor(
     SnowflakeQueryMixin, SnowflakeConnectionMixin, SnowflakeCommonMixin
 ):
-    def __init__(self, config: SnowflakeV2Config, report: SnowflakeV2Report) -> None:
+    def __init__(
+        self,
+        config: SnowflakeV2Config,
+        report: SnowflakeV2Report,
+        dataset_urn_builder: Callable[[str], str],
+    ) -> None:
         self.config: SnowflakeV2Config = config
         self.report: SnowflakeV2Report = report
+        self.dataset_urn_builder = dataset_urn_builder
         self.logger = logger
         self.connection: Optional[SnowflakeConnection] = None
 
-    def get_workunits(
+    def get_usage_workunits(
         self, discovered_datasets: List[str]
     ) -> Iterable[MetadataWorkUnit]:
         self.connection = self.create_connection()
@@ -138,7 +142,14 @@ class SnowflakeUsageExtractor(
         # Now, we report the usage as well as operation metadata even if user email is absent
 
         if self.config.include_usage_stats:
-            yield from self.get_usage_workunits(discovered_datasets)
+            yield from auto_empty_dataset_usage_statistics(
+                self._get_workunits_internal(discovered_datasets),
+                config=self.config,
+                dataset_urns={
+                    self.dataset_urn_builder(dataset_identifier)
+                    for dataset_identifier in discovered_datasets
+                },
+            )
 
         if self.config.include_operational_stats:
             # Generate the operation workunits.
@@ -148,7 +159,7 @@ class SnowflakeUsageExtractor(
                     event, discovered_datasets
                 )
 
-    def get_usage_workunits(
+    def _get_workunits_internal(
         self, discovered_datasets: List[str]
     ) -> Iterable[MetadataWorkUnit]:
         with PerfTimer() as timer:
@@ -210,15 +221,9 @@ class SnowflakeUsageExtractor(
                 userCounts=self._map_user_counts(json.loads(row["USER_COUNTS"])),
                 fieldCounts=self._map_field_counts(json.loads(row["FIELD_COUNTS"])),
             )
-            dataset_urn = make_dataset_urn_with_platform_instance(
-                self.platform,
-                dataset_identifier,
-                self.config.platform_instance,
-                self.config.env,
-            )
 
             yield MetadataChangeProposalWrapper(
-                entityUrn=dataset_urn, aspect=stats
+                entityUrn=self.dataset_urn_builder(dataset_identifier), aspect=stats
             ).as_workunit()
         except Exception as e:
             logger.debug(
@@ -368,12 +373,6 @@ class SnowflakeUsageExtractor(
                     )
                     continue
 
-                dataset_urn = make_dataset_urn_with_platform_instance(
-                    self.platform,
-                    dataset_identifier,
-                    self.config.platform_instance,
-                    self.config.env,
-                )
                 operation_aspect = OperationClass(
                     timestampMillis=reported_time,
                     lastUpdatedTimestamp=last_updated_timestamp,
@@ -384,7 +383,7 @@ class SnowflakeUsageExtractor(
                     else None,
                 )
                 mcp = MetadataChangeProposalWrapper(
-                    entityUrn=dataset_urn,
+                    entityUrn=self.dataset_urn_builder(dataset_identifier),
                     aspect=operation_aspect,
                 )
                 wu = MetadataWorkUnit(

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
@@ -23,7 +23,6 @@ class UnityCatalogReport(StaleEntityRemovalSourceReport):
     num_queries_parsed_by_spark_plan: int = 0
 
     num_operational_stats_workunits_emitted: int = 0
-    num_usage_workunits_emitted: int = 0
 
     profile_table_timeouts: LossyList[str] = field(default_factory=LossyList)
     profile_table_empty: LossyList[str] = field(default_factory=LossyList)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -191,7 +191,9 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 table_urn_builder=self.gen_dataset_urn,
                 user_urn_builder=self.gen_user_urn,
             )
-            yield from usage_extractor.run(self.table_refs | self.view_refs)
+            yield from usage_extractor.get_usage_workunits(
+                self.table_refs | self.view_refs
+            )
 
         if self.config.profiling.enabled:
             assert wait_on_warehouse

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/usage.py
@@ -10,6 +10,7 @@ from databricks.sdk.service.sql import QueryStatementType
 from sqllineage.runner import LineageRunner
 
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.source_helpers import auto_empty_dataset_usage_statistics
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.unity.config import UnityCatalogSourceConfig
 from datahub.ingestion.source.unity.proxy import UnityCatalogApiProxy
@@ -62,20 +63,24 @@ class UnityCatalogUsageExtractor:
             )
         return self._spark_sql_parser
 
-    def run(self, table_refs: Set[TableReference]) -> Iterable[MetadataWorkUnit]:
+    def get_usage_workunits(
+        self, table_refs: Set[TableReference]
+    ) -> Iterable[MetadataWorkUnit]:
         try:
-            table_map = defaultdict(list)
-            for ref in table_refs:
-                table_map[ref.table].append(ref)
-                table_map[f"{ref.schema}.{ref.table}"].append(ref)
-                table_map[ref.qualified_table_name].append(ref)
-
-            yield from self._generate_workunits(table_map)
+            yield from self._get_workunits_internal(table_refs)
         except Exception as e:
             logger.error("Error processing usage", exc_info=True)
             self.report.report_warning("usage-extraction", str(e))
 
-    def _generate_workunits(self, table_map: TableMap) -> Iterable[MetadataWorkUnit]:
+    def _get_workunits_internal(
+        self, table_refs: Set[TableReference]
+    ) -> Iterable[MetadataWorkUnit]:
+        table_map = defaultdict(list)
+        for ref in table_refs:
+            table_map[ref.table].append(ref)
+            table_map[f"{ref.schema}.{ref.table}"].append(ref)
+            table_map[ref.qualified_table_name].append(ref)
+
         for query in self._get_queries():
             self.report.num_queries += 1
             table_info = self._parse_query(query, table_map)
@@ -100,12 +105,14 @@ class UnityCatalogUsageExtractor:
             )
             return
 
-        for wu in self.usage_aggregator.generate_workunits(
-            resource_urn_builder=self.table_urn_builder,
-            user_urn_builder=self.user_urn_builder,
-        ):
-            self.report.num_usage_workunits_emitted += 1
-            yield wu
+        yield from auto_empty_dataset_usage_statistics(
+            self.usage_aggregator.generate_workunits(
+                resource_urn_builder=self.table_urn_builder,
+                user_urn_builder=self.user_urn_builder,
+            ),
+            dataset_urns={self.table_urn_builder(ref) for ref in table_refs},
+            config=self.config,
+        )
 
     def _generate_operation_workunit(
         self, query: Query, table_info: QueryTableInfo

--- a/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_filtered_golden.json
+++ b/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_filtered_golden.json
@@ -1,26 +1,52 @@
 [
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.users,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:test-name\", \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1631664000000}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631696400000,
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "actor": "urn:li:corpuser:test-name",
+            "operationType": "INSERT",
+            "lastUpdatedTimestamp": 1631664000000
+        }
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.users,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
-        "value": "{\"timestampMillis\": 1631577600000, \"eventGranularity\": {\"unit\": \"DAY\", \"multiple\": 1}, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"uniqueUserCount\": 1, \"totalSqlQueries\": 1, \"topSqlQueries\": [\"select userid from users\"], \"userCounts\": [{\"user\": \"urn:li:corpuser:test-name\", \"count\": 1, \"userEmail\": \"test-name@acryl.io\"}], \"fieldCounts\": []}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631577600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "select userid from users"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:test-name",
+                    "count": 1,
+                    "userEmail": "test-name@acryl.io"
+                }
+            ],
+            "fieldCounts": []
+        }
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_golden.json
+++ b/metadata-ingestion/tests/integration/redshift-usage/redshift_usages_golden.json
@@ -1,74 +1,152 @@
 [
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.users,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:test-name\", \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1631664000000}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631696400000,
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "actor": "urn:li:corpuser:test-name",
+            "operationType": "INSERT",
+            "lastUpdatedTimestamp": 1631664000000
+        }
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,db1.schema1.category,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:real_shirshanka\", \"operationType\": \"INSERT\", \"lastUpdatedTimestamp\": 1631664000000}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631696400000,
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "actor": "urn:li:corpuser:real_shirshanka",
+            "operationType": "INSERT",
+            "lastUpdatedTimestamp": 1631664000000
+        }
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.orders,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {
-        "value": "{\"timestampMillis\": 1629795600000, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"actor\": \"urn:li:corpuser:real_shirshanka\", \"operationType\": \"DELETE\", \"lastUpdatedTimestamp\": 1631664000000}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631696400000,
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "actor": "urn:li:corpuser:real_shirshanka",
+            "operationType": "DELETE",
+            "lastUpdatedTimestamp": 1631664000000
+        }
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.users,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
-        "value": "{\"timestampMillis\": 1631577600000, \"eventGranularity\": {\"unit\": \"DAY\", \"multiple\": 1}, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"uniqueUserCount\": 1, \"totalSqlQueries\": 1, \"topSqlQueries\": [\"select userid from users\"], \"userCounts\": [{\"user\": \"urn:li:corpuser:test-name\", \"count\": 1, \"userEmail\": \"test-name@acryl.io\"}], \"fieldCounts\": []}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631577600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "select userid from users"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:test-name",
+                    "count": 1,
+                    "userEmail": "test-name@acryl.io"
+                }
+            ],
+            "fieldCounts": []
+        }
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,db1.schema1.category,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
-        "value": "{\"timestampMillis\": 1631577600000, \"eventGranularity\": {\"unit\": \"DAY\", \"multiple\": 1}, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"uniqueUserCount\": 1, \"totalSqlQueries\": 1, \"topSqlQueries\": [\"select catid from category\"], \"userCounts\": [{\"user\": \"urn:li:corpuser:real_shirshanka\", \"count\": 1, \"userEmail\": \"real_shirshanka@acryl.io\"}], \"fieldCounts\": []}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631577600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "select catid from category"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:real_shirshanka",
+                    "count": 1,
+                    "userEmail": "real_shirshanka@acryl.io"
+                }
+            ],
+            "fieldCounts": []
+        }
     }
 },
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,dev.public.orders,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
-        "value": "{\"timestampMillis\": 1631577600000, \"eventGranularity\": {\"unit\": \"DAY\", \"multiple\": 1}, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"uniqueUserCount\": 1, \"totalSqlQueries\": 1, \"topSqlQueries\": [\"select cost from orders\"], \"userCounts\": [{\"user\": \"urn:li:corpuser:real_shirshanka\", \"count\": 1, \"userEmail\": \"real_shirshanka@acryl.io\"}], \"fieldCounts\": []}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1631577600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 1,
+            "topSqlQueries": [
+                "select cost from orders"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:real_shirshanka",
+                    "count": 1,
+                    "userEmail": "real_shirshanka@acryl.io"
+                }
+            ],
+            "fieldCounts": []
+        }
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/redshift-usage/test_redshift_usage.py
+++ b/metadata-ingestion/tests/integration/redshift-usage/test_redshift_usage.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
 
+from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.sink.file import write_metadata_file
 from datahub.ingestion.source.redshift.config import RedshiftConfig
@@ -21,7 +22,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
 )
 from tests.test_helpers import mce_helpers
 
-FROZEN_TIME = "2021-08-24 09:00:00"
+FROZEN_TIME = "2021-09-15 09:00:00"
 
 
 def test_redshift_usage_config():
@@ -94,6 +95,7 @@ def test_redshift_usage_source(mock_cursor, mock_connection, pytestconfig, tmp_p
         config=config,
         connection=mock_connection,
         report=source_report,
+        dataset_urn_builder=lambda table: make_dataset_urn("redshift", table),
     )
 
     all_tables: Dict[str, Dict[str, List[Union[RedshiftView, RedshiftTable]]]] = {
@@ -127,7 +129,7 @@ def test_redshift_usage_source(mock_cursor, mock_connection, pytestconfig, tmp_p
             ]
         },
     }
-    mwus = usage_extractor.generate_usage(all_tables=all_tables)
+    mwus = usage_extractor.get_usage_workunits(all_tables=all_tables)
     metadata: List[
         Union[
             MetadataChangeEvent,
@@ -137,6 +139,7 @@ def test_redshift_usage_source(mock_cursor, mock_connection, pytestconfig, tmp_p
     ] = []
 
     for mwu in mwus:
+        print(mwu.metadata)
         metadata.append(mwu.metadata)
 
     # There should be 2 calls (usage aspects -1, operation aspects -1).
@@ -200,6 +203,7 @@ def test_redshift_usage_filtering(mock_cursor, mock_connection, pytestconfig, tm
         config=config,
         connection=mock_connection,
         report=RedshiftReport(),
+        dataset_urn_builder=lambda table: make_dataset_urn("redshift", table),
     )
 
     all_tables: Dict[str, Dict[str, List[Union[RedshiftView, RedshiftTable]]]] = {
@@ -215,7 +219,7 @@ def test_redshift_usage_filtering(mock_cursor, mock_connection, pytestconfig, tm
             ]
         },
     }
-    mwus = usage_extractor.generate_usage(all_tables=all_tables)
+    mwus = usage_extractor.get_usage_workunits(all_tables=all_tables)
     metadata: List[
         Union[
             MetadataChangeEvent,

--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 
+from datahub.configuration.time_window_config import BucketDuration
 from datahub.ingestion.source.snowflake import snowflake_query
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
 
@@ -247,6 +248,18 @@ def default_query_results(query):  # noqa: C901
             }
             for op_idx in range(1, NUM_OPS + 1)
         ]
+    elif (
+        query
+        == snowflake_query.SnowflakeQuery.usage_per_object_per_time_bucket_for_time_window(
+            1654499820000,
+            1654586220000,
+            use_base_objects=False,
+            top_n_queries=10,
+            include_top_n_queries=True,
+            time_bucket_size=BucketDuration.DAY,
+        )
+    ):
+        return []
     elif query in (
         snowflake_query.SnowflakeQuery.table_to_table_lineage_history(
             1654499820000,

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -5111,6 +5111,342 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_9,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_4,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_2,PROD)",
+    "changeType": "CREATE",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "operation",
     "aspect": {

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake.py
@@ -119,7 +119,7 @@ def test_snowflake_basic(pytestconfig, tmp_path, mock_time, mock_datahub_graph):
                         include_technical_schema=True,
                         include_table_lineage=True,
                         include_view_lineage=True,
-                        include_usage_stats=False,
+                        include_usage_stats=True,
                         use_legacy_lineage_method=False,
                         validate_upstreams_against_patterns=False,
                         include_operational_stats=True,

--- a/metadata-ingestion/tests/unit/test_bigquery_usage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_usage.py
@@ -1,13 +1,15 @@
 import logging
 import random
 from datetime import datetime, timedelta, timezone
-from typing import cast
+from typing import Iterable, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 from freezegun import freeze_time
+from test_helpers.mce_helpers import assert_mces_equal
 
 from datahub.configuration.time_window_config import BucketDuration
+from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import (
@@ -195,7 +197,37 @@ def config() -> BigQueryV2Config:
 @pytest.fixture
 def usage_extractor(config: BigQueryV2Config) -> BigQueryUsageExtractor:
     report = BigQueryV2Report()
-    return BigQueryUsageExtractor(config, report)
+    return BigQueryUsageExtractor(
+        config,
+        report,
+        lambda ref: make_dataset_urn("bigquery", str(ref.table_identifier)),
+    )
+
+
+def make_zero_usage_workunit(
+    table: Table, time: datetime, bucket_duration: BucketDuration = BucketDuration.DAY
+) -> MetadataWorkUnit:
+    return make_usage_workunit(
+        table=table,
+        dataset_usage_statistics=DatasetUsageStatisticsClass(
+            timestampMillis=int(time.timestamp() * 1000),
+            eventGranularity=TimeWindowSizeClass(unit=bucket_duration, multiple=1),
+            totalSqlQueries=0,
+            uniqueUserCount=0,
+            topSqlQueries=[],
+            userCounts=[],
+            fieldCounts=[],
+        ),
+    )
+
+
+def compare_workunits(
+    output: Iterable[MetadataWorkUnit], expected: Iterable[MetadataWorkUnit]
+) -> None:
+    assert_mces_equal(
+        [wu.metadata.to_obj() for wu in output],
+        [wu.metadata.to_obj() for wu in expected],
+    )
 
 
 def test_usage_counts_single_bucket_resource_project(
@@ -217,8 +249,8 @@ def test_usage_counts_single_bucket_resource_project(
         proabability_of_project_mismatch=0.5,
     )
 
-    workunits = usage_extractor._run(events, TABLE_REFS.values())
-    assert list(workunits) == [
+    workunits = usage_extractor._get_workunits_internal(events, TABLE_REFS.values())
+    expected = [
         make_usage_workunit(
             table=TABLE_1,
             dataset_usage_statistics=DatasetUsageStatisticsClass(
@@ -256,8 +288,11 @@ def test_usage_counts_single_bucket_resource_project(
                     ),
                 ],
             ),
-        )
+        ),
+        make_zero_usage_workunit(TABLE_2, TS_1),
+        make_zero_usage_workunit(VIEW_1, TS_1),
     ]
+    compare_workunits(workunits, expected)
 
 
 def test_usage_counts_multiple_buckets_and_resources_view_usage(
@@ -292,8 +327,8 @@ def test_usage_counts_multiple_buckets_and_resources_view_usage(
         proabability_of_project_mismatch=0.5,
     )
 
-    workunits = usage_extractor._run(events, TABLE_REFS.values())
-    assert list(workunits) == [
+    workunits = usage_extractor._get_workunits_internal(events, TABLE_REFS.values())
+    expected = [
         # TS 1
         make_usage_workunit(
             table=TABLE_1,
@@ -493,6 +528,7 @@ def test_usage_counts_multiple_buckets_and_resources_view_usage(
             ),
         ),
     ]
+    compare_workunits(workunits, expected)
     assert usage_extractor.report.num_view_query_events == 5
     assert usage_extractor.report.num_view_query_events_failed_sql_parsing == 0
     assert usage_extractor.report.num_view_query_events_failed_table_identification == 0
@@ -531,8 +567,8 @@ def test_usage_counts_multiple_buckets_and_resources_no_view_usage(
         proabability_of_project_mismatch=0.5,
     )
 
-    workunits = usage_extractor._run(events, TABLE_REFS.values())
-    assert list(workunits) == [
+    workunits = usage_extractor._get_workunits_internal(events, TABLE_REFS.values())
+    expected = [
         # TS 1
         make_usage_workunit(
             table=TABLE_1,
@@ -723,7 +759,10 @@ def test_usage_counts_multiple_buckets_and_resources_no_view_usage(
                 ],
             ),
         ),
+        make_zero_usage_workunit(VIEW_1, TS_1),
+        # TS_2 not included as only 1 minute of it was ingested
     ]
+    compare_workunits(workunits, expected)
     assert usage_extractor.report.num_view_query_events == 0
 
 
@@ -745,8 +784,24 @@ def test_usage_counts_no_query_event(
                 payload=None,
             )
         )
-        workunits = usage_extractor._run([event], [str(ref)])
-        assert list(workunits) == []
+        workunits = usage_extractor._get_workunits_internal([event], [str(ref)])
+        expected = [
+            MetadataChangeProposalWrapper(
+                entityUrn=ref.to_urn("PROD"),
+                aspect=DatasetUsageStatisticsClass(
+                    timestampMillis=int(TS_1.timestamp() * 1000),
+                    eventGranularity=TimeWindowSizeClass(
+                        unit=BucketDuration.DAY, multiple=1
+                    ),
+                    totalSqlQueries=0,
+                    uniqueUserCount=0,
+                    topSqlQueries=[],
+                    userCounts=[],
+                    fieldCounts=[],
+                ),
+            ).as_workunit()
+        ]
+        compare_workunits(workunits, expected)
         assert not caplog.records
 
 
@@ -787,8 +842,10 @@ def test_usage_counts_no_columns(
         ),
     ]
     with caplog.at_level(logging.WARNING):
-        workunits = usage_extractor._run(events, TABLE_REFS.values())
-        assert list(workunits) == [
+        workunits = usage_extractor._get_workunits_internal(
+            events, [TABLE_REFS[TABLE_1.name]]
+        )
+        expected = [
             make_usage_workunit(
                 table=TABLE_1,
                 dataset_usage_statistics=DatasetUsageStatisticsClass(
@@ -810,6 +867,7 @@ def test_usage_counts_no_columns(
                 ),
             )
         ]
+        compare_workunits(workunits, expected)
         assert not caplog.records
 
 
@@ -849,8 +907,8 @@ def test_operational_stats(
     )
 
     events = generate_events(queries, projects, table_to_project, config=config)
-    workunits = usage_extractor._run(events, table_refs.values())
-    assert list(workunits) == [
+    workunits = usage_extractor._get_workunits_internal(events, table_refs.values())
+    expected = [
         make_operational_workunit(
             table_refs[query.object_modified.name],
             OperationClass(
@@ -887,6 +945,15 @@ def test_operational_stats(
         for query in queries
         if query.object_modified and query.type in OPERATION_STATEMENT_TYPES.values()
     ]
+    compare_workunits(
+        [
+            wu
+            for wu in workunits
+            if isinstance(wu.metadata, MetadataChangeProposalWrapper)
+            and isinstance(wu.metadata.aspect, OperationClass)
+        ],
+        expected,
+    )
 
 
 def test_get_tables_from_query(usage_extractor):

--- a/metadata-ingestion/tests/unit/test_bigqueryv2_usage_source.py
+++ b/metadata-ingestion/tests/unit/test_bigqueryv2_usage_source.py
@@ -111,7 +111,9 @@ AND
     OR
     protoPayload.metadata.tableDataRead.reason = "JOB"
 )"""  # noqa: W293
-    source = BigQueryUsageExtractor(config, BigQueryV2Report())
+    source = BigQueryUsageExtractor(
+        config, BigQueryV2Report(), dataset_urn_builder=lambda _: ""
+    )
     filter: str = source._generate_filter(BQ_AUDIT_V2)
     assert filter == expected_filter
 


### PR DESCRIPTION
Contains a lot more refactoring than I would like. Tried standardizing each usage source:
- Add `dataset_urn_builder` method to unify dataset urn creation logic between source and usage extractor. I don't like this too much, esp with tests, but think it's preferred to the old way which was just matched logic between the two
- Standardize method names: entrypoint `get_usage_workunits` and helper `_get_internal_workunits`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
