### PR TITLE
Container link in browse v2 sidebar

### DIFF
--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -23,7 +23,7 @@ export enum EventType {
     BrowseV2ToggleSidebarEvent,
     BrowseV2ToggleNodeEvent,
     BrowseV2SelectNodeEvent,
-    BrowseV2ContainerLinkClickEvent,
+    BrowseV2EntityLinkClickEvent,
     EntityViewEvent,
     EntitySectionViewEvent,
     EntityActionEvent,
@@ -256,8 +256,9 @@ export interface BrowseV2SelectNodeEvent extends BaseEvent {
 /**
  * Logged when a user clicks a container link in the sidebar
  */
-export interface BrowseV2ContainerLinkClickEvent extends BaseEvent {
-    type: EventType.BrowseV2ContainerLinkClickEvent;
+export interface BrowseV2EntityLinkClickEvent extends BaseEvent {
+    type: EventType.BrowseV2EntityLinkClickEvent;
+    targetNode: 'browse';
     entity: string;
     environment?: string;
     platform?: string;
@@ -625,7 +626,7 @@ export type Event =
     | BrowseV2ToggleSidebarEvent
     | BrowseV2ToggleNodeEvent
     | BrowseV2SelectNodeEvent
-    | BrowseV2ContainerLinkClickEvent
+    | BrowseV2EntityLinkClickEvent
     | EntityViewEvent
     | EntitySectionViewEvent
     | EntityActionEvent

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -23,7 +23,7 @@ export enum EventType {
     BrowseV2ToggleSidebarEvent,
     BrowseV2ToggleNodeEvent,
     BrowseV2SelectNodeEvent,
-    BrowseV2ClickContainerLinkEvent,
+    BrowseV2ContainerLinkClickEvent,
     EntityViewEvent,
     EntitySectionViewEvent,
     EntityActionEvent,
@@ -256,8 +256,8 @@ export interface BrowseV2SelectNodeEvent extends BaseEvent {
 /**
  * Logged when a user clicks a container link in the sidebar
  */
-export interface BrowseV2ClickContainerLinkEvent extends BaseEvent {
-    type: EventType.BrowseV2ClickContainerLinkEvent;
+export interface BrowseV2ContainerLinkClickEvent extends BaseEvent {
+    type: EventType.BrowseV2ContainerLinkClickEvent;
     entity: string;
     environment?: string;
     platform?: string;
@@ -625,7 +625,7 @@ export type Event =
     | BrowseV2ToggleSidebarEvent
     | BrowseV2ToggleNodeEvent
     | BrowseV2SelectNodeEvent
-    | BrowseV2ClickContainerLinkEvent
+    | BrowseV2ContainerLinkClickEvent
     | EntityViewEvent
     | EntitySectionViewEvent
     | EntityActionEvent

--- a/datahub-web-react/src/app/analytics/event.ts
+++ b/datahub-web-react/src/app/analytics/event.ts
@@ -23,6 +23,7 @@ export enum EventType {
     BrowseV2ToggleSidebarEvent,
     BrowseV2ToggleNodeEvent,
     BrowseV2SelectNodeEvent,
+    BrowseV2ClickContainerLinkEvent,
     EntityViewEvent,
     EntitySectionViewEvent,
     EntityActionEvent,
@@ -246,6 +247,17 @@ export interface BrowseV2SelectNodeEvent extends BaseEvent {
     type: EventType.BrowseV2SelectNodeEvent;
     targetNode: 'browse';
     action: 'select' | 'deselect';
+    entity: string;
+    environment?: string;
+    platform?: string;
+    targetDepth: number;
+}
+
+/**
+ * Logged when a user clicks a container link in the sidebar
+ */
+export interface BrowseV2ClickContainerLinkEvent extends BaseEvent {
+    type: EventType.BrowseV2ClickContainerLinkEvent;
     entity: string;
     environment?: string;
     platform?: string;
@@ -613,6 +625,7 @@ export type Event =
     | BrowseV2ToggleSidebarEvent
     | BrowseV2ToggleNodeEvent
     | BrowseV2SelectNodeEvent
+    | BrowseV2ClickContainerLinkEvent
     | EntityViewEvent
     | EntitySectionViewEvent
     | EntityActionEvent

--- a/datahub-web-react/src/app/context/userContext.tsx
+++ b/datahub-web-react/src/app/context/userContext.tsx
@@ -8,7 +8,7 @@ export type LocalState = {
     selectedViewUrn?: string | null;
     selectedPath?: string | null;
     selectedSearch?: string | null;
-    showBrowseV2Sidebar?: boolean | null;
+    showBrowseV2Sidebar?: boolean;
 };
 
 /**

--- a/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
+++ b/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
@@ -40,7 +40,7 @@ const ToggleSidebarButton = ({ isOpen, onClick }: Props) => {
     if (pauseTooltip) return button;
 
     return (
-        <Tooltip title={title} placement={placement} arrowPointAtCenter>
+        <Tooltip title={title} placement={placement} arrowPointAtCenter mouseEnterDelay={2}>
             {button}
         </Tooltip>
     );

--- a/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
+++ b/datahub-web-react/src/app/search/ToggleSidebarButton.tsx
@@ -40,7 +40,7 @@ const ToggleSidebarButton = ({ isOpen, onClick }: Props) => {
     if (pauseTooltip) return button;
 
     return (
-        <Tooltip title={title} placement={placement} arrowPointAtCenter mouseEnterDelay={2}>
+        <Tooltip title={title} placement={placement} arrowPointAtCenter mouseEnterDelay={1}>
             {button}
         </Tooltip>
     );

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -31,6 +31,7 @@ const FolderStyled = styled(FolderOutlined)`
 const Count = styled(Typography.Text)`
     font-size: 12px;
     color: ${(props) => props.color};
+    padding-right: 2px;
 `;
 
 const BrowseNode = () => {
@@ -97,6 +98,7 @@ const BrowseNode = () => {
                             size={14}
                             depth={browsePathLength}
                             maxWidth={isContainer ? 175 : 200}
+                            padLeft
                         >
                             {/* {displayName} {displayName} {displayName} {displayName} {displayName} {displayName}{' '}
                             {displayName} {displayName} {displayName}{' '} */}

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Tooltip, Typography } from 'antd';
+import { Typography } from 'antd';
 import { FolderOutlined } from '@ant-design/icons';
-import Icon from '@ant-design/icons/lib/components/Icon';
 import { useHistory } from 'react-router';
 import { formatNumber } from '../../shared/formatNumber';
 import ExpandableNode from './ExpandableNode';
@@ -23,21 +22,8 @@ import {
 } from './BrowseContext';
 import useSidebarAnalytics from './useSidebarAnalytics';
 import { EntityType } from '../../../types.generated';
-import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
 import { useEntityRegistry } from '../../useEntityRegistry';
-
-// todo - move this back into ExpandableNode if it makes sense
-const SelectableHeader = styled(ExpandableNode.Header)<{ isSelected: boolean }>`
-    & {
-        border: 1px solid ${(props) => (props.isSelected ? props.theme.styles['primary-color'] : 'transparent')};
-        background-color: ${(props) => (props.isSelected ? props.theme.styles['primary-color-light'] : 'transparent')};
-        border-radius: 8px;
-    }
-
-    &:hover {
-        background-color: ${(props) => props.theme.styles['primary-color-light']};
-    }
-`;
+import ContainerLink from './ContainerLink';
 
 const FolderStyled = styled(FolderOutlined)`
     font-size: 16px;
@@ -47,16 +33,6 @@ const FolderStyled = styled(FolderOutlined)`
 const Count = styled(Typography.Text)`
     font-size: 12px;
     color: ${(props) => props.color};
-`;
-
-const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
-    && {
-        color: ${(props) => props.theme.styles['primary-color']};
-        ${(props) => !props.isSelected && 'display: none;'}
-        ${SelectableHeader}:hover & {
-            display: inherit;
-        }
-    }
 `;
 
 const BrowseNode = () => {
@@ -107,11 +83,13 @@ const BrowseNode = () => {
 
     const color = '#000';
 
+    // todo - maybe show the full container, but then when we hover over the header, we slide the text over to make room for the container?
+
     return (
         <ExpandableNode
             isOpen={isOpen && !isClosing && loaded}
             header={
-                <SelectableHeader
+                <ExpandableNode.SelectableHeader
                     isOpen={isOpen}
                     isSelected={isBrowsePathSelected}
                     onClick={onClickBrowseHeader}
@@ -125,26 +103,20 @@ const BrowseNode = () => {
                             dataTestId={`browse-node-expand-${displayName}`}
                         />
                         <FolderStyled />
-                        <ExpandableNode.Title color={color} size={14} depth={browsePathLength}>
-                            {displayName} {displayName} {displayName} {displayName} {displayName} {displayName}{' '}
-                            {displayName} {displayName} {displayName}{' '}
+                        <ExpandableNode.Title
+                            color={color}
+                            size={14}
+                            depth={browsePathLength}
+                            maxWidth={isContainer ? 175 : 200}
+                        >
+                            {/* {displayName} {displayName} {displayName} {displayName} {displayName} {displayName}{' '}
+                            {displayName} {displayName} {displayName}{' '} */}
+                            {displayName}
                         </ExpandableNode.Title>
-                        {isContainer && (
-                            <Tooltip placement="top" title={`view ${displayName} profile`}>
-                                <ExpandableNode.StaticButton
-                                    icon={
-                                        <ContainerIcon
-                                            isSelected={isBrowsePathSelected}
-                                            component={ExternalLink}
-                                            onClick={onClickContainerButton}
-                                        />
-                                    }
-                                />
-                            </Tooltip>
-                        )}
+                        {isContainer && <ContainerLink onClick={onClickContainerButton} />}
                     </ExpandableNode.HeaderLeft>
                     <Count color={color}>{formatNumber(987654321)}</Count>
-                </SelectableHeader>
+                </ExpandableNode.SelectableHeader>
             }
             body={
                 <ExpandableNode.Body>

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -20,8 +20,7 @@ import {
     useBrowseDisplayName,
 } from './BrowseContext';
 import useSidebarAnalytics from './useSidebarAnalytics';
-import { EntityType } from '../../../types.generated';
-import ContainerLink from './ContainerLink';
+import EntityLink from './EntityLink';
 
 const FolderStyled = styled(FolderOutlined)`
     font-size: 16px;
@@ -44,10 +43,9 @@ const BrowseNode = () => {
     const browseResultGroup = useBrowseResultGroup();
     const { trackToggleNodeEvent } = useSidebarAnalytics();
     const { count, entity } = browseResultGroup;
+    const hasEntityLink = !!entity;
     const displayName = useBrowseDisplayName();
     const { trackSelectNodeEvent } = useSidebarAnalytics();
-
-    const isContainer = entity?.type === EntityType.Container;
 
     const { isOpen, isClosing, toggle } = useToggle({
         initialValue: isBrowsePathPrefix && !isBrowsePathSelected,
@@ -95,12 +93,12 @@ const BrowseNode = () => {
                             color={color}
                             size={14}
                             depth={browsePathLength}
-                            maxWidth={isContainer ? 175 : 200}
+                            maxWidth={hasEntityLink ? 175 : 200}
                             padLeft
                         >
                             {displayName}
                         </ExpandableNode.Title>
-                        {isContainer && <ContainerLink entity={entity} />}
+                        {hasEntityLink && <EntityLink entity={entity} targetNode="browse" />}
                     </ExpandableNode.HeaderLeft>
                     <Count color={color}>{formatNumber(count)}</Count>
                 </ExpandableNode.SelectableHeader>

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Typography } from 'antd';
+import { Tooltip, Typography } from 'antd';
 import { FolderOutlined } from '@ant-design/icons';
+import Icon from '@ant-design/icons/lib/components/Icon';
+import { useHistory } from 'react-router';
 import { formatNumber } from '../../shared/formatNumber';
 import ExpandableNode from './ExpandableNode';
 import useBrowsePagination from './useBrowsePagination';
@@ -20,6 +22,22 @@ import {
     useBrowseDisplayName,
 } from './BrowseContext';
 import useSidebarAnalytics from './useSidebarAnalytics';
+import { EntityType } from '../../../types.generated';
+import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
+import { useEntityRegistry } from '../../useEntityRegistry';
+
+// todo - move this back into ExpandableNode if it makes sense
+const SelectableHeader = styled(ExpandableNode.Header)<{ isSelected: boolean }>`
+    & {
+        border: 1px solid ${(props) => (props.isSelected ? props.theme.styles['primary-color'] : 'transparent')};
+        background-color: ${(props) => (props.isSelected ? props.theme.styles['primary-color-light'] : 'transparent')};
+        border-radius: 8px;
+    }
+
+    &:hover {
+        background-color: ${(props) => props.theme.styles['primary-color-light']};
+    }
+`;
 
 const FolderStyled = styled(FolderOutlined)`
     font-size: 16px;
@@ -31,7 +49,19 @@ const Count = styled(Typography.Text)`
     color: ${(props) => props.color};
 `;
 
+const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
+    && {
+        color: ${(props) => props.theme.styles['primary-color']};
+        ${(props) => !props.isSelected && 'display: none;'}
+        ${SelectableHeader}:hover & {
+            display: inherit;
+        }
+    }
+`;
+
 const BrowseNode = () => {
+    const registry = useEntityRegistry();
+    const history = useHistory();
     const isBrowsePathPrefix = useIsBrowsePathPrefix();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const onSelectBrowsePath = useOnSelectBrowsePath();
@@ -43,6 +73,8 @@ const BrowseNode = () => {
     const { count } = browseResultGroup;
     const displayName = useBrowseDisplayName();
     const { trackSelectNodeEvent } = useSidebarAnalytics();
+
+    const isContainer = browseResultGroup.entity?.type === EntityType.Container;
 
     const { isOpen, isClosing, toggle } = useToggle({
         initialValue: isBrowsePathPrefix && !isBrowsePathSelected,
@@ -60,6 +92,13 @@ const BrowseNode = () => {
         trackSelectNodeEvent(isNowSelected ? 'select' : 'deselect', 'browse');
     };
 
+    const onClickContainerButton = () => {
+        const { entity } = browseResultGroup;
+        if (!entity) return;
+        const containerUrl = registry.getEntityUrl(entity.type, entity.urn);
+        history.push(containerUrl);
+    };
+
     const { error, groups, loaded, observable, path, refetch } = useBrowsePagination({
         skip: !isOpen || !browseResultGroup.hasSubGroups,
     });
@@ -72,7 +111,7 @@ const BrowseNode = () => {
         <ExpandableNode
             isOpen={isOpen && !isClosing && loaded}
             header={
-                <ExpandableNode.SelectableHeader
+                <SelectableHeader
                     isOpen={isOpen}
                     isSelected={isBrowsePathSelected}
                     onClick={onClickBrowseHeader}
@@ -87,11 +126,25 @@ const BrowseNode = () => {
                         />
                         <FolderStyled />
                         <ExpandableNode.Title color={color} size={14} depth={browsePathLength}>
-                            {displayName}
+                            {displayName} {displayName} {displayName} {displayName} {displayName} {displayName}{' '}
+                            {displayName} {displayName} {displayName}{' '}
                         </ExpandableNode.Title>
+                        {isContainer && (
+                            <Tooltip placement="top" title={`view ${displayName} profile`}>
+                                <ExpandableNode.StaticButton
+                                    icon={
+                                        <ContainerIcon
+                                            isSelected={isBrowsePathSelected}
+                                            component={ExternalLink}
+                                            onClick={onClickContainerButton}
+                                        />
+                                    }
+                                />
+                            </Tooltip>
+                        )}
                     </ExpandableNode.HeaderLeft>
-                    <Count color={color}>{formatNumber(count)}</Count>
-                </ExpandableNode.SelectableHeader>
+                    <Count color={color}>{formatNumber(987654321)}</Count>
+                </SelectableHeader>
             }
             body={
                 <ExpandableNode.Body>

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -102,7 +102,7 @@ const BrowseNode = () => {
                         </ExpandableNode.Title>
                         {isContainer && <ContainerLink entity={entity} />}
                     </ExpandableNode.HeaderLeft>
-                    <Count color={color}>{formatNumber(987654321)}</Count>
+                    <Count color={color}>{formatNumber(count)}</Count>
                 </ExpandableNode.SelectableHeader>
             }
             body={

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -73,8 +73,6 @@ const BrowseNode = () => {
 
     const color = '#000';
 
-    // todo - maybe show the full container, but then when we hover over the header, we slide the text over to make room for the container?
-
     return (
         <ExpandableNode
             isOpen={isOpen && !isClosing && loaded}
@@ -100,11 +98,9 @@ const BrowseNode = () => {
                             maxWidth={isContainer ? 175 : 200}
                             padLeft
                         >
-                            {/* {displayName} {displayName} {displayName} {displayName} {displayName} {displayName}{' '}
-                            {displayName} {displayName} {displayName}{' '} */}
                             {displayName}
                         </ExpandableNode.Title>
-                        {isContainer && entity && <ContainerLink entity={entity} />}
+                        {isContainer && <ContainerLink entity={entity} />}
                     </ExpandableNode.HeaderLeft>
                     <Count color={color}>{formatNumber(987654321)}</Count>
                 </ExpandableNode.SelectableHeader>

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { Typography } from 'antd';
 import { FolderOutlined } from '@ant-design/icons';
-import { useHistory } from 'react-router';
 import { formatNumber } from '../../shared/formatNumber';
 import ExpandableNode from './ExpandableNode';
 import useBrowsePagination from './useBrowsePagination';
@@ -22,7 +21,6 @@ import {
 } from './BrowseContext';
 import useSidebarAnalytics from './useSidebarAnalytics';
 import { EntityType } from '../../../types.generated';
-import { useEntityRegistry } from '../../useEntityRegistry';
 import ContainerLink from './ContainerLink';
 
 const FolderStyled = styled(FolderOutlined)`
@@ -36,8 +34,6 @@ const Count = styled(Typography.Text)`
 `;
 
 const BrowseNode = () => {
-    const registry = useEntityRegistry();
-    const history = useHistory();
     const isBrowsePathPrefix = useIsBrowsePathPrefix();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const onSelectBrowsePath = useOnSelectBrowsePath();
@@ -46,11 +42,11 @@ const BrowseNode = () => {
     const platformAggregation = usePlatformAggregation();
     const browseResultGroup = useBrowseResultGroup();
     const { trackToggleNodeEvent } = useSidebarAnalytics();
-    const { count } = browseResultGroup;
+    const { count, entity } = browseResultGroup;
     const displayName = useBrowseDisplayName();
     const { trackSelectNodeEvent } = useSidebarAnalytics();
 
-    const isContainer = browseResultGroup.entity?.type === EntityType.Container;
+    const isContainer = entity?.type === EntityType.Container;
 
     const { isOpen, isClosing, toggle } = useToggle({
         initialValue: isBrowsePathPrefix && !isBrowsePathSelected,
@@ -66,13 +62,6 @@ const BrowseNode = () => {
         const isNowSelected = !isBrowsePathSelected;
         onSelectBrowsePath(isNowSelected);
         trackSelectNodeEvent(isNowSelected ? 'select' : 'deselect', 'browse');
-    };
-
-    const onClickContainerButton = () => {
-        const { entity } = browseResultGroup;
-        if (!entity) return;
-        const containerUrl = registry.getEntityUrl(entity.type, entity.urn);
-        history.push(containerUrl);
     };
 
     const { error, groups, loaded, observable, path, refetch } = useBrowsePagination({
@@ -113,7 +102,7 @@ const BrowseNode = () => {
                             {displayName} {displayName} {displayName}{' '} */}
                             {displayName}
                         </ExpandableNode.Title>
-                        {isContainer && <ContainerLink onClick={onClickContainerButton} />}
+                        {isContainer && entity && <ContainerLink entity={entity} />}
                     </ExpandableNode.HeaderLeft>
                     <Count color={color}>{formatNumber(987654321)}</Count>
                 </ExpandableNode.SelectableHeader>

--- a/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
@@ -1,16 +1,15 @@
 import { Tooltip } from 'antd';
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Icon from '@ant-design/icons/lib/components/Icon';
-import { useHistory } from 'react-router';
 import { useBrowseDisplayName, useIsBrowsePathSelected } from './BrowseContext';
 import ExpandableNode from './ExpandableNode';
 import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
 import { useEntityRegistry } from '../../useEntityRegistry';
-import { Entity } from '../../../types.generated';
+import { Entity, Maybe } from '../../../types.generated';
 import useSidebarAnalytics from './useSidebarAnalytics';
 
-// todo - this hover rule feels a little weird
 const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
     && {
         color: ${(props) => props.theme.styles['primary-color']};
@@ -22,7 +21,7 @@ const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
 `;
 
 type Props = {
-    entity: Entity;
+    entity?: Maybe<Entity>;
 };
 
 // The tooltip needs some text to hold onto
@@ -33,23 +32,25 @@ const EmptySpace = styled.span`
 
 const ContainerLink = ({ entity }: Props) => {
     const registry = useEntityRegistry();
-    const history = useHistory();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const displayName = useBrowseDisplayName();
     const { trackClickContainerLinkEvent } = useSidebarAnalytics();
+    const containerUrl = entity ? registry.getEntityUrl(entity.type, entity.urn) : null;
 
     const onClickButton = () => {
         trackClickContainerLinkEvent();
-        const containerUrl = registry.getEntityUrl(entity.type, entity.urn);
-        history.push(containerUrl);
     };
+
+    if (!containerUrl) return null;
 
     return (
         <Tooltip placement="top" title={`view ${displayName} profile`} mouseEnterDelay={1}>
-            <ExpandableNode.StaticButton
-                icon={<ContainerIcon isSelected={isBrowsePathSelected} component={ExternalLink} />}
-                onClick={onClickButton}
-            />
+            <Link to={containerUrl}>
+                <ExpandableNode.StaticButton
+                    icon={<ContainerIcon isSelected={isBrowsePathSelected} component={ExternalLink} />}
+                    onClick={onClickButton}
+                />
+            </Link>
             <EmptySpace />
         </Tooltip>
     );

--- a/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
@@ -8,6 +8,7 @@ import ExpandableNode from './ExpandableNode';
 import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { Entity } from '../../../types.generated';
+import useSidebarAnalytics from './useSidebarAnalytics';
 
 // todo - this hover rule feels a little weird
 const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
@@ -35,8 +36,10 @@ const ContainerLink = ({ entity }: Props) => {
     const history = useHistory();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const displayName = useBrowseDisplayName();
+    const { trackClickContainerLinkEvent } = useSidebarAnalytics();
 
     const onClickButton = () => {
+        trackClickContainerLinkEvent();
         const containerUrl = registry.getEntityUrl(entity.type, entity.urn);
         history.push(containerUrl);
     };

--- a/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
@@ -2,9 +2,12 @@ import { Tooltip } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 import Icon from '@ant-design/icons/lib/components/Icon';
+import { useHistory } from 'react-router';
 import { useBrowseDisplayName, useIsBrowsePathSelected } from './BrowseContext';
 import ExpandableNode from './ExpandableNode';
 import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { Entity } from '../../../types.generated';
 
 // todo - this hover rule feels a little weird
 const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
@@ -18,7 +21,7 @@ const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
 `;
 
 type Props = {
-    onClick: () => void;
+    entity: Entity;
 };
 
 // The tooltip needs some text to hold onto
@@ -27,17 +30,22 @@ const EmptySpace = styled.span`
     content: ' ';
 `;
 
-const ContainerLink = ({ onClick }: Props) => {
+const ContainerLink = ({ entity }: Props) => {
+    const registry = useEntityRegistry();
+    const history = useHistory();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const displayName = useBrowseDisplayName();
 
-    // todo - add a delay
+    const onClickButton = () => {
+        const containerUrl = registry.getEntityUrl(entity.type, entity.urn);
+        history.push(containerUrl);
+    };
 
     return (
         <Tooltip placement="top" title={`view ${displayName} profile`} mouseEnterDelay={1}>
             <ExpandableNode.StaticButton
                 icon={<ContainerIcon isSelected={isBrowsePathSelected} component={ExternalLink} />}
-                onClick={onClick}
+                onClick={onClickButton}
             />
             <EmptySpace />
         </Tooltip>

--- a/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
@@ -1,0 +1,47 @@
+import { Tooltip } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+import Icon from '@ant-design/icons/lib/components/Icon';
+import { useBrowseDisplayName, useIsBrowsePathSelected } from './BrowseContext';
+import ExpandableNode from './ExpandableNode';
+import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
+
+// todo - this hover rule feels a little weird
+const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
+    && {
+        color: ${(props) => props.theme.styles['primary-color']};
+        ${(props) => !props.isSelected && 'display: none;'}
+        ${ExpandableNode.SelectableHeader}:hover & {
+            display: inherit;
+        }
+    }
+`;
+
+type Props = {
+    onClick: () => void;
+};
+
+// The tooltip needs some text to hold onto
+const EmptySpace = styled.span`
+    display: 'none';
+    content: ' ';
+`;
+
+const ContainerLink = ({ onClick }: Props) => {
+    const isBrowsePathSelected = useIsBrowsePathSelected();
+    const displayName = useBrowseDisplayName();
+
+    // todo - add a delay
+
+    return (
+        <Tooltip placement="top" title={`view ${displayName} profile`} mouseEnterDelay={1}>
+            <ExpandableNode.StaticButton
+                icon={<ContainerIcon isSelected={isBrowsePathSelected} component={ExternalLink} />}
+                onClick={onClick}
+            />
+            <EmptySpace />
+        </Tooltip>
+    );
+};
+
+export default ContainerLink;

--- a/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ContainerLink.tsx
@@ -44,7 +44,7 @@ const ContainerLink = ({ entity }: Props) => {
     if (!containerUrl) return null;
 
     return (
-        <Tooltip placement="top" title={`view ${displayName} profile`} mouseEnterDelay={1}>
+        <Tooltip placement="top" title={`View ${displayName} profile`} mouseEnterDelay={1}>
             <Link to={containerUrl}>
                 <ExpandableNode.StaticButton
                     icon={<ContainerIcon isSelected={isBrowsePathSelected} component={ExternalLink} />}

--- a/datahub-web-react/src/app/search/sidebar/EntityLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EntityLink.tsx
@@ -9,8 +9,9 @@ import { ReactComponent as ExternalLink } from '../../../images/link-out.svg';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { Entity, Maybe } from '../../../types.generated';
 import useSidebarAnalytics from './useSidebarAnalytics';
+import { BrowseV2EntityLinkClickEvent } from '../../analytics';
 
-const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
+const Linkicon = styled(Icon)<{ isSelected: boolean }>`
     && {
         color: ${(props) => props.theme.styles['primary-color']};
         ${(props) => !props.isSelected && 'display: none;'}
@@ -22,6 +23,7 @@ const ContainerIcon = styled(Icon)<{ isSelected: boolean }>`
 
 type Props = {
     entity?: Maybe<Entity>;
+    targetNode: BrowseV2EntityLinkClickEvent['targetNode'];
 };
 
 // The tooltip needs some text to hold onto
@@ -30,24 +32,24 @@ const EmptySpace = styled.span`
     content: ' ';
 `;
 
-const ContainerLink = ({ entity }: Props) => {
+const EntityLink = ({ entity, targetNode }: Props) => {
     const registry = useEntityRegistry();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const displayName = useBrowseDisplayName();
-    const { trackClickContainerLinkEvent } = useSidebarAnalytics();
-    const containerUrl = entity ? registry.getEntityUrl(entity.type, entity.urn) : null;
+    const { trackLinkClickEvent } = useSidebarAnalytics();
+    const entityUrl = entity ? registry.getEntityUrl(entity.type, entity.urn) : null;
 
     const onClickButton = () => {
-        trackClickContainerLinkEvent();
+        trackLinkClickEvent(targetNode);
     };
 
-    if (!containerUrl) return null;
+    if (!entityUrl) return null;
 
     return (
         <Tooltip placement="top" title={`View ${displayName} profile`} mouseEnterDelay={1}>
-            <Link to={containerUrl}>
+            <Link to={entityUrl}>
                 <ExpandableNode.StaticButton
-                    icon={<ContainerIcon isSelected={isBrowsePathSelected} component={ExternalLink} />}
+                    icon={<Linkicon isSelected={isBrowsePathSelected} component={ExternalLink} />}
                     onClick={onClickButton}
                 />
             </Link>
@@ -56,4 +58,4 @@ const ContainerLink = ({ entity }: Props) => {
     );
 };
 
-export default ContainerLink;
+export default EntityLink;

--- a/datahub-web-react/src/app/search/sidebar/EntityLink.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EntityLink.tsx
@@ -36,11 +36,11 @@ const EntityLink = ({ entity, targetNode }: Props) => {
     const registry = useEntityRegistry();
     const isBrowsePathSelected = useIsBrowsePathSelected();
     const displayName = useBrowseDisplayName();
-    const { trackLinkClickEvent } = useSidebarAnalytics();
+    const { trackEntityLinkClickEvent } = useSidebarAnalytics();
     const entityUrl = entity ? registry.getEntityUrl(entity.type, entity.urn) : null;
 
     const onClickButton = () => {
-        trackLinkClickEvent(targetNode);
+        trackEntityLinkClickEvent(targetNode);
     };
 
     if (!entityUrl) return null;

--- a/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
@@ -19,6 +19,7 @@ import { useHasFilterField } from './SidebarContext';
 const Count = styled(Typography.Text)`
     font-size: 12px;
     color: ${(props) => props.color};
+    padding-left: 4px;
 `;
 
 const EntityNode = () => {
@@ -62,9 +63,7 @@ const EntityNode = () => {
                     data-testid={`browse-entity-${registry.getCollectionName(entityType)}`}
                 >
                     <ExpandableNode.HeaderLeft>
-                        <ExpandableNode.StaticButton
-                            icon={registry.getIcon(entityType, 16, IconStyleType.HIGHLIGHT, color)}
-                        />
+                        {registry.getIcon(entityType, 16, IconStyleType.HIGHLIGHT, color)}
                         <ExpandableNode.Title color={color} size={16}>
                             {registry.getCollectionName(entityType)}
                         </ExpandableNode.Title>

--- a/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
@@ -64,7 +64,7 @@ const EntityNode = () => {
                 >
                     <ExpandableNode.HeaderLeft>
                         {registry.getIcon(entityType, 16, IconStyleType.HIGHLIGHT, color)}
-                        <ExpandableNode.Title color={color} size={16}>
+                        <ExpandableNode.Title color={color} size={16} padLeft>
                             {registry.getCollectionName(entityType)}
                         </ExpandableNode.Title>
                         <Count color={color}>{formatNumber(entityAggregation.count)}</Count>

--- a/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
@@ -160,7 +160,7 @@ ExpandableNode.Title = ({
 }) => {
     return (
         <BaseTitleContainer depth={depth} maxWidth={maxWidth} padLeft={padLeft}>
-            <BaseTitle ellipsis={{ tooltip: { mouseEnterDelay: 2 } }} color={color} size={size}>
+            <BaseTitle ellipsis={{ tooltip: { mouseEnterDelay: 1 } }} color={color} size={size}>
                 {children}
             </BaseTitle>
         </BaseTitleContainer>

--- a/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
@@ -45,27 +45,15 @@ ExpandableNode.Header = styled.div<{ isOpen: boolean; isSelected?: boolean; show
     justify-content: space-between;
     cursor: pointer;
     user-select: none;
-    padding: 2px 4px 2px 4px;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    padding-right: 2px;
     border-bottom: 1px solid ${(props) => (props.isOpen || !props.showBorder ? 'transparent' : ANTD_GRAY[4])};
-`;
-
-ExpandableNode.SelectableHeader = styled(ExpandableNode.Header)<{ isSelected: boolean }>`
-    && {
-        border: 1px solid ${(props) => (props.isSelected ? props.theme.styles['primary-color'] : 'transparent')};
-        background-color: ${(props) => (props.isSelected ? props.theme.styles['primary-color-light'] : 'transparent')};
-        border-radius: 8px;
-        transition: box-shadow 100ms ease-in-out;
-        box-shadow: 'none';
-    }
-    &&:hover {
-        box-shadow: ${(props) => props.theme.styles['box-shadow-hover']};
-    }
 `;
 
 ExpandableNode.HeaderLeft = styled.div`
     display: flex;
     align-items: center;
-    gap: 4px;
 `;
 
 const BaseButton = styled(Button)`
@@ -84,8 +72,12 @@ const RotatingButton = styled(BaseButton)<{ deg: number }>`
     transition: transform 250ms;
 `;
 
-ExpandableNode.StaticButton = ({ icon }: { icon: JSX.Element }) => {
-    return <BaseButton ghost size="small" type="ghost" icon={icon} />;
+ExpandableNode.StaticButton = ({ icon, onClick }: { icon: JSX.Element; onClick?: () => void }) => {
+    const onClickButton: MouseEventHandler = (e) => {
+        e.stopPropagation();
+        onClick?.();
+    };
+    return <BaseButton ghost size="small" type="ghost" icon={icon} onClick={onClickButton} />;
 };
 
 ExpandableNode.TriangleButton = ({
@@ -130,7 +122,7 @@ ExpandableNode.CircleButton = ({ isOpen, color }: { isOpen: boolean; color: stri
 
 // Reduce the ellipsis tolerance the deeper we get into the browse path
 const BaseTitleContainer = styled.div<{ depth: number }>`
-    max-width: ${(props) => 200 - props.depth * 8}px;
+    max-width: ${(props) => 175 - props.depth * 8}px;
 `;
 
 const BaseTitle = styled(Typography.Text)<{ color: string; size: number }>`

--- a/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
@@ -133,9 +133,9 @@ ExpandableNode.CircleButton = ({ isOpen, color }: { isOpen: boolean; color: stri
 };
 
 // Reduce the ellipsis tolerance the deeper we get into the browse path
-const BaseTitleContainer = styled.div<{ depth: number; maxWidth: number }>`
-    /* todo - can we only do the 175 for container cases?, or maybe detect child count? */
+const BaseTitleContainer = styled.div<{ depth: number; maxWidth: number; padLeft: boolean }>`
     max-width: ${(props) => props.maxWidth - props.depth * 8}px;
+    padding-left: ${(props) => (props.padLeft ? 4 : 0)}px;
 `;
 
 const BaseTitle = styled(Typography.Text)<{ color: string; size: number }>`
@@ -149,15 +149,17 @@ ExpandableNode.Title = ({
     depth = 0,
     children,
     maxWidth = 200,
+    padLeft = false,
 }: {
     color: string;
     size: number;
     depth?: number;
     children: ReactNode;
     maxWidth?: number;
+    padLeft?: boolean;
 }) => {
     return (
-        <BaseTitleContainer depth={depth} maxWidth={maxWidth}>
+        <BaseTitleContainer depth={depth} maxWidth={maxWidth} padLeft={padLeft}>
             <BaseTitle ellipsis={{ tooltip: { mouseEnterDelay: 2 } }} color={color} size={size}>
                 {children}
             </BaseTitle>

--- a/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/ExpandableNode.tsx
@@ -51,6 +51,18 @@ ExpandableNode.Header = styled.div<{ isOpen: boolean; isSelected?: boolean; show
     border-bottom: 1px solid ${(props) => (props.isOpen || !props.showBorder ? 'transparent' : ANTD_GRAY[4])};
 `;
 
+ExpandableNode.SelectableHeader = styled(ExpandableNode.Header)<{ isSelected: boolean }>`
+    & {
+        border: 1px solid ${(props) => (props.isSelected ? props.theme.styles['primary-color'] : 'transparent')};
+        background-color: ${(props) => (props.isSelected ? props.theme.styles['primary-color-light'] : 'transparent')};
+        border-radius: 8px;
+    }
+
+    &:hover {
+        background-color: ${(props) => props.theme.styles['primary-color-light']};
+    }
+`;
+
 ExpandableNode.HeaderLeft = styled.div`
     display: flex;
     align-items: center;
@@ -121,8 +133,9 @@ ExpandableNode.CircleButton = ({ isOpen, color }: { isOpen: boolean; color: stri
 };
 
 // Reduce the ellipsis tolerance the deeper we get into the browse path
-const BaseTitleContainer = styled.div<{ depth: number }>`
-    max-width: ${(props) => 175 - props.depth * 8}px;
+const BaseTitleContainer = styled.div<{ depth: number; maxWidth: number }>`
+    /* todo - can we only do the 175 for container cases?, or maybe detect child count? */
+    max-width: ${(props) => props.maxWidth - props.depth * 8}px;
 `;
 
 const BaseTitle = styled(Typography.Text)<{ color: string; size: number }>`
@@ -135,15 +148,17 @@ ExpandableNode.Title = ({
     size,
     depth = 0,
     children,
+    maxWidth = 200,
 }: {
     color: string;
     size: number;
     depth?: number;
     children: ReactNode;
+    maxWidth?: number;
 }) => {
     return (
-        <BaseTitleContainer depth={depth}>
-            <BaseTitle ellipsis={{ tooltip: true }} color={color} size={size}>
+        <BaseTitleContainer depth={depth} maxWidth={maxWidth}>
+            <BaseTitle ellipsis={{ tooltip: { mouseEnterDelay: 2 } }} color={color} size={size}>
                 {children}
             </BaseTitle>
         </BaseTitleContainer>

--- a/datahub-web-react/src/app/search/sidebar/PlatformNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/PlatformNode.tsx
@@ -81,7 +81,7 @@ const PlatformNode = () => {
                             dataTestId={`browse-platform-${label}`}
                         />
                         <PlatformIconContainer>{icon}</PlatformIconContainer>
-                        <ExpandableNode.Title color={color} size={14}>
+                        <ExpandableNode.Title color={color} size={14} padLeft>
                             {label}
                         </ExpandableNode.Title>
                     </ExpandableNode.HeaderLeft>

--- a/datahub-web-react/src/app/search/sidebar/SidebarLoadingError.tsx
+++ b/datahub-web-react/src/app/search/sidebar/SidebarLoadingError.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { Alert, Button } from 'antd';
+import styled from 'styled-components';
+
+const StyledAlert = styled(Alert)`
+    white-space: normal;
+`;
 
 type Props = {
     onClickRetry?: () => void;
@@ -7,8 +12,8 @@ type Props = {
 
 const SidebarLoadingError = ({ onClickRetry }: Props) => {
     return (
-        <Alert
-            message="There was a problem loading the sidebar."
+        <StyledAlert
+            message="The sidebar failed to load."
             showIcon
             type="error"
             action={

--- a/datahub-web-react/src/app/search/sidebar/useSidebarAnalytics.ts
+++ b/datahub-web-react/src/app/search/sidebar/useSidebarAnalytics.ts
@@ -50,7 +50,7 @@ const useSidebarAnalytics = () => {
 
     const trackClickContainerLinkEvent = () => {
         analytics.event({
-            type: EventType.BrowseV2ClickContainerLinkEvent,
+            type: EventType.BrowseV2ContainerLinkClickEvent,
             entity: entityDisplayName,
             environment: environmentDisplayName,
             platform: platformDisplayName,

--- a/datahub-web-react/src/app/search/sidebar/useSidebarAnalytics.ts
+++ b/datahub-web-react/src/app/search/sidebar/useSidebarAnalytics.ts
@@ -1,5 +1,10 @@
 import { EntityType } from '../../../types.generated';
-import { BrowseV2SelectNodeEvent, BrowseV2ToggleNodeEvent, EventType } from '../../analytics';
+import {
+    BrowseV2EntityLinkClickEvent,
+    BrowseV2SelectNodeEvent,
+    BrowseV2ToggleNodeEvent,
+    EventType,
+} from '../../analytics';
 import analytics from '../../analytics/analytics';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import {
@@ -48,9 +53,10 @@ const useSidebarAnalytics = () => {
         });
     };
 
-    const trackClickContainerLinkEvent = () => {
+    const trackEntityLinkClickEvent = (targetNode: BrowseV2EntityLinkClickEvent['targetNode']) => {
         analytics.event({
-            type: EventType.BrowseV2ContainerLinkClickEvent,
+            type: EventType.BrowseV2EntityLinkClickEvent,
+            targetNode,
             entity: entityDisplayName,
             environment: environmentDisplayName,
             platform: platformDisplayName,
@@ -58,7 +64,7 @@ const useSidebarAnalytics = () => {
         });
     };
 
-    return { trackToggleNodeEvent, trackSelectNodeEvent, trackClickContainerLinkEvent } as const;
+    return { trackToggleNodeEvent, trackSelectNodeEvent, trackEntityLinkClickEvent } as const;
 };
 
 export default useSidebarAnalytics;

--- a/datahub-web-react/src/app/search/sidebar/useSidebarAnalytics.ts
+++ b/datahub-web-react/src/app/search/sidebar/useSidebarAnalytics.ts
@@ -48,7 +48,17 @@ const useSidebarAnalytics = () => {
         });
     };
 
-    return { trackToggleNodeEvent, trackSelectNodeEvent } as const;
+    const trackClickContainerLinkEvent = () => {
+        analytics.event({
+            type: EventType.BrowseV2ClickContainerLinkEvent,
+            entity: entityDisplayName,
+            environment: environmentDisplayName,
+            platform: platformDisplayName,
+            targetDepth,
+        });
+    };
+
+    return { trackToggleNodeEvent, trackSelectNodeEvent, trackClickContainerLinkEvent } as const;
 };
 
 export default useSidebarAnalytics;

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -21,7 +21,7 @@ public enum DataHubUsageEventType {
   BROWSE_V2_TOGGLE_SIDEBAR_EVENT("BrowseV2ToggleSidebarEvent"),
   BROWSE_V2_TOGGLE_NODE_EVENT("BrowseV2ToggleNodeEvent"),
   BROWSE_V2_SELECT_NODE_EVENT("BrowseV2SelectNodeEvent"),
-  BROWSE_V2_CONTAINER_LINK_CLICK_EVENT("BrowseV2ContainerLinkClickEvent"),
+  BROWSE_V2_ENTITY_LINK_CLICK_EVENT("BrowseV2EntityLinkClickEvent"),
   ENTITY_VIEW_EVENT("EntityViewEvent"),
   ENTITY_SECTION_VIEW_EVENT("EntitySectionViewEvent"),
   ENTITY_ACTION_EVENT("EntityActionEvent"),

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -21,6 +21,7 @@ public enum DataHubUsageEventType {
   BROWSE_V2_TOGGLE_SIDEBAR_EVENT("BrowseV2ToggleSidebarEvent"),
   BROWSE_V2_TOGGLE_NODE_EVENT("BrowseV2ToggleNodeEvent"),
   BROWSE_V2_SELECT_NODE_EVENT("BrowseV2SelectNodeEvent"),
+  BROWSE_V2_CLICK_CONTAINER_LINK_EVENT("BrowseV2ClickContainerLinkEvent"),
   ENTITY_VIEW_EVENT("EntityViewEvent"),
   ENTITY_SECTION_VIEW_EVENT("EntitySectionViewEvent"),
   ENTITY_ACTION_EVENT("EntityActionEvent"),

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -21,7 +21,7 @@ public enum DataHubUsageEventType {
   BROWSE_V2_TOGGLE_SIDEBAR_EVENT("BrowseV2ToggleSidebarEvent"),
   BROWSE_V2_TOGGLE_NODE_EVENT("BrowseV2ToggleNodeEvent"),
   BROWSE_V2_SELECT_NODE_EVENT("BrowseV2SelectNodeEvent"),
-  BROWSE_V2_CLICK_CONTAINER_LINK_EVENT("BrowseV2ClickContainerLinkEvent"),
+  BROWSE_V2_CONTAINER_LINK_CLICK_EVENT("BrowseV2ContainerLinkClickEvent"),
   ENTITY_VIEW_EVENT("EntityViewEvent"),
   ENTITY_SECTION_VIEW_EVENT("EntitySectionViewEvent"),
   ENTITY_ACTION_EVENT("EntityActionEvent"),


### PR DESCRIPTION
Changes
* Adds a container link to the browse v2 sidebar
* Analytics when clicking the container link
* Delay the sidebar tooltips by 2s
* Removes flex gap and replaces with padding because some button components inherently are padding their contained icons so it was doubling their padding with the extra gap.
* Shrink the ellipsis maxWidth when we're dealing with a container, would be really nice to use a dynamic width ellipsis here but it doesn't work and I've wrestled it a few times with no success.
* Fixes a UI glitch in the error component when we're more nested.

<img width="363" alt="Screenshot 2023-06-26 at 1 33 23 PM" src="https://github.com/datahub-project/datahub/assets/2107911/4c64cab1-2aeb-4c0d-98cf-d6e6ce307511">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
