### PR TITLE
fix(ui) Only show search and browse V2 onboarding steps if flag is on

### DIFF
--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -21,8 +21,9 @@ import { DownloadSearchResults, DownloadSearchResultsInput } from './utils/types
 import SearchFilters from './filters/SearchFilters';
 import useGetSearchQueryInputs from './useGetSearchQueryInputs';
 import useSearchFilterAnalytics from './filters/useSearchFilterAnalytics';
-import { useIsSearchV2, useSearchVersion } from './useSearchAndBrowseVersion';
+import { useIsBrowseV2, useIsSearchV2, useSearchVersion } from './useSearchAndBrowseVersion';
 import useFilterMode from './filters/useFilterMode';
+import { useUpdateEducationStepIdsAllowlist } from '../onboarding/useUpdateEducationStepIdsAllowlist';
 
 /**
  * A search results page.
@@ -30,6 +31,7 @@ import useFilterMode from './filters/useFilterMode';
 export const SearchPage = () => {
     const { trackClearAllFiltersEvent } = useSearchFilterAnalytics();
     const showSearchFiltersV2 = useIsSearchV2();
+    const showBrowseV2 = useIsBrowseV2();
     const searchVersion = useSearchVersion();
     const history = useHistory();
     const { query, unionType, filters, orFilters, viewUrn, page, activeType } = useGetSearchQueryInputs();
@@ -166,6 +168,12 @@ export const SearchPage = () => {
             setSelectedEntities([]);
         }
     }, [isSelectMode]);
+
+    // Render new search filters v2 onboarding step if the feature flag is on
+    useUpdateEducationStepIdsAllowlist(showSearchFiltersV2, SEARCH_RESULTS_FILTERS_V2_INTRO);
+
+    // Render new browse v2 onboarding step if the feature flag is on
+    useUpdateEducationStepIdsAllowlist(showBrowseV2, SEARCH_RESULTS_BROWSE_SIDEBAR_ID);
 
     return (
         <>


### PR DESCRIPTION
Optionally show the 2 new onboarding steps for new search and new browse experiences if their respective flags are enabled.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
