### PR TITLE
fix(cli/quickstart): handle docker hangs gracefully

### DIFF
--- a/docker/docker-compose-without-neo4j.yml
+++ b/docker/docker-compose-without-neo4j.yml
@@ -42,9 +42,9 @@ services:
     env_file: datahub-gms/env/docker-without-neo4j.env
     healthcheck:
       test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
-      start_period: 20s
+      start_period: 90s
       interval: 1s
-      retries: 20
+      retries: 3
       timeout: 5s
     depends_on:
       datahub-upgrade:
@@ -116,9 +116,9 @@ services:
           memory: 1G
     healthcheck:
       test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
-      start_period: 5s
+      start_period: 20s
       interval: 1s
-      retries: 5
+      retries: 3
       timeout: 5s
     volumes:
     - esdata:/usr/share/elasticsearch/data
@@ -131,9 +131,9 @@ services:
     env_file: schema-registry/env/docker.env
     healthcheck:
       test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
-      start_period: 5s
+      start_period: 30s
       interval: 1s
-      retries: 5
+      retries: 3
       timeout: 5s
     depends_on:
       broker:
@@ -147,7 +147,7 @@ services:
     env_file: broker/env/docker.env
     healthcheck:
       test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
-      start_period: 5s
+      start_period: 30s
       interval: 1s
       retries: 5
       timeout: 5s
@@ -165,9 +165,9 @@ services:
     env_file: zookeeper/env/docker.env
     healthcheck:
       test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
-      start_period: 2s
+      start_period: 10s
       interval: 5s
-      retries: 5
+      retries: 3
       timeout: 5s
     volumes:
     - zkdata:/var/lib/zookeeper

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -36,9 +36,9 @@ services:
     restart: on-failure
     healthcheck:
       test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
-      start_period: 2s
+      start_period: 10s
       interval: 1s
-      retries: 5
+      retries: 3
       timeout: 5s
     volumes:
     - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -40,9 +40,9 @@ services:
         dockerfile: docker/datahub-gms/Dockerfile
     healthcheck:
       test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
-      start_period: 20s
+      start_period: 90s
       interval: 1s
-      retries: 20
+      retries: 3
       timeout: 5s
     depends_on:
       datahub-upgrade:
@@ -119,9 +119,9 @@ services:
           memory: 1G
     healthcheck:
       test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
-      start_period: 5s
+      start_period: 20s
       interval: 1s
-      retries: 5
+      retries: 3
       timeout: 5s
     volumes:
     - esdata:/usr/share/elasticsearch/data
@@ -150,9 +150,9 @@ services:
     env_file: schema-registry/env/docker.env
     healthcheck:
       test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
-      start_period: 5s
+      start_period: 30s
       interval: 1s
-      retries: 5
+      retries: 3
       timeout: 5s
     depends_on:
       broker:
@@ -166,7 +166,7 @@ services:
     env_file: broker/env/docker.env
     healthcheck:
       test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
-      start_period: 5s
+      start_period: 30s
       interval: 1s
       retries: 5
       timeout: 5s
@@ -184,9 +184,9 @@ services:
     env_file: zookeeper/env/docker.env
     healthcheck:
       test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
-      start_period: 2s
+      start_period: 10s
       interval: 5s
-      retries: 5
+      retries: 3
       timeout: 5s
     volumes:
     - zkdata:/var/lib/zookeeper

--- a/docker/quickstart/docker-compose-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-m1.quickstart.yml
@@ -19,7 +19,7 @@ services:
     healthcheck:
       interval: 1s
       retries: 5
-      start_period: 5s
+      start_period: 30s
       test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
       timeout: 5s
     hostname: broker
@@ -105,8 +105,8 @@ services:
     - METADATA_SERVICE_AUTH_ENABLED=false
     healthcheck:
       interval: 1s
-      retries: 20
-      start_period: 20s
+      retries: 3
+      start_period: 90s
       test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
       timeout: 5s
     hostname: datahub-gms
