### PR TITLE
feat(ingest): allow lower freq profiling based on date of month/day of week

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -310,7 +310,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                     project_id=project_id,
                     dataset_name=result[0].name,
                     tables={},
-                    with_data_read_permission=config.profiling.enabled,
+                    with_data_read_permission=config.is_profiling_enabled(),
                 )
                 if len(list(tables)) == 0:
                     return CapabilityReport(
@@ -612,7 +612,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             )
         except Exception as e:
             error_message = f"Unable to get datasets for project {project_id}, skipping. The error was: {e}"
-            if self.config.profiling.enabled:
+            if self.config.is_profiling_enabled():
                 error_message = f"Unable to get datasets for project {project_id}, skipping. Does your service account has bigquery.datasets.get permission? The error was: {e}"
             logger.error(error_message)
             self.report.report_failure(
@@ -647,7 +647,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
             except Exception as e:
                 error_message = f"Unable to get tables for dataset {bigquery_dataset.name} in project {project_id}, skipping. Does your service account has bigquery.tables.list, bigquery.routines.get, bigquery.routines.list permission? The error was: {e}"
-                if self.config.profiling.enabled:
+                if self.config.is_profiling_enabled():
                     error_message = f"Unable to get tables for dataset {bigquery_dataset.name} in project {project_id}, skipping. Does your service account has bigquery.tables.list, bigquery.routines.get, bigquery.routines.list permission, bigquery.tables.getData permission? The error was: {e}"
 
                 trace = traceback.format_exc()
@@ -659,7 +659,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                 )
                 continue
 
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             logger.info(f"Starting profiling project {project_id}")
             self.report.set_ingestion_stage(project_id, "Profiling")
             yield from self.profiler.get_workunits(
@@ -793,7 +793,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
         if self.config.include_views:
             db_views[dataset_name] = list(
                 BigQueryDataDictionary.get_views_for_dataset(
-                    conn, project_id, dataset_name, self.config.profiling.enabled
+                    conn, project_id, dataset_name, self.config.is_profiling_enabled()
                 )
             )
 
@@ -841,7 +841,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
 
         # We only collect profile ignore list if profiling is enabled and profile_table_level_only is false
         if (
-            self.config.profiling.enabled
+            self.config.is_profiling_enabled()
             and not self.config.profiling.profile_table_level_only
         ):
             table.columns_ignore_from_profiling = self.generate_profile_ignore_list(
@@ -1218,7 +1218,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             # https://cloud.google.com/bigquery/docs/information-schema-partitions
             max_batch_size: int = (
                 self.config.number_of_datasets_process_in_batch
-                if not self.config.profiling.enabled
+                if not self.config.is_profiling_enabled()
                 else self.config.number_of_datasets_process_in_batch_if_profiling_enabled
             )
 
@@ -1235,7 +1235,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                         project_id,
                         dataset_name,
                         items_to_get,
-                        with_data_read_permission=self.config.profiling.enabled,
+                        with_data_read_permission=self.config.is_profiling_enabled(),
                     )
                     items_to_get.clear()
 
@@ -1245,7 +1245,7 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
                     project_id,
                     dataset_name,
                     items_to_get,
-                    with_data_read_permission=self.config.profiling.enabled,
+                    with_data_read_permission=self.config.is_profiling_enabled(),
                 )
 
         self.report.metadata_extraction_sec[f"{project_id}.{dataset_name}"] = round(

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -204,7 +204,7 @@ class ElasticProfiling(ConfigModel):
         description="Whether to enable profiling for the elastic search source.",
     )
     operation_config: OperationConfig = Field(
-        default_factory=OperationConfig, description="To specify operation configs."
+        default_factory=OperationConfig, description="Experimental feature. To specify operation configs."
     )
 
     def is_profiling_enabled(self) -> bool:

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -208,9 +208,6 @@ class ElasticProfiling(ConfigModel):
         description="Experimental feature. To specify operation configs.",
     )
 
