### PR TITLE
fix(ui) Fix UI issues with self-referencing column level lineage

### DIFF
--- a/datahub-web-react/src/app/lineage/utils/columnLineageUtils.ts
+++ b/datahub-web-react/src/app/lineage/utils/columnLineageUtils.ts
@@ -127,6 +127,21 @@ export function encodeSchemaField(fieldPath: string) {
 export function getSourceUrnFromSchemaFieldUrn(schemaFieldUrn: string) {
     return schemaFieldUrn.replace('urn:li:schemaField:(', '').split(')')[0].concat(')');
 }
+
 export function getFieldPathFromSchemaFieldUrn(schemaFieldUrn: string) {
     return decodeSchemaField(schemaFieldUrn.replace('urn:li:schemaField:(', '').split(')')[1].replace(',', ''));
+}
+
+export function isSameColumn({
+    sourceUrn,
+    targetUrn,
+    sourceField,
+    targetField,
+}: {
+    sourceUrn: string;
+    targetUrn: string;
+    sourceField: string;
+    targetField: string;
+}) {
+    return sourceUrn === targetUrn && sourceField === targetField;
 }

--- a/datahub-web-react/src/app/lineage/utils/extendAsyncEntities.ts
+++ b/datahub-web-react/src/app/lineage/utils/extendAsyncEntities.ts
@@ -5,6 +5,7 @@ import {
     decodeSchemaField,
     getFieldPathFromSchemaFieldUrn,
     getSourceUrnFromSchemaFieldUrn,
+    isSameColumn,
 } from './columnLineageUtils';
 
 const breakFieldUrn = (ref: SchemaFieldRef) => {
@@ -21,6 +22,17 @@ function updateFineGrainedMap(
     downstreamEntityUrn: string,
     downstreamField: string,
 ) {
+    // ignore self-referential CLL fields
+    if (
+        isSameColumn({
+            sourceUrn: upstreamEntityUrn,
+            targetUrn: downstreamEntityUrn,
+            sourceField: upstreamField,
+            targetField: downstreamField,
+        })
+    ) {
+        return;
+    }
     const mapForUrn = fineGrainedMap.forward[upstreamEntityUrn] || {};
     const mapForField = mapForUrn[upstreamField] || {};
     const listForDownstream = [...(mapForField[downstreamEntityUrn] || [])];

--- a/datahub-web-react/src/app/lineage/utils/highlightColumnLineage.ts
+++ b/datahub-web-react/src/app/lineage/utils/highlightColumnLineage.ts
@@ -1,4 +1,5 @@
 import { ColumnEdge } from '../types';
+import { isSameColumn } from './columnLineageUtils';
 
 function highlightDownstreamColumnLineage(
     sourceField: string,
@@ -12,7 +13,9 @@ function highlightDownstreamColumnLineage(
             const [targetUrn, fieldPaths] = entry;
             (fieldPaths as string[]).forEach((targetField) => {
                 edges.push({ sourceUrn, sourceField, targetUrn, targetField });
-                highlightDownstreamColumnLineage(targetField, targetUrn, edges, fineGrainedMap);
+                if (!isSameColumn({ sourceUrn, targetUrn, sourceField, targetField })) {
+                    highlightDownstreamColumnLineage(targetField, targetUrn, edges, fineGrainedMap);
+                }
             });
         });
     }
@@ -30,7 +33,9 @@ function highlightUpstreamColumnLineage(
             const [sourceUrn, fieldPaths] = entry;
             (fieldPaths as string[]).forEach((sourceField) => {
                 edges.push({ targetUrn, targetField, sourceUrn, sourceField });
-                highlightUpstreamColumnLineage(sourceField, sourceUrn, edges, fineGrainedMap);
+                if (!isSameColumn({ sourceUrn, targetUrn, sourceField, targetField })) {
+                    highlightUpstreamColumnLineage(sourceField, sourceUrn, edges, fineGrainedMap);
+                }
             });
         });
     }


### PR DESCRIPTION
If you have columns on a dataset that you set as self-referencing with column level lineage, we try to draw an arrow from the column to itself, but it looks off in the UI. A safer bet is to simply not try and draw that edge in the first place. Also, this self referencing would cause a call-stack issue with a recursive function we have, so this PR protects against that in case we somehow start showing self-referencing CLL again.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
