### PR TITLE
feat(ingest/snowflake): View CLL from sql parsing of view definition

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -65,7 +65,12 @@ class SnowflakeV2Config(
 
     include_column_lineage: bool = Field(
         default=True,
-        description="If enabled, populates the column lineage. Supported only for snowflake table-to-table and view-to-table lineage edge (not supported in table-to-view or view-to-view lineage edge yet). Requires appropriate grants given to the role.",
+        description="Populates table->table and view->table column lineage. Requires appropriate grants given to the role and the Snowflake Enterprise Edition or above.",
+    )
+
+    include_view_column_lineage: bool = Field(
+        default=False,
+        description="Populates view->view and table->view column lineage.",
     )
 
     _check_role_grants_removed = pydantic_removed_field("check_role_grants")
@@ -88,7 +93,11 @@ class SnowflakeV2Config(
 
     use_legacy_lineage_method: bool = Field(
         default=False,
-        description="Whether to use the legacy lineage computation method. If set to False, ingestion uses new optimised lineage extraction method that requires less ingestion process memory.",
+        description=(
+            "Whether to use the legacy lineage computation method. "
+            "By default, uses new optimised lineage extraction method that requires less ingestion process memory. "
+            "Table-to-view and view-to-view column-level lineage are not supported with the legacy method."
+        ),
     )
 
     validate_upstreams_against_patterns: bool = Field(
@@ -179,3 +188,7 @@ class SnowflakeV2Config(
         return BaseSnowflakeConfig.get_sql_alchemy_url(
             self, database=database, username=username, password=password, role=role
         )
+
+    @property
+    def parse_view_ddl(self) -> bool:
+        return self.include_view_column_lineage

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_legacy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_legacy.py
@@ -2,7 +2,7 @@ import json
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Callable, Dict, FrozenSet, Iterable, List, Optional, Set
+from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Set
 
 from pydantic import Field
 from pydantic.error_wrappers import ValidationError
@@ -193,8 +193,9 @@ class SnowflakeLineageExtractor(
         self.dataset_urn_builder = dataset_urn_builder
         self.connection: Optional[SnowflakeConnection] = None
 
+    # Kwargs used by new snowflake lineage extractor need to be ignored here
     def get_workunits(
-        self, discovered_tables: List[str], discovered_views: List[str]
+        self, discovered_tables: List[str], discovered_views: List[str], **_kwargs: Any
     ) -> Iterable[MetadataWorkUnit]:
         self.connection = self.create_connection()
         if self.connection is None:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_v2.py
@@ -1,8 +1,19 @@
 import json
 import logging
 from collections import defaultdict
-from dataclasses import dataclass, field
-from typing import Callable, Dict, FrozenSet, Iterable, List, Optional, Set
+from dataclasses import dataclass
+from typing import (
+    Callable,
+    Collection,
+    Dict,
+    Iterable,
+    List,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 from snowflake.connector import SnowflakeConnection
 
@@ -13,6 +24,7 @@ from datahub.ingestion.source.aws.s3_util import make_s3_urn
 from datahub.ingestion.source.snowflake.constants import (
     LINEAGE_PERMISSION_ERROR,
     SnowflakeEdition,
+    SnowflakeObjectDomain,
 )
 from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
@@ -31,6 +43,11 @@ from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
 )
 from datahub.metadata.schema_classes import DatasetLineageTypeClass, UpstreamClass
 from datahub.utilities.perf_timer import PerfTimer
+from datahub.utilities.sqlglot_lineage import (
+    SchemaResolver,
+    SqlParsingResult,
+    sqlglot_lineage,
+)
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -40,25 +57,6 @@ class SnowflakeColumnId:
     columnName: str
     objectName: str
     objectDomain: Optional[str] = None
-
-
-@dataclass(frozen=True)
-class SnowflakeColumnFineGrainedLineage:
-    """
-    Fie grained upstream of column,
-    which represents a transformation applied on input columns"""
-
-    inputColumns: FrozenSet[SnowflakeColumnId]
-    # Transform function, query etc can be added here
-
-
-@dataclass
-class SnowflakeColumnUpstreams:
-    """All upstreams of a column"""
-
-    upstreams: Set[SnowflakeColumnFineGrainedLineage] = field(
-        default_factory=set, init=False
-    )
 
 
 class SnowflakeLineageExtractor(
@@ -91,7 +89,11 @@ class SnowflakeLineageExtractor(
         self.connection: Optional[SnowflakeConnection] = None
 
     def get_workunits(
-        self, discovered_tables: List[str], discovered_views: List[str]
+        self,
+        discovered_tables: List[str],
+        discovered_views: List[str],
+        schema_resolver: SchemaResolver,
+        view_definitions: MutableMapping[str, str],
     ) -> Iterable[MetadataWorkUnit]:
         self.connection = self.create_connection()
         if self.connection is None:
@@ -101,18 +103,20 @@ class SnowflakeLineageExtractor(
 
         if self.config.include_view_lineage:
             if len(discovered_views) > 0:
-                yield from self.get_view_upstream_workunits(discovered_views)
+                yield from self.get_view_upstream_workunits(
+                    discovered_views=discovered_views,
+                    schema_resolver=schema_resolver,
+                    view_definitions=view_definitions,
+                )
             else:
                 logger.info("No views found. Skipping View Lineage Extraction.")
 
         yield from self.get_table_upstream_workunits(discovered_tables)
 
         if self._external_lineage_map:  # Some external lineage is yet to be emitted
-            yield from self.get_table_external_upstream_workunits(discovered_tables)
+            yield from self.get_table_external_upstream_workunits()
 
-    def get_table_external_upstream_workunits(
-        self, discovered_tables: List[str]
-    ) -> Iterable[MetadataWorkUnit]:
+    def get_table_external_upstream_workunits(self) -> Iterable[MetadataWorkUnit]:
         for (
             dataset_name,
             external_lineage,
@@ -133,7 +137,6 @@ class SnowflakeLineageExtractor(
                 "Snowflake Account is Standard Edition. Table to Table and View to Table Lineage Feature is not supported."
             )  # See Edition Note above for why
         else:
-            results = None
             with PerfTimer() as timer:
                 results = self._fetch_upstream_lineages_for_tables()
                 self.report.table_lineage_query_secs = timer.elapsed_seconds()
@@ -141,16 +144,30 @@ class SnowflakeLineageExtractor(
             if not results:
                 return
 
-            yield from self._build_upstream_lineage_workunits_from_query_result(
-                discovered_tables, results
-            )
+            yield from self._gen_workunits_from_query_result(discovered_tables, results)
             logger.info(
                 f"Upstream lineage detected for {self.report.num_tables_with_upstreams} tables.",
             )
 
-    def _build_upstream_lineage_workunits_from_query_result(
-        self, discovered_assets, results, upstream_for_view=False
-    ):
+    def _gen_workunit_from_sql_parsing_result(
+        self,
+        dataset_identifier: str,
+        result: SqlParsingResult,
+    ) -> MetadataWorkUnit:
+        upstreams, fine_upstreams = self.get_upstreams_from_sql_parsing_result(
+            self.dataset_urn_builder(dataset_identifier), result
+        )
+        self.report.num_views_with_upstreams += 1
+        return self._create_upstream_lineage_workunit(
+            dataset_identifier, upstreams, fine_upstreams
+        )
+
+    def _gen_workunits_from_query_result(
+        self,
+        discovered_assets: Collection[str],
+        results: Iterable[dict],
+        upstream_for_view: bool = False,
+    ) -> Iterable[MetadataWorkUnit]:
         for db_row in results:
             dataset_name = self.get_dataset_identifier_from_qualified_name(
                 db_row["DOWNSTREAM_TABLE_NAME"]
@@ -173,9 +190,25 @@ class SnowflakeLineageExtractor(
                 logger.debug(f"No lineage found for {dataset_name}")
 
     def get_view_upstream_workunits(
-        self, discovered_views: List[str]
+        self,
+        discovered_views: List[str],
+        schema_resolver: SchemaResolver,
+        view_definitions: MutableMapping[str, str],
     ) -> Iterable[MetadataWorkUnit]:
-        results = None
+        views_processed = set()
+        if self.config.include_column_lineage:
+            with PerfTimer() as timer:
+                for view_identifier, view_definition in view_definitions.items():
+                    result = self._run_sql_parser(
+                        view_identifier, view_definition, schema_resolver
+                    )
+                    if result:
+                        views_processed.add(view_identifier)
+                        yield self._gen_workunit_from_sql_parsing_result(
+                            view_identifier, result
+                        )
+                self.report.view_lineage_parse_secs = timer.elapsed_seconds()
+
         with PerfTimer() as timer:
             results = self._fetch_upstream_lineages_for_views()
             self.report.view_upstream_lineage_query_secs = timer.elapsed_seconds()
@@ -183,16 +216,46 @@ class SnowflakeLineageExtractor(
         if not results:
             return
 
-        yield from self._build_upstream_lineage_workunits_from_query_result(
-            discovered_views, results, upstream_for_view=True
+        yield from self._gen_workunits_from_query_result(
+            set(discovered_views) - views_processed, results, upstream_for_view=True
         )
         logger.info(
             f"Upstream lineage detected for {self.report.num_views_with_upstreams} views.",
         )
 
+    def _run_sql_parser(
+        self, dataset_identifier: str, query: str, schema_resolver: SchemaResolver
+    ) -> Optional[SqlParsingResult]:
+        try:
+            database, schema, _view = dataset_identifier.split(".")
+        except ValueError:
+            logger.warning(f"Invalid view identifier: {dataset_identifier}")
+            return None
+        raw_lineage = sqlglot_lineage(
+            query,
+            schema_resolver=schema_resolver,
+            default_db=database,
+            default_schema=schema,
+        )
+        if raw_lineage.debug_info.table_error:
+            logger.debug(
+                f"Failed to parse lineage for view {dataset_identifier}: "
+                f"{raw_lineage.debug_info.table_error}"
+            )
+            self.report.num_view_definitions_failed_parsing += 1
+            return None
+        elif raw_lineage.debug_info.column_error:
+            self.report.num_view_definitions_failed_column_parsing += 1
+        else:
+            self.report.num_view_definitions_parsed += 1
+        return raw_lineage
+
     def _create_upstream_lineage_workunit(
-        self, dataset_name, upstreams, fine_upstreams=[]
-    ):
+        self,
+        dataset_name: str,
+        upstreams: Sequence[UpstreamClass],
+        fine_upstreams: Sequence[FineGrainedLineage] = (),
+    ) -> MetadataWorkUnit:
         logger.debug(
             f"Upstream lineage of '{dataset_name}': {[u.dataset for u in upstreams]}"
         )
@@ -200,7 +263,7 @@ class SnowflakeLineageExtractor(
             self.report.upstream_lineage[dataset_name] = [u.dataset for u in upstreams]
 
         upstream_lineage = UpstreamLineage(
-            upstreams=upstreams,
+            upstreams=sorted(upstreams, key=lambda x: x.dataset),
             fineGrainedLineages=sorted(
                 fine_upstreams,
                 key=lambda x: (x.downstreams, x.upstreams),
@@ -211,7 +274,9 @@ class SnowflakeLineageExtractor(
             entityUrn=self.dataset_urn_builder(dataset_name), aspect=upstream_lineage
         ).as_workunit()
 
-    def get_upstreams_from_query_result_row(self, dataset_name, db_row):
+    def get_upstreams_from_query_result_row(
+        self, dataset_name: str, db_row: dict
+    ) -> Tuple[List[UpstreamClass], List[FineGrainedLineage]]:
         upstreams: List[UpstreamClass] = []
         fine_upstreams: List[FineGrainedLineage] = []
 
@@ -236,6 +301,36 @@ class SnowflakeLineageExtractor(
             upstreams += self.get_external_upstreams(external_lineage)
 
         return upstreams, fine_upstreams
+
+    def get_upstreams_from_sql_parsing_result(
+        self, downstream_table_urn: str, result: SqlParsingResult
+    ) -> Tuple[List[UpstreamClass], List[FineGrainedLineage]]:
+        # Note: This ignores the out_tables section of the sql parsing result.
+        upstreams = [
+            UpstreamClass(dataset=upstream_table_urn, type=DatasetLineageTypeClass.VIEW)
+            for upstream_table_urn in set(result.in_tables)
+        ]
+
+        # Maps downstream_col -> [upstream_col]
+        fine_lineage: Dict[str, Set[SnowflakeColumnId]] = defaultdict(set)
+        for column_lineage in result.column_lineage or []:
+            out_column = column_lineage.downstream.column
+            for upstream_column_info in column_lineage.upstreams:
+                fine_lineage[out_column].add(
+                    SnowflakeColumnId(
+                        columnName=upstream_column_info.column,
+                        objectName=upstream_column_info.table,
+                        objectDomain=SnowflakeObjectDomain.VIEW.value,
+                    )
+                )
+        fine_upstreams = [
+            self.build_finegrained_lineage(
+                downstream_table_urn, downstream_col, upstream_cols
+            )
+            for downstream_col, upstream_cols in fine_lineage.items()
+        ]
+
+        return upstreams, list(filter(None, fine_upstreams))
 
     def _populate_external_lineage_map(self, discovered_tables: List[str]) -> None:
         with PerfTimer() as timer:
@@ -406,18 +501,14 @@ class SnowflakeLineageExtractor(
                 fine_upstream = self.build_finegrained_lineage(
                     dataset_urn=dataset_urn,
                     col=column_name,
-                    fine_upstream=SnowflakeColumnFineGrainedLineage(
-                        frozenset(
-                            [
-                                SnowflakeColumnId(
-                                    columnName=col["column_name"],
-                                    objectName=col["object_name"],
-                                    objectDomain=col["object_domain"],
-                                )
-                                for col in upstream_columns
-                            ]
+                    upstream_columns={
+                        SnowflakeColumnId(
+                            columnName=col["column_name"],
+                            objectName=col["object_name"],
+                            objectDomain=col["object_domain"],
                         )
-                    ),
+                        for col in upstream_columns
+                    },
                 )
                 if not fine_upstream:
                     continue
@@ -447,11 +538,9 @@ class SnowflakeLineageExtractor(
         self,
         dataset_urn: str,
         col: str,
-        fine_upstream: SnowflakeColumnFineGrainedLineage,
+        upstream_columns: Set[SnowflakeColumnId],
     ) -> Optional[FineGrainedLineage]:
-        fieldPath = col
-
-        column_upstreams = self.build_finegrained_lineage_upstreams(fine_upstream)
+        column_upstreams = self.build_finegrained_lineage_upstreams(upstream_columns)
         if not column_upstreams:
             return None
         finegrained_lineage_entry = FineGrainedLineage(
@@ -462,7 +551,7 @@ class SnowflakeLineageExtractor(
             downstreamType=FineGrainedLineageDownstreamType.FIELD,
             downstreams=[
                 builder.make_schema_field_urn(
-                    dataset_urn, self.snowflake_identifier(fieldPath)
+                    dataset_urn, self.snowflake_identifier(col)
                 )
             ],
         )
@@ -470,10 +559,10 @@ class SnowflakeLineageExtractor(
         return finegrained_lineage_entry
 
     def build_finegrained_lineage_upstreams(
-        self, fine_upstream: SnowflakeColumnFineGrainedLineage
+        self, upstream_columms: Set[SnowflakeColumnId]
     ) -> List[str]:
         column_upstreams = []
-        for upstream_col in fine_upstream.inputColumns:
+        for upstream_col in upstream_columms:
             if (
                 upstream_col.objectName
                 and upstream_col.columnName

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
@@ -26,6 +26,7 @@ class SnowflakeV2Report(
 
     usage_aggregation_query_secs: float = -1
     table_lineage_query_secs: float = -1
+    view_lineage_parse_secs: float = -1
     view_upstream_lineage_query_secs: float = -1
     view_downstream_lineage_query_secs: float = -1
     external_lineage_queries_secs: float = -1
@@ -58,6 +59,10 @@ class SnowflakeV2Report(
     num_tables_with_external_upstreams_only: int = 0
     num_tables_with_upstreams: int = 0
     num_views_with_upstreams: int = 0
+
+    num_view_definitions_parsed: int = 0
+    num_view_definitions_failed_parsing: int = 0
+    num_view_definitions_failed_column_parsing: int = 0
 
     def report_entity_scanned(self, name: str, ent_type: str = "table") -> None:
         """

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -88,6 +88,7 @@ class SnowflakeTable(BaseTable):
 
 @dataclass
 class SnowflakeView(BaseView):
+    materialized: bool = False
     columns: List[SnowflakeColumn] = field(default_factory=list)
     tags: Optional[List[SnowflakeTag]] = None
     column_tags: Dict[str, List[SnowflakeTag]] = field(default_factory=dict)
@@ -321,6 +322,8 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
                     comment=table["comment"],
                     view_definition=table["text"],
                     last_altered=table["created_on"],
+                    materialized=table.get("is_materialized", "false").lower()
+                    == "true",
                 )
             )
         return views

--- a/metadata-ingestion/src/datahub/ingestion/source_config/sql/snowflake.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/sql/snowflake.py
@@ -91,7 +91,7 @@ class BaseSnowflakeConfig(BaseTimeWindowConfig):
     )
     include_view_lineage: bool = pydantic.Field(
         default=True,
-        description="If enabled, populates the snowflake view->table and table->view lineages (no view->view lineage yet). Requires appropriate grants given to the role, and include_table_lineage to be True. view->table lineage requires Snowflake Enterprise Edition or above.",
+        description="If enabled, populates the snowflake view->table and table->view lineages. Requires appropriate grants given to the role, and include_table_lineage to be True. view->table lineage requires Snowflake Enterprise Edition or above.",
     )
     connect_args: Optional[Dict[str, Any]] = pydantic.Field(
         default=None,

--- a/metadata-ingestion/src/datahub/utilities/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlglot_lineage.py
@@ -20,6 +20,7 @@ from datahub.emitter.mce_builder import (
     DEFAULT_ENV,
     make_dataset_urn_with_platform_instance,
 )
+from datahub.ingestion.api.closeable import Closeable
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.source.bigquery_v2.bigquery_audit import BigqueryTableIdentifier
 from datahub.metadata.schema_classes import SchemaMetadataClass
@@ -223,7 +224,7 @@ def _table_level_lineage(
     return tables, modified
 
 
-class SchemaResolver:
+class SchemaResolver(Closeable):
     def __init__(
         self,
         *,
@@ -339,6 +340,9 @@ class SchemaResolver:
         }
 
     # TODO add a method to load all from graphql
+
+    def close(self) -> None:
+        self._schema_cache.close()
 
 
 # TODO: Once PEP 604 is supported (Python 3.10), we can unify these into a


### PR DESCRIPTION
cc @mayurinehate just for visibility

Looking to remove legacy lineage in another PR
Some questions / comments:
- I'd like to make the schema resolver take in a callable `dataset_urn_builder` like I do for the lineage and usage extractors, rather than taking in platform and env and calling the mce_builder method itself. It likely won't make a difference but I like having one function so we can be sure all dataset urns are generated in the same way, since we do that in a lot of places
- I added a close method to the schema resolver and call it in the snowflake source's close method. However, the bigquery source notes that doesn't get called if ingestion is not successful and thus has its own cleanup method. Can we unify this, ideally around the source's close method?
- We mention how we want to sort fine grained lineage to avoid duplicate lineages... I'm slightly worried about something similar for regular upstreamclass lineage, so I cast `set` on `sql_parsing_result.in_tables` and I sort the list too. Is this necessary?

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