@@ -162,8 +162,8 @@ services:
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 20s
       test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
       timeout: 5s
     hostname: elasticsearch
@@ -211,8 +211,8 @@ services:
     - MYSQL_ROOT_PASSWORD=datahub
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 2s
+      retries: 3
+      start_period: 10s
       test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
       timeout: 5s
     hostname: mysql
@@ -268,8 +268,8 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 30s
       test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
       timeout: 5s
     hostname: schema-registry
@@ -283,8 +283,8 @@ services:
     - ZOOKEEPER_TICK_TIME=2000
     healthcheck:
       interval: 5s
-      retries: 5
-      start_period: 2s
+      retries: 3
+      start_period: 10s
       test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
       timeout: 5s
     hostname: zookeeper

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -19,7 +19,7 @@ services:
     healthcheck:
       interval: 1s
       retries: 5
-      start_period: 5s
+      start_period: 30s
       test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
       timeout: 5s
     hostname: broker
@@ -100,8 +100,8 @@ services:
     - UI_INGESTION_ENABLED=true
     healthcheck:
       interval: 1s
-      retries: 20
-      start_period: 20s
+      retries: 3
+      start_period: 90s
       test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
       timeout: 5s
     hostname: datahub-gms
@@ -155,8 +155,8 @@ services:
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 20s
       test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
       timeout: 5s
     hostname: elasticsearch
@@ -242,8 +242,8 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 30s
       test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
       timeout: 5s
     hostname: schema-registry
@@ -257,8 +257,8 @@ services:
     - ZOOKEEPER_TICK_TIME=2000
     healthcheck:
       interval: 5s
-      retries: 5
-      start_period: 2s
+      retries: 3
+      start_period: 10s
       test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
       timeout: 5s
     hostname: zookeeper

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -19,7 +19,7 @@ services:
     healthcheck:
       interval: 1s
       retries: 5
-      start_period: 5s
+      start_period: 30s
       test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
       timeout: 5s
     hostname: broker
@@ -100,8 +100,8 @@ services:
     - UI_INGESTION_ENABLED=true
     healthcheck:
       interval: 1s
-      retries: 20
-      start_period: 20s
+      retries: 3
+      start_period: 90s
       test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
       timeout: 5s
     hostname: datahub-gms
@@ -155,8 +155,8 @@ services:
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 20s
       test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
       timeout: 5s
     hostname: elasticsearch
@@ -242,8 +242,8 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 30s
       test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
       timeout: 5s
     hostname: schema-registry
@@ -257,8 +257,8 @@ services:
     - ZOOKEEPER_TICK_TIME=2000
     healthcheck:
       interval: 5s
-      retries: 5
-      start_period: 2s
+      retries: 3
+      start_period: 10s
       test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
       timeout: 5s
     hostname: zookeeper

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -19,7 +19,7 @@ services:
     healthcheck:
       interval: 1s
       retries: 5
-      start_period: 5s
+      start_period: 30s
       test: nc -z broker $${DATAHUB_MAPPED_KAFKA_BROKER_PORT:-9092}
       timeout: 5s
     hostname: broker
@@ -105,8 +105,8 @@ services:
     - METADATA_SERVICE_AUTH_ENABLED=false
     healthcheck:
       interval: 1s
-      retries: 20
-      start_period: 20s
+      retries: 3
+      start_period: 90s
       test: curl -sS --fail http://datahub-gms:${DATAHUB_MAPPED_GMS_PORT:-8080}/health
       timeout: 5s
     hostname: datahub-gms
@@ -162,8 +162,8 @@ services:
     - ES_JAVA_OPTS=-Xms256m -Xmx512m -Dlog4j2.formatMsgNoLookups=true
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 20s
       test: curl -sS --fail http://elasticsearch:$${DATAHUB_MAPPED_ELASTIC_PORT:-9200}/_cluster/health?wait_for_status=yellow&timeout=0s
       timeout: 5s
     hostname: elasticsearch
