### PR TITLE
Add retries to JavaEntityClient:deleteReferencesTo

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DeleteDomainResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/DeleteDomainResolver.java
@@ -5,7 +5,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -40,7 +39,7 @@ public class DeleteDomainResolver implements DataFetcher<CompletableFuture<Boole
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(urn, context.getAuthentication());
-            } catch (RemoteInvocationException e) {
+            } catch (Exception e) {
               log.error(String.format("Caught exception while attempting to clear all entity references for Domain with urn %s", urn), e);
             }
           });

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -6,7 +6,6 @@ import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -43,7 +42,7 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(entityUrn, context.getAuthentication());
-            } catch (RemoteInvocationException e) {
+            } catch (Exception e) {
               log.error(String.format("Caught exception while attempting to clear all entity references for glossary entity with urn %s", entityUrn), e);
             }
           });

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/RemoveGroupResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/RemoveGroupResolver.java
@@ -5,7 +5,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +37,7 @@ public class RemoveGroupResolver implements DataFetcher<CompletableFuture<Boolea
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(urn, context.getAuthentication());
-            } catch (RemoteInvocationException e) {
+            } catch (Exception e) {
               log.error(String.format("Caught exception while attempting to clear all entity references for group with urn %s", urn), e);
             }
           });

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/tag/DeleteTagResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/tag/DeleteTagResolver.java
@@ -6,7 +6,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -41,7 +40,7 @@ public class DeleteTagResolver implements DataFetcher<CompletableFuture<Boolean>
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(urn, context.getAuthentication());
-            } catch (RemoteInvocationException e) {
+            } catch (Exception e) {
               log.error(String.format(
                   "Caught exception while attempting to clear all entity references for Tag with urn %s", urn), e);
             }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/RemoveUserResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/user/RemoveUserResolver.java
@@ -5,7 +5,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.entity.client.EntityClient;
-import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +37,7 @@ public class RemoveUserResolver implements DataFetcher<CompletableFuture<Boolean
           CompletableFuture.runAsync(() -> {
             try {
               _entityClient.deleteEntityReferences(urn, context.getAuthentication());
-            } catch (RemoteInvocationException e) {
+            } catch (Exception e) {
               log.error(String.format("Caught exception while attempting to clear all entity references for user with urn %s", urn), e);
             }
           });

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -579,7 +579,7 @@ public class JavaEntityClient implements EntityClient {
         }
     }
 
