### PR TITLE
fix(ui) Fix broken dataPlatformInstance references

### DIFF
--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -34,6 +34,7 @@ import { ContainerEntity } from './app/entity/container/ContainerEntity';
 import GlossaryNodeEntity from './app/entity/glossaryNode/GlossaryNodeEntity';
 import { DataPlatformEntity } from './app/entity/dataPlatform/DataPlatformEntity';
 import { DataProductEntity } from './app/entity/dataProduct/DataProductEntity';
+import { DataPlatformInstanceEntity } from './app/entity/dataPlatformInstance/DataPlatformInstanceEntity';
 
 /*
     Construct Apollo Client
@@ -116,6 +117,7 @@ const App: React.VFC = () => {
         register.register(new GlossaryNodeEntity());
         register.register(new DataPlatformEntity());
         register.register(new DataProductEntity());
+        register.register(new DataPlatformInstanceEntity());
         return register;
     }, []);
 

--- a/datahub-web-react/src/app/entity/dataPlatformInstance/DataPlatformInstanceEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataPlatformInstance/DataPlatformInstanceEntity.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { DataPlatformInstance, EntityType } from '../../../types.generated';
+import { Entity } from '../Entity';
+import { GenericEntityProperties } from '../shared/types';
+import { getDataForEntityType } from '../shared/containers/profile/utils';
+
+/**
+ * Definition of the DataHub DataPlatformInstance entity.
+ * Most of this still needs to be filled out.
+ */
+export class DataPlatformInstanceEntity implements Entity<DataPlatformInstance> {
+    type: EntityType = EntityType.DataPlatformInstance;
+
+    icon = () => {
+        return <></>;
+    };
+
+    isSearchEnabled = () => false;
+
+    isBrowseEnabled = () => false;
+
+    isLineageEnabled = () => false;
+
+    getAutoCompleteFieldName = () => 'name';
+
+    getPathName = () => 'dataPlatformInstance';
+
+    getEntityName = () => 'Data Platform Instance';
+
+    getCollectionName = () => 'Data Platform Instances';
+
+    renderProfile = () => <></>;
+
+    getOverridePropertiesFromEntity = (): GenericEntityProperties => {
+        return {};
+    };
+
+    renderPreview = () => {
+        return <></>;
+    };
+
+    renderSearch = () => {
+        return <></>;
+    };
+
+    displayName = (data: DataPlatformInstance) => {
+        return data?.instanceId || data.urn;
+    };
+
+    getGenericEntityProperties = (data: DataPlatformInstance) => {
+        return getDataForEntityType({
+            data,
+            entityType: this.type,
+            getOverrideProperties: this.getOverridePropertiesFromEntity,
+        });
+    };
+
+    supportedCapabilities = () => {
+        return new Set([]);
+    };
+}

--- a/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseNode.tsx
@@ -21,6 +21,7 @@ import {
 } from './BrowseContext';
 import useSidebarAnalytics from './useSidebarAnalytics';
 import EntityLink from './EntityLink';
+import { EntityType } from '../../../types.generated';
 
 const FolderStyled = styled(FolderOutlined)`
     font-size: 16px;
@@ -42,7 +43,7 @@ const BrowseNode = () => {
     const platformAggregation = usePlatformAggregation();
     const browseResultGroup = useBrowseResultGroup();
     const { count, entity } = browseResultGroup;
-    const hasEntityLink = !!entity;
+    const hasEntityLink = !!entity && entity.type !== EntityType.DataPlatformInstance;
     const displayName = useBrowseDisplayName();
     const { trackSelectNodeEvent, trackToggleNodeEvent } = useSidebarAnalytics();
 

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1112,4 +1112,7 @@ fragment entityDisplayNameFields on Entity {
             name
         }
     }
+    ... on DataPlatformInstance {
+        instanceId
+    }
 }


### PR DESCRIPTION
With the new search and browse experiences, we introduced dataPlatformInstances to a new place where they are treated like full-blown entities. For example, a dataPlatformInstance urn will often be in browse paths. We then try to use the entity registry in many different places to render an entity name, but would get an error thrown if we tried to do that for a dataPlatformInstance.

This PR adds `DataPlatformInstanceEntitiy` to the frontend entity registry so we can render the display name properly. The other pieces are unimportant and will be unused entirely (we never try to render a profile for a data platform instance). What's more, is that if we ever tried to do any of these methods anywhere else in the app, the app would just crash like it did when I tried to get entity name so this is definitely a win.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
