### PR TITLE
Sidebar local storage setting + toggle tooltip

### DIFF
--- a/datahub-web-react/src/app/context/userContext.tsx
+++ b/datahub-web-react/src/app/context/userContext.tsx
@@ -8,6 +8,7 @@ export type LocalState = {
     selectedViewUrn?: string | null;
     selectedPath?: string | null;
     selectedSearch?: string | null;
+    showBrowseV2Sidebar?: boolean | null;
 };
 
 /**

--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -23,10 +23,8 @@ import BrowseSidebar from './sidebar';
 import ToggleSidebarButton from './ToggleSidebarButton';
 import { SidebarProvider } from './sidebar/SidebarContext';
 import { BrowseProvider } from './sidebar/BrowseContext';
-import analytics from '../analytics/analytics';
-import useToggle from '../shared/useToggle';
-import { EventType } from '../analytics';
 import { useIsBrowseV2, useIsSearchV2 } from './useSearchAndBrowseVersion';
+import useToggleSidebar from './useToggleSidebar';
 
 const SearchResultsWrapper = styled.div<{ showUpdatedStyles: boolean }>`
     display: flex;
@@ -151,6 +149,7 @@ export const SearchResults = ({
 }: Props) => {
     const showSearchFiltersV2 = useIsSearchV2();
     const showBrowseV2 = useIsBrowseV2();
+    const { isSidebarOpen, toggleSidebar } = useToggleSidebar();
     const pageStart = searchResponse?.start || 0;
     const pageSize = searchResponse?.count || 0;
     const totalResults = searchResponse?.total || 0;
@@ -160,15 +159,6 @@ export const SearchResults = ({
 
     const searchResultUrns = combinedSiblingSearchResults.map((result) => result.entity.urn) || [];
     const selectedEntityUrns = selectedEntities.map((entity) => entity.urn);
-
-    const { isOpen: isSidebarOpen, toggle: toggleSidebar } = useToggle({
-        initialValue: true,
-        onToggle: (isNowOpen: boolean) =>
-            analytics.event({
-                type: EventType.BrowseV2ToggleSidebarEvent,
-                action: isNowOpen ? 'open' : 'close',
-            }),
-    });
 
     return (
         <>

--- a/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
+++ b/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
@@ -30,6 +30,7 @@ const ToggleSidebarButton = ({ isOpen, onClick }: Props) => {
 
     const button = (
         <Button
+            data-testid="browse-v2-toggle"
             size="small"
             onClick={onClickButton}
             icon={<ToggleIcon component={isOpen ? CollapseIcon : ExpandIcon} />}

--- a/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
+++ b/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
@@ -1,6 +1,6 @@
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import Icon from '@ant-design/icons/lib/components/Icon';
-import { Button } from 'antd';
+import { Button, Tooltip } from 'antd';
 import styled from 'styled-components';
 import { ReactComponent as ExpandIcon } from '../../images/expand.svg';
 import { ReactComponent as CollapseIcon } from '../../images/collapse.svg';
@@ -12,9 +12,36 @@ const ToggleIcon = styled(Icon)`
     }
 `;
 
-const ToggleSidebarButton = ({ isOpen, onClick }: { isOpen: boolean; onClick: () => void }) => {
+type Props = {
+    isOpen: boolean;
+    onClick: () => void;
+};
+
+const ToggleSidebarButton = ({ isOpen, onClick }: Props) => {
+    const [pauseTooltip, setPauseTooltip] = useState(false);
+    const title = isOpen ? 'Hide the navigation panel' : 'Open the navigation panel';
+    const placement = isOpen ? 'bottom' : 'bottomRight';
+
+    const onClickButton = () => {
+        setPauseTooltip(true);
+        window.setTimeout(() => setPauseTooltip(false), 250);
+        onClick();
+    };
+
+    const button = (
+        <Button
+            size="small"
+            onClick={onClickButton}
+            icon={<ToggleIcon component={isOpen ? CollapseIcon : ExpandIcon} />}
+        />
+    );
+
+    if (pauseTooltip) return button;
+
     return (
-        <Button size="small" onClick={onClick} icon={<ToggleIcon component={isOpen ? CollapseIcon : ExpandIcon} />} />
+        <Tooltip title={title} placement={placement} arrowPointAtCenter>
+            {button}
+        </Tooltip>
     );
 };
 

--- a/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
@@ -10,7 +10,7 @@ import { SEARCH_RESULTS_BROWSE_SIDEBAR_ID } from '../../onboarding/config/Search
 
 const Sidebar = styled.div<{ visible: boolean; width: number }>`
     height: 100%;
-    width: ${(props) => (props.visible ? `${props.width}px` : '0px')};
+    width: ${(props) => (props.visible ? `${props.width}px` : '0')};
     transition: width 250ms ease-in-out;
     border-right: 1px solid ${(props) => props.theme.styles['border-color-base']};
     background-color: #f8f9fa;

--- a/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
@@ -10,7 +10,7 @@ import { SEARCH_RESULTS_BROWSE_SIDEBAR_ID } from '../../onboarding/config/Search
 
 const Sidebar = styled.div<{ visible: boolean; width: number }>`
     height: 100%;
-    width: ${(props) => (props.visible ? `${props.width}px` : '0')};
+    width: ${(props) => (props.visible ? `${props.width}px` : '0px')};
     transition: width 250ms ease-in-out;
     border-right: 1px solid ${(props) => props.theme.styles['border-color-base']};
     background-color: #f8f9fa;

--- a/datahub-web-react/src/app/search/useToggleSidebar.ts
+++ b/datahub-web-react/src/app/search/useToggleSidebar.ts
@@ -1,0 +1,23 @@
+import { EventType } from '../analytics';
+import analytics from '../analytics/analytics';
+import { useUserContext } from '../context/useUserContext';
+import useToggle from '../shared/useToggle';
+
+const useToggleSidebar = () => {
+    const { localState, updateLocalState } = useUserContext();
+
+    const { isOpen: isSidebarOpen, toggle: toggleSidebar } = useToggle({
+        initialValue: localState.showBrowseV2Sidebar ?? true,
+        onToggle: (isNowOpen: boolean) => {
+            analytics.event({
+                type: EventType.BrowseV2ToggleSidebarEvent,
+                action: isNowOpen ? 'open' : 'close',
+            });
+            updateLocalState({ ...localState, showBrowseV2Sidebar: isNowOpen });
+        },
+    });
+
+    return { isSidebarOpen, toggleSidebar } as const;
+};
+
+export default useToggleSidebar;

--- a/datahub-web-react/src/app/shared/useToggle.ts
+++ b/datahub-web-react/src/app/shared/useToggle.ts
@@ -2,25 +2,32 @@ import { useState } from 'react';
 
 const NOOP = (_: boolean) => {};
 
-const useToggle = ({ initialValue = false, closeDelay = 0, onToggle = NOOP } = {}) => {
+const useToggle = ({ initialValue = false, closeDelay = 0, openDelay = 0, onToggle = NOOP } = {}) => {
     const [isOpen, setIsOpen] = useState<boolean>(initialValue);
-    const [isClosing, setIsClosing] = useState(false);
+    const [transition, setTransition] = useState<'opening' | 'closing' | null>(null);
+    const isOpening = transition === 'opening';
+    const isClosing = transition === 'closing';
+    const isTransitioning = transition !== null;
 
     const toggle = () => {
         if (isOpen) {
-            setIsClosing(true);
+            setTransition('closing');
             window.setTimeout(() => {
                 setIsOpen(false);
+                setTransition(null);
                 onToggle(false);
             }, closeDelay);
         } else {
-            setIsClosing(false);
-            setIsOpen(true);
-            onToggle(true);
+            setTransition('opening');
+            window.setTimeout(() => {
+                setIsOpen(true);
+                setTransition(null);
+                onToggle(true);
+            }, openDelay);
         }
     };
 
-    return { isOpen, isClosing, toggle } as const;
+    return { isOpen, isClosing, isOpening, isTransitioning, toggle } as const;
 };
 
 export default useToggle;

--- a/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
@@ -36,7 +36,7 @@ describe("search", () => {
     cy.get("[data-testid=browse-v2").should("not.exist");
   });
 
-  it("should hide the hide and show when the toggle button is clicked", () => {
+  it("should hide and show the sidebar when the toggle button is clicked", () => {
     setBrowseFeatureFlag(true);
     cy.login();
     cy.visit("/");

--- a/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
@@ -36,6 +36,25 @@ describe("search", () => {
     cy.get("[data-testid=browse-v2").should("not.exist");
   });
 
+  it("should hide the hide and show when the toggle button is clicked", () => {
+    setBrowseFeatureFlag(true);
+    cy.login();
+    cy.visit("/");
+    cy.get("input[data-testid=search-input]").type("*{enter}");
+
+    cy.get("[data-testid=browse-v2")
+      .invoke("css", "width")
+      .should("match", /\d\d\dpx/);
+    cy.get("[data-testid=browse-v2-toggle").click();
+    cy.get("[data-testid=browse-v2")
+      .invoke("css", "width")
+      .should("match", /0px/);
+    cy.get("[data-testid=browse-v2-toggle").click();
+    cy.get("[data-testid=browse-v2")
+      .invoke("css", "width")
+      .should("match", /\d\d\dpx/);
+  });
+
   it("should take you to the old browse experience when clicking entity type on home page with the browse flag off", () => {
     setBrowseFeatureFlag(false);
     cy.login();

--- a/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
+++ b/smoke-test/tests/cypress/cypress/e2e/browse/browseV2.js
@@ -44,15 +44,31 @@ describe("search", () => {
 
     cy.get("[data-testid=browse-v2")
       .invoke("css", "width")
-      .should("match", /\d\d\dpx/);
+      .should("match", /^\d\d\dpx$/);
+
     cy.get("[data-testid=browse-v2-toggle").click();
+
     cy.get("[data-testid=browse-v2")
       .invoke("css", "width")
-      .should("match", /0px/);
-    cy.get("[data-testid=browse-v2-toggle").click();
+      .should("match", /^\dpx$/);
+
+    cy.reload();
+
     cy.get("[data-testid=browse-v2")
       .invoke("css", "width")
-      .should("match", /\d\d\dpx/);
+      .should("match", /^\dpx$/);
+
+    cy.get("[data-testid=browse-v2-toggle").click();
+
+    cy.get("[data-testid=browse-v2")
+      .invoke("css", "width")
+      .should("match", /^\d\d\dpx$/);
+
+    cy.reload();
+
+    cy.get("[data-testid=browse-v2")
+      .invoke("css", "width")
+      .should("match", /^\d\d\dpx$/);
   });
 
   it("should take you to the old browse experience when clicking entity type on home page with the browse flag off", () => {


### PR DESCRIPTION
The sidebar now remembers whether you had previously opened or closed it. Per device via localStorage. Tooltip is now added on the toggle button.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