-    private <T> T withRetry(@Nonnull final Supplier<T> block) {
+    protected <T> T withRetry(@Nonnull final Supplier<T> block) {
         final BackoffPolicy backoffPolicy = new ExponentialBackoff(DEFAULT_RETRY_INTERVAL);
         int attemptCount = 0;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/service/DataProductService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/DataProductService.java
@@ -22,7 +22,6 @@ import com.linkedin.metadata.entity.AspectUtils;
 import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.utils.EntityKeyUtils;
-import com.linkedin.r2.RemoteInvocationException;
 import lombok.extern.slf4j.Slf4j;
 
 import javax.annotation.Nonnull;
@@ -251,7 +250,7 @@ public class DataProductService {
       CompletableFuture.runAsync(() -> {
         try {
           _entityClient.deleteEntityReferences(dataProductUrn, authentication);
-        } catch (RemoteInvocationException e) {
+        } catch (Exception e) {
           log.error(String.format("Caught exception while attempting to clear all entity references for DataProduct with urn %s", dataProductUrn), e);
         }
       });

--- a/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.client;
 
+import com.linkedin.data.template.RequiredFieldNotPresentException;
 import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.metadata.entity.DeleteEntityService;
 import com.linkedin.metadata.entity.EntityService;
@@ -60,13 +61,12 @@ public class JavaEntityClientTest {
     }
 
     @Test
-    void testSuccessAndNoRetries() {
+    void testSuccessWithNoRetries() {
         JavaEntityClient client = getJavaEntityClient();
 
         Supplier<Object> mockSupplier = mock(Supplier.class);
 
-        when(mockSupplier.get())
-                .thenReturn(42);
+        when(mockSupplier.get()).thenReturn(42);
 
         assertEquals(client.withRetry(mockSupplier), 42);
         verify(mockSupplier, times(1)).get();
@@ -102,5 +102,18 @@ public class JavaEntityClientTest {
 
         assertThrows(IllegalStateException.class, () -> client.withRetry(mockSupplier));
         verify(mockSupplier, times(4)).get();
+    }
+
+    @Test
+    void testThrowAfterNonRetryableException() {
+        JavaEntityClient client = getJavaEntityClient();
+
+        Supplier<Object> mockSupplier = mock(Supplier.class);
+
+        when(mockSupplier.get())
+                .thenThrow(new RequiredFieldNotPresentException("error"));
+
+        assertThrows(RequiredFieldNotPresentException.class, () -> client.withRetry(mockSupplier));
+        verify(mockSupplier, times(1)).get();
     }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
@@ -1,0 +1,106 @@
+package com.linkedin.metadata.client;
+
+import com.linkedin.entity.client.RestliEntityClient;
+import com.linkedin.metadata.entity.DeleteEntityService;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.event.EventProducer;
+import com.linkedin.metadata.search.EntitySearchService;
+import com.linkedin.metadata.search.LineageSearchService;
+import com.linkedin.metadata.search.SearchService;
+import com.linkedin.metadata.search.client.CachingEntitySearchService;
+import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class JavaEntityClientTest {
+
+    private EntityService _mockEntityService;
+    private DeleteEntityService _deleteEntityService;
+    private EntitySearchService _entitySearchService;
+    private CachingEntitySearchService _cachingEntitySearchService;
+    private SearchService _searchService;
+    private LineageSearchService _lineageSearchService;
+    private TimeseriesAspectService _timeseriesAspectService;
+    private EventProducer _eventProducer;
+    private RestliEntityClient _restliEntityClient;
+
+    @BeforeMethod
+    public void setupTest() {
+        _mockEntityService = mock(EntityService.class);
+        _deleteEntityService = mock(DeleteEntityService.class);
+        _entitySearchService = mock(EntitySearchService.class);
+        _cachingEntitySearchService = mock(CachingEntitySearchService.class);
+        _searchService = mock(SearchService.class);
+        _lineageSearchService = mock(LineageSearchService.class);
+        _timeseriesAspectService = mock(TimeseriesAspectService.class);
+        _eventProducer = mock(EventProducer.class);
+        _restliEntityClient = mock(RestliEntityClient.class);
+    }
+
+    private JavaEntityClient getJavaEntityClient() {
+        return new JavaEntityClient(
+                _mockEntityService,
+                _deleteEntityService,
+                _entitySearchService,
+                _cachingEntitySearchService,
+                _searchService,
+                _lineageSearchService,
+                _timeseriesAspectService,
+                _eventProducer,
+                _restliEntityClient);
+    }
+
+    @Test
+    void testSuccessAndNoRetries() {
+        JavaEntityClient client = getJavaEntityClient();
+
+        Supplier<Object> mockSupplier = mock(Supplier.class);
+
+        when(mockSupplier.get())
+                .thenReturn(42);
+
+        assertEquals(client.withRetry(mockSupplier), 42);
+        verify(mockSupplier, times(1)).get();
+    }
+
+    @Test
+    void testSuccessAfterMultipleRetries() {
+        JavaEntityClient client = getJavaEntityClient();
+
+        Supplier<Object> mockSupplier = mock(Supplier.class);
+
+        when(mockSupplier.get())
+                .thenThrow(new IllegalStateException("error"))
+                .thenThrow(new IllegalStateException("error"))
+                .thenThrow(new IllegalStateException("error"))
+                .thenReturn(42);
+
+        assertEquals(client.withRetry(mockSupplier), 42);
+        verify(mockSupplier, times(4)).get();
+    }
+
+    @Test
+    void testThrowAfterMultipleRetries() {
+        JavaEntityClient client = getJavaEntityClient();
+
+        Supplier<Object> mockSupplier = mock(Supplier.class);
+
+        when(mockSupplier.get())
+                .thenThrow(new IllegalStateException("error"))
+                .thenThrow(new IllegalStateException("error"))
+                .thenThrow(new IllegalStateException("error"))
+                .thenThrow(new IllegalStateException("error"));
+
+        assertThrows(IllegalStateException.class, () -> client.withRetry(mockSupplier));
+        verify(mockSupplier, times(4)).get();
+    }
+}


### PR DESCRIPTION
Since we suspect failing calls to deleteReferencesTo (there may be other places) this PR adds retry logic. Normally, retries would not be the best thing to do here, but since we don't have a great way to rollback resolvers on failure at the moment this may help reduce the frequency of data inconsistencies. Also address other places we may not be catching all exceptions in runAsync so we get better logging.

Could use some pointers on testing / appropriate way to structure this.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
