### PR TITLE
test(ingest/testing-utils): Add back delta info ignore path

### DIFF
--- a/metadata-ingestion/src/datahub/testing/compare_metadata_json.py
+++ b/metadata-ingestion/src/datahub/testing/compare_metadata_json.py
@@ -89,7 +89,7 @@ def diff_metadata_json(
     golden: MetadataJson,
     ignore_paths: Sequence[str] = (),
 ) -> Union[DeepDiff, MCPDiff]:
-    ignore_paths = (*ignore_paths, *default_exclude_paths)
+    ignore_paths = (*ignore_paths, *default_exclude_paths, r"root\[\d+].delta_info")
     try:
         golden_map = get_aspects_by_urn(golden)
         output_map = get_aspects_by_urn(output)

--- a/metadata-ingestion/src/datahub/testing/mcp_diff.py
+++ b/metadata-ingestion/src/datahub/testing/mcp_diff.py
@@ -1,6 +1,7 @@
+import json
 import re
 from collections import defaultdict
-from dataclasses import dataclass, field
+import dataclasses
 from typing import Any, Dict, List, Sequence, Set, Tuple, Union
 
 import deepdiff.serialization
@@ -27,13 +28,13 @@ ReportType = Literal[
 ]
 
 
-@dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True)
 class AspectForDiff:
     urn: str
     change_type: str
     aspect_name: str
-    aspect: Dict[str, Any] = field(hash=False)
-    delta_info: "DeltaInfo" = field(hash=False)
+    aspect: Dict[str, Any] = dataclasses.field(hash=False)
+    delta_info: "DeltaInfo" = dataclasses.field(hash=False, repr=False)
 
     @classmethod
     def create_from_mcp(cls, idx: int, obj: Dict[str, Any]) -> "AspectForDiff":
@@ -46,8 +47,17 @@ class AspectForDiff:
             delta_info=DeltaInfo(idx=idx, original=obj),
         )
 
+    def __repr__(self):
+        d = {
+            field.name: getattr(self, field.name)
+            for field in dataclasses.fields(self)
+            if field.repr
+        }
+        d["aspect"] = "<aspect>"
+        return "\n" + "\t" * 2 + str(json.dumps(d))
 
-@dataclass
+
+@dataclasses.dataclass
 class DeltaInfo:
     """Information about an MCP used to construct a diff delta.
 
@@ -59,6 +69,10 @@ class DeltaInfo:
 
 
 class DeltaInfoOperator(BaseOperator):
+    """Warning: Doesn't seem to be working right now.
+    Ignored via an ignore path as an extra layer of defense.
+    """
+
     def __init__(self):
         super().__init__(types=[DeltaInfo])
 
@@ -93,7 +107,7 @@ def get_aspects_by_urn(obj: object) -> AspectsByUrn:
     return d
 
 
-@dataclass
+@dataclasses.dataclass
 class MCPAspectDiff:
     aspects_added: Dict[int, AspectForDiff]
     aspects_removed: Dict[int, AspectForDiff]
@@ -126,7 +140,7 @@ class MCPAspectDiff:
         )
 
 
-@dataclass
+@dataclasses.dataclass
 class MCPDiff:
     aspect_changes: Dict[str, Dict[str, MCPAspectDiff]]  # urn -> aspect -> diff
     urns_added: Set[str]
@@ -169,7 +183,7 @@ class MCPDiff:
     def convert_path(path: str) -> str:
         # Attempt to use paths intended for the root golden... sorry for the regex
         return re.sub(
-            r"root\\?\[([0-9]+|\\d\+)\\?]\\?\['aspect'\\?](\\?\['(json|value)'\\?])?",
+            r"^root\\?\[([0-9]+|\\d\+)\\?]\\?\['aspect'\\?](\\?\['(json|value)'\\?])?",
             r"root\[\\d+].aspect",
             path,
         )

--- a/metadata-ingestion/src/datahub/testing/mcp_diff.py
+++ b/metadata-ingestion/src/datahub/testing/mcp_diff.py
@@ -1,7 +1,7 @@
+import dataclasses
 import json
 import re
 from collections import defaultdict
-import dataclasses
 from typing import Any, Dict, List, Sequence, Set, Tuple, Union
 
 import deepdiff.serialization


### PR DESCRIPTION
For some reason, the custom operator doesn't seem to be working when running connector tests, resulting in the diffs printing `AspectForDiff` objects. I wasn't able to debug the custom operator, so I'm just adding the ignore path back to ignore the delta info object... It seemed to be working before, so I'd like to leave it in, e.g. if the error is due to a change by deepdiff -- it causes no harm.

I also add a custom repr method to AspectForDiff in case this happens again just to make the error messages a bit nicer, but we really shouldn't hit this.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
