### PR TITLE
feat(ui) Allow a configurable default tab for domain entity profile page

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.featureflags.FeatureFlags;
 import com.linkedin.datahub.graphql.generated.AnalyticsConfig;
 import com.linkedin.datahub.graphql.generated.AppConfig;
 import com.linkedin.datahub.graphql.generated.AuthConfig;
+import com.linkedin.datahub.graphql.generated.EntityProfileConfig;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FeatureFlagsConfig;
 import com.linkedin.datahub.graphql.generated.IdentityManagementConfig;
@@ -132,6 +133,11 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
       QueriesTabConfig queriesTabConfig = new QueriesTabConfig();
       queriesTabConfig.setQueriesTabResultSize(_visualConfiguration.getQueriesTab().getQueriesTabResultSize());
       visualConfig.setQueriesTab(queriesTabConfig);
+    }
+    if (_visualConfiguration != null && _visualConfiguration.getEntityProfile() != null) {
+      EntityProfileConfig entityProfileConfig = new EntityProfileConfig();
+      entityProfileConfig.setDomainDefaultTab(_visualConfiguration.getEntityProfile().getDomainDefaultTab());
+      visualConfig.setEntityProfile(entityProfileConfig);
     }
     appConfig.setVisualConfig(visualConfig);
 

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -211,6 +211,11 @@ type VisualConfig {
   Configuration for the queries tab
   """
   queriesTab: QueriesTabConfig
+
+  """
+  Configuration for the queries tab
+  """
+  entityProfile: EntityProfileConfig
 }
 
 """
@@ -221,6 +226,18 @@ type QueriesTabConfig {
   Number of queries to show in the queries tab
   """
   queriesTabResultSize: Int
+}
+
+
+"""
+Configuration for the queries tab
+"""
+type EntityProfileConfig {
+  """
+  The enum value from EntityProfileTab for which tab should be showed by default on
+  Domain profile pages. If null, rely on default sorting from React code.
+  """
+  domainDefaultTab: String
 }
 
 """

--- a/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entity/domain/DomainEntity.tsx
@@ -13,6 +13,7 @@ import { DomainEntitiesTab } from './DomainEntitiesTab';
 import { EntityMenuItems } from '../shared/EntityDropdown/EntityDropdown';
 import { EntityActionItem } from '../shared/entity/EntityActions';
 import DataProductsTab from './DataProductsTab/DataProductsTab';
+import { EntityProfileTab } from '../shared/constants';
 // import { EntityActionItem } from '../shared/entity/EntityActions';
 
 /**
@@ -72,14 +73,17 @@ export class DomainEntity implements Entity<Domain> {
             isNameEditable
             tabs={[
                 {
+                    id: EntityProfileTab.DOMAIN_ENTITIES_TAB,
                     name: 'Entities',
                     component: DomainEntitiesTab,
                 },
                 {
+                    id: EntityProfileTab.DOCUMENTATION_TAB,
                     name: 'Documentation',
                     component: DocumentationTab,
                 },
                 {
+                    id: EntityProfileTab.DATA_PRODUCTS_TAB,
                     name: 'Data Products',
                     component: DataProductsTab,
                 },

--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -93,3 +93,10 @@ export const GLOSSARY_ENTITY_TYPES = [EntityType.GlossaryTerm, EntityType.Glossa
 export const DEFAULT_SYSTEM_ACTOR_URNS = ['urn:li:corpuser:__datahub_system', 'urn:li:corpuser:unknown'];
 
 export const VIEW_ENTITY_PAGE = 'VIEW_ENTITY_PAGE';
+
+// only values for Domain Entity for custom configurable default tab
+export enum EntityProfileTab {
+    DOMAIN_ENTITIES_TAB = 'DOMAIN_ENTITIES_TAB',
+    DOCUMENTATION_TAB = 'DOCUMENTATION_TAB',
+    DATA_PRODUCTS_TAB = 'DATA_PRODUCTS_TAB',
+}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -8,6 +8,7 @@ import { Message } from '../../../../shared/Message';
 import {
     getEntityPath,
     getOnboardingStepIdsForEntityType,
+    sortEntityProfileTabs,
     useRoutedTab,
     useUpdateGlossaryEntityDataOnChange,
 } from './utils';
@@ -43,6 +44,7 @@ import {
     LINEAGE_GRAPH_INTRO_ID,
     LINEAGE_GRAPH_TIME_FILTER_ID,
 } from '../../../../onboarding/config/LineageGraphOnboardingConfig';
+import { useAppConfig } from '../../../../useAppConfig';
 
 type Props<T, U> = {
     urn: string;
@@ -168,8 +170,10 @@ export const EntityProfile = <T, U>({
     const isHideSiblingMode = useIsSeparateSiblingsMode();
     const entityRegistry = useEntityRegistry();
     const history = useHistory();
+    const appConfig = useAppConfig();
     const isCompact = React.useContext(CompactContext);
     const tabsWithDefaults = tabs.map((tab) => ({ ...tab, display: { ...defaultTabDisplayConfig, ...tab.display } }));
+    const sortedTabs = sortEntityProfileTabs(appConfig.config, entityType, tabsWithDefaults);
     const sideBarSectionsWithDefaults = sidebarSections.map((sidebarSection) => ({
         ...sidebarSection,
         display: { ...defaultSidebarSection, ...sidebarSection.display },
@@ -235,7 +239,7 @@ export const EntityProfile = <T, U>({
             },
         })) || [];
 
-    const visibleTabs = [...tabsWithDefaults, ...autoRenderTabs].filter((tab) =>
+    const visibleTabs = [...sortedTabs, ...autoRenderTabs].filter((tab) =>
         tab.display?.visible(entityData, dataPossiblyCombinedWithSiblings),
     );
 

--- a/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
@@ -203,16 +203,20 @@ export function getOnboardingStepIdsForEntityType(entityType: EntityType): strin
     }
 }
 
+function sortTabsWithDefaultTabId(tabs: EntityTab[], defaultTabId: string) {
+    return tabs.sort((tabA, tabB) => {
+        if (tabA.id === defaultTabId) return -1;
+        if (tabB.id === defaultTabId) return 1;
+        return 0;
+    });
+}
+
 export function sortEntityProfileTabs(appConfig: AppConfig, entityType: EntityType, tabs: EntityTab[]) {
     const sortedTabs = [...tabs];
 
     if (entityType === EntityType.Domain && appConfig.visualConfig.entityProfile?.domainDefaultTab) {
         const defaultTabId = appConfig.visualConfig.entityProfile.domainDefaultTab;
-        sortedTabs.sort((tabA, tabB) => {
-            if (tabA.id === defaultTabId) return -1;
-            if (tabB.id === defaultTabId) return 1;
-            return 0;
-        });
+        sortTabsWithDefaultTabId(sortedTabs, defaultTabId);
     }
 
     return sortedTabs;

--- a/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-router';
 import queryString from 'query-string';
 import { isEqual } from 'lodash';
-import { EntityType } from '../../../../../types.generated';
+import { AppConfig, EntityType } from '../../../../../types.generated';
 import useIsLineageMode from '../../../../lineage/utils/useIsLineageMode';
 import { useEntityRegistry } from '../../../../useEntityRegistry';
 import EntityRegistry from '../../../EntityRegistry';
@@ -201,4 +201,19 @@ export function getOnboardingStepIdsForEntityType(entityType: EntityType): strin
         default:
             return [];
     }
+}
+
+export function sortEntityProfileTabs(appConfig: AppConfig, entityType: EntityType, tabs: EntityTab[]) {
+    const sortedTabs = [...tabs];
+
+    if (entityType === EntityType.Domain && appConfig.visualConfig.entityProfile?.domainDefaultTab) {
+        const defaultTabId = appConfig.visualConfig.entityProfile.domainDefaultTab;
+        sortedTabs.sort((tabA, tabB) => {
+            if (tabA.id === defaultTabId) return -1;
+            if (tabB.id === defaultTabId) return 1;
+            return 0;
+        });
+    }
+
+    return sortedTabs;
 }

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -48,6 +48,7 @@ export type EntityTab = {
         enabled: (GenericEntityProperties, T) => boolean; // Whether the tab is enabled on the UI. Defaults to true.
     };
     properties?: any;
+    id?: string;
 };
 
 export type EntitySidebarSection = {

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -24,6 +24,9 @@ export const DEFAULT_APP_CONFIG = {
         queriesTab: {
             queriesTabResultSize: 5,
         },
+        entityProfile: {
+            domainDefaultTab: null,
+        },
     },
     authConfig: {
         tokenAuthEnabled: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -40,6 +40,9 @@ query appConfig {
             queriesTab {
                 queriesTabResultSize
             }
+            entityProfile {
+                domainDefaultTab
+            }
         }
         telemetryConfig {
             enableThirdPartyLogging

--- a/metadata-io/src/main/java/com/linkedin/metadata/config/EntityProfileConfig.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/config/EntityProfileConfig.java
@@ -1,0 +1,12 @@
+package com.linkedin.metadata.config;
+
+import lombok.Data;
+
+
+@Data
+public class EntityProfileConfig {
+  /**
+   * The default tab to show first on a Domain entity profile. Defaults to React code sorting if not present.
+   */
+  public String domainDefaultTab;
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/config/VisualConfiguration.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/config/VisualConfiguration.java
@@ -17,4 +17,9 @@ public class VisualConfiguration {
    * Queries tab related configurations
    */
   public QueriesTabConfig queriesTab;
+
+  /**
+   * Queries tab related configurations
+   */
+  public EntityProfileConfig entityProfile;
 }

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -108,6 +108,9 @@ visualConfig:
   assets:
     logoUrl: ${REACT_APP_LOGO_URL:/assets/platforms/datahublogo.png}
     faviconUrl: ${REACT_APP_FAVICON_URL:/assets/favicon.ico}
+  entityProfile:
+    # we only support default tab for domains right now. In order to implement for other entities, update React code
+    domainDefaultTab: ${DOMAIN_DEFAULT_TAB:DOCUMENTATION_TAB} # set to DOCUMENTATION to show documentation tab first
 
 # Storage Layer
 

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -110,7 +110,7 @@ visualConfig:
     faviconUrl: ${REACT_APP_FAVICON_URL:/assets/favicon.ico}
   entityProfile:
     # we only support default tab for domains right now. In order to implement for other entities, update React code
-    domainDefaultTab: ${DOMAIN_DEFAULT_TAB:DOCUMENTATION_TAB} # set to DOCUMENTATION to show documentation tab first
+    domainDefaultTab: ${DOMAIN_DEFAULT_TAB:} # set to DOCUMENTATION to show documentation tab first
 
 # Storage Layer
 

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -110,7 +110,7 @@ visualConfig:
     faviconUrl: ${REACT_APP_FAVICON_URL:/assets/favicon.ico}
   entityProfile:
     # we only support default tab for domains right now. In order to implement for other entities, update React code
-    domainDefaultTab: ${DOMAIN_DEFAULT_TAB:} # set to DOCUMENTATION to show documentation tab first
+    domainDefaultTab: ${DOMAIN_DEFAULT_TAB:} # set to DOCUMENTATION_TAB to show documentation tab first
 
 # Storage Layer
 


### PR DESCRIPTION
We've heard from people that they desire to make the Domain entity profile page default tab (which tab is first that the user lands on) configurable. This PR does that by creating a new visual config env variable that users can set as one of the values for the new `EntityProfileTab` enum values. We then show the tab that that variable specifies first. Otherwise, default back to normal sort order based on the react code.

We considered how to possible make this extensible to other entity types but we started getting into the weeds with needing to build out a whole UI configuration feature where we take in an external yaml or something and it ended up just being too much. If we want to consider making more things like this configurable in the UI, a bigger conversation should be had about the best way to solve it. Maybe we eventually allow users to define a config through the UI and save it in their DB? it was just getting to complicated to try and solve with a simple env variable.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
