### PR TITLE
chore(assertions): catch any exception on assertion delete

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
@@ -14,7 +14,6 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -54,7 +53,7 @@ public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Bo
             CompletableFuture.runAsync(() -> {
               try {
                 _entityClient.deleteEntityReferences(assertionUrn, context.getAuthentication());
-              } catch (RemoteInvocationException e) {
+              } catch (Exception e) {
                 log.error(String.format("Caught exception while attempting to clear all entity references for assertion with urn %s", assertionUrn), e);
               }
             });


### PR DESCRIPTION
We are not seeing logs in some cases where we expected to see them when deleting assertions. It could be because we're not catching all kinds of exceptions in the async future.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
