### PR TITLE
fix(ingestion) Fixes producing MAE events with browsePathsV2 aspect

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/ChartAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/ChartAspect.pdl
@@ -8,6 +8,7 @@ import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.DataPlatformInstance
 import com.linkedin.common.GlossaryTerms
 import com.linkedin.common.InstitutionalMemory
@@ -26,5 +27,6 @@ typeref ChartAspect = union[
   BrowsePaths,
   GlossaryTerms,
   InstitutionalMemory,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DashboardAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DashboardAspect.pdl
@@ -7,6 +7,7 @@ import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.DataPlatformInstance
 import com.linkedin.common.GlossaryTerms
 import com.linkedin.common.InstitutionalMemory
@@ -24,5 +25,6 @@ typeref DashboardAspect = union[
   BrowsePaths,
   GlossaryTerms,
   InstitutionalMemory,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataFlowAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataFlowAspect.pdl
@@ -7,6 +7,7 @@ import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.DataPlatformInstance
 import com.linkedin.common.GlossaryTerms
 import com.linkedin.common.InstitutionalMemory
@@ -24,5 +25,6 @@ typeref DataFlowAspect = union[
   BrowsePaths,
   GlossaryTerms,
   InstitutionalMemory,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataJobAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataJobAspect.pdl
@@ -8,6 +8,7 @@ import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.DataPlatformInstance
 import com.linkedin.common.GlossaryTerms
 import com.linkedin.common.InstitutionalMemory
@@ -26,5 +27,6 @@ typeref DataJobAspect = union[
   BrowsePaths,
   GlossaryTerms,
   InstitutionalMemory,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DatasetAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DatasetAspect.pdl
@@ -15,6 +15,7 @@ import com.linkedin.common.Status
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.GlossaryTerms
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.DataPlatformInstance
 
 /**
@@ -36,5 +37,6 @@ typeref DatasetAspect = union[
   GlossaryTerms,
   BrowsePaths,
   DataPlatformInstance,
-  ViewProperties
+  ViewProperties,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLFeatureAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLFeatureAspect.pdl
@@ -7,6 +7,7 @@ import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.Deprecation
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.DataPlatformInstance
 
@@ -22,5 +23,6 @@ typeref MLFeatureAspect = union[
   Deprecation,
   BrowsePaths,
   GlobalTags,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLFeatureTableAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLFeatureTableAspect.pdl
@@ -7,6 +7,7 @@ import com.linkedin.common.Status
 import com.linkedin.ml.metadata.MLFeatureTableProperties
 import com.linkedin.common.Deprecation
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.DataPlatformInstance
 
@@ -22,5 +23,6 @@ typeref MLFeatureTableAspect = union[
   Deprecation,
   BrowsePaths,
   GlobalTags,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLModelAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLModelAspect.pdl
@@ -17,6 +17,7 @@ import com.linkedin.common.Status
 import com.linkedin.common.Cost
 import com.linkedin.common.Deprecation
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.DataPlatformInstance
 
@@ -42,5 +43,6 @@ typeref MLModelAspect = union[
   Deprecation,
   BrowsePaths,
   GlobalTags,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLModelGroupAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/MLModelGroupAspect.pdl
@@ -6,6 +6,7 @@ import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 import com.linkedin.common.Deprecation
 import com.linkedin.common.BrowsePaths
+import com.linkedin.common.BrowsePathsV2
 import com.linkedin.common.GlobalTags
 import com.linkedin.common.DataPlatformInstance
 
@@ -20,5 +21,6 @@ typeref MLModelGroupAspect = union[
   Deprecation,
   BrowsePaths,
   GlobalTags,
-  DataPlatformInstance
+  DataPlatformInstance,
+  BrowsePathsV2
 ]

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -381,6 +381,21 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "BrowsePathEntry",
+    "namespace" : "com.linkedin.common",
+    "doc" : "Represents a single level in an entity's browsePathV2",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "string",
+      "doc" : "The ID of the browse path entry. This is what gets stored in the index.\nIf there's an urn associated with this entry, id and urn will be the same"
+    }, {
+      "name" : "urn",
+      "type" : "Urn",
+      "doc" : "Optional urn pointing to some entity in DataHub",
+      "optional" : true
+    } ]
+  }, {
+    "type" : "record",
     "name" : "BrowsePaths",
     "namespace" : "com.linkedin.common",
     "doc" : "Shared aspect containing Browse Paths to be indexed for an entity.",
@@ -400,6 +415,28 @@
     } ],
     "Aspect" : {
       "name" : "browsePaths"
+    }
+  }, {
+    "type" : "record",
+    "name" : "BrowsePathsV2",
+    "namespace" : "com.linkedin.common",
+    "doc" : "Shared aspect containing a Browse Path to be indexed for an entity.",
+    "fields" : [ {
+      "name" : "path",
+      "type" : {
+        "type" : "array",
+        "items" : "BrowsePathEntry"
+      },
+      "doc" : "A valid browse path for the entity. This field is provided by DataHub by default.\nThis aspect is a newer version of browsePaths where we can encode more information in the path.\nThis path is also based on containers for a given entity if it has containers.\n\nThis is stored in elasticsearch as unit-separator delimited strings and only includes platform specific folders or containers.\nThese paths should not include high level info captured elsewhere ie. Platform and Environment.",
+      "Searchable" : {
+        "/*/id" : {
+          "fieldName" : "browsePathV2",
+          "fieldType" : "BROWSE_PATH_V2"
+        }
+      }
+    } ],
+    "Aspect" : {
+      "name" : "browsePathsV2"
     }
   }, "com.linkedin.common.ChangeAuditStamps", {
     "type" : "typeref",
@@ -2342,7 +2379,7 @@
                   "Aspect" : {
                     "name" : "chartKey"
                   }
-                }, "com.linkedin.chart.ChartInfo", "com.linkedin.chart.ChartQuery", "com.linkedin.chart.EditableChartProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.chart.ChartInfo", "com.linkedin.chart.ChartQuery", "com.linkedin.chart.EditableChartProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the chart. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -2789,7 +2826,7 @@
                   "Aspect" : {
                     "name" : "dashboardKey"
                   }
