### PR TITLE
feat(ingest/snowflake): snowpipe s3 lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -28,7 +28,7 @@ logger = logging.Logger(__name__)
 #
 # DBT incremental models create temporary tables ending with __dbt_tmp
 # Ref - https://discourse.getdbt.com/t/handling-bigquery-incremental-dbt-tmp-tables/7540
-DEFAULT_UPSTREAMS_DENY_LIST = [
+DEFAULT_TABLES_DENY_LIST = [
     r".*\.FIVETRAN_.*_STAGING\..*",  # fivetran
     r".*__DBT_TMP$",  # dbt
     rf".*\.SEGMENT_{UUID_REGEX}",  # segment
@@ -105,9 +105,14 @@ class SnowflakeV2Config(
         description="List of regex patterns for tags to include in ingestion. Only used if `extract_tags` is enabled.",
     )
 
-    upstreams_deny_pattern: List[str] = Field(
-        default=DEFAULT_UPSTREAMS_DENY_LIST,
-        description="[Advanced] Regex patterns for upstream tables to filter in ingestion. Specify regex to match the entire table name in database.schema.table format. Defaults are to set in such a way to ignore the temporary staging tables created by known ETL tools. Not used if `use_legacy_lineage_method=True`",
+    # This is required since access_history table does not capture whether the table was temporary table.
+    temporary_tables_pattern: List[str] = Field(
+        default=DEFAULT_TABLES_DENY_LIST,
+        description="[Advanced] Regex patterns for temporary tables to filter in lineage ingestion. Specify regex to match the entire table name in database.schema.table format. Defaults are to set in such a way to ignore the temporary staging tables created by known ETL tools. Not used if `use_legacy_lineage_method=True`",
+    )
+
+    rename_upstreams_deny_pattern_to_temporary_table_pattern = pydantic_renamed_field(
+        "upstreams_deny_pattern", "temporary_tables_pattern"
     )
 
     @validator("include_column_lineage")

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -1,23 +1,21 @@
 from typing import List, Optional
 
 from datahub.ingestion.source.snowflake.constants import SnowflakeObjectDomain
-from datahub.ingestion.source.snowflake.snowflake_config import (
-    DEFAULT_UPSTREAMS_DENY_LIST,
-)
+from datahub.ingestion.source.snowflake.snowflake_config import DEFAULT_TABLES_DENY_LIST
 
 
 def create_deny_regex_sql_filter(
-    upstreams_deny_pattern: List[str], filter_cols: List[str]
+    deny_pattern: List[str], filter_cols: List[str]
 ) -> str:
     upstream_sql_filter = (
         " AND ".join(
             [
                 (f"NOT RLIKE({col_name},'{regexp}','i')")
                 for col_name in filter_cols
-                for regexp in upstreams_deny_pattern
+                for regexp in deny_pattern
             ]
         )
-        if upstreams_deny_pattern
+        if deny_pattern
         else ""
     )
 
@@ -158,7 +156,6 @@ class SnowflakeQuery:
 
     @staticmethod
     def get_all_tags_in_database_without_propagation(db_name: str) -> str:
-
         allowed_object_domains = (
             "("
             f"'{SnowflakeObjectDomain.DATABASE.upper()}',"
@@ -461,7 +458,7 @@ class SnowflakeQuery:
         end_time_millis: int,
         include_view_lineage: bool = True,
         include_column_lineage: bool = True,
-        upstreams_deny_pattern: List[str] = DEFAULT_UPSTREAMS_DENY_LIST,
+        upstreams_deny_pattern: List[str] = DEFAULT_TABLES_DENY_LIST,
     ) -> str:
         if include_column_lineage:
             return SnowflakeQuery.table_upstreams_with_column_lineage(
@@ -535,6 +532,34 @@ class SnowflakeQuery:
         FROM external_table_lineage_history
         WHERE downstream_table_domain = '{SnowflakeObjectDomain.TABLE.capitalize()}'
         QUALIFY ROW_NUMBER() OVER (PARTITION BY downstream_table_name ORDER BY query_start_time DESC) = 1"""
+
+    @staticmethod
+    def copy_lineage_history(
+        start_time_millis: int,
+        end_time_millis: int,
+        downstreams_deny_pattern: List[str],
+    ) -> str:
+        temp_table_filter = create_deny_regex_sql_filter(
+            downstreams_deny_pattern,
+            ["DOWNSTREAM_TABLE_NAME"],
+        )
+
+        return f"""
+        SELECT
+            ARRAY_UNIQUE_AGG(h.stage_location) AS "UPSTREAM_LOCATIONS",
+            concat(
+                h.table_catalog_name, '.', h.table_schema_name,
+                '.', h.table_name
+            ) AS "DOWNSTREAM_TABLE_NAME"
+        FROM
+            snowflake.account_usage.copy_history h
+        WHERE h.status in ('Loaded','Partially loaded')
+            AND DOWNSTREAM_TABLE_NAME IS NOT NULL
+            AND h.last_load_time >= to_timestamp_ltz({start_time_millis}, 3)
+            AND h.last_load_time < to_timestamp_ltz({end_time_millis}, 3)
+            {("AND " + temp_table_filter) if temp_table_filter else ""}
+        GROUP BY DOWNSTREAM_TABLE_NAME;
+        """
 
     @staticmethod
     def get_access_history_date_range() -> str:

--- a/metadata-ingestion/tests/unit/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_source.py
@@ -12,7 +12,7 @@ from datahub.ingestion.source.snowflake.constants import (
     SnowflakeCloudProvider,
 )
 from datahub.ingestion.source.snowflake.snowflake_config import (
-    DEFAULT_UPSTREAMS_DENY_LIST,
+    DEFAULT_TABLES_DENY_LIST,
     SnowflakeV2Config,
 )
 from datahub.ingestion.source.snowflake.snowflake_query import (
@@ -645,8 +645,6 @@ def test_snowflake_query_create_deny_regex_sql():
     )
 
     assert (
-        create_deny_regex_sql_filter(
-            DEFAULT_UPSTREAMS_DENY_LIST, ["upstream_table_name"]
-        )
+        create_deny_regex_sql_filter(DEFAULT_TABLES_DENY_LIST, ["upstream_table_name"])
         == r"NOT RLIKE(upstream_table_name,'.*\.FIVETRAN_.*_STAGING\..*','i') AND NOT RLIKE(upstream_table_name,'.*__DBT_TMP$','i') AND NOT RLIKE(upstream_table_name,'.*\.SEGMENT_[a-f0-9]{8}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{12}','i') AND NOT RLIKE(upstream_table_name,'.*\.STAGING_.*_[a-f0-9]{8}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{12}','i')"
     )

--- a/metadata-ingestion/tests/unit/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_source.py
@@ -648,3 +648,15 @@ def test_snowflake_query_create_deny_regex_sql():
         create_deny_regex_sql_filter(DEFAULT_TABLES_DENY_LIST, ["upstream_table_name"])
         == r"NOT RLIKE(upstream_table_name,'.*\.FIVETRAN_.*_STAGING\..*','i') AND NOT RLIKE(upstream_table_name,'.*__DBT_TMP$','i') AND NOT RLIKE(upstream_table_name,'.*\.SEGMENT_[a-f0-9]{8}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{12}','i') AND NOT RLIKE(upstream_table_name,'.*\.STAGING_.*_[a-f0-9]{8}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{4}[-_][a-f0-9]{12}','i')"
     )
+
+
+def test_snowflake_temporary_patterns_config_rename():
+    conf = SnowflakeV2Config.parse_obj(
+        {
+            "account_id": "test",
+            "username": "user",
+            "password": "password",
+            "upstreams_deny_pattern": [".*tmp.*"],
+        }
+    )
+    assert conf.temporary_tables_pattern == [".*tmp.*"]


### PR DESCRIPTION
Adds lineage support for snowflake copy queries 
`copy into <table> from <s3 stage>`
by accessing [`snowflake.account_usage.copy_history`](https://docs.snowflake.com/sql-reference/account-usage/copy_history)  table. This works for all snowflake editions.

Earlier query to access_history to locate lineage for snowflake copy queries like `copy into <table> from <s3 location>` is removed, as above table already captures this lineage as well.

This support is added only in new optimised lineage (default method), not in legacy lineage method, which will be removed in near future.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