-    def is_profiling_enabled(self) -> bool:
-        return self.enabled and is_profiling_enabled(self.operation_config)
-
 
 class CollapseUrns(ConfigModel):
     urns_suffix_regex: List[str] = Field(
@@ -306,6 +303,11 @@ class ElasticsearchSourceConfig(PlatformInstanceConfigMixin, EnvConfigMixin):
     collapse_urns: CollapseUrns = Field(
         default_factory=CollapseUrns,
     )
+
+    def is_profiling_enabled(self) -> bool:
+        return self.profiling.enabled and is_profiling_enabled(
+            self.profiling.operation_config
+        )
 
     @validator("host")
     def host_colon_port_comma(cls, host_val: str) -> str:
@@ -522,7 +524,7 @@ class ElasticsearchSource(Source):
                 ),
             )
 
-        if self.source_config.profiling.is_profiling_enabled():
+        if self.source_config.is_profiling_enabled():
             if self.cat_response is None:
                 self.cat_response = self.client.cat.indices(
                     params={

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -204,7 +204,8 @@ class ElasticProfiling(ConfigModel):
         description="Whether to enable profiling for the elastic search source.",
     )
     operation_config: OperationConfig = Field(
-        default_factory=OperationConfig, description="Experimental feature. To specify operation configs."
+        default_factory=OperationConfig,
+        description="Experimental feature. To specify operation configs.",
     )
 
     def is_profiling_enabled(self) -> bool:

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -207,7 +207,7 @@ class ElasticProfiling(ConfigModel):
         default_factory=OperationConfig, description="To specify operation configs."
     )
 
-    def is_profiling_enabld(self) -> bool:
+    def is_profiling_enabled(self) -> bool:
         return self.enabled and is_profiling_enabled(self.operation_config)
 
 
@@ -521,7 +521,7 @@ class ElasticsearchSource(Source):
                 ),
             )
 