-                }, "com.linkedin.dashboard.DashboardInfo", "com.linkedin.dashboard.EditableDashboardProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.dashboard.DashboardInfo", "com.linkedin.dashboard.EditableDashboardProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the dashboard. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -2846,7 +2883,7 @@
                   "Aspect" : {
                     "name" : "dataFlowKey"
                   }
-                }, "com.linkedin.datajob.DataFlowInfo", "com.linkedin.datajob.EditableDataFlowProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.datajob.DataFlowInfo", "com.linkedin.datajob.EditableDataFlowProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the data flow. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -2902,7 +2939,7 @@
                   "Aspect" : {
                     "name" : "dataJobKey"
                   }
-                }, "com.linkedin.datajob.DataJobInfo", "com.linkedin.datajob.DataJobInputOutput", "com.linkedin.datajob.EditableDataJobProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.datajob.DataJobInfo", "com.linkedin.datajob.DataJobInputOutput", "com.linkedin.datajob.EditableDataJobProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the data job. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -3524,7 +3561,7 @@
                   "Aspect" : {
                     "name" : "editableSchemaMetadata"
                   }
-                }, "com.linkedin.common.GlobalTags", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.BrowsePaths", "com.linkedin.common.DataPlatformInstance", "com.linkedin.dataset.ViewProperties" ]
+                }, "com.linkedin.common.GlobalTags", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.BrowsePaths", "com.linkedin.common.DataPlatformInstance", "com.linkedin.dataset.ViewProperties", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the dataset. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4221,7 +4258,7 @@
                   "Aspect" : {
                     "name" : "sourceCode"
                   }
-                }, "com.linkedin.common.Status", "com.linkedin.common.Cost", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Status", "com.linkedin.common.Cost", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLModel. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4402,7 +4439,7 @@
                   "Aspect" : {
                     "name" : "mlFeatureProperties"
                   }
-                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLFeature. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4512,7 +4549,7 @@
                   "Aspect" : {
                     "name" : "mlFeatureTableProperties"
                   }
-                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLFeatureTable. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4702,7 +4739,7 @@
                   "Aspect" : {
                     "name" : "mlModelGroupProperties"
                   }
