### PR TITLE
ci(docs): add missing deps for lxml package for vercel

### DIFF
--- a/metadata-ingestion/scripts/install_deps.sh
+++ b/metadata-ingestion/scripts/install_deps.sh
@@ -17,8 +17,8 @@ else
             openldap-clients \
             sqlite-devel \
             xz-devel \
-            libxml2 \
-            libxslt
+            libxml2-devel \
+            libxslt-devel
     else
         $sudo_cmd apt-get update && $sudo_cmd apt-get install -y \
             librdkafka-dev \

--- a/metadata-ingestion/scripts/install_deps.sh
+++ b/metadata-ingestion/scripts/install_deps.sh
@@ -16,7 +16,9 @@ else
             cyrus-sasl-devel \
             openldap-clients \
             sqlite-devel \
-            xz-devel
+            xz-devel \
+            libxml2 \
+            libxslt
     else
         $sudo_cmd apt-get update && $sudo_cmd apt-get install -y \
             librdkafka-dev \


### PR DESCRIPTION
Caused by a new release of lxml.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
