### PR TITLE
fix(browse): filter entities by whether they might exist in the instance

### DIFF
--- a/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
@@ -3,10 +3,9 @@ import styled from 'styled-components';
 import { Typography } from 'antd';
 import EntityNode from './EntityNode';
 import { BrowseProvider } from './BrowseContext';
-import useAggregationsQuery from './useAggregationsQuery';
-import { ENTITY_FILTER_NAME } from '../utils/constants';
 import SidebarLoadingError from './SidebarLoadingError';
 import { SEARCH_RESULTS_BROWSE_SIDEBAR_ID } from '../../onboarding/config/SearchOnboardingConfig';
+import useSidebarEntities from './useSidebarEntities';
 
 const Sidebar = styled.div<{ visible: boolean; width: number }>`
     height: 100%;
@@ -40,9 +39,8 @@ type Props = {
 };
 
 const BrowseSidebar = ({ visible, width }: Props) => {
-    const { error, entityAggregations } = useAggregationsQuery({
+    const { error, entityAggregations, retry } = useSidebarEntities({
         skip: !visible,
-        facets: [ENTITY_FILTER_NAME],
     });
 
     return (
@@ -57,7 +55,7 @@ const BrowseSidebar = ({ visible, width }: Props) => {
                         <EntityNode />
                     </BrowseProvider>
                 ))}
-                {error && <SidebarLoadingError />}
+                {error && <SidebarLoadingError onClickRetry={retry} />}
             </SidebarBody>
         </Sidebar>
     );

--- a/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EntityNode.tsx
@@ -41,7 +41,7 @@ const EntityNode = () => {
         if (count) toggle();
     };
 
-    const { loaded, error, environmentAggregations, platformAggregations } = useAggregationsQuery({
+    const { loaded, error, environmentAggregations, platformAggregations, retry } = useAggregationsQuery({
         skip: !isOpen,
         facets: [ORIGIN_FILTER_NAME, PLATFORM_FILTER_NAME],
     });
@@ -93,7 +93,7 @@ const EntityNode = () => {
                                   <PlatformNode />
                               </BrowseProvider>
                           ))}
-                    {error && <SidebarLoadingError />}
+                    {error && <SidebarLoadingError onClickRetry={retry} />}
                 </ExpandableNode.Body>
             }
         />

--- a/datahub-web-react/src/app/search/sidebar/EnvironmentNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/EnvironmentNode.tsx
@@ -38,7 +38,7 @@ const EnvironmentNode = () => {
         if (count) toggle();
     };
 
-    const { loaded, error, platformAggregations } = useAggregationsQuery({
+    const { loaded, error, platformAggregations, retry } = useAggregationsQuery({
         skip: !isOpen,
         facets: [PLATFORM_FILTER_NAME],
     });
@@ -75,7 +75,7 @@ const EnvironmentNode = () => {
                             <PlatformNode />
                         </BrowseProvider>
                     ))}
-                    {error && <SidebarLoadingError />}
+                    {error && <SidebarLoadingError onClickRetry={retry} />}
                 </ExpandableNode.Body>
             }
         />

--- a/datahub-web-react/src/app/search/sidebar/useAggregationsQuery.ts
+++ b/datahub-web-react/src/app/search/sidebar/useAggregationsQuery.ts
@@ -1,5 +1,5 @@
 import { useAggregateAcrossEntitiesQuery } from '../../../graphql/search.generated';
-import { AndFilterInput, EntityType } from '../../../types.generated';
+import { EntityType } from '../../../types.generated';
 import { GLOSSARY_ENTITY_TYPES } from '../../entity/shared/constants';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import { ENTITY_FILTER_NAME, ORIGIN_FILTER_NAME, PLATFORM_FILTER_NAME } from '../utils/constants';
@@ -8,14 +8,11 @@ import { useSidebarFilters } from './useSidebarFilters';
 
 type Props = {
     facets: string[];
-    types?: EntityType[];
-    orFilters?: AndFilterInput[];
-    viewUrn?: string;
-    query?: string;
     skip: boolean;
+    excludeFilters?: boolean;
 };
 
-const useAggregationsQuery = ({ facets, types, orFilters, viewUrn, query, skip }: Props) => {
+const useAggregationsQuery = ({ facets, excludeFilters = false, skip }: Props) => {
     const registry = useEntityRegistry();
     const sidebarFilters = useSidebarFilters();
 
@@ -30,11 +27,11 @@ const useAggregationsQuery = ({ facets, types, orFilters, viewUrn, query, skip }
         fetchPolicy: 'cache-first',
         variables: {
             input: {
-                types: types ?? sidebarFilters.entityFilters,
+                ...(excludeFilters ? {} : { types: sidebarFilters.entityFilters }),
                 facets,
-                orFilters: orFilters ?? sidebarFilters.orFilters,
-                viewUrn: viewUrn ?? sidebarFilters.viewUrn,
-                query: query ?? sidebarFilters.query,
+                ...(excludeFilters ? {} : { orFilters: sidebarFilters.orFilters }),
+                ...(excludeFilters ? {} : { viewUrn: sidebarFilters.viewUrn }),
+                query: excludeFilters ? '*' : sidebarFilters.query,
                 searchFlags: {
                     maxAggValues: MAX_AGGREGATION_VALUES,
                 },

--- a/datahub-web-react/src/app/search/sidebar/useSidebarEntities.ts
+++ b/datahub-web-react/src/app/search/sidebar/useSidebarEntities.ts
@@ -18,9 +18,8 @@ const useSidebarEntities = ({ skip }: Props) => {
 
     const { error: baseError, entityAggregations: baseEntityAggregations } = useAggregationsQuery({
         skip,
-        query: '*',
-        orFilters: [],
         facets: [ENTITY_FILTER_NAME],
+        excludeFilters: true,
     });
 
     const result = useMemo(() => {

--- a/datahub-web-react/src/app/search/sidebar/useSidebarEntities.ts
+++ b/datahub-web-react/src/app/search/sidebar/useSidebarEntities.ts
@@ -9,29 +9,26 @@ type Props = {
 const useSidebarEntities = ({ skip }: Props) => {
     const {
         error: filteredError,
-        entityAggregations: filteredAggregations,
-        retry,
+        entityAggregations: filteredAggs,
+        retry: retryFilteredAggs,
     } = useAggregationsQuery({
         skip,
         facets: [ENTITY_FILTER_NAME],
     });
 
-    const { error: baseError, entityAggregations: baseEntityAggregations } = useAggregationsQuery({
+    const { error: baseError, entityAggregations: baseAggs } = useAggregationsQuery({
         skip,
         facets: [ENTITY_FILTER_NAME],
         excludeFilters: true,
     });
 
     const result = useMemo(() => {
-        if (filteredError || baseError) return filteredAggregations;
-        if (!filteredAggregations) return filteredAggregations;
-        if (!baseEntityAggregations) return baseEntityAggregations;
-        return filteredAggregations.filter((agg) =>
-            baseEntityAggregations.some((base) => base.value === agg.value && !!base.count),
-        );
-    }, [baseEntityAggregations, baseError, filteredAggregations, filteredError]);
+        if (filteredError || baseError) return filteredAggs; // Fallback to filtered aggs on any error
+        if (!filteredAggs || !baseAggs) return null; // If we're loading one of the queries, wait to render
+        return filteredAggs.filter((agg) => baseAggs.some((base) => base.value === agg.value && !!base.count));
+    }, [baseAggs, baseError, filteredAggs, filteredError]);
 
-    return { error: filteredError, entityAggregations: result, retry } as const;
+    return { error: filteredError, entityAggregations: result, retry: retryFilteredAggs } as const;
 };
 
 export default useSidebarEntities;

--- a/datahub-web-react/src/app/search/sidebar/useSidebarEntities.ts
+++ b/datahub-web-react/src/app/search/sidebar/useSidebarEntities.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { ENTITY_FILTER_NAME } from '../utils/constants';
+import useAggregationsQuery from './useAggregationsQuery';
+
+type Props = {
+    skip: boolean;
+};
+
+const useSidebarEntities = ({ skip }: Props) => {
+    const {
+        error: filteredError,
+        entityAggregations: filteredAggregations,
+        retry,
+    } = useAggregationsQuery({
+        skip,
+        facets: [ENTITY_FILTER_NAME],
+    });
+
+    const { error: baseError, entityAggregations: baseEntityAggregations } = useAggregationsQuery({
+        skip,
+        query: '*',
+        orFilters: [],
+        facets: [ENTITY_FILTER_NAME],
+    });
+
+    const result = useMemo(() => {
+        if (filteredError || baseError) return filteredAggregations;
+        if (!filteredAggregations) return filteredAggregations;
+        if (!baseEntityAggregations) return baseEntityAggregations;
+        return filteredAggregations.filter((agg) =>
+            baseEntityAggregations.some((base) => base.value === agg.value && !!base.count),
+        );
+    }, [baseEntityAggregations, baseError, filteredAggregations, filteredError]);
+
+    return { error: filteredError, entityAggregations: result, retry } as const;
+};
+
+export default useSidebarEntities;


### PR DESCRIPTION
Changes
* Filters the entities further via a second query for possible entities in the instance
* If the base queried error'd for some reason, we fallback to the base filteredEntities
* Makes the aggregation queries retryable

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
