### PR TITLE
feat(ingest): Add metabase database id to platform instance mapping

### DIFF
--- a/metadata-ingestion/docs/sources/metabase/metabase.md
+++ b/metadata-ingestion/docs/sources/metabase/metabase.md
@@ -9,6 +9,14 @@ the underlying datasets in the `glue` platform, the following snippet can be use
 DataHub will try to determine database name from Metabase [api/database](https://www.metabase.com/docs/latest/api-documentation.html#database)
 payload. However, the name can be overridden from `database_alias_map` for a given database connected to Metabase.
 
+If several platform instances with the same platform (e.g. from several distinct clickhouse clusters) are present in DataHub,
+the mapping between database id in Metabase and platform instance in DataHub may be configured with the following map:
+```yml
+  database_id_to_instance_map:
+    "42": platform_instance_in_datahub
+```
+The key in this map must be string, not integer although  Metabase API provides `id` as number.
+If `database_id_to_instance_map` is not specified, `platform_instance_map` is used for platform instance mapping. If none of the above are specified, platform instance is not used when constructing `urn` when searching for dataset relations.
 ## Compatibility
 
 Metabase version [v0.41.2](https://www.metabase.com/start/oss/)

--- a/metadata-ingestion/docs/sources/metabase/metabase.yml
+++ b/metadata-ingestion/docs/sources/metabase/metabase.yml
@@ -15,6 +15,8 @@ source:
     # Optional mapping of platform types to instance ids
     platform_instance_map: # optional
       postgres: test_postgres    # optional
+    database_id_to_instance_map: # optional
+      "42": platform_instance_in_datahub # optional
 
 sink:
   # sink configs

--- a/metadata-ingestion/tests/unit/test_metabase_source.py
+++ b/metadata-ingestion/tests/unit/test_metabase_source.py
@@ -1,0 +1,42 @@
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.source import SourceReport
+from datahub.ingestion.source.metabase import MetabaseConfig, MetabaseSource
+
+
+class TestMetabaseSource(MetabaseSource):
+    def __init__(self, ctx: PipelineContext, config: MetabaseConfig):
+        self.config = config
+        self.report = SourceReport()
+
+
+def test_get_platform_instance():
+    ctx = PipelineContext(run_id="test-metabase")
+    config = MetabaseConfig()
+    config.connect_uri = "http://localhost:3000"
+    # config.database_id_to_instance_map = {"42": "my_main_clickhouse"}
+    # config.platform_instance_map = {"clickhouse": "my_only_clickhouse"}
+    metabase = TestMetabaseSource(ctx, config)
+
+    # no mappings defined
+    assert metabase.get_platform_instance("clickhouse", 42) is None
+
+    # database_id_to_instance_map is defined, key is present
+    metabase.config.database_id_to_instance_map = {"42": "my_main_clickhouse"}
+    assert metabase.get_platform_instance(None, 42) == "my_main_clickhouse"
+
+    # database_id_to_instance_map is defined, key is missing
+    assert metabase.get_platform_instance(None, 999) is None
+
+    # database_id_to_instance_map is defined, key is missing, platform_instance_map is defined and key present
+    metabase.config.platform_instance_map = {"clickhouse": "my_only_clickhouse"}
+    assert metabase.get_platform_instance("clickhouse", 999) == "my_only_clickhouse"
+
+    # database_id_to_instance_map is defined, key is missing, platform_instance_map is defined and key missing
+    assert metabase.get_platform_instance("missing-platform", 999) is None
+
+    # database_id_to_instance_map is missing, platform_instance_map is defined and key present
+    metabase.config.database_id_to_instance_map = None
+    assert metabase.get_platform_instance("clickhouse", 999) == "my_only_clickhouse"
+
+    # database_id_to_instance_map is missing, platform_instance_map is defined and key missing
+    assert metabase.get_platform_instance("missing-platform", 999) is None


### PR DESCRIPTION
## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Since DataHub supports [platform instances](https://datahubproject.io/docs/platform-instances/) there may be several distinct instances with the same platform in the same environment. When ingesting charts from Metabase it should be possible to find the corresponding datasets (tables) in DataHub.

For example, the dataset URN searched during ingestion is:
- *without* the patch: `urn:li:dataPlatform:clickhouse,event.new_app,PROD`
- *with* the patch: `urn:li:dataPlatform:clickhouse,clichouse_analytics_prod.event.new_app,PROD`
with only the latter URN being valid for dataset ingested with `platform_instance` specified.

The change still leaves `name_to_instance_map` optional and if `platform_instance` is not used, the mapping may be skipped.


Also the change adds a case for Metabase user not being found which is normal for deactivated users. I believe this case should not be considered as failure as people in companies quit or change their roles while charts and dashboards they created are still used by the company. I believe this behavior has already been mentioned in #5294. Unfortunately Metabase API does not support GET'ting individual user details for deactivated users, only has options to [list them](https://github.com/metabase/metabase/blob/master/docs/api/user.md#get-apiuserid). Thus checking for 404 looks like a reasonable and yet simple workaround.