### PR TITLE
feat(stats): make rowcount more human readable

### DIFF
--- a/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
@@ -6,7 +6,7 @@ import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
-import { countFormatter } from '../../../../utils/formatter';
+import { countFormatter, needsFormatting } from '../../../../utils/formatter';
 import ExpandingStat from '../../dataset/shared/ExpandingStat';
 
 const StatText = styled.span`
@@ -37,6 +37,7 @@ export const ChartStatsSummary = ({
         (!!chartCount && (
             <ExpandingStat
                 color={ANTD_GRAY[8]}
+                disabled={!needsFormatting(chartCount)}
                 render={(isExpanded) => (
                     <>
                         <b>{isExpanded ? chartCount : countFormatter(chartCount)}</b> charts

--- a/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
@@ -7,6 +7,7 @@ import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 import { countFormatter } from '../../../../utils/formatter';
+import ExpandingStat from '../../dataset/shared/ExpandingStat';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
@@ -34,9 +35,14 @@ export const ChartStatsSummary = ({
 }: Props) => {
     const statsViews = [
         (!!chartCount && (
-            <StatText>
-                <b>{countFormatter(chartCount)}</b> charts
-            </StatText>
+            <ExpandingStat
+                color={ANTD_GRAY[8]}
+                render={(isExpanded) => (
+                    <>
+                        <b>{isExpanded ? chartCount : countFormatter(chartCount)}</b> charts
+                    </>
+                )}
+            />
         )) ||
             undefined,
         (!!viewCount && (

--- a/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
@@ -40,7 +40,8 @@ export const ChartStatsSummary = ({
                 disabled={!needsFormatting(chartCount)}
                 render={(isExpanded) => (
                     <>
-                        <b>{isExpanded ? chartCount : countFormatter(chartCount)}</b> charts
+                        <b>{isExpanded ? formatNumberWithoutAbbreviation(chartCount) : countFormatter(chartCount)}</b>{' '}
+                        charts
                     </>
                 )}
             />

--- a/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
@@ -36,13 +36,12 @@ export const ChartStatsSummary = ({
     const statsViews = [
         (!!chartCount && (
             <ExpandingStat
-                color={ANTD_GRAY[8]}
                 disabled={!needsFormatting(chartCount)}
                 render={(isExpanded) => (
-                    <>
+                    <StatText color={ANTD_GRAY[8]}>
                         <b>{isExpanded ? formatNumberWithoutAbbreviation(chartCount) : countFormatter(chartCount)}</b>{' '}
                         charts
-                    </>
+                    </StatText>
                 )}
             />
         )) ||

--- a/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/chart/shared/ChartStatsSummary.tsx
@@ -6,6 +6,7 @@ import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
+import { countFormatter } from '../../../../utils/formatter';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
@@ -34,7 +35,7 @@ export const ChartStatsSummary = ({
     const statsViews = [
         (!!chartCount && (
             <StatText>
-                <b>{chartCount}</b> charts
+                <b>{countFormatter(chartCount)}</b> charts
             </StatText>
         )) ||
             undefined,

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -6,6 +6,7 @@ import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
+import { countFormatter } from '../../../../utils/formatter';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
@@ -34,7 +35,7 @@ export const DashboardStatsSummary = ({
     const statsViews = [
         (!!chartCount && (
             <StatText>
-                <b>{chartCount}</b> charts
+                <b>{countFormatter(chartCount)}</b> charts
             </StatText>
         )) ||
             undefined,

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -6,7 +6,7 @@ import { formatNumberWithoutAbbreviation } from '../../../shared/formatNumber';
 import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
-import { countFormatter } from '../../../../utils/formatter';
+import { countFormatter, needsFormatting } from '../../../../utils/formatter';
 import ExpandingStat from '../../dataset/shared/ExpandingStat';
 
 const StatText = styled.span`
