### PR TITLE
refactor(graphql): make graphql engine extensible

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -463,6 +463,8 @@ public class GmsGraphQLEngine {
             // Add new plugins here
         );
 
+        this.graphQLPlugins.forEach(plugin -> plugin.init(args));
+
         this.entityClient = args.entityClient;
         this.graphClient = args.graphClient;
         this.usageClient = args.usageClient;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -330,6 +330,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -427,6 +428,11 @@ public class GmsGraphQLEngine {
     private final OwnershipType ownershipType;
 
     /**
+     * A list of GraphQL Plugins that extend the core engine
+     */
+    private final List<GmsGraphQLPlugin> graphQLPlugins;
+
+    /**
      * Configures the graph objects that can be fetched primary key.
      */
     public final List<EntityType<?, ?>> entityTypes;
@@ -452,6 +458,10 @@ public class GmsGraphQLEngine {
     public final List<BrowsableEntityType<?, ?>> browsableTypes;
 
     public GmsGraphQLEngine(final GmsGraphQLEngineArgs args) {
+
+        this.graphQLPlugins = List.of(
+            // Add new plugins here
+        );
 
         this.entityClient = args.entityClient;
         this.graphClient = args.graphClient;
@@ -558,6 +568,14 @@ public class GmsGraphQLEngine {
             ownershipType
         );
         this.loadableTypes = new ArrayList<>(entityTypes);
+        // Extend loadable types with types from the plugins
+        // This allows us to offer search and browse capabilities out of the box for those types
+        for (GmsGraphQLPlugin plugin: this.graphQLPlugins) {
+            Collection<? extends LoadableType<?, ?>> pluginLoadableTypes = plugin.getLoadableTypes();
+            if (pluginLoadableTypes != null) {
+                this.loadableTypes.addAll(pluginLoadableTypes);
+            }
+        }
         this.ownerTypes = ImmutableList.of(corpUserType, corpGroupType);
         this.searchableTypes = loadableTypes.stream()
             .filter(type -> (type instanceof SearchableEntityType<?, ?>))
@@ -573,7 +591,7 @@ public class GmsGraphQLEngine {
      * Returns a {@link Supplier} responsible for creating a new {@link DataLoader} from
      * a {@link LoadableType}.
      */
-    public Map<String, Function<QueryContext, DataLoader<?, ?>>> loaderSuppliers(final List<LoadableType<?, ?>> loadableTypes) {
+    public Map<String, Function<QueryContext, DataLoader<?, ?>>> loaderSuppliers(final Collection<? extends LoadableType<?, ?>> loadableTypes) {
         return loadableTypes
             .stream()
             .collect(Collectors.toMap(
@@ -581,6 +599,15 @@ public class GmsGraphQLEngine {
                 (graphType) -> (context) -> createDataLoader(graphType, context)
             ));
     }
+
+    /**
+     * Final call to wire up any extra resolvers the plugin might want to add on
+     * @param builder
+     */
+    private void configurePluginResolvers(final RuntimeWiring.Builder builder) {
+        this.graphQLPlugins.forEach(plugin -> plugin.wireAnyResolvers(builder));
+    }
+
 
     public void configureRuntimeWiring(final RuntimeWiring.Builder builder) {
         configureQueryResolvers(builder);
@@ -619,10 +646,13 @@ public class GmsGraphQLEngine {
         configureViewResolvers(builder);
         configureQueryEntityResolvers(builder);
         configureOwnershipTypeResolver(builder);
+        configurePluginResolvers(builder);
     }
 
+
     public GraphQLEngine.Builder builder() {
-        return GraphQLEngine.builder()
+        final GraphQLEngine.Builder builder = GraphQLEngine.builder();
+        builder
             .addSchema(fileBasedSchema(GMS_SCHEMA_FILE))
             .addSchema(fileBasedSchema(SEARCH_SCHEMA_FILE))
             .addSchema(fileBasedSchema(APP_SCHEMA_FILE))
@@ -633,10 +663,23 @@ public class GmsGraphQLEngine {
             .addSchema(fileBasedSchema(TIMELINE_SCHEMA_FILE))
             .addSchema(fileBasedSchema(TESTS_SCHEMA_FILE))
             .addSchema(fileBasedSchema(STEPS_SCHEMA_FILE))
-            .addSchema(fileBasedSchema(LINEAGE_SCHEMA_FILE))
+            .addSchema(fileBasedSchema(LINEAGE_SCHEMA_FILE));
+
+        for (GmsGraphQLPlugin plugin: this.graphQLPlugins) {
+            List<String> pluginSchemaFiles = plugin.getSchemaFiles();
+            if (pluginSchemaFiles != null) {
+                pluginSchemaFiles.forEach(schema -> builder.addSchema(fileBasedSchema(schema)));
+            }
+            Collection<? extends LoadableType<?, ?>> pluginLoadableTypes = plugin.getLoadableTypes();
+            if (pluginLoadableTypes != null) {
+                pluginLoadableTypes.forEach(loadableType -> builder.addDataLoaders(loaderSuppliers(pluginLoadableTypes)));
+            }
+        }
+            builder
             .addDataLoaders(loaderSuppliers(loadableTypes))
             .addDataLoader("Aspect", context -> createDataLoader(aspectType, context))
             .configureRuntimeWiring(this::configureRuntimeWiring);
+        return builder;
     }
 
     public static String fileBasedSchema(String fileName) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -605,7 +605,7 @@ public class GmsGraphQLEngine {
      * @param builder
      */
     private void configurePluginResolvers(final RuntimeWiring.Builder builder) {
-        this.graphQLPlugins.forEach(plugin -> plugin.wireAnyResolvers(builder));
+        this.graphQLPlugins.forEach(plugin -> plugin.configureExtraResolvers(builder));
     }
 
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLPlugin.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLPlugin.java
@@ -1,0 +1,44 @@
+package com.linkedin.datahub.graphql;
+
+import com.linkedin.datahub.graphql.types.LoadableType;
+import graphql.schema.idl.RuntimeWiring;
+import java.util.Collection;
+import java.util.List;
+
+
+/**
+ * An interface that allows the Core GMS GraphQL Engine to be extended without requiring
+ * code changes in the GmsGraphQLEngine class if new entities, relationships or resolvers
+ * need to be introduced. This is useful if you are maintaining a fork of DataHub and
+ * don't want to deal with merge conflicts.
+ */
+public interface GmsGraphQLPlugin {
+
+  /**
+   * Initialization method that allows the plugin to instantiate
+   * @param args
+   */
+  void init(GmsGraphQLEngineArgs args);
+
+  /**
+   * Return a list of schema files that contain graphql definitions
+   * that are served by this plugin
+   * @return
+   */
+  List<String> getSchemaFiles();
+
+  /**
+   * Return a list of LoadableTypes that this plugin serves
+   * @return
+   */
+  Collection<? extends LoadableType<?, ?>> getLoadableTypes();
+
+  /**
+   * Optional callback that a plugin can implement to wire up any Query, Mutation or Type specific resolvers.
+   * @param wiringBuilder
+   */
+  default void wireAnyResolvers(final RuntimeWiring.Builder wiringBuilder) {
+
+  }
+
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLPlugin.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLPlugin.java
@@ -34,10 +34,10 @@ public interface GmsGraphQLPlugin {
   Collection<? extends LoadableType<?, ?>> getLoadableTypes();
 
   /**
-   * Optional callback that a plugin can implement to wire up any Query, Mutation or Type specific resolvers.
+   * Optional callback that a plugin can implement to configure any Query, Mutation or Type specific resolvers.
    * @param wiringBuilder
    */
-  default void wireAnyResolvers(final RuntimeWiring.Builder wiringBuilder) {
+  default void configureExtraResolvers(final RuntimeWiring.Builder wiringBuilder) {
 
   }
 


### PR DESCRIPTION
This is an extremely small PR meant to create a pathway for extensions to the GraphQL engine to be managed without requiring code changes to the monolith. This should result in an easier merge experience for teams running DataHub forks. 

I intentionally didn't make larger scale changes to the core engine because I wanted existing forks to have the simplest merge experience.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
