### PR TITLE
fix(ingest/snowflake): fix privatelink external url

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -80,7 +80,7 @@ class SnowflakeCommonMixin:
         privatelink: bool = False,
     ) -> Optional[str]:
         if privatelink:
-            url = f"https://app.{account_locator}.{cloud_region_id}.privatelink.snowflakecomputing.com/"
+            url = f"https://app.{cloud_region_id}.privatelink.snowflakecomputing.com/{cloud_region_id}/{account_locator}"
         elif cloud == SNOWFLAKE_DEFAULT_CLOUD:
             url = f"https://app.snowflake.com/{cloud_region_id}/{account_locator}/"
         else:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -80,7 +80,7 @@ class SnowflakeCommonMixin:
         privatelink: bool = False,
     ) -> Optional[str]:
         if privatelink:
-            url = f"https://app.{cloud_region_id}.privatelink.snowflakecomputing.com/{cloud_region_id}/{account_locator}"
+            url = f"https://app.{account_locator}.{cloud_region_id}.privatelink.snowflakecomputing.com/"
         elif cloud == SNOWFLAKE_DEFAULT_CLOUD:
             url = f"https://app.snowflake.com/{cloud_region_id}/{account_locator}/"
         else:


### PR DESCRIPTION
Change private link url to match proper format. Before `view in snowflake` results in `Connection denied
Snowflake cannot be accessed from your current network connection (<IP_ADDRESS>). Contact your security administrator.`

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
