### PR TITLE
fix(ingest): Pass platform correctly for better browse path v2 telemetry

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 
 from datahub.configuration.common import ConfigModel
 from datahub.configuration.source_common import PlatformInstanceConfigMixin
-from datahub.emitter.mcp_builder import PlatformKey, mcps_from_mce
+from datahub.emitter.mcp_builder import mcps_from_mce
 from datahub.ingestion.api.closeable import Closeable
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope, WorkUnit
 from datahub.ingestion.api.report import Report
@@ -249,19 +249,14 @@ class Source(Closeable, metaclass=ABCMeta):
             env and env.lower(),
         ]
 
-        platform_key: Optional[PlatformKey] = None
-        if (
-            platform
-            and isinstance(config, PlatformInstanceConfigMixin)
-            and config.platform_instance
-        ):
-            platform_key = PlatformKey(
-                platform=platform, instance=config.platform_instance
-            )
+        platform_instance: Optional[str] = None
+        if isinstance(config, PlatformInstanceConfigMixin) and config.platform_instance:
+            platform_instance = platform_instance
 
         return partial(
             auto_browse_path_v2,
-            platform_key=platform_key,
+            platform=platform,
+            platform_instance=platform_instance,
             drop_dirs=[s for s in browse_path_drop_dirs if s is not None],
             dry_run=dry_run,
         )


### PR DESCRIPTION
I was only passing `platform_key` when platform instance was set, as functionally this was the only time it was needed. However, this means most of the time, we aren't getting `platform` for telemetry. I'd like to put out a full-fledged release to get this telemetry in ASAP. We already have an event with an "invalid" batch, but no platform so it's hard to debug.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