-                }, "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLModelGroup. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -5646,7 +5683,7 @@
     }, {
       "name" : "maxAggValues",
       "type" : "int",
-      "doc" : "The maximum number of values in an facet aggregation",
+      "doc" : "The maximum number of values in a facet aggregation",
       "default" : 20
     }, {
       "name" : "fulltext",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -381,6 +381,21 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "BrowsePathEntry",
+    "namespace" : "com.linkedin.common",
+    "doc" : "Represents a single level in an entity's browsePathV2",
+    "fields" : [ {
+      "name" : "id",
+      "type" : "string",
+      "doc" : "The ID of the browse path entry. This is what gets stored in the index.\nIf there's an urn associated with this entry, id and urn will be the same"
+    }, {
+      "name" : "urn",
+      "type" : "Urn",
+      "doc" : "Optional urn pointing to some entity in DataHub",
+      "optional" : true
+    } ]
+  }, {
+    "type" : "record",
     "name" : "BrowsePaths",
     "namespace" : "com.linkedin.common",
     "doc" : "Shared aspect containing Browse Paths to be indexed for an entity.",
@@ -400,6 +415,28 @@
     } ],
     "Aspect" : {
       "name" : "browsePaths"
+    }
+  }, {
+    "type" : "record",
+    "name" : "BrowsePathsV2",
+    "namespace" : "com.linkedin.common",
+    "doc" : "Shared aspect containing a Browse Path to be indexed for an entity.",
+    "fields" : [ {
+      "name" : "path",
+      "type" : {
+        "type" : "array",
+        "items" : "BrowsePathEntry"
+      },
+      "doc" : "A valid browse path for the entity. This field is provided by DataHub by default.\nThis aspect is a newer version of browsePaths where we can encode more information in the path.\nThis path is also based on containers for a given entity if it has containers.\n\nThis is stored in elasticsearch as unit-separator delimited strings and only includes platform specific folders or containers.\nThese paths should not include high level info captured elsewhere ie. Platform and Environment.",
+      "Searchable" : {
+        "/*/id" : {
+          "fieldName" : "browsePathV2",
+          "fieldType" : "BROWSE_PATH_V2"
+        }
+      }
+    } ],
+    "Aspect" : {
+      "name" : "browsePathsV2"
     }
   }, "com.linkedin.common.ChangeAuditStamps", {
     "type" : "typeref",
@@ -2336,7 +2373,7 @@
                   "Aspect" : {
                     "name" : "chartKey"
                   }
-                }, "com.linkedin.chart.ChartInfo", "com.linkedin.chart.ChartQuery", "com.linkedin.chart.EditableChartProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.chart.ChartInfo", "com.linkedin.chart.ChartQuery", "com.linkedin.chart.EditableChartProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the chart. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -2783,7 +2820,7 @@
                   "Aspect" : {
                     "name" : "dashboardKey"
                   }
-                }, "com.linkedin.dashboard.DashboardInfo", "com.linkedin.dashboard.EditableDashboardProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.dashboard.DashboardInfo", "com.linkedin.dashboard.EditableDashboardProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the dashboard. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -2840,7 +2877,7 @@
                   "Aspect" : {
                     "name" : "dataFlowKey"
                   }
-                }, "com.linkedin.datajob.DataFlowInfo", "com.linkedin.datajob.EditableDataFlowProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.datajob.DataFlowInfo", "com.linkedin.datajob.EditableDataFlowProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the data flow. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -2896,7 +2933,7 @@
                   "Aspect" : {
                     "name" : "dataJobKey"
                   }
-                }, "com.linkedin.datajob.DataJobInfo", "com.linkedin.datajob.DataJobInputOutput", "com.linkedin.datajob.EditableDataJobProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.datajob.DataJobInfo", "com.linkedin.datajob.DataJobInputOutput", "com.linkedin.datajob.EditableDataJobProperties", "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.GlobalTags", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the data job. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -3518,7 +3555,7 @@
                   "Aspect" : {
                     "name" : "editableSchemaMetadata"
                   }
-                }, "com.linkedin.common.GlobalTags", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.BrowsePaths", "com.linkedin.common.DataPlatformInstance", "com.linkedin.dataset.ViewProperties" ]
+                }, "com.linkedin.common.GlobalTags", "com.linkedin.common.GlossaryTerms", "com.linkedin.common.BrowsePaths", "com.linkedin.common.DataPlatformInstance", "com.linkedin.dataset.ViewProperties", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the dataset. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4215,7 +4252,7 @@
                   "Aspect" : {
                     "name" : "sourceCode"
                   }
-                }, "com.linkedin.common.Status", "com.linkedin.common.Cost", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Status", "com.linkedin.common.Cost", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLModel. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4396,7 +4433,7 @@
                   "Aspect" : {
                     "name" : "mlFeatureProperties"
                   }
-                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLFeature. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4506,7 +4543,7 @@
                   "Aspect" : {
                     "name" : "mlFeatureTableProperties"
                   }
-                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Ownership", "com.linkedin.common.InstitutionalMemory", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLFeatureTable. Depending on the use case, this can either be all, or a selection, of supported aspects."
@@ -4696,7 +4733,7 @@
                   "Aspect" : {
                     "name" : "mlModelGroupProperties"
                   }
-                }, "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance" ]
+                }, "com.linkedin.common.Ownership", "com.linkedin.common.Status", "com.linkedin.common.Deprecation", "com.linkedin.common.BrowsePaths", "com.linkedin.common.GlobalTags", "com.linkedin.common.DataPlatformInstance", "com.linkedin.common.BrowsePathsV2" ]
               }
             },
             "doc" : "The list of metadata aspects associated with the MLModelGroup. Depending on the use case, this can either be all, or a selection, of supported aspects."


### PR DESCRIPTION
We were seeing error logs in GMS when ingesting data that included browsePathsV2 when we tried to produce MAE events. This is because browse pathsV2 are not in any entity snapshots. In order to reduce noise, this PR simply adds that aspect to relevant entity snapshots.

Ingestion would still successfully run anyways as this is a legacy thing, but we want to prevent unnecessary noise for now.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
