### PR TITLE
docs(website): adjust markprompt z-index so it's not covered by nav

### DIFF
--- a/docs-website/src/components/MarkpromptHelp/markprompthelp.module.scss
+++ b/docs-website/src/components/MarkpromptHelp/markprompthelp.module.scss
@@ -73,12 +73,14 @@ button {
 
 .MarkpromptOverlay {
   position: fixed;
+  z-index: calc(var(--ifm-z-index-fixed) + 1);
   inset: 0;
   animation: overlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1);
   background-color: var(--markprompt-overlay);
 }
 
 .MarkpromptContent {
+  z-index: calc(var(--ifm-z-index-fixed) + 2);
   background-color: var(--markprompt-muted);
   border-radius: var(--markprompt-radius);
   border: 1px solid var(--markprompt-border);
@@ -89,7 +91,7 @@ button {
   transform: translate(-50%, -50%);
   width: 80vw;
   max-width: 600px;
-  height: calc(100vh - 200px);
+  height: calc(100vh - 100px);
   max-height: 600px;
   animation-name: contentShow;
   animation-duration: 300ms;


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
