### PR TITLE
fix(ingest/s3): Fix for flaky s3 test - uploading s3 files in consistent order

### DIFF
--- a/metadata-ingestion/tests/integration/s3/test_s3.py
+++ b/metadata-ingestion/tests/integration/s3/test_s3.py
@@ -56,7 +56,7 @@ def s3_populate(pytestconfig, s3_resource, s3_client, bucket_names):
             pytestconfig.rootpath / "tests/integration/s3/test_data/local_system/"
         )
         for root, _dirs, files in os.walk(test_resources_dir):
-            for file in files:
+            for file in sorted(files):
                 full_path = os.path.join(root, file)
                 rel_path = os.path.relpath(full_path, test_resources_dir)
                 bkt.upload_file(full_path, rel_path)


### PR DESCRIPTION
Making sure the order of the uploaded s3 files are always the same in test
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
