### PR TITLE
fix(java) Add try catch block when backfilling browse v2

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2Step.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2Step.java
@@ -114,7 +114,12 @@ public class BackfillBrowsePathsV2Step extends UpgradeStep {
     }
 
     for (SearchEntity searchEntity : scrollResult.getEntities()) {
-      ingestBrowsePathsV2(searchEntity.getEntity(), auditStamp);
+      try {
+        ingestBrowsePathsV2(searchEntity.getEntity(), auditStamp);
+      } catch (Exception e) {
+        // don't stop the whole step because of one bad urn or one bad ingestion
+        log.error(String.format("Error ingesting default browsePathsV2 aspect for urn %s", searchEntity.getEntity()), e);
+      }
     }
 
     return scrollResult.getScrollId();

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2Step.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2Step.java
@@ -40,7 +40,7 @@ public class BackfillBrowsePathsV2Step extends UpgradeStep {
       Constants.ML_FEATURE_TABLE_ENTITY_NAME,
       Constants.ML_FEATURE_ENTITY_NAME
   );
-  private static final String VERSION = "1";
+  private static final String VERSION = "2";
   private static final String UPGRADE_ID = "backfill-default-browse-paths-v2-step";
   private static final Integer BATCH_SIZE = 5000;
 

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2StepTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2StepTest.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
 
 public class BackfillBrowsePathsV2StepTest {
-  private static final String VERSION_1 = "1";
+  private static final String VERSION = "2";
   private static final String UPGRADE_URN = String.format(
       "urn:li:%s:%s",
       Constants.DATA_HUB_UPGRADE_ENTITY_NAME,
@@ -110,7 +110,7 @@ public class BackfillBrowsePathsV2StepTest {
     final SearchService mockSearchService = initMockSearchService();
 
     final Urn upgradeEntityUrn = Urn.createFromString(UPGRADE_URN);
-    com.linkedin.upgrade.DataHubUpgradeRequest upgradeRequest = new com.linkedin.upgrade.DataHubUpgradeRequest().setVersion(VERSION_1);
+    com.linkedin.upgrade.DataHubUpgradeRequest upgradeRequest = new com.linkedin.upgrade.DataHubUpgradeRequest().setVersion(VERSION);
     Map<String, EnvelopedAspect> upgradeRequestAspects = new HashMap<>();
     upgradeRequestAspects.put(Constants.DATA_HUB_UPGRADE_REQUEST_ASPECT_NAME,
         new EnvelopedAspect().setValue(new Aspect(upgradeRequest.data())));


### PR DESCRIPTION
If there's one bad urn in someone's instance or something unexpected when ingesting a singular browsePathsV2 aspect, we raise an error and the whole process terminates. This catches that error and logs it while allowing us to continue on with the other entities to backfill.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