-        if self.source_config.profiling.is_profiling_enabld():
+        if self.source_config.profiling.is_profiling_enabled():
             if self.cat_response is None:
                 self.cat_response = self.client.cat.indices(
                     params={

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_profiling_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_profiling_config.py
@@ -7,6 +7,7 @@ import pydantic
 from pydantic.fields import Field
 
 from datahub.configuration.common import AllowDenyPattern, ConfigModel
+from datahub.ingestion.source_config.operation_config import OperationConfig
 
 _PROFILING_FLAGS_TO_REPORT = {
     "turn_off_expensive_profiling_metrics",
@@ -21,6 +22,10 @@ logger = logging.getLogger(__name__)
 class GEProfilingConfig(ConfigModel):
     enabled: bool = Field(
         default=False, description="Whether profiling should be done."
+    )
+    operation_config: OperationConfig = Field(
+        default_factory=OperationConfig,
+        description="Experimental feature. To specify operation configs.",
     )
     limit: Optional[int] = Field(
         default=None,

--- a/metadata-ingestion/src/datahub/ingestion/source/glue_profiling_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue_profiling_config.py
@@ -3,6 +3,7 @@ from typing import Optional
 from pydantic.fields import Field
 
 from datahub.configuration.common import AllowDenyPattern, ConfigModel
+from datahub.ingestion.source_config.operation_config import OperationConfig
 
 
 class GlueProfilingConfig(ConfigModel):
@@ -53,4 +54,9 @@ class GlueProfilingConfig(ConfigModel):
     partition_patterns: AllowDenyPattern = Field(
         default=AllowDenyPattern.allow_all(),
         description="""Regex patterns for filtering partitions for profile. The pattern should be a string like: "{'key':'value'}".""",
+    )
+
+    operation_config: OperationConfig = Field(
+        default_factory=OperationConfig,
+        description="Experimental feature. To specify operation configs.",
     )

--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg.py
@@ -199,7 +199,7 @@ class IcebergSource(StatefulIngestionSourceBase):
         if dpi_aspect:
             yield dpi_aspect
 
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             profiler = IcebergProfiler(self.report, self.config.profiling)
             yield from profiler.profile_table(dataset_name, dataset_urn, table)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
@@ -51,7 +51,7 @@ class RedshiftProfiler(GenericProfiler):
     ) -> Iterable[MetadataWorkUnit]:
         # Extra default SQLAlchemy option for better connection pooling and threading.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             self.config.options.setdefault(
                 "max_overflow", self.config.profiling.max_workers
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -408,7 +408,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
                 connection=connection, all_tables=all_tables, database=database
             )
 
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             profiler = RedshiftProfiler(
                 config=self.config,
                 report=self.report,

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/config.py
@@ -18,6 +18,7 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
+from datahub.ingestion.source_config.operation_config import is_profiling_enabled
 
 # hide annoying debug errors from py4j
 logging.getLogger("py4j").setLevel(logging.ERROR)
@@ -83,6 +84,11 @@ class DataLakeSourceConfig(
     _rename_path_spec_to_plural = pydantic_renamed_field(
         "path_spec", "path_specs", lambda path_spec: [path_spec]
     )
+
+    def is_profiling_enabled(self) -> bool:
+        return self.profiling.enabled and is_profiling_enabled(
+            self.profiling.operation_config
+        )
 
     @pydantic.validator("path_specs", always=True)
     def check_path_specs_and_infer_platform(

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/datalake_profiler_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/datalake_profiler_config.py
@@ -5,11 +5,16 @@ from pydantic.fields import Field
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import AllowDenyPattern
+from datahub.ingestion.source_config.operation_config import OperationConfig
 
 
 class DataLakeProfilerConfig(ConfigModel):
     enabled: bool = Field(
         default=False, description="Whether profiling should be done."
+    )
+    operation_config: OperationConfig = Field(
+        default_factory=OperationConfig,
+        description="Experimental feature. To specify operation configs.",
     )
 
     # These settings will override the ones below.

--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -264,14 +264,17 @@ class S3Source(StatefulIngestionSourceBase):
             config_option: config.dict().get(config_option)
             for config_option in config_options_to_report
         }
-        config_report = {**config_report, "profiling_enabled": config.profiling.enabled}
+        config_report = {
+            **config_report,
+            "profiling_enabled": config.is_profiling_enabled(),
+        }
 
         telemetry.telemetry_instance.ping(
             "data_lake_config",
             config_report,
         )
 
-        if config.profiling.enabled:
+        if config.is_profiling_enabled():
             telemetry.telemetry_instance.ping(
                 "data_lake_profiling_config",
                 {
@@ -659,7 +662,7 @@ class S3Source(StatefulIngestionSourceBase):
             table_data.table_path, dataset_urn
         )
 
-        if self.source_config.profiling.enabled:
+        if self.source_config.is_profiling_enabled():
             yield from self.get_table_profile(table_data, dataset_urn)
 
     def get_prefix(self, relative_path: str) -> str:
@@ -884,7 +887,7 @@ class S3Source(StatefulIngestionSourceBase):
                 for guid, table_data in table_dict.items():
                     yield from self.ingest_table(table_data, path_spec)
 
-            if not self.source_config.profiling.enabled:
+            if not self.source_config.is_profiling_enabled():
                 return
 
             total_time_taken = timer.elapsed_seconds()

--- a/metadata-ingestion/src/datahub/ingestion/source/salesforce.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/salesforce.py
@@ -30,6 +30,10 @@ from datahub.ingestion.api.decorators import (
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
+from datahub.ingestion.source_config.operation_config import (
+    OperationConfig,
+    is_profiling_enabled,
+)
 from datahub.metadata.schema_classes import (
     AuditStampClass,
     BooleanTypeClass,
@@ -69,6 +73,10 @@ class SalesforceProfilingConfig(ConfigModel):
     enabled: bool = Field(
         default=False,
         description="Whether profiling should be done. Supports only table-level profiling at this stage",
+    )
+    operation_config: OperationConfig = Field(
+        default_factory=OperationConfig,
+        description="Experimental feature. To specify operation configs.",
     )
 
     # TODO - support field level profiling
@@ -123,6 +131,11 @@ class SalesforceConfig(DatasetSourceConfigMixin):
         default=AllowDenyPattern.allow_all(),
         description="Regex patterns for profiles to filter in ingestion, allowed by the `object_pattern`.",
     )
+
+    def is_profiling_enabled(self) -> bool:
+        return self.profiling.enabled and is_profiling_enabled(
+            self.profiling.operation_config
+        )
 
     @validator("instance_url")
     def remove_trailing_slash(cls, v):
@@ -329,7 +342,7 @@ class SalesforceSource(Source):
         if self.config.domain is not None:
             yield from self.get_domain_workunit(sObjectName, datasetUrn)
 
-        if self.config.profiling.enabled and self.config.profile_pattern.allowed(
+        if self.config.is_profiling_enabled() and self.config.profile_pattern.allowed(
             sObjectName
         ):
             yield from self.get_profile_workunit(sObjectName, datasetUrn)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
@@ -58,7 +58,7 @@ class SnowflakeProfiler(GenericProfiler, SnowflakeCommonMixin):
     ) -> Iterable[MetadataWorkUnit]:
         # Extra default SQLAlchemy option for better connection pooling and threading.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             self.config.options.setdefault(
                 "max_overflow", self.config.profiling.max_workers
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -272,7 +272,7 @@ class SnowflakeV2Source(
                 run_id=self.ctx.run_id,
             )
 
-        if config.profiling.enabled:
+        if config.is_profiling_enabled():
             # For profiling
             self.profiler = SnowflakeProfiler(
                 config, self.report, self.profiling_state_handler
@@ -701,7 +701,7 @@ class SnowflakeV2Source(
         for snowflake_schema in snowflake_db.schemas:
             yield from self._process_schema(snowflake_schema, db_name)
 
-        if self.config.profiling.enabled and self.db_tables:
+        if self.config.is_profiling_enabled() and self.db_tables:
             yield from self.profiler.get_workunits(snowflake_db, self.db_tables)
 
     def fetch_schemas_for_database(self, snowflake_db, db_name):

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mysql.py
@@ -86,7 +86,7 @@ class MySQLSource(TwoTierSQLAlchemySource):
         return cls(config, ctx)
 
     def add_profile_metadata(self, inspector: Inspector) -> None:
-        if not self.config.profiling.enabled:
+        if not self.config.is_profiling_enabled():
             return
         with inspector.engine.connect() as conn:
             for row in conn.execute(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -345,7 +345,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
 
         config_report = {
             **config_report,
-            "profiling_enabled": config.profiling.enabled,
+            "profiling_enabled": config.is_profiling_enabled(),
             "platform": platform,
         }
 
@@ -354,7 +354,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
             config_report,
         )
 
-        if config.profiling.enabled:
+        if config.is_profiling_enabled():
             telemetry.telemetry_instance.ping(
                 "sql_profiling_config",
                 config.profiling.config_for_telemetry(),
@@ -494,7 +494,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
 
         # Extra default SQLAlchemy option for better connection pooling and threading.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow
-        if sql_config.profiling.enabled:
+        if sql_config.is_profiling_enabled():
             sql_config.options.setdefault(
                 "max_overflow", sql_config.profiling.max_workers
             )
@@ -502,7 +502,7 @@ class SQLAlchemySource(StatefulIngestionSourceBase):
         for inspector in self.get_inspectors():
             profiler = None
             profile_requests: List["GEProfilerRequest"] = []
-            if sql_config.profiling.enabled:
+            if sql_config.is_profiling_enabled():
                 profiler = self.get_profiler_instance(inspector)
                 try:
                     self.add_profile_metadata(inspector)

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
@@ -16,6 +16,7 @@ from datahub.ingestion.source.state.stale_entity_removal_handler import (
 from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
+from datahub.ingestion.source_config.operation_config import is_profiling_enabled
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -65,6 +66,11 @@ class SQLAlchemyConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin):
     profiling: GEProfilingConfig = GEProfilingConfig()
     # Custom Stateful Ingestion settings
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = None
+
+    def is_profiling_enabled(self) -> bool:
+        return self.profiling.enabled and is_profiling_enabled(
+            self.profiling.operation_config
+        )
 
     @pydantic.root_validator(pre=True)
     def view_pattern_is_table_pattern_unless_specified(

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
@@ -139,7 +139,7 @@ class VerticaSource(SQLAlchemySource):
 
         # Extra default SQLAlchemy option for better connection pooling and threading.
         # https://docs.sqlalchemy.org/en/14/core/pooling.html#sqlalchemy.pool.QueuePool.params.max_overflow
-        if sql_config.profiling.enabled:
+        if sql_config.is_profiling_enabled():
             sql_config.options.setdefault(
                 "max_overflow", sql_config.profiling.max_workers
             )
@@ -147,7 +147,7 @@ class VerticaSource(SQLAlchemySource):
         for inspector in self.get_inspectors():
             profiler = None
             profile_requests: List["GEProfilerRequest"] = []
-            if sql_config.profiling.enabled:
+            if sql_config.is_profiling_enabled():
                 profiler = self.get_profiler_instance(inspector)
 
             db_name = self.get_db_name(inspector)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -17,12 +17,20 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulProfilingConfigMixin,
 )
 from datahub.ingestion.source.usage.usage_common import BaseUsageConfig
+from datahub.ingestion.source_config.operation_config import (
+    OperationConfig,
+    is_profiling_enabled,
+)
 
 
 class UnityCatalogProfilerConfig(ConfigModel):
     # TODO: Reduce duplicate code with DataLakeProfilerConfig, GEProfilingConfig, SQLAlchemyConfig
     enabled: bool = Field(
         default=False, description="Whether profiling should be done."
+    )
+    operation_config: OperationConfig = Field(
+        default_factory=OperationConfig,
+        description="Experimental feature. To specify operation configs.",
     )
 
     warehouse_id: Optional[str] = Field(
@@ -141,6 +149,11 @@ class UnityCatalogSourceConfig(
     profiling: UnityCatalogProfilerConfig = Field(
         default=UnityCatalogProfilerConfig(), description="Data profiling configuration"
     )
+
+    def is_profiling_enabled(self) -> bool:
+        return self.profiling.enabled and is_profiling_enabled(
+            self.profiling.operation_config
+        )
 
     stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = pydantic.Field(
         default=None, description="Unity Catalog Stateful Ingestion Config."

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/connection_test.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/connection_test.py
@@ -60,7 +60,7 @@ class UnityCatalogConnectionTest:
             return CapabilityReport(capable=False, failure_reason=str(e))
 
     def profiling_connectivity(self) -> Optional[CapabilityReport]:
-        if not self.config.profiling.enabled:
+        if not self.config.is_profiling_enabled():
             return None
         try:
             return CapabilityReport(capable=self.proxy.check_profiling_connectivity())

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -175,7 +175,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         wait_on_warehouse = None
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             # Can take several minutes, so start now and wait later
             wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
             if wait_on_warehouse is None:
@@ -200,7 +200,7 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 self.table_refs | self.view_refs
             )
 
-        if self.config.profiling.enabled:
+        if self.config.is_profiling_enabled():
             assert wait_on_warehouse
             timeout = timedelta(seconds=self.config.profiling.max_wait_secs)
             wait_on_warehouse.result(timeout)

--- a/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
@@ -1,0 +1,82 @@
+import datetime
+import logging
+from typing import Optional
+
+import click
+import pydantic
+from pydantic.fields import Field
+
+from datahub.configuration.common import ConfigModel, ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+
+class OperationConfig(ConfigModel):
+    lower_freq_profile_enabled: bool = Field(
+        default=False,
+        description="Whether to do profiling at lower freq or not. This does not do any scheduling just adds additional checks to when not to run profiling.",
+    )
+    profile_day_of_week: Optional[int] = Field(
+        default=None,
+        description="Number between 0 to 6 for day of week (both inclusive). 0 is Monday and 6 is Sunday. If not specified, defaults to Nothing and this field does not take affect.",
+    )
+    profile_date_of_month: Optional[int] = Field(
+        default=None,
+        description="Number between 1 to 31 for date of month (both inclusive). If not specified, defaults to Nothing and this field does not take affect.",
+    )
+
+    @pydantic.validator("profile_day_of_week")
+    def validate_profile_day_of_week(cls, v) -> Optional[int]:
+        profile_day_of_week = v
+        if profile_day_of_week is None:
+            return None
+        if profile_day_of_week < 0 or profile_day_of_week > 6:
+            raise ConfigurationError(
+                f"Invalid value {profile_day_of_week} for profile_day_of_week. Must be between 0 to 6 (both inclusive)."
+            )
+        return profile_day_of_week
+
+    @pydantic.validator("profile_date_of_month")
+    def validate_profile_date_of_month(cls, v) -> Optional[int]:
+        profile_date_of_month = v
+        if profile_date_of_month is None:
+            return None
+        if profile_date_of_month < 1 or profile_date_of_month > 31:
+            raise ConfigurationError(
+                f"Invalid value {profile_date_of_month} for profile_date_of_month. Must be between 1 to 31 (both inclusive)."
+            )
+        return profile_date_of_month
+
+
+def is_profiling_enabled(operation_config: OperationConfig) -> bool:
+    if operation_config.lower_freq_profile_enabled is False:
+        return True
+    if (
+        operation_config.profile_day_of_week is None
+        and operation_config.profile_date_of_month is None
+    ):
+        click.secho(
+            "Lower freq profiling setting is enabled but no day of week or date of month is specified. Profiling will be done.",
+            fg="yellow",
+        )
+    logger.info("Lower freq profiling setting is enabled.")
+    today = datetime.date.today()
+    if (
+        operation_config.profile_day_of_week is not None
+        and operation_config.profile_date_of_month != today.weekday()
+    ):
+        click.secho(
+            "Profiling won't be done because weekday does not match config profile_date_of_month.",
+            fg="yellow",
+        )
+        return False
+    if (
+        operation_config.profile_date_of_month is not None
+        and operation_config.profile_date_of_month != today.day
+    ):
+        click.secho(
+            "Profiling won't be done because date of month does not match config profile_date_of_month.",
+            fg="yellow",
+        )
+        return False
+    return True

--- a/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
@@ -25,7 +25,7 @@ class OperationConfig(ConfigModel):
     )
 
     @pydantic.root_validator(pre=True)
-    def lower_freq_configs_are_set(cls, values: Dict[str, Any]) -> Any:
+    def lower_freq_configs_are_set(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         lower_freq_profile_enabled = values.get("lower_freq_profile_enabled")
         profile_day_of_week = values.get("profile_day_of_week")
         profile_date_of_month = values.get("profile_date_of_month")
@@ -37,9 +37,10 @@ class OperationConfig(ConfigModel):
             raise ConfigurationError(
                 "Lower freq profiling setting is enabled but no day of week or date of month is specified. Profiling will be done.",
             )
+        return values
 
     @pydantic.validator("profile_day_of_week")
-    def validate_profile_day_of_week(cls, v) -> Optional[int]:
+    def validate_profile_day_of_week(cls, v: Optional[int]) -> Optional[int]:
         profile_day_of_week = v
         if profile_day_of_week is None:
             return None
@@ -50,7 +51,7 @@ class OperationConfig(ConfigModel):
         return profile_day_of_week
 
     @pydantic.validator("profile_date_of_month")
-    def validate_profile_date_of_month(cls, v) -> Optional[int]:
+    def validate_profile_date_of_month(cls, v: Optional[int]) -> Optional[int]:
         profile_date_of_month = v
         if profile_date_of_month is None:
             return None

--- a/metadata-ingestion/tests/unit/test_elasticsearch_source.py
+++ b/metadata-ingestion/tests/unit/test_elasticsearch_source.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Tuple
 import pydantic
 import pytest
 
+from datahub.configuration.common import ConfigurationError
 from datahub.ingestion.source.elastic_search import (
     CollapseUrns,
     ElasticsearchSourceConfig,
@@ -15,6 +16,20 @@ from datahub.ingestion.source.elastic_search import (
 from datahub.metadata.com.linkedin.pegasus2avro.schema import SchemaField
 
 logger = logging.getLogger(__name__)
+
+
+def test_elasticsearch_throws_error_wrong_operation_config():
+    with pytest.raises(ConfigurationError):
+        ElasticsearchSourceConfig.parse_obj(
+            {
+                "profiling": {
+                    "enabled": True,
+                    "operation_config": {
+                        "lower_freq_profile_enabled": True,
+                    },
+                }
+            }
+        )
 
 
 def assert_field_paths_are_unique(fields: List[SchemaField]) -> None:


### PR DESCRIPTION
This allows us to have a common interface that we can use across connectors. Currently it is only to allow for better control of ingestion profiling but we can use the same interface to control various aspects of ingestion.

This is required for profiling currently because it is a costly operation and organisations want to do profiling at a lower cadence. Day of week or date of month is simple enough to implement in python code that we do not have to do anything source config and we can easily allow this on all sources compared to doing source specific changes.

Doing it initially only for elasticsearch for review. Once the approach is reviewed will add this for all sources where profiling is present.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