@@ -37,6 +37,7 @@ export const DashboardStatsSummary = ({
         (!!chartCount && (
             <ExpandingStat
                 color={ANTD_GRAY[8]}
+                disabled={!needsFormatting(chartCount)}
                 render={(isExpanded) => (
                     <>
                         <b>{isExpanded ? chartCount : countFormatter(chartCount)}</b> charts

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -7,6 +7,7 @@ import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 import { countFormatter } from '../../../../utils/formatter';
+import ExpandingStat from '../../dataset/shared/ExpandingStat';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
@@ -34,9 +35,14 @@ export const DashboardStatsSummary = ({
 }: Props) => {
     const statsViews = [
         (!!chartCount && (
-            <StatText>
-                <b>{countFormatter(chartCount)}</b> charts
-            </StatText>
+            <ExpandingStat
+                color={ANTD_GRAY[8]}
+                render={(isExpanded) => (
+                    <>
+                        <b>{isExpanded ? chartCount : countFormatter(chartCount)}</b> charts
+                    </>
+                )}
+            />
         )) ||
             undefined,
         (!!viewCount && (

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -36,13 +36,12 @@ export const DashboardStatsSummary = ({
     const statsViews = [
         (!!chartCount && (
             <ExpandingStat
-                color={ANTD_GRAY[8]}
                 disabled={!needsFormatting(chartCount)}
                 render={(isExpanded) => (
-                    <>
+                    <StatText color={ANTD_GRAY[8]}>
                         <b>{isExpanded ? formatNumberWithoutAbbreviation(chartCount) : countFormatter(chartCount)}</b>{' '}
                         charts
-                    </>
+                    </StatText>
                 )}
             />
         )) ||

--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -40,7 +40,8 @@ export const DashboardStatsSummary = ({
                 disabled={!needsFormatting(chartCount)}
                 render={(isExpanded) => (
                     <>
-                        <b>{isExpanded ? chartCount : countFormatter(chartCount)}</b> charts
+                        <b>{isExpanded ? formatNumberWithoutAbbreviation(chartCount) : countFormatter(chartCount)}</b>{' '}
+                        charts
                     </>
                 )}
             />

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -47,10 +47,9 @@ export const DatasetStatsSummary = ({
     const statsViews = [
         !!rowCount && (
             <ExpandingStat
-                color={displayedColor}
                 disabled={isTooltipMode || !needsFormatting(rowCount)}
                 render={(isExpanded) => (
-                    <>
+                    <StatText color={displayedColor}>
                         <TableOutlined style={{ marginRight: 8, color: displayedColor }} />
                         <b>{isExpanded ? formatNumberWithoutAbbreviation(rowCount) : countFormatter(rowCount)}</b> rows
                         {!!columnCount && (
@@ -64,7 +63,7 @@ export const DatasetStatsSummary = ({
                                 columns
                             </>
                         )}
-                    </>
+                    </StatText>
                 )}
             />
         ),

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -7,6 +7,7 @@ import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 import { FormattedBytesStat } from './FormattedBytesStat';
+import { countFormatter } from '../../../../utils/formatter';
 
 const StatText = styled.span<{ color: string }>`
     color: ${(props) => props.color};
@@ -43,7 +44,7 @@ export const DatasetStatsSummary = ({
         !!rowCount && (
             <StatText color={displayedColor}>
                 <TableOutlined style={{ marginRight: 8, color: displayedColor }} />
-                <b>{formatNumberWithoutAbbreviation(rowCount)}</b> rows
+                <b>{countFormatter(rowCount)}</b> rows
                 {!!columnCount && (
                     <>
                         , <b>{formatNumberWithoutAbbreviation(columnCount)}</b> columns

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -8,6 +8,7 @@ import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/tim
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 import { FormattedBytesStat } from './FormattedBytesStat';
 import { countFormatter } from '../../../../utils/formatter';
+import ExpandingStat from './ExpandingStat';
 
 const StatText = styled.span<{ color: string }>`
     color: ${(props) => props.color};
@@ -26,6 +27,7 @@ type Props = {
     uniqueUserCountLast30Days?: number | null;
     lastUpdatedMs?: number | null;
     color?: string;
+    mode?: 'normal' | 'tooltip-content';
 };
 
 export const DatasetStatsSummary = ({
@@ -37,20 +39,28 @@ export const DatasetStatsSummary = ({
     uniqueUserCountLast30Days,
     lastUpdatedMs,
     color,
+    mode = 'normal',
 }: Props) => {
-    const displayedColor = color !== undefined ? color : ANTD_GRAY[7];
+    const isTooltipMode = mode === 'tooltip-content';
+    const displayedColor = isTooltipMode ? '' : color ?? ANTD_GRAY[7];
 
     const statsViews = [
         !!rowCount && (
-            <StatText color={displayedColor}>
-                <TableOutlined style={{ marginRight: 8, color: displayedColor }} />
-                <b>{countFormatter(rowCount)}</b> rows
-                {!!columnCount && (
+            <ExpandingStat
+                color={displayedColor}
+                disabled={isTooltipMode}
+                render={(isExpanded) => (
                     <>
-                        , <b>{formatNumberWithoutAbbreviation(columnCount)}</b> columns
+                        <TableOutlined style={{ marginRight: 8, color: displayedColor }} />
+                        <b>{isExpanded ? rowCount : countFormatter(rowCount)}</b> rows
+                        {!!columnCount && (
+                            <>
+                                , <b>{formatNumberWithoutAbbreviation(columnCount)}</b> columns
+                            </>
+                        )}
                     </>
                 )}
-            </StatText>
+            />
         ),
         !!sizeInBytes && (
             <StatText color={displayedColor}>

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -7,7 +7,7 @@ import { ANTD_GRAY } from '../../shared/constants';
 import { toLocalDateTimeString, toRelativeTimeString } from '../../../shared/time/timeUtils';
 import { StatsSummary } from '../../shared/components/styled/StatsSummary';
 import { FormattedBytesStat } from './FormattedBytesStat';
-import { countFormatter } from '../../../../utils/formatter';
+import { countFormatter, needsFormatting } from '../../../../utils/formatter';
 import ExpandingStat from './ExpandingStat';
 
 const StatText = styled.span<{ color: string }>`
@@ -48,7 +48,7 @@ export const DatasetStatsSummary = ({
         !!rowCount && (
             <ExpandingStat
                 color={displayedColor}
-                disabled={isTooltipMode}
+                disabled={isTooltipMode || !needsFormatting(rowCount)}
                 render={(isExpanded) => (
                     <>
                         <TableOutlined style={{ marginRight: 8, color: displayedColor }} />

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -52,10 +52,16 @@ export const DatasetStatsSummary = ({
                 render={(isExpanded) => (
                     <>
                         <TableOutlined style={{ marginRight: 8, color: displayedColor }} />
-                        <b>{isExpanded ? rowCount : countFormatter(rowCount)}</b> rows
+                        <b>{isExpanded ? formatNumberWithoutAbbreviation(rowCount) : countFormatter(rowCount)}</b> rows
                         {!!columnCount && (
                             <>
-                                , <b>{formatNumberWithoutAbbreviation(columnCount)}</b> columns
+                                ,{' '}
+                                <b>
+                                    {isExpanded
+                                        ? formatNumberWithoutAbbreviation(columnCount)
+                                        : countFormatter(columnCount)}
+                                </b>{' '}
+                                columns
                             </>
                         )}
                     </>

--- a/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
@@ -1,17 +1,8 @@
-import React, { ReactNode, useRef, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import styled from 'styled-components';
 
 const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; color: string }>`
     color: ${(props) => props.color};
-    ${(props) =>
-        !props.disabled &&
-        !props.expanded &&
-        `
-    :hover {
-        color: ${props.theme.styles['primary-color']};
-        cursor: pointer;
-    }
-`}
 `;
 
 const ExpandingStat = ({
@@ -23,11 +14,14 @@ const ExpandingStat = ({
     disabled?: boolean;
     render: (isExpanded: boolean) => ReactNode;
 }) => {
-    const ref = useRef<HTMLSpanElement>(null);
     const [isExpanded, setIsExpanded] = useState(false);
 
-    const onClickContainer = () => {
+    const onMouseEnter = () => {
         if (!disabled) setIsExpanded(true);
+    };
+
+    const onMouseLeave = () => {
+        if (!disabled) setIsExpanded(false);
     };
 
     return (
@@ -35,8 +29,8 @@ const ExpandingStat = ({
             disabled={disabled}
             expanded={isExpanded}
             color={color}
-            ref={ref}
-            onClick={onClickContainer}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
         >
             {render(isExpanded)}
         </ExpandingStatContainer>

--- a/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
@@ -1,20 +1,28 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; color: string }>`
-    color: ${(props) => props.color};
+const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; width: string }>`
+    overflow: hidden;
+    white-space: nowrap;
+    width: ${(props) => props.width};
+    transition: width 250ms ease;
 `;
 
 const ExpandingStat = ({
-    color,
     disabled = false,
     render,
 }: {
-    color: string;
     disabled?: boolean;
     render: (isExpanded: boolean) => ReactNode;
 }) => {
+    const contentRef = useRef<HTMLSpanElement>(null);
+    const [width, setWidth] = useState<string>('inherit');
     const [isExpanded, setIsExpanded] = useState(false);
+
+    useEffect(() => {
+        if (!contentRef.current) return;
+        setWidth(`${contentRef.current.offsetWidth}px`);
+    }, [isExpanded]);
 
     const onMouseEnter = () => {
         if (!disabled) setIsExpanded(true);
@@ -28,11 +36,11 @@ const ExpandingStat = ({
         <ExpandingStatContainer
             disabled={disabled}
             expanded={isExpanded}
-            color={color}
+            width={width}
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
         >
-            {render(isExpanded)}
+            <span ref={contentRef}>{render(isExpanded)}</span>
         </ExpandingStatContainer>
     );
 };

--- a/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; color: string }>`
+    color: ${(props) => props.color};
+    ${(props) =>
+        !props.disabled &&
+        !props.expanded &&
+        `
+    :hover {
+        color: ${props.theme.styles['primary-color']};
+        cursor: pointer;
+    }
+`}
+`;
+
+const ExpandingStat = ({
+    color,
+    disabled = false,
+    render,
+}: {
+    color: string;
+    disabled?: boolean;
+    render: (isExpanded: boolean) => ReactNode;
+}) => {
+    const ref = useRef<HTMLSpanElement>(null);
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const onClickContainer = () => {
+        if (!disabled) setIsExpanded(true);
+    };
+
+    return (
+        <ExpandingStatContainer
+            disabled={disabled}
+            expanded={isExpanded}
+            color={color}
+            ref={ref}
+            onClick={onClickContainer}
+        >
+            {render(isExpanded)}
+        </ExpandingStatContainer>
+    );
+};
+
+export default ExpandingStat;

--- a/datahub-web-react/src/app/entity/shared/components/styled/StatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/StatsSummary.tsx
@@ -8,15 +8,15 @@ type Props = {
 
 const StatsContainer = styled.div`
     margin-top: 8px;
+    display: flex;
+    align-items: center;
 `;
 
 const StatDivider = styled.div`
-    display: inline-block;
     padding-left: 10px;
     margin-right: 10px;
     border-right: 1px solid ${ANTD_GRAY[4]};
     height: 21px;
-    vertical-align: text-top;
 `;
 
 export const StatsSummary = ({ stats }: Props) => {
@@ -25,10 +25,10 @@ export const StatsSummary = ({ stats }: Props) => {
             {stats && stats.length > 0 && (
                 <StatsContainer>
                     {stats.map((statView, index) => (
-                        <span>
+                        <>
                             {statView}
                             {index < stats.length - 1 && <StatDivider />}
-                        </span>
+                        </>
                     ))}
                 </StatsContainer>
             )}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Dataset/StatsSidebarSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Dataset/StatsSidebarSection.tsx
@@ -8,7 +8,7 @@ import { ANTD_GRAY } from '../../../../constants';
 import { useBaseEntity, useRouteToTab } from '../../../../EntityContext';
 import { SidebarHeader } from '../SidebarHeader';
 import { InfoItem } from '../../../../components/styled/InfoItem';
-import { countSeparator } from '../../../../../../../utils/formatter/index';
+import { formatNumberWithoutAbbreviation } from '../../../../../../shared/formatNumber';
 
 const HeaderInfoBody = styled(Typography.Text)`
     font-size: 16px;
@@ -83,7 +83,7 @@ export const SidebarStatsSection = () => {
                             onClick={() => routeToTab({ tabName: 'Queries' })}
                             width={INFO_ITEM_WIDTH_PX}
                         >
-                            <HeaderInfoBody>{countSeparator(latestProfile?.rowCount)}</HeaderInfoBody>
+                            <HeaderInfoBody>{formatNumberWithoutAbbreviation(latestProfile?.rowCount)}</HeaderInfoBody>
                         </InfoItem>
                     ) : null}
                     {latestProfile?.columnCount ? (

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/TableStats.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 import { CorpUser, Maybe, UserUsageCounts } from '../../../../../../../types.generated';
 import { InfoItem } from '../../../../components/styled/InfoItem';
 import { ANTD_GRAY } from '../../../../constants';
-import { countFormatter, countSeparator } from '../../../../../../../utils/formatter/index';
+import { countFormatter } from '../../../../../../../utils/formatter/index';
 import { ExpandedActorGroup } from '../../../../components/styled/ExpandedActorGroup';
+import { formatNumberWithoutAbbreviation } from '../../../../../../shared/formatNumber';
 
 type Props = {
     rowCount?: number;
@@ -57,7 +58,7 @@ export default function TableStats({
             <StatContainer justifyContent={justifyContent}>
                 {rowCount && (
                     <InfoItem title="Rows">
-                        <Tooltip title={countSeparator(rowCount)} placement="right">
+                        <Tooltip title={formatNumberWithoutAbbreviation(rowCount)} placement="right">
                             <Typography.Text strong style={{ fontSize: 24 }} data-testid="table-stats-rowcount">
                                 {countFormatter(rowCount)}
                             </Typography.Text>

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteItem.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteItem.tsx
@@ -39,7 +39,7 @@ export default function AutoCompleteItem({ query, entity }: Props) {
 
     return (
         <Tooltip
-            overlayStyle={{ maxWidth: 500, visibility: displayTooltip ? 'visible' : 'hidden' }}
+            overlayStyle={{ maxWidth: 750, visibility: displayTooltip ? 'visible' : 'hidden' }}
             style={{ width: '100%' }}
             title={<AutoCompleteTooltipContent entity={entity} />}
             placement="top"

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteTooltipContent.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteTooltipContent.tsx
@@ -53,7 +53,7 @@ export default function AutoCompleteTooltipContent({ entity }: Props) {
                     }
                     queryCountLast30Days={(entity as Dataset).statsSummary?.queryCountLast30Days}
                     uniqueUserCountLast30Days={(entity as Dataset).statsSummary?.uniqueUserCountLast30Days}
-                    color="" // need to pass in empty color so that tooltip decides the color here
+                    mode="tooltip-content"
                 />
             )}
         </ContentWrapper>

--- a/datahub-web-react/src/utils/formatter/index.ts
+++ b/datahub-web-react/src/utils/formatter/index.ts
@@ -1,8 +1,8 @@
-const intlFormat = (num) => {
+const intlFormat = (num: number) => {
     return new Intl.NumberFormat().format(Math.round(num * 10) / 10);
 };
 
-export const countFormatter: (num: number) => string = (num: number) => {
+export const countFormatter = (num: number) => {
     if (num >= 1000000000) {
         return `${intlFormat(num / 1000000000)}B`;
     }
@@ -13,8 +13,4 @@ export const countFormatter: (num: number) => string = (num: number) => {
     if (num >= 1000) return `${intlFormat(num / 1000)}K`;
 
     return intlFormat(num);
-};
-
-export const countSeparator = (num) => {
-    return num.toLocaleString();
 };

--- a/datahub-web-react/src/utils/formatter/index.ts
+++ b/datahub-web-react/src/utils/formatter/index.ts
@@ -1,4 +1,6 @@
-const NumMap = {
+type NumMapType = Record<'billion' | 'million' | 'thousand', { value: number; symbol: string }>;
+
+const NumMap: NumMapType = {
     billion: {
         value: 1000000000,
         symbol: 'B',

--- a/datahub-web-react/src/utils/formatter/index.ts
+++ b/datahub-web-react/src/utils/formatter/index.ts
@@ -1,16 +1,29 @@
-const intlFormat = (num: number) => {
-    return new Intl.NumberFormat().format(Math.round(num * 10) / 10);
-};
+const NumMap = {
+    billion: {
+        value: 1000000000,
+        symbol: 'B',
+    },
+    million: {
+        value: 1000000,
+        symbol: 'M',
+    },
+    thousand: {
+        value: 1000,
+        symbol: 'K',
+    },
+} as const;
+
+const isBillions = (num: number) => num >= NumMap.billion.value;
+const isMillions = (num: number) => num >= NumMap.million.value;
+const isThousands = (num: number) => num >= NumMap.thousand.value;
+
+const intlFormat = (num: number) => new Intl.NumberFormat().format(Math.round(num * 10) / 10);
+
+export const needsFormatting = (num: number) => isThousands(num);
 
 export const countFormatter = (num: number) => {
-    if (num >= 1000000000) {
-        return `${intlFormat(num / 1000000000)}B`;
-    }
-    if (num >= 1000000) {
-        return `${intlFormat(num / 1000000)}M`;
-    }
-
-    if (num >= 1000) return `${intlFormat(num / 1000)}K`;
-
+    if (isBillions(num)) return `${intlFormat(num / NumMap.billion.value)}${NumMap.billion.symbol}`;
+    if (isMillions(num)) return `${intlFormat(num / NumMap.million.value)}${NumMap.million.symbol}`;
+    if (isThousands(num)) return `${intlFormat(num / NumMap.thousand.value)}${NumMap.thousand.symbol}`;
     return intlFormat(num);
 };


### PR DESCRIPTION
Formats the numeric display for the row count (10K, 10M, etc) like other numbers around Datahub. At some point we will want to consolidate `src/utils/formatter/index.ts` and `src/app/shared/formatNumber.ts`. They're similar but not quite, one uses the `Intl.NumberFormat` which may be a more flexible approach.

To still provide a way for users to get to the true number values in the UI, you can still hover the row/cols and they'll expand. A tooltip was another approach that felt a little too busy on the UI and covers up the dataset name. This feels a little more out of the way and inline with the rest of the content. I didn't refactor all the fields to use this new approach right away because that would take quite a bit more time and we'll want to see how people feel about this new approach before building upon it further (or rolling it back).

https://github.com/datahub-project/datahub/assets/2107911/5b650cfc-ebd1-49e7-b8c1-ba33923ad43f

Autocomplete

<img width="550" alt="image" src="https://github.com/datahub-project/datahub/assets/2107911/6ad1a5e0-8b68-47b5-bc37-9502b3841709">

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
