### PR TITLE
test(ingest/kafka-connect): Attempt to fix flaky test

### DIFF
--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -305,7 +305,7 @@ def loaded_kafka_connect(kafka_connect_runner):
 
     # Give time for connectors to process the table data
     kafka_connect_runner.wait_until_responsive(
-        timeout=20,
+        timeout=30,
         pause=1,
         check=lambda: have_connectors_processed("test_connect"),
     )

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -1,5 +1,4 @@
 import subprocess
-import time
 from typing import Any, Dict, List, cast
 from unittest import mock
 


### PR DESCRIPTION
We used to have 70s of sleep here, trying to avoid that. If this doesn't work though maybe I'll just stick in a sleep.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
