### PR TITLE
chore(ci): add back optional static sleep for tests

### DIFF
--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -1,8 +1,15 @@
 import time
+import os
 import subprocess
+
 _ELASTIC_BUFFER_WRITES_TIME_IN_SEC: int = 1
+USE_STATIC_SLEEP: bool = bool(os.getenv("USE_STATIC_SLEEP", False))
+ELASTICSEARCH_REFRESH_INTERVAL_SECONDS: int = int(os.getenv("ELASTICSEARCH_REFRESH_INTERVAL_SECONDS", 5))
 
 def wait_for_writes_to_sync(max_timeout_in_sec: int = 120) -> None:
+    if USE_STATIC_SLEEP:
+        time.sleep(ELASTICSEARCH_REFRESH_INTERVAL_SECONDS)
+        return
     start_time = time.time()
     # get offsets
     lag_zero = False


### PR DESCRIPTION
In https://github.com/datahub-project/datahub/pull/8094 an assumption was made that these tests will only be running in docker environments. In the case where that is not the case adding back static sleep as an option until those specific cases can be supported.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
