### PR TITLE
fix(embed): hide chart & dashboard previews if not for looker

### DIFF
--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -25,6 +25,7 @@ import { capitalizeFirstLetterOnly } from '../../shared/textUtil';
 import DataProductSection from '../shared/containers/profile/sidebar/DataProduct/DataProductSection';
 import { getDataProduct } from '../shared/utils';
 import EmbeddedProfile from '../shared/embed/EmbeddedProfile';
+import { LOOKER_URN } from '../../ingest/source/builder/constants';
 
 /**
  * Definition of the DataHub Chart entity.
@@ -99,8 +100,10 @@ export class ChartEntity implements Entity<Chart> {
                     name: 'Preview',
                     component: EmbedTab,
                     display: {
-                        visible: (_, chart: GetChartQuery) => !!chart?.chart?.embed?.renderUrl,
-                        enabled: (_, chart: GetChartQuery) => !!chart?.chart?.embed?.renderUrl,
+                        visible: (_, chart: GetChartQuery) =>
+                            !!chart?.chart?.embed?.renderUrl && chart?.chart?.platform.urn === LOOKER_URN,
+                        enabled: (_, chart: GetChartQuery) =>
+                            !!chart?.chart?.embed?.renderUrl && chart?.chart?.platform.urn === LOOKER_URN,
                     },
                 },
                 {

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -29,6 +29,7 @@ import { EmbedTab } from '../shared/tabs/Embed/EmbedTab';
 import EmbeddedProfile from '../shared/embed/EmbeddedProfile';
 import DataProductSection from '../shared/containers/profile/sidebar/DataProduct/DataProductSection';
 import { getDataProduct } from '../shared/utils';
+import { LOOKER_URN } from '../../ingest/source/builder/constants';
 
 /**
  * Definition of the DataHub Dashboard entity.
@@ -113,8 +114,12 @@ export class DashboardEntity implements Entity<Dashboard> {
                     name: 'Preview',
                     component: EmbedTab,
                     display: {
-                        visible: (_, dashboard: GetDashboardQuery) => !!dashboard?.dashboard?.embed?.renderUrl,
-                        enabled: (_, dashboard: GetDashboardQuery) => !!dashboard?.dashboard?.embed?.renderUrl,
+                        visible: (_, dashboard: GetDashboardQuery) =>
+                            !!dashboard?.dashboard?.embed?.renderUrl &&
+                            dashboard?.dashboard?.platform.urn === LOOKER_URN,
+                        enabled: (_, dashboard: GetDashboardQuery) =>
+                            !!dashboard?.dashboard?.embed?.renderUrl &&
+                            dashboard?.dashboard?.platform.urn === LOOKER_URN,
                     },
                 },
                 {


### PR DESCRIPTION
It takes some FE work to enable previews for any source. Recently, preview links for tableau were added on the source side but they did not work on the UI due to auth/XSS/etc.

Adding a safeguard here to only show previews in looker for the time being.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
