### PR TITLE
test(ingest/airflow): Fix test for airflow 2.6.3

### DIFF
--- a/metadata-ingestion/src/datahub_provider/_airflow_shims.py
+++ b/metadata-ingestion/src/datahub_provider/_airflow_shims.py
@@ -5,12 +5,14 @@ from airflow.models.baseoperator import BaseOperator
 try:
     from airflow.models.mappedoperator import MappedOperator
     from airflow.models.operator import Operator
+    from airflow.operators.empty import EmptyOperator
 except ModuleNotFoundError:
     # Operator isn't a real class, but rather a type alias defined
     # as the union of BaseOperator and MappedOperator.
     # Since older versions of Airflow don't have MappedOperator, we can just use BaseOperator.
     Operator = BaseOperator  # type: ignore
     MappedOperator = None  # type: ignore
+    from airflow.operators.dummy import DummyOperator as EmptyOperator  # type: ignore
 
 try:
     from airflow.sensors.external_task import ExternalTaskSensor
@@ -22,5 +24,6 @@ assert AIRFLOW_PATCHED
 __all__ = [
     "Operator",
     "MappedOperator",
+    "EmptyOperator",
     "ExternalTaskSensor",
 ]

--- a/metadata-ingestion/tests/unit/test_airflow.py
+++ b/metadata-ingestion/tests/unit/test_airflow.py
@@ -1,5 +1,3 @@
-from datahub_provider._airflow_compat import AIRFLOW_PATCHED
-
 import datetime
 import json
 import os
@@ -15,10 +13,10 @@ import packaging.version
 import pytest
 from airflow.lineage import apply_lineage, prepare_lineage
 from airflow.models import DAG, Connection, DagBag, DagRun, TaskInstance
-from airflow.operators.empty import EmptyOperator
 
 import datahub.emitter.mce_builder as builder
 from datahub_provider import get_provider_info
+from datahub_provider._airflow_shims import AIRFLOW_PATCHED, EmptyOperator
 from datahub_provider.entities import Dataset, Urn
 from datahub_provider.hooks.datahub import DatahubKafkaHook, DatahubRestHook
 from datahub_provider.operators.datahub import DatahubEmitterOperator

--- a/metadata-ingestion/tests/unit/test_airflow.py
+++ b/metadata-ingestion/tests/unit/test_airflow.py
@@ -15,7 +15,7 @@ import packaging.version
 import pytest
 from airflow.lineage import apply_lineage, prepare_lineage
 from airflow.models import DAG, Connection, DagBag, DagRun, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 import datahub.emitter.mce_builder as builder
 from datahub_provider import get_provider_info
@@ -238,12 +238,12 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
         dag = DAG(dag_id="test_lineage_is_sent_to_backend", start_date=DEFAULT_DATE)
 
         with dag:
-            op1 = DummyOperator(
+            op1 = EmptyOperator(
                 task_id="task1_upstream",
                 inlets=inlets,
                 outlets=outlets,
             )
-            op2 = DummyOperator(
+            op2 = EmptyOperator(
                 task_id="task2",
                 inlets=inlets,
                 outlets=outlets,
@@ -257,13 +257,14 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
         if AIRFLOW_VERSION < packaging.version.parse("2.2.0"):
             ti = TaskInstance(task=op2, execution_date=DEFAULT_DATE)
             # Ignoring type here because DagRun state is just a sring at Airflow 1
-            dag_run = DagRun(state="success", run_id=f"scheduled_{DEFAULT_DATE}")  # type: ignore
+            dag_run = DagRun(state="success", run_id=f"scheduled_{DEFAULT_DATE.isoformat()}")  # type: ignore
         else:
             from airflow.utils.state import DagRunState
 
             ti = TaskInstance(task=op2, run_id=f"test_airflow-{DEFAULT_DATE}")
             dag_run = DagRun(
-                state=DagRunState.SUCCESS, run_id=f"scheduled_{DEFAULT_DATE}"
+                state=DagRunState.SUCCESS,
+                run_id=f"scheduled_{DEFAULT_DATE.isoformat()}",
             )
 
         ti.dag_run = dag_run  # type: ignore
@@ -372,7 +373,7 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
                 )
                 assert (
                     mock_emitter.method_calls[9].args[0].entityUrn
-                    == "urn:li:dataProcessInstance:b6375e5f5faeb543cfb5d7d8a47661fb"
+                    == "urn:li:dataProcessInstance:5e274228107f44cc2dd7c9782168cc29"
                 )
 
                 assert (
@@ -381,7 +382,7 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
                 )
                 assert (
                     mock_emitter.method_calls[10].args[0].entityUrn
-                    == "urn:li:dataProcessInstance:b6375e5f5faeb543cfb5d7d8a47661fb"
+                    == "urn:li:dataProcessInstance:5e274228107f44cc2dd7c9782168cc29"
                 )
                 assert (
                     mock_emitter.method_calls[11].args[0].aspectName
@@ -389,7 +390,7 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
                 )
                 assert (
                     mock_emitter.method_calls[11].args[0].entityUrn
-                    == "urn:li:dataProcessInstance:b6375e5f5faeb543cfb5d7d8a47661fb"
+                    == "urn:li:dataProcessInstance:5e274228107f44cc2dd7c9782168cc29"
                 )
                 assert (
                     mock_emitter.method_calls[12].args[0].aspectName
@@ -397,7 +398,7 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
                 )
                 assert (
                     mock_emitter.method_calls[12].args[0].entityUrn
-                    == "urn:li:dataProcessInstance:b6375e5f5faeb543cfb5d7d8a47661fb"
+                    == "urn:li:dataProcessInstance:5e274228107f44cc2dd7c9782168cc29"
                 )
                 assert mock_emitter.method_calls[13].args[0].aspectName == "status"
                 assert (
@@ -415,7 +416,7 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
                 )
                 assert (
                     mock_emitter.method_calls[15].args[0].entityUrn
-                    == "urn:li:dataProcessInstance:b6375e5f5faeb543cfb5d7d8a47661fb"
+                    == "urn:li:dataProcessInstance:5e274228107f44cc2dd7c9782168cc29"
                 )
                 assert (
                     mock_emitter.method_calls[16].args[0].aspectName
@@ -423,5 +424,5 @@ def test_lineage_backend(mock_emit, inlets, outlets, capture_executions):
                 )
                 assert (
                     mock_emitter.method_calls[16].args[0].entityUrn
-                    == "urn:li:dataProcessInstance:b6375e5f5faeb543cfb5d7d8a47661fb"
+                    == "urn:li:dataProcessInstance:5e274228107f44cc2dd7c9782168cc29"
                 )


### PR DESCRIPTION
Old date serialization broke new regex for run_id. Also swaps DummyOperator -> EmptyOperator as per deprecation message

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
