### PR TITLE
fix(search) Add facets list to our cache key to avoid cache collisions

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/cache/CachingAllEntitiesSearchAggregator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/cache/CachingAllEntitiesSearchAggregator.java
@@ -9,7 +9,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.javatuples.Quintet;
+import org.javatuples.Sextet;
 import org.springframework.cache.CacheManager;
 
 import static com.datahub.util.RecordUtils.*;
@@ -29,8 +29,8 @@ public class CachingAllEntitiesSearchAggregator {
     return new CacheableSearcher<>(cacheManager.getCache(ALL_ENTITIES_SEARCH_AGGREGATOR_CACHE_NAME), batchSize,
         querySize -> aggregator.search(entities, input, postFilters, sortCriterion, querySize.getFrom(),
             querySize.getSize(), searchFlags, facets),
-        querySize -> Quintet.with(entities, input, postFilters != null ? toJsonString(postFilters) : null,
-            sortCriterion != null ? toJsonString(sortCriterion) : null, querySize), searchFlags, enableCache)
+        querySize -> Sextet.with(entities, input, postFilters != null ? toJsonString(postFilters) : null,
+            sortCriterion != null ? toJsonString(sortCriterion) : null, facets, querySize), searchFlags, enableCache)
         .getSearchResults(from, size);
   }
 }


### PR DESCRIPTION
Our `aggregateAcrossEntities` endpoint uses our search under the hood and passes in a list of `facets` that we want to fetch. There were cache collisions between our normal search and `aggregateAcrossEntities` where we would get the same results unexpectedly between them. This is because `facets` weren't being added to our cache key. This PR does that.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
