### PR TITLE
feat(usage): add max width to users tooltip

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedActorGroup.tsx
@@ -4,7 +4,9 @@ import styled from 'styled-components';
 import { CorpGroup, CorpUser } from '../../../../../types.generated';
 import { ExpandedActor } from './ExpandedActor';
 
-const PopoverActors = styled.div``;
+const PopoverActors = styled.div`
+    width: 600px;
+`;
 
 const ActorsContainer = styled.div`
     display: flex;


### PR DESCRIPTION
When there are lots of users, the usage modal would get a bit wonky because it didn't have a max-width it became unable to align left. 

![CleanShot 2023-06-28 at 16 57 24](https://github.com/datahub-project/datahub/assets/2455694/4aa3b0f1-cc23-45c9-9ffb-241fdeeedd56)

I added a max-width that allows it to align left regardless of list size:
![CleanShot 2023-06-28 at 16 58 08](https://github.com/datahub-project/datahub/assets/2455694/4a95ace8-fb17-4148-ac0f-ff8ddbc39a40)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
