### PR TITLE
docs(lineage): add read lineage example

### DIFF
--- a/docs/act-on-metadata/impact-analysis.md
+++ b/docs/act-on-metadata/impact-analysis.md
@@ -71,7 +71,7 @@ Follow these simple steps to understand the full dependency chain of your data e
 * [searchAcrossLineage](../../graphql/queries.md#searchacrosslineage)
 * [searchAcrossLineageInput](../../graphql/inputObjects.md#searchacrosslineageinput)
 
-Looking for an example of how to use `searchAcrossLineage` to read lineage? Look [here](../../api/tutorials/lineage/#read-lineage)
+Looking for an example of how to use `searchAcrossLineage` to read lineage? Look [here](../api/tutorials/lineage.md#read-lineage)
 
 ### DataHub Blog
 

--- a/docs/act-on-metadata/impact-analysis.md
+++ b/docs/act-on-metadata/impact-analysis.md
@@ -71,6 +71,8 @@ Follow these simple steps to understand the full dependency chain of your data e
 * [searchAcrossLineage](../../graphql/queries.md#searchacrosslineage)
 * [searchAcrossLineageInput](../../graphql/inputObjects.md#searchacrosslineageinput)
 
+Looking for an example of how to use `searchAcrossLineage` to read lineage? Look [here](../../api/tutorials/lineage/#read-lineage)
+
 ### DataHub Blog
 
 * [Dependency Impact Analysis, Data Validation Outcomes, and MORE! - Highlights from DataHub v0.8.27 & v.0.8.28](https://blog.datahubproject.io/dependency-impact-analysis-data-validation-outcomes-and-more-1302604da233)

--- a/docs/api/tutorials/lineage.md
+++ b/docs/api/tutorials/lineage.md
@@ -171,6 +171,8 @@ mutation searchAcrossLineage {
 }
 ```
 
+This example shows using lineage degrees as a filter, but additional search filters can be included here as well. 
+
 </TabItem>
 <TabItem value="curl" label="Curl">
 

--- a/docs/api/tutorials/lineage.md
+++ b/docs/api/tutorials/lineage.md
@@ -131,3 +131,65 @@ You can now see the lineage between `fct_users_deleted` and `logging_events`.
 You can now see the column-level lineage between datasets. Note that you have to enable `Show Columns` to be able to see the column-level lineage.
 
 ![column-level-lineage-added](../../imgs/apis/tutorials/column-level-lineage-added.png)
+
+## Read Lineage
+
+<Tabs>
+<TabItem value="graphql" label="GraphQL" default>
+
+```json
+mutation searchAcrossLineage {
+  searchAcrossLineage(
+    input: {
+      query: "*"
+      urn: "urn:li:dataset:(urn:li:dataPlatform:dbt,long_tail_companions.adoption.human_profiles,PROD)"
+      start: 0
+      count: 10
+      direction: DOWNSTREAM
+      orFilters: [
+        {
+          and: [
+            {
+              condition: EQUAL
+              negated: false
+              field: "degree"
+              values: ["1", "2", "3+"]
+            }
+          ]
+        }
+      ]
+    }
+  ) {
+    searchResults {
+      degree
+      entity {
+        urn
+        type
+      }
+    }
+  }
+}
+```
+
+</TabItem>
+<TabItem value="curl" label="Curl">
+
+```shell
+```shell
+curl --location --request POST 'http://localhost:8080/api/graphql' \
+--header 'Authorization: Bearer <my-access-token>' \
+--header 'Content-Type: application/json'  --data-raw '{ { "query": "mutation searchAcrossLineage { searchAcrossLineage( input: { query: \"*\" urn: \"urn:li:dataset:(urn:li:dataPlatform:dbt,long_tail_companions.adoption.human_profiles,PROD)\" start: 0 count: 10 direction: DOWNSTREAM orFilters: [ { and: [ { condition: EQUAL negated: false field: \"degree\" values: [\"1\", \"2\", \"3+\"] } ] } ] } ) { searchResults { degree entity { urn type } } }}"
+}}'
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+{{ inline /metadata-ingestion/examples/library/read_lineage_rest.py show_path_as_comment }}
+```
+
+</TabItem>
+</Tabs>
+
+This will perform a multi-hop lineage search on the urn specified. For more information about the `searchAcrossLineage` mutation, please refer to [searchAcrossLineage](https://datahubproject.io/docs/graphql/queries/#searchacrosslineage).

--- a/docs/api/tutorials/lineage.md
+++ b/docs/api/tutorials/lineage.md
@@ -175,7 +175,6 @@ mutation searchAcrossLineage {
 <TabItem value="curl" label="Curl">
 
 ```shell
-```shell
 curl --location --request POST 'http://localhost:8080/api/graphql' \
 --header 'Authorization: Bearer <my-access-token>' \
 --header 'Content-Type: application/json'  --data-raw '{ { "query": "mutation searchAcrossLineage { searchAcrossLineage( input: { query: \"*\" urn: \"urn:li:dataset:(urn:li:dataPlatform:dbt,long_tail_companions.adoption.human_profiles,PROD)\" start: 0 count: 10 direction: DOWNSTREAM orFilters: [ { and: [ { condition: EQUAL negated: false field: \"degree\" values: [\"1\", \"2\", \"3+\"] } ] } ] } ) { searchResults { degree entity { urn type } } }}"

--- a/metadata-ingestion/examples/library/read_lineage_rest.py
+++ b/metadata-ingestion/examples/library/read_lineage_rest.py
@@ -23,7 +23,7 @@ mutation searchAcrossLineage {
               field: "degree"
               values: ["1", "2", "3+"]
             }
-          ]
+          ]                                     # Additional search filters can be included here as well
         }
       ]
     }

--- a/metadata-ingestion/examples/library/read_lineage_rest.py
+++ b/metadata-ingestion/examples/library/read_lineage_rest.py
@@ -1,0 +1,43 @@
+# read-modify-write requires access to the DataHubGraph (RestEmitter is not enough)
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+
+gms_endpoint = "http://localhost:8080"
+graph = DataHubGraph(DatahubClientConfig(server=gms_endpoint))
+
+# Query multiple aspects from entity
+query = """
+mutation searchAcrossLineage {
+  searchAcrossLineage(
+    input: {
+      query: "*"
+      urn: "urn:li:dataset:(urn:li:dataPlatform:dbt,long_tail_companions.adoption.human_profiles,PROD)"
+      start: 0
+      count: 10
+      direction: DOWNSTREAM
+      orFilters: [
+        {
+          and: [
+            {
+              condition: EQUAL
+              negated: false
+              field: "degree"
+              values: ["1", "2", "3+"]
+            }
+          ]
+        }
+      ]
+    }
+  ) {
+    searchResults {
+      degree
+      entity {
+        urn
+        type
+      }
+    }
+  }
+}
+"""
+result = graph.execute_graphql(query=query)
+
+print(result)


### PR DESCRIPTION
## Summary

This adds an example for read lineage to the docs. Here's a preview:
![Screenshot 2023-06-27 at 5 21 44 PM](https://github.com/datahub-project/datahub/assets/110510035/391f5b9f-473d-47ab-8b0f-db2df5af0614)
![Screenshot 2023-06-27 at 5 21 52 PM](https://github.com/datahub-project/datahub/assets/110510035/f002637a-1af8-4804-971e-42bed005169a)

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://
github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
