### PR TITLE
Fix query_tab test that was failing on CI run

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/query/query_tab.js
+++ b/smoke-test/tests/cypress/cypress/e2e/query/query_tab.js
@@ -11,7 +11,7 @@ describe("manage queries", () => {
     cy.openEntityTab("Queries")
   })
 
-  it("go to querys tab on dataset page then, create, edit, make default, delete a view", () => {
+  it("go to queries tab on dataset page then, create, edit, make default, delete a view", () => {
     const runId = Date.now()
 
     // Headers
@@ -27,6 +27,7 @@ describe("manage queries", () => {
     cy.get('.ProseMirror').click();
     cy.get('.ProseMirror').type(`Test Description-${runId}`);
     cy.get('[data-testid="query-builder-save-button"]').click();
+    cy.waitTextVisible("Created Query!");
 
     // Verify the card
     cy.waitTextVisible(`+ Test Query-${runId}`);
@@ -36,10 +37,10 @@ describe("manage queries", () => {
 
     // View the Query
     cy.get('[data-testid="query-content-0"]').click();
+    cy.get('.ant-modal-content').waitTextVisible(`+ Test Query-${runId}`);
+    cy.get('.ant-modal-content').waitTextVisible(`Test Table-${runId}`);
+    cy.get('.ant-modal-content').waitTextVisible(`Test Description-${runId}`);
     cy.get('[data-testid="query-modal-close-button"]').click();
-    cy.waitTextVisible(`+ Test Query-${runId}`);
-    cy.waitTextVisible(`Test Table-${runId}`);
-    cy.waitTextVisible(`Test Description-${runId}`);
 
     // Edit the Query
     cy.get('[data-testid="query-edit-button-0"]').click()
@@ -52,20 +53,23 @@ describe("manage queries", () => {
     cy.get('.ProseMirror').clear();
     cy.get('.ProseMirror').type(`Edited Description-${runId}`);
     cy.get('[data-testid="query-builder-save-button"]').click();
+    cy.waitTextVisible("Edited Query!");
 
-    // Verify the card
+    // Verify edited Query card
+    cy.get('[data-testid="query-content-0"]').scrollIntoView().should('be.visible');
     cy.waitTextVisible(`+ Test Query-${runId} + Edited Query-${runId}`);
-    cy.waitTextVisible(`Edited Description-${runId}`);
+    cy.waitTextVisible(`Edited Table-${runId}`);
     cy.waitTextVisible(`Edited Description-${runId}`);
 
     // Delete the Query
     cy.get('[data-testid="query-more-button-0"]').click();
     cy.get('[data-testid="query-delete-button-0"]').click();
     cy.contains('Yes').click();
+    cy.waitTextVisible("Deleted Query!");
 
     // Query should be gone
     cy.ensureTextNotPresent(`+ Test Query-${runId} + Edited Query-${runId}`);
-    cy.ensureTextNotPresent(`Edited Description-${runId}`);
+    cy.ensureTextNotPresent(`Edited Table-${runId}`);
     cy.ensureTextNotPresent(`Edited Description-${runId}`);
   });
 });


### PR DESCRIPTION
Fixed some duplicated steps
Added verifications for Query added/edited/removed notifications
Fixed a case when query tab was verified instead of query view
Main fix: This test been failing on CI with error "Timed out retrying after 10000ms: Expected to find content: '+ Test Query-1689481016643 + Edited Query-1689481016643' but never did."
This happened because cypress scrolled queries view and at some point this element become invisible for cypress while still present on UI and DOM.
Note: 'waitTextVisible' function always check for visibility of element(not only if it present in DOM)
To fix this I've used 'scrollIntoView' Cypress function for the Test query element.

https://linear.app/acryl-data/issue/OBS-46/qa-query-tab-smoke-test

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
