### PR TITLE
fix aggregation sorting in browsev2 sidebar

### DIFF
--- a/datahub-web-react/src/app/search/filters/utils.tsx
+++ b/datahub-web-react/src/app/search/filters/utils.tsx
@@ -183,7 +183,7 @@ export function getFilterIconAndLabel(
         ) : (
             entityRegistry.getIcon(EntityType.DataPlatform, size || 12, IconStyleType.ACCENT, ANTD_GRAY[9])
         );
-        label = entityRegistry.getDisplayName(EntityType.DataPlatform, filterEntity);
+        label = filterEntity ? entityRegistry.getDisplayName(EntityType.DataPlatform, filterEntity) : filterValue;
     } else if (filterField === BROWSE_PATH_V2_FILTER_NAME) {
         icon = <FolderFilled size={size} color="black" />;
         label = getLastBrowseEntryFromFilterValue(filterValue);

--- a/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
@@ -46,7 +46,8 @@ const EntityNode = () => {
     });
 
     const showEnvironments =
-        environmentAggregations.length > 1 || (hasEnvironmentFilter && !!environmentAggregations.length);
+        environmentAggregations &&
+        (environmentAggregations.length > 1 || (hasEnvironmentFilter && !!environmentAggregations.length));
     const color = count > 0 ? '#000' : ANTD_GRAY[8];
 
     return (
@@ -75,7 +76,7 @@ const EntityNode = () => {
             body={
                 <ExpandableNode.Body>
                     {showEnvironments
-                        ? environmentAggregations.map((environmentAggregation) => (
+                        ? environmentAggregations?.map((environmentAggregation) => (
                               <BrowseProvider
                                   key={environmentAggregation.value}
                                   entityAggregation={entityAggregation}
@@ -84,7 +85,7 @@ const EntityNode = () => {
                                   <EnvironmentNode />
                               </BrowseProvider>
                           ))
-                        : platformAggregations.map((platformAggregation) => (
+                        : platformAggregations?.map((platformAggregation) => (
                               <BrowseProvider
                                   key={platformAggregation.value}
                                   entityAggregation={entityAggregation}

--- a/datahub-web-react/src/app/search/sidebar/EnvironmentNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EnvironmentNode.tsx
@@ -19,6 +19,7 @@ import useSidebarAnalytics from './useSidebarAnalytics';
 const Count = styled(Typography.Text)`
     font-size: 12px;
     color: ${(props) => props.color};
+    padding-right: 8px;
 `;
 
 const EnvironmentNode = () => {
@@ -64,7 +65,7 @@ const EnvironmentNode = () => {
             }
             body={
                 <ExpandableNode.Body>
-                    {platformAggregations.map((platformAggregation) => (
+                    {platformAggregations?.map((platformAggregation) => (
                         <BrowseProvider
                             key={platformAggregation.value}
                             entityAggregation={entityAggregation}

--- a/datahub-web-react/src/app/search/sidebar/PlatformNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/PlatformNode.tsx
@@ -28,12 +28,12 @@ const PlatformIconContainer = styled.div`
 const Count = styled(Typography.Text)`
     font-size: 12px;
     color: ${(props) => props.color};
+    padding-right: 8px;
 `;
 
 const BrowseGroupListContainer = styled.div`
     background: white;
     border-radius: 8px;
-    padding-bottom: 8px;
     padding-right: 8px;
 `;
 

--- a/datahub-web-react/src/app/search/sidebar/useAggregationsQuery.ts
+++ b/datahub-web-react/src/app/search/sidebar/useAggregationsQuery.ts
@@ -47,17 +47,25 @@ const useAggregationsQuery = ({ facets, skip }: Props) => {
             const type = aggregation.value as EntityType;
             return registry.getEntity(type).isBrowseEnabled() && !GLOSSARY_ENTITY_TYPES.includes(type);
         })
+        .sort((a, b) => {
+            const nameA = registry.getCollectionName(a.value as EntityType);
+            const nameB = registry.getCollectionName(b.value as EntityType);
+            return nameA.localeCompare(nameB);
+        });
+
+    const environmentAggregations = data?.aggregateAcrossEntities?.facets
+        ?.find((facet) => facet.field === ORIGIN_FILTER_NAME)
+        ?.aggregations.filter((aggregation) => aggregation.count)
         .sort((a, b) => a.value.localeCompare(b.value));
 
-    const environmentAggregations =
-        data?.aggregateAcrossEntities?.facets
-            ?.find((facet) => facet.field === ORIGIN_FILTER_NAME)
-            ?.aggregations.filter((aggregation) => aggregation.count) ?? [];
-
-    const platformAggregations =
-        data?.aggregateAcrossEntities?.facets
-            ?.find((facet) => facet.field === PLATFORM_FILTER_NAME)
-            ?.aggregations.filter((aggregation) => aggregation.count) ?? [];
+    const platformAggregations = data?.aggregateAcrossEntities?.facets
+        ?.find((facet) => facet.field === PLATFORM_FILTER_NAME)
+        ?.aggregations.filter((aggregation) => aggregation.count)
+        .sort((a, b) => {
+            const nameA = registry.getDisplayName(EntityType.DataPlatform, a.entity);
+            const nameB = registry.getDisplayName(EntityType.DataPlatform, b.entity);
+            return nameA.localeCompare(nameB);
+        });
 
     return {
         loading,

--- a/datahub-web-react/src/app/search/sidebar/useAggregationsQuery.ts
+++ b/datahub-web-react/src/app/search/sidebar/useAggregationsQuery.ts
@@ -62,8 +62,8 @@ const useAggregationsQuery = ({ facets, skip }: Props) => {
         ?.find((facet) => facet.field === PLATFORM_FILTER_NAME)
         ?.aggregations.filter((aggregation) => aggregation.count)
         .sort((a, b) => {
-            const nameA = registry.getDisplayName(EntityType.DataPlatform, a.entity);
-            const nameB = registry.getDisplayName(EntityType.DataPlatform, b.entity);
+            const nameA = a.entity ? registry.getDisplayName(EntityType.DataPlatform, a.entity) : a.value;
+            const nameB = b.entity ? registry.getDisplayName(EntityType.DataPlatform, b.entity) : b.value;
             return nameA.localeCompare(nameB);
         });
 


### PR DESCRIPTION
Changes
* Sort aggregations by display name on the frontend
* Align counts vertically

<img width="359" alt="image" src="https://github.com/datahub-project/datahub/assets/2107911/63d91a56-6080-4172-83c1-1c26cf29c7b4">

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
