### PR TITLE
docs(es): Update aws deploy docs to correct ElasticSearch version

### DIFF
--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -230,7 +230,7 @@ Run `helm upgrade --install datahub datahub/datahub --values values.yaml` to app
 
 ### Elasticsearch Service
 
-Provision an elasticsearch domain running elasticsearch version 7.9 or above that shares the VPC with the kubernetes
+Provision an elasticsearch domain running elasticsearch version 7.10 or above that shares the VPC with the kubernetes
 cluster or has VPC peering set up between the VPC of the kubernetes cluster. Once the domain is provisioned, you should
 be able to see the following page. Take a note of the endpoint marked by the red box.
 


### PR DESCRIPTION
As of https://github.com/datahub-project/datahub/releases/tag/v0.10.1 release we do not support ElasticSearch 7.9 and below. Update the doc to correctly specify 7.10 as the oldest supported version. 
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