@@ -211,8 +211,8 @@ services:
     - MYSQL_ROOT_PASSWORD=datahub
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 2s
+      retries: 3
+      start_period: 10s
       test: mysqladmin ping -h mysql -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
       timeout: 5s
     hostname: mysql
@@ -268,8 +268,8 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=broker:29092
     healthcheck:
       interval: 1s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 30s
       test: nc -z schema-registry ${DATAHUB_MAPPED_SCHEMA_REGISTRY_PORT:-8081}
       timeout: 5s
     hostname: schema-registry
@@ -283,8 +283,8 @@ services:
     - ZOOKEEPER_TICK_TIME=2000
     healthcheck:
       interval: 5s
-      retries: 5
-      start_period: 2s
+      retries: 3
+      start_period: 10s
       test: echo srvr | nc zookeeper $${DATAHUB_MAPPED_ZK_PORT:-2181}
       timeout: 5s
     hostname: zookeeper

--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -704,7 +704,7 @@ def quickstart(
             # As such, we'll only use the quiet flag if we're in an interactive environment.
             # If we're in quiet mode, then we'll show a spinner instead.
             quiet = not sys.stderr.isatty()
-            with (PerfTimer() as timer, click_spinner.spinner(disable=not quiet)):
+            with PerfTimer() as timer, click_spinner.spinner(disable=not quiet):
                 subprocess.run(
                     [*base_command, "pull", *(("-q",) if quiet else ())],
                     check=True,

--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -34,6 +34,7 @@ from datahub.cli.quickstart_versioning import QuickstartVersionMappingConfig
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.telemetry import telemetry
 from datahub.upgrade import upgrade
+from datahub.utilities.perf_timer import PerfTimer
 from datahub.utilities.sample_data import BOOTSTRAP_MCES_FILE, download_sample_data
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,7 @@ KAFKA_SETUP_QUICKSTART_COMPOSE_FILE = (
 
 
 _QUICKSTART_MAX_WAIT_TIME = datetime.timedelta(minutes=10)
+_QUICKSTART_UP_TIMEOUT = datetime.timedelta(minutes=1)
 _QUICKSTART_STATUS_CHECK_INTERVAL = datetime.timedelta(seconds=2)
 
 
@@ -702,14 +704,28 @@ def quickstart(
             # As such, we'll only use the quiet flag if we're in an interactive environment.
             # If we're in quiet mode, then we'll show a spinner instead.
             quiet = not sys.stderr.isatty()
-            with click_spinner.spinner(disable=not quiet):
+            with (PerfTimer() as timer, click_spinner.spinner(disable=not quiet)):
                 subprocess.run(
                     [*base_command, "pull", *(("-q",) if quiet else ())],
                     check=True,
                     env=_docker_subprocess_env(),
                 )
+
+            telemetry.telemetry_instance.ping(
+                "quickstart-image-pull",
+                {
+                    "status": "success",
+                    "duration": timer.elapsed_seconds(),
+                },
+            )
             click.secho("Finished pulling docker images!")
     except subprocess.CalledProcessError:
+        telemetry.telemetry_instance.ping(
+            "quickstart-image-pull",
+            {
+                "status": "failure",
+            },
+        )
         click.secho(
             "Error while pulling images. Going to attempt to move on to docker compose up assuming the images have "
             "been built locally",
@@ -739,6 +755,7 @@ def quickstart(
             subprocess.run(
                 base_command + ["up", "-d", "--remove-orphans"],
                 env=_docker_subprocess_env(),
+                timeout=_QUICKSTART_UP_TIMEOUT.total_seconds(),
             )
             up_attempts += 1
 


### PR DESCRIPTION
- Handle retries when docker compose up hangs.
- Tweaks our healthchecks so that the startup grace periods are longer.

The changes in docker/quickstart are autogenerated from the ones in the docker/ dir.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
