### PR TITLE
fix(ingestion) Remove legacy MAE production in gms ingestion code

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -831,16 +831,6 @@ public class EntityService {
       produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, oldValue, updatedValue, oldSystemMetadata,
           updatedSystemMetadata, result.getAuditStamp(), isNoOp ? ChangeType.RESTATE : ChangeType.UPSERT);
       produceMCLTimer.stop();
-
-      // For legacy reasons, keep producing to the MAE event stream without blocking ingest
-      try {
-        Timer.Context produceMAETimer = MetricUtils.timer(this.getClass(), "produceMAE").time();
-        produceMetadataAuditEvent(urn, aspectName, oldValue, updatedValue, result.getOldSystemMetadata(),
-            result.getNewSystemMetadata(), MetadataAuditOperation.UPDATE);
-        produceMAETimer.stop();
-      } catch (Exception e) {
-        log.warn("Unable to produce legacy MAE, entity may not have legacy Snapshot schema.", e);
-      }
     } else {
       log.debug("Skipped producing MetadataAuditEvent for ingested aspect {}, urn {}. Aspect has not changed.",
           aspectName, urn);


### PR DESCRIPTION
Removes a block of code producing MAEs that were unnecessarily clogging our logs. This should clean ip GMS logs when ingesting sample data on quickstart. MAEs are deprecated and incomplete already and were already causing unnecessary errors in our system. This removes support for them entirely.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
