### PR TITLE
Update presto-on-hive URN in data_platforms.json

### DIFF
--- a/metadata-service/war/src/main/resources/boot/data_platforms.json
+++ b/metadata-service/war/src/main/resources/boot/data_platforms.json
@@ -427,7 +427,7 @@
     }
   },
   {
-    "urn": "urn:li:dataPlatform:presto_on_hive",
+    "urn": "urn:li:dataPlatform:presto-on-hive",
     "aspect": {
       "datasetNameDelimiter": ".",
       "name": "presto-on-hive",


### PR DESCRIPTION
This was typo'd when the source was initially introduced. The source emits MCPs using presto-on-hive syntax, see for example:

https://github.com/datahub-project/datahub/blob/bec018257c8c7c9af7dc79d91e8db34414188ff0/metadata-ingestion/tests/integration/presto-on-hive/presto_on_hive_mces_golden_2.json#L491


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
