### PR TITLE
fix(ingestion-redshift): Fix Redshift ingestion logs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -813,7 +813,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
                     )
                 else:
                     logger.debug(
-                        f"View {database}.{schema}.{table.name} is filtered by view_pattern"
+                        f"View {database}.{schema}.{view.name} is filtered by view_pattern"
                     )
                     self.report.view_filtered[f"{database}.{schema}"] = (
                         self.report.view_filtered.get(f"{database}.{schema}", 0) + 1


### PR DESCRIPTION
## Checklist

- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Referring table variable in the view for loop gets the below error
```packages/datahub/ingestion/source/redshift/redshift.py", line 818, in cache_tables_and_views
    f"View {database}.{schema}.{table.name} is filtered by view_pattern"
UnboundLocalError: local variable 'table' referenced before assignment
