### PR TITLE
fix(ingest): Generate browse paths v2 for more sources; properly pass platform_instance

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -251,7 +251,7 @@ class Source(Closeable, metaclass=ABCMeta):
 
         platform_instance: Optional[str] = None
         if isinstance(config, PlatformInstanceConfigMixin) and config.platform_instance:
-            platform_instance = platform_instance
+            platform_instance = config.platform_instance
 
         return partial(
             auto_browse_path_v2,

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker.py
@@ -11,7 +11,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.aws.sagemaker_processors.common import (
     SagemakerSourceConfig,
@@ -56,9 +55,6 @@ class SagemakerSource(Source):
     def create(cls, config_dict, ctx):
         config = SagemakerSourceConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         # get common lineage graph

--- a/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/csv_enricher.py
@@ -17,7 +17,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source_config.csv_enricher import CSVEnricherConfig
 from datahub.metadata.schema_classes import (
@@ -589,9 +588,6 @@ class CSVEnricherSource(Source):
             if owner_urn.startswith("urn:li:")
         ]
         return owners
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         # As per https://stackoverflow.com/a/49150749/5004662, we want to use

--- a/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/delta_lake/source.py
@@ -21,7 +21,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.aws.s3_boto_utils import get_s3_tags
 from datahub.ingestion.source.aws.s3_util import (
@@ -339,9 +338,6 @@ class DeltaLakeSource(Source):
             )
         for folder in os.listdir(path):
             yield os.path.join(path, folder)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         self.container_WU_creator = ContainerWUCreator(

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -33,7 +33,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.common.subtypes import DatasetSubTypes
 from datahub.metadata.com.linkedin.pegasus2avro.common import StatusClass
@@ -351,9 +350,6 @@ class ElasticsearchSource(Source):
     ) -> "ElasticsearchSource":
         config = ElasticsearchSourceConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         indices = self.client.indices.get_alias()

--- a/metadata-ingestion/src/datahub/ingestion/source/feast.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/feast.py
@@ -1,7 +1,5 @@
 import sys
 
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
-
 if sys.version_info < (3, 8):
     raise ImportError("Feast is only supported on Python 3.8+")
 
@@ -369,9 +367,6 @@ class FeastRepositorySource(Source):
     def create(cls, config_dict, ctx):
         config = FeastRepositorySourceConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         for feature_view in self.feature_store.list_feature_views():

--- a/metadata-ingestion/src/datahub/ingestion/source/metabase.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metabase.py
@@ -21,7 +21,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.com.linkedin.pegasus2avro.common import (
     AuditStamp,
@@ -610,9 +609,6 @@ class MetabaseSource(Source):
     def create(cls, config_dict: dict, ctx: PipelineContext) -> Source:
         config = MetabaseConfig.parse_obj(config_dict)
         return cls(ctx, config)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         yield from self.emit_card_mces()

--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
@@ -20,11 +20,7 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import (
-    auto_status_aspect,
-    auto_workunit,
-    auto_workunit_reporter,
-)
+from datahub.ingestion.api.source_helpers import auto_workunit
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.utilities.registries.domain_registry import DomainRegistry
@@ -502,14 +498,6 @@ class BusinessGlossaryFileSource(Source):
         config = load_config_file(file_name)
         glossary_cfg = BusinessGlossaryConfig.parse_obj(config)
         return glossary_cfg
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(
-            self.report,
-            auto_status_aspect(
-                self.get_workunits_internal(),
-            ),
-        )
 
     def get_workunits_internal(
         self,

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -25,7 +25,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.com.linkedin.pegasus2avro.common import (
     AuditStamp,
@@ -796,9 +795,6 @@ class ModeSource(Source):
     def create(cls, config_dict: dict, ctx: PipelineContext) -> Source:
         config = ModeConfig.parse_obj(config_dict)
         return cls(ctx, config)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         yield from self.emit_dashboard_mces()

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -2,10 +2,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict, Iterable, List, Optional, Tuple, Type, Union, ValuesView
 
-import bson
-import bson.dbref
-import bson.int64
-import bson.objectid
 import bson.timestamp
 import pymongo
 import pymongo.collection
@@ -26,7 +22,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.schema_inference.object import (
     SchemaDescription,
@@ -300,9 +295,6 @@ class MongoDBSource(Source):
             TypeClass = NullTypeClass
 
         return SchemaFieldDataType(type=TypeClass())
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         platform = "mongodb"

--- a/metadata-ingestion/src/datahub/ingestion/source/nifi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/nifi.py
@@ -31,7 +31,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     DataFlowInfoClass,
@@ -1023,9 +1022,6 @@ class NifiSource(Source):
 
         token_response.raise_for_status()
         self.session.headers.update({"Authorization": "Bearer " + token_response.text})
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         try:

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -18,7 +18,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.openapi_parser import (
     clean_url,
@@ -212,9 +211,6 @@ class APISource(Source, ABC):
     ) -> ApiWorkUnit:
         mce = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
         return ApiWorkUnit(id=dataset_name, mce=mce)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[ApiWorkUnit]:  # noqa: C901
         config = self.config

--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi_report_server/report_server.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi_report_server/report_server.py
@@ -26,7 +26,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.powerbi_report_server.constants import (
     API_ENDPOINTS,
@@ -532,9 +531,6 @@ class PowerBiReportServerDashboardSource(Source):
     def create(cls, config_dict, ctx):
         config = PowerBiReportServerDashboardSourceConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         """

--- a/metadata-ingestion/src/datahub/ingestion/source/redash.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redash.py
@@ -24,7 +24,6 @@ from datahub.ingestion.api.decorators import (  # SourceCapability,; capability,
 )
 from datahub.ingestion.api.registry import import_path
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.com.linkedin.pegasus2avro.common import (
     AuditStamp,
@@ -775,9 +774,6 @@ class RedashSource(Source):
 
     def add_config_to_report(self) -> None:
         self.report.api_page_limit = self.config.api_page_limit
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         self.validate_connection()

--- a/metadata-ingestion/src/datahub/ingestion/source/salesforce.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/salesforce.py
@@ -281,7 +281,7 @@ class SalesforceSource(Source):
                 )
             )
 
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
+    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         sObjects = self.get_salesforce_objects()
 
         for sObject in sObjects:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/vertica.py
@@ -27,7 +27,6 @@ from datahub.ingestion.api.decorators import (
     platform_name,
     support_status,
 )
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.sql_common import (
     SQLAlchemySource,
@@ -143,9 +142,6 @@ class VerticaSource(SQLAlchemySource):
     def create(cls, config_dict: Dict, ctx: PipelineContext) -> "VerticaSource":
         config = VerticaConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[Union[MetadataWorkUnit, SqlWorkUnit]]:
         sql_config = self.config

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/clickhouse_usage.py
@@ -22,7 +22,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.clickhouse import ClickHouseConfig
 from datahub.ingestion.source.usage.usage_common import (
@@ -110,9 +109,6 @@ class ClickHouseUsageSource(Source):
     def create(cls, config_dict, ctx):
         config = ClickHouseUsageConfig.parse_obj(config_dict)
         return cls(ctx, config)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         """Gets ClickHouse usage stats as work units"""

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/redshift_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/redshift_usage.py
@@ -24,7 +24,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.redshift import RedshiftConfig
 from datahub.ingestion.source.usage.usage_common import (
@@ -217,9 +216,6 @@ class RedshiftUsageSource(Source):
     def create(cls, config_dict: Dict, ctx: PipelineContext) -> "RedshiftUsageSource":
         config = RedshiftUsageConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         """Gets Redshift usage stats as work units"""

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/starburst_trino_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/starburst_trino_usage.py
@@ -21,7 +21,6 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import Source, SourceReport
-from datahub.ingestion.api.source_helpers import auto_workunit_reporter
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.trino import TrinoConfig
 from datahub.ingestion.source.usage.usage_common import (
@@ -129,9 +128,6 @@ class TrinoUsageSource(Source):
     def create(cls, config_dict, ctx):
         config = TrinoUsageConfig.parse_obj(config_dict)
         return cls(ctx, config)
-
-    def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        return auto_workunit_reporter(self.report, self.get_workunits_internal())
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         access_events = self._get_trino_history()

--- a/metadata-ingestion/src/datahub/testing/compare_metadata_json.py
+++ b/metadata-ingestion/src/datahub/testing/compare_metadata_json.py
@@ -14,7 +14,7 @@ from deepdiff import DeepDiff
 
 from datahub.ingestion.sink.file import write_metadata_file
 from datahub.ingestion.source.file import read_metadata_file
-from datahub.testing.mcp_diff import MCPDiff, get_aspects_by_urn
+from datahub.testing.mcp_diff import CannotCompareMCPs, MCPDiff, get_aspects_by_urn
 
 logger = logging.getLogger(__name__)
 
@@ -98,12 +98,15 @@ def diff_metadata_json(
             output=output_map,
             ignore_paths=ignore_paths,
         )
+    except CannotCompareMCPs as e:
+        logger.info(f"{e}, falling back to MCE diff")
     except AssertionError as e:
         logger.warning(f"Reverting to old diff method: {e}")
         logger.debug("Error with new diff method", exc_info=True)
-        return DeepDiff(
-            golden,
-            output,
-            exclude_regex_paths=ignore_paths,
-            ignore_order=True,
-        )
+
+    return DeepDiff(
+        golden,
+        output,
+        exclude_regex_paths=ignore_paths,
+        ignore_order=True,
+    )

--- a/metadata-ingestion/src/datahub/testing/mcp_diff.py
+++ b/metadata-ingestion/src/datahub/testing/mcp_diff.py
@@ -83,6 +83,10 @@ class DeltaInfoOperator(BaseOperator):
 AspectsByUrn = Dict[str, Dict[str, List[AspectForDiff]]]
 
 
+class CannotCompareMCPs(Exception):
+    pass
+
+
 def get_aspects_by_urn(obj: object) -> AspectsByUrn:
     """Restructure a list of serialized MCPs by urn and aspect.
     Retains information like the original dict and index to facilitate `apply_delta` later.
@@ -95,7 +99,7 @@ def get_aspects_by_urn(obj: object) -> AspectsByUrn:
     for i, entry in enumerate(obj):
         assert isinstance(entry, dict), entry
         if "proposedSnapshot" in entry:
-            raise AssertionError("Found MCEs in output")
+            raise CannotCompareMCPs("Found MCEs")
         elif "entityUrn" in entry and "aspectName" in entry and "aspect" in entry:
             urn = entry["entityUrn"]
             aspect_name = entry["aspectName"]

--- a/metadata-ingestion/tests/integration/clickhouse/clickhouse_mces_golden.json
+++ b/metadata-ingestion/tests/integration/clickhouse/clickhouse_mces_golden.json
@@ -75,7 +75,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -177,6 +182,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 }
@@ -246,11 +255,11 @@
                             "primary_key": "col_Int64",
                             "sampling_key": "",
                             "storage_policy": "default",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "10",
                             "total_bytes": "671",
-                            "data_paths": "['/var/lib/clickhouse/store/2d4/2d43771f-2a9f-4a28-962e-992a7c08102f/']",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/mv_target_table.sql"
+                            "data_paths": "['/var/lib/clickhouse/store/6cb/6cbac4d1-c700-4f8a-9cc9-542cc349e497/']",
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/mv_target_table.sql"
                         },
                         "name": "mv_target_table",
                         "description": "This is target table for materialized view",
@@ -395,6 +404,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 },
@@ -444,11 +457,11 @@
                             "primary_key": "",
                             "sampling_key": "",
                             "storage_policy": "default",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "0",
                             "total_bytes": "0",
-                            "data_paths": "['/var/lib/clickhouse/store/700/70013972-f4ad-4c8b-a4bd-b397c9cc727f/']",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/test_data_types.sql"
+                            "data_paths": "['/var/lib/clickhouse/store/339/339ddf61-6dc4-47ae-9ae5-a358864e6457/']",
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/test_data_types.sql"
                         },
                         "name": "test_data_types",
                         "description": "This table has basic types",
@@ -1022,6 +1035,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 },
@@ -1095,11 +1112,11 @@
                             "primary_key": "",
                             "sampling_key": "",
                             "storage_policy": "",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "None",
                             "total_bytes": "None",
                             "data_paths": "[]",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/test_dict.sql"
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/test_dict.sql"
                         },
                         "name": "test_dict",
                         "description": "",
@@ -1205,6 +1222,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 },
@@ -1254,11 +1275,11 @@
                             "primary_key": "",
                             "sampling_key": "",
                             "storage_policy": "default",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "0",
                             "total_bytes": "0",
-                            "data_paths": "['/var/lib/clickhouse/store/04c/04c9735e-af23-4850-a034-8da8f03d75af/']",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/test_nested_data_types.sql"
+                            "data_paths": "['/var/lib/clickhouse/store/22c/22c46b00-4f2a-444a-8bee-73e60b9deba6/']",
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/test_nested_data_types.sql"
                         },
                         "name": "test_nested_data_types",
                         "description": "This table has nested types",
@@ -1468,6 +1489,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 },
@@ -1541,11 +1566,11 @@
                             "primary_key": "",
                             "sampling_key": "",
                             "storage_policy": "",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "None",
                             "total_bytes": "None",
-                            "data_paths": "['/var/lib/clickhouse/store/2d4/2d43771f-2a9f-4a28-962e-992a7c08102f/']",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/mv_with_target_table.sql",
+                            "data_paths": "['/var/lib/clickhouse/store/6cb/6cbac4d1-c700-4f8a-9cc9-542cc349e497/']",
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/mv_with_target_table.sql",
                             "view_definition": "",
                             "is_view": "True"
                         },
@@ -1709,6 +1734,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 },
@@ -1782,11 +1811,11 @@
                             "primary_key": "",
                             "sampling_key": "",
                             "storage_policy": "",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "0",
                             "total_bytes": "0",
-                            "data_paths": "['/var/lib/clickhouse/store/649/64934dd8-0347-4e30-a604-8b27022dc799/']",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/mv_without_target_table.sql",
+                            "data_paths": "['/var/lib/clickhouse/store/0f1/0f172bf3-80e5-4ba7-9ae3-938da0a9799d/']",
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/mv_without_target_table.sql",
                             "view_definition": "",
                             "is_view": "True"
                         },
@@ -1950,6 +1979,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
+                {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"
                 },
@@ -2023,11 +2056,11 @@
                             "primary_key": "",
                             "sampling_key": "",
                             "storage_policy": "",
-                            "metadata_modification_time": "2023-07-03 18:52:30",
+                            "metadata_modification_time": "2023-07-24 21:34:01",
                             "total_rows": "None",
                             "total_bytes": "None",
                             "data_paths": "[]",
-                            "metadata_path": "/var/lib/clickhouse/store/e2e/e2e3221c-2ffa-4009-b71e-ad306b778310/test_view.sql",
+                            "metadata_path": "/var/lib/clickhouse/store/0a2/0a2bd3dd-893f-4f9a-b310-92e4c830091a/test_view.sql",
                             "view_definition": "",
                             "is_view": "True"
                         },
@@ -2138,6 +2171,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:clickhouse,clickhousetestserver)"
+                },
                 {
                     "id": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c",
                     "urn": "urn:li:container:ab016b94aa0d75c5b9205c33260e989c"

--- a/metadata-ingestion/tests/integration/csv-enricher/csv_enricher_golden.json
+++ b/metadata-ingestion/tests/integration/csv-enricher/csv_enricher_golden.json
@@ -1,932 +1,1142 @@
 [
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
                 }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
             }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
         }
     },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "domains",
-        "aspect": {
-            "json": {
-                "domains": [
-                    "urn:li:domain:Engineering"
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "editableDatasetProperties",
-        "aspect": {
-            "json": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                },
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                },
-                "description": "new description"
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "container",
-        "entityUrn": "urn:li:container:DATABASE",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "container",
-        "entityUrn": "urn:li:container:DATABASE",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "container",
-        "entityUrn": "urn:li:container:DATABASE",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "chart",
-        "entityUrn": "urn:li:chart:(looker,baz1)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "chart",
-        "entityUrn": "urn:li:chart:(looker,baz1)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "chart",
-        "entityUrn": "urn:li:chart:(looker,baz1)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(looker,baz)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(looker,baz)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dashboard",
-        "entityUrn": "urn:li:dashboard:(looker,baz)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlFeature",
-        "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlFeature",
-        "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlFeature",
-        "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlFeatureTable",
-        "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlFeatureTable",
-        "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlFeatureTable",
-        "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlPrimaryKey",
-        "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlPrimaryKey",
-        "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlPrimaryKey",
-        "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlModel",
-        "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlModel",
-        "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlModel",
-        "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlModelGroup",
-        "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlModelGroup",
-        "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "mlModelGroup",
-        "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataJob",
-        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataJob",
-        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataJob",
-        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataFlow",
-        "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataFlow",
-        "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataFlow",
-        "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "notebook",
-        "entityUrn": "urn:li:notebook:(querybook,1234)",
-        "changeType": "UPSERT",
-        "aspectName": "glossaryTerms",
-        "aspect": {
-            "json": {
-                "terms": [
-                    {
-                        "urn": "urn:li:glossaryTerm:CustomerAccount"
-                    }
-                ],
-                "auditStamp": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "notebook",
-        "entityUrn": "urn:li:notebook:(querybook,1234)",
-        "changeType": "UPSERT",
-        "aspectName": "globalTags",
-        "aspect": {
-            "json": {
-                "tags": [
-                    {
-                        "tag": "urn:li:tag:Legacy"
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "notebook",
-        "entityUrn": "urn:li:notebook:(querybook,1234)",
-        "changeType": "UPSERT",
-        "aspectName": "ownership",
-        "aspect": {
-            "json": {
-                "owners": [
-                    {
-                        "owner": "urn:li:corpuser:datahub",
-                        "type": "TECHNICAL_OWNER"
-                    },
-                    {
-                        "owner": "urn:li:corpuser:jdoe",
-                        "type": "TECHNICAL_OWNER"
-                    }
-                ],
-                "lastModified": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                }
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
-    },
-    {
-        "entityType": "dataset",
-        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
-        "changeType": "UPSERT",
-        "aspectName": "editableSchemaMetadata",
-        "aspect": {
-            "json": {
-                "created": {
-                    "time": 1643871600000,
-                    "actor": "urn:li:corpuser:ingestion"
-                },
-                "lastModified": {
-                    "time": 0,
-                    "actor": "urn:li:corpuser:unknown"
-                },
-                "editableSchemaFieldInfo": [
-                    {
-                        "fieldPath": "field_foo",
-                        "description": "field_foo!",
-                        "glossaryTerms": {
-                            "terms": [
-                                {
-                                    "urn": "urn:li:glossaryTerm:AccountBalance"
-                                }
-                            ],
-                            "auditStamp": {
-                                "time": 1643871600000,
-                                "actor": "urn:li:corpuser:ingestion"
-                            }
-                        }
-                    },
-                    {
-                        "fieldPath": "field_bar",
-                        "description": "field_bar?",
-                        "globalTags": {
-                            "tags": [
-                                {
-                                    "tag": "urn:li:tag:Legacy"
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        "systemMetadata": {
-            "lastObserved": 1643871600000,
-            "runId": "test-csv-enricher"
-        }
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
     }
-    ]
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+        "json": {
+            "domains": [
+                "urn:li:domain:Engineering"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "editableDatasetProperties",
+    "aspect": {
+        "json": {
+            "created": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            },
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            },
+            "description": "new description"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:DATABASE",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:DATABASE",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:DATABASE",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:DATABASE",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(looker,baz1)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(looker,baz1)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(looker,baz1)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(looker,baz)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(looker,baz)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(looker,baz)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "notebook",
+    "entityUrn": "urn:li:notebook:(querybook,1234)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:CustomerAccount"
+                }
+            ],
+            "auditStamp": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "notebook",
+    "entityUrn": "urn:li:notebook:(querybook,1234)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:Legacy"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "notebook",
+    "entityUrn": "urn:li:notebook:(querybook,1234)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "TECHNICAL_OWNER"
+                },
+                {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "editableSchemaMetadata",
+    "aspect": {
+        "json": {
+            "created": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:ingestion"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "editableSchemaFieldInfo": [
+                {
+                    "fieldPath": "field_foo",
+                    "description": "field_foo!",
+                    "glossaryTerms": {
+                        "terms": [
+                            {
+                                "urn": "urn:li:glossaryTerm:AccountBalance"
+                            }
+                        ],
+                        "auditStamp": {
+                            "time": 1643871600000,
+                            "actor": "urn:li:corpuser:ingestion"
+                        }
+                    }
+                },
+                {
+                    "fieldPath": "field_bar",
+                    "description": "field_bar?",
+                    "globalTags": {
+                        "tags": [
+                            {
+                                "tag": "urn:li:tag:Legacy"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(looker,baz1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(airflow,dag_abc,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(looker,baz)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:DATABASE",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Legacy",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Legacy"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(airflow,dag_abc,PROD),task_123)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test_feature_table_all_feature_dtypes,test_BOOL_LIST_feature)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:science,scienceModel,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test_feature_table_all_feature_dtypes,dummy_entity_1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,user_features)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:science,scienceGroup,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+},
+{
+    "entityType": "notebook",
+    "entityUrn": "urn:li:notebook:(querybook,1234)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "test-csv-enricher"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/delta_lake/delta_lake_minio_mces_golden.json
+++ b/metadata-ingestion/tests/integration/delta_lake/delta_lake_minio_mces_golden.json
@@ -135,7 +135,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -155,7 +155,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -170,7 +170,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -185,7 +185,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -202,7 +202,22 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
+        "runId": "delta-lake-test"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -222,7 +237,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -237,7 +252,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -252,7 +267,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -269,7 +284,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -284,7 +299,27 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
+        "runId": "delta-lake-test"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:acebf8bcf966274632d3d2b710ef4947",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd",
+                    "urn": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -299,7 +334,7 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 },
@@ -310,7 +345,7 @@
     "aspectName": "operation",
     "aspect": {
         "json": {
-            "timestampMillis": 1615443388097,
+            "timestampMillis": 1672531200000,
             "partitionSpec": {
                 "type": "FULL_TABLE",
                 "partition": "FULL_TABLE_SNAPSHOT"
@@ -326,7 +361,31 @@
         }
     },
     "systemMetadata": {
-        "lastObserved": 1615443388097,
+        "lastObserved": 1672531200000,
+        "runId": "delta-lake-test"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-test-bucket/delta_tables/sales,DEV)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd",
+                    "urn": "urn:li:container:34fc0473e206bb1f4307aadf4177b2fd"
+                },
+                {
+                    "id": "urn:li:container:acebf8bcf966274632d3d2b710ef4947",
+                    "urn": "urn:li:container:acebf8bcf966274632d3d2b710ef4947"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1672531200000,
         "runId": "delta-lake-test"
     }
 }

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_allow_table.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_allow_table.json
@@ -168,6 +168,26 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:189046201d696e7810132cfa64dad337",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -243,6 +263,30 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:189046201d696e7810132cfa64dad337"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -336,6 +380,34 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -420,6 +492,38 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:a282913be26fceff334523c2be119df1",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -495,6 +599,42 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:a282913be26fceff334523c2be119df1",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                },
+                {
+                    "id": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+                    "urn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -649,6 +789,46 @@
                 "readVersion": "3"
             },
             "lastUpdatedTimestamp": 1655831477768
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-platform.tests/integration/delta_lake/test_data/delta_tables/my_table_basic,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                },
+                {
+                    "id": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+                    "urn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+                },
+                {
+                    "id": "urn:li:container:a282913be26fceff334523c2be119df1",
+                    "urn": "urn:li:container:a282913be26fceff334523c2be119df1"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -831,6 +1011,46 @@
                 "isolationLevel": "Serializable"
             },
             "lastUpdatedTimestamp": 1655664815399
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-platform.tests/integration/delta_lake/test_data/delta_tables/sales,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                },
+                {
+                    "id": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+                    "urn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+                },
+                {
+                    "id": "urn:li:container:a282913be26fceff334523c2be119df1",
+                    "urn": "urn:li:container:a282913be26fceff334523c2be119df1"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -1090,6 +1310,46 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-platform.tests/integration/delta_lake/test_data/delta_tables/my_table_no_name,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                },
+                {
+                    "id": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+                    "urn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+                },
+                {
+                    "id": "urn:li:container:a282913be26fceff334523c2be119df1",
+                    "urn": "urn:li:container:a282913be26fceff334523c2be119df1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-platform.tests/integration/delta_lake/test_data/delta_tables/level1/my_table_inner,UAT)",
@@ -1272,6 +1532,46 @@
     }
 },
 {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:3df8f6b0f3a70d42cf70612a2fe5e5ef",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                },
+                {
+                    "id": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+                    "urn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+                },
+                {
+                    "id": "urn:li:container:a282913be26fceff334523c2be119df1",
+                    "urn": "urn:li:container:a282913be26fceff334523c2be119df1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-platform.tests/integration/delta_lake/test_data/delta_tables/level1/my_table_inner,UAT)",
     "changeType": "UPSERT",
@@ -1418,6 +1718,50 @@
                 "readVersion": "3"
             },
             "lastUpdatedTimestamp": 1655831866541
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "allow_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,my-platform.tests/integration/delta_lake/test_data/delta_tables/level1/my_table_inner,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:delta-lake,my-platform)"
+                },
+                {
+                    "id": "urn:li:container:189046201d696e7810132cfa64dad337",
+                    "urn": "urn:li:container:189046201d696e7810132cfa64dad337"
+                },
+                {
+                    "id": "urn:li:container:acf0f3806f475a7397ee745329ef2967",
+                    "urn": "urn:li:container:acf0f3806f475a7397ee745329ef2967"
+                },
+                {
+                    "id": "urn:li:container:1876d057d0ee364677b85427342e2c82",
+                    "urn": "urn:li:container:1876d057d0ee364677b85427342e2c82"
+                },
+                {
+                    "id": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4",
+                    "urn": "urn:li:container:7888b6dab77b7e77709699c9a1b81aa4"
+                },
+                {
+                    "id": "urn:li:container:a282913be26fceff334523c2be119df1",
+                    "urn": "urn:li:container:a282913be26fceff334523c2be119df1"
+                },
+                {
+                    "id": "urn:li:container:3df8f6b0f3a70d42cf70612a2fe5e5ef",
+                    "urn": "urn:li:container:3df8f6b0f3a70d42cf70612a2fe5e5ef"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_inner_table.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_inner_table.json
@@ -166,6 +166,21 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -239,6 +254,26 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -330,6 +365,30 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -412,6 +471,34 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -485,6 +572,38 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -639,6 +758,42 @@
                 "readVersion": "3"
             },
             "lastUpdatedTimestamp": 1655831477768
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/my_table_basic,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                },
+                {
+                    "id": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+                    "urn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -821,6 +976,42 @@
                 "isolationLevel": "Serializable"
             },
             "lastUpdatedTimestamp": 1655664815399
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/sales,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                },
+                {
+                    "id": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+                    "urn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -1080,6 +1271,42 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/my_table_no_name,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                },
+                {
+                    "id": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+                    "urn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/level1/my_table_inner,UAT)",
@@ -1260,6 +1487,42 @@
     }
 },
 {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:6bb6dc6de93177210067d00b45b481bb",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                },
+                {
+                    "id": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+                    "urn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/level1/my_table_inner,UAT)",
     "changeType": "UPSERT",
@@ -1406,6 +1669,46 @@
                 "readVersion": "3"
             },
             "lastUpdatedTimestamp": 1655831866541
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "inner_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/level1/my_table_inner,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                },
+                {
+                    "id": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+                    "urn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
+                },
+                {
+                    "id": "urn:li:container:6bb6dc6de93177210067d00b45b481bb",
+                    "urn": "urn:li:container:6bb6dc6de93177210067d00b45b481bb"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_relative_path.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_relative_path.json
@@ -165,6 +165,21 @@
     }
 },
 {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:85267d161e1a2ffa647cec6c1188549f",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "relative_path.json"
+    }
+},
+{
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,delta_tables/my_table_basic,UAT)",
     "changeType": "UPSERT",
@@ -311,6 +326,26 @@
                 "readVersion": "3"
             },
             "lastUpdatedTimestamp": 1655831477768
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "relative_path.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,delta_tables/my_table_basic,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:85267d161e1a2ffa647cec6c1188549f",
+                    "urn": "urn:li:container:85267d161e1a2ffa647cec6c1188549f"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_single_table.json
+++ b/metadata-ingestion/tests/integration/delta_lake/golden_files/local/golden_mces_single_table.json
@@ -165,6 +165,21 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -238,6 +253,26 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -329,6 +364,30 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json"
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -402,6 +461,34 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -492,6 +579,38 @@
     }
 },
 {
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json"
+    }
+},
+{
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/my_table_basic,UAT)",
     "changeType": "UPSERT",
@@ -527,6 +646,42 @@
                 "readVersion": "3"
             },
             "lastUpdatedTimestamp": 1655831477768
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "single_table.json"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:delta-lake,tests/integration/delta_lake/test_data/delta_tables/my_table_basic,UAT)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf",
+                    "urn": "urn:li:container:bdfaaacd66870755e65612e0b88dd4bf"
+                },
+                {
+                    "id": "urn:li:container:974a39dc631803eddedc699cc9bb9759",
+                    "urn": "urn:li:container:974a39dc631803eddedc699cc9bb9759"
+                },
+                {
+                    "id": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6",
+                    "urn": "urn:li:container:dae543a1ed7ecfea4079a971dc7805a6"
+                },
+                {
+                    "id": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4",
+                    "urn": "urn:li:container:ee050cda8eca59687021c24cbc0bb8a4"
+                },
+                {
+                    "id": "urn:li:container:ad4b596846e8e010114b1ec82b324fab",
+                    "urn": "urn:li:container:ad4b596846e8e010114b1ec82b324fab"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/feast/feast_repository_mces_golden.json
+++ b/metadata-ingestion/tests/integration/feast/feast_repository_mces_golden.json
@@ -1,6 +1,5 @@
 [
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
             "urn": "urn:li:mlPrimaryKey:(feature_store.driver_hourly_stats,driver_id)",
@@ -14,7 +13,6 @@
                     "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
                         "description": "Driver ID",
                         "dataType": "ORDINAL",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
                         ]
@@ -23,17 +21,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
             "urn": "urn:li:mlFeature:(feature_store.driver_hourly_stats,conv_rate)",
@@ -47,7 +40,6 @@
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
                         "description": "Conv rate",
                         "dataType": "CONTINUOUS",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
                         ]
@@ -56,17 +48,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
             "urn": "urn:li:mlFeature:(feature_store.driver_hourly_stats,acc_rate)",
@@ -80,7 +67,6 @@
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
                         "description": "Acc rate",
                         "dataType": "CONTINUOUS",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
                         ]
@@ -89,17 +75,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
             "urn": "urn:li:mlFeature:(feature_store.driver_hourly_stats,avg_daily_trips)",
@@ -113,7 +94,6 @@
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
                         "description": "Avg daily trips",
                         "dataType": "ORDINAL",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
                         ]
@@ -122,17 +102,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
             "urn": "urn:li:mlFeature:(feature_store.driver_hourly_stats,string_feature)",
@@ -146,7 +121,6 @@
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
                         "description": "String feature",
                         "dataType": "TEXT",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
                         ]
@@ -155,17 +129,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
             "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,feature_store.driver_hourly_stats)",
@@ -185,7 +154,6 @@
                 {
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
                         "customProperties": {},
-                        "description": null,
                         "mlFeatures": [
                             "urn:li:mlFeature:(feature_store.driver_hourly_stats,conv_rate)",
                             "urn:li:mlFeature:(feature_store.driver_hourly_stats,acc_rate)",
@@ -200,17 +168,31 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,feature_store.driver_hourly_stats)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "feature_store"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "feast-repository-test"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
             "urn": "urn:li:mlFeature:(feature_store.transformed_conv_rate,conv_rate_plus_val1)",
@@ -222,9 +204,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-                        "description": null,
                         "dataType": "CONTINUOUS",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:request,vals_to_add,PROD)",
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
@@ -234,17 +214,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
             "urn": "urn:li:mlFeature:(feature_store.transformed_conv_rate,conv_rate_plus_val2)",
@@ -256,9 +231,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-                        "description": null,
                         "dataType": "CONTINUOUS",
-                        "version": null,
                         "sources": [
                             "urn:li:dataset:(urn:li:dataPlatform:request,vals_to_add,PROD)",
                             "urn:li:dataset:(urn:li:dataPlatform:file,data.driver_stats_with_string.parquet,PROD)"
@@ -268,17 +241,12 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
     }
 },
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
             "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,feature_store.transformed_conv_rate)",
@@ -298,7 +266,6 @@
                 {
                     "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
                         "customProperties": {},
-                        "description": null,
                         "mlFeatures": [
                             "urn:li:mlFeature:(feature_store.transformed_conv_rate,conv_rate_plus_val1)",
                             "urn:li:mlFeature:(feature_store.transformed_conv_rate,conv_rate_plus_val2)"
@@ -309,13 +276,28 @@
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "feast-repository-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "feast-repository-test"
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,feature_store.transformed_conv_rate)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "feature_store"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "feast-repository-test"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/metabase/metabase_mces_golden.json
+++ b/metadata-ingestion/tests/integration/metabase/metabase_mces_golden.json
@@ -1,56 +1,6 @@
 [
 {
     "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
-            "urn": "urn:li:dashboard:(metabase,1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
-                        "customProperties": {},
-                        "title": "Dashboard 1",
-                        "description": "",
-                        "charts": [
-                            "urn:li:chart:(metabase,1)",
-                            "urn:li:chart:(metabase,2)"
-                        ],
-                        "datasets": [],
-                        "lastModified": {
-                            "created": {
-                                "time": 1639417721742,
-                                "actor": "urn:li:corpuser:admin@metabase.com"
-                            },
-                            "lastModified": {
-                                "time": 1639417721742,
-                                "actor": "urn:li:corpuser:admin@metabase.com"
-                            }
-                        },
-                        "dashboardUrl": "http://localhost:3000/dashboard/1"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:admin@metabase.com",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1636614000000,
-        "runId": "metabase-test"
-    }
-},
-{
-    "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
             "urn": "urn:li:chart:(metabase,1)",
             "aspects": [
@@ -126,14 +76,13 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1639417717110,
+                                "time": 1636614000000,
                                 "actor": "urn:li:corpuser:admin@metabase.com"
                             },
                             "lastModified": {
-                                "time": 1639417717110,
+                                "time": 1636614000000,
                                 "actor": "urn:li:corpuser:admin@metabase.com"
-                            },
-                            "deleted": null
+                            }
                         },
                         "chartUrl": "http://localhost:3000/card/2",
                         "inputs": [
@@ -159,6 +108,101 @@
                     }
                 }
             ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1636614000000,
+        "runId": "metabase-test"
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
+            "urn": "urn:li:dashboard:(metabase,1)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
+                        "customProperties": {},
+                        "title": "Dashboard 1",
+                        "description": "",
+                        "charts": [
+                            "urn:li:chart:(metabase,1)",
+                            "urn:li:chart:(metabase,2)"
+                        ],
+                        "datasets": [],
+                        "lastModified": {
+                            "created": {
+                                "time": 1639417721742,
+                                "actor": "urn:li:corpuser:admin@metabase.com"
+                            },
+                            "lastModified": {
+                                "time": 1639417721742,
+                                "actor": "urn:li:corpuser:admin@metabase.com"
+                            }
+                        },
+                        "dashboardUrl": "http://localhost:3000/dashboard/1"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:admin@metabase.com",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1636614000000,
+        "runId": "metabase-test"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(metabase,1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1636614000000,
+        "runId": "metabase-test"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(metabase,2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1636614000000,
+        "runId": "metabase-test"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(metabase,1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/mode/mode_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mode/mode_mces_golden.json
@@ -1,6 +1,5 @@
 [
 {
-    "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
             "urn": "urn:li:dashboard:(mode,2934237)",
@@ -8,7 +7,6 @@
                 {
                     "com.linkedin.pegasus2avro.dashboard.DashboardInfo": {
                         "customProperties": {},
-                        "externalUrl": null,
                         "title": "Report 1",
                         "description": "First Report",
                         "charts": [
@@ -18,19 +16,14 @@
                         "lastModified": {
                             "created": {
                                 "time": 1639169724316,
-                                "actor": "urn:li:corpuser:modeuser",
-                                "impersonator": null
+                                "actor": "urn:li:corpuser:modeuser"
                             },
                             "lastModified": {
                                 "time": 1639182684451,
-                                "actor": "urn:li:corpuser:modeuser",
-                                "impersonator": null
-                            },
-                            "deleted": null
+                                "actor": "urn:li:corpuser:modeuser"
+                            }
                         },
-                        "dashboardUrl": "https://app.mode.com/acryl/reports/9d2da37fa91e",
-                        "access": null,
-                        "lastRefreshed": null
+                        "dashboardUrl": "https://app.mode.com/acryl/reports/9d2da37fa91e"
                     }
                 },
                 {
@@ -45,31 +38,49 @@
                         "owners": [
                             {
                                 "owner": "urn:li:corpuser:modeuser",
-                                "type": "DATAOWNER",
-                                "source": null
+                                "type": "DATAOWNER"
                             }
                         ],
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         }
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1638860400000,
-        "runId": "mode-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "mode-test"
     }
 },
 {
-    "auditHeader": null,
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(mode,2934237)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "acryl"
+                },
+                {
+                    "id": "AcrylTest"
+                },
+                {
+                    "id": "Report 1"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "mode-test"
+    }
+},
+{
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
             "urn": "urn:li:chart:(mode,f622b9ee725b)",
@@ -80,37 +91,31 @@
                             "Columns": "payment_date,Staff First Name,amount,Staff Last Name",
                             "Filters": "amount"
                         },
-                        "externalUrl": null,
                         "title": "Customer Staff Table",
                         "description": "",
                         "lastModified": {
                             "created": {
                                 "time": 1639170083088,
-                                "actor": "urn:li:corpuser:modeuser",
-                                "impersonator": null
+                                "actor": "urn:li:corpuser:modeuser"
                             },
                             "lastModified": {
                                 "time": 1639182684438,
-                                "actor": "urn:li:corpuser:modeuser",
-                                "impersonator": null
-                            },
-                            "deleted": null
+                                "actor": "urn:li:corpuser:modeuser"
+                            }
                         },
                         "chartUrl": "https://app.mode.com/acryltest/reports/9d2da37fa91e/viz/f622b9ee725b",
                         "inputs": [
                             {
-                                "string": "urn:li:dataset:(urn:li:dataPlatform:postgres,dvdrental.public.rental,PROD)"
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:postgres,dvdrental.public.staff,PROD)"
                             },
                             {
                                 "string": "urn:li:dataset:(urn:li:dataPlatform:postgres,dvdrental.public.payment,PROD)"
                             },
                             {
-                                "string": "urn:li:dataset:(urn:li:dataPlatform:postgres,dvdrental.public.staff,PROD)"
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:postgres,dvdrental.public.rental,PROD)"
                             }
                         ],
-                        "type": "TABLE",
-                        "access": null,
-                        "lastRefreshed": null
+                        "type": "TABLE"
                     }
                 },
                 {
@@ -131,27 +136,82 @@
                         "owners": [
                             {
                                 "owner": "urn:li:corpuser:modeuser",
-                                "type": "DATAOWNER",
-                                "source": null
+                                "type": "DATAOWNER"
                             }
                         ],
                         "lastModified": {
                             "time": 0,
-                            "actor": "urn:li:corpuser:unknown",
-                            "impersonator": null
+                            "actor": "urn:li:corpuser:unknown"
                         }
                     }
                 }
             ]
         }
     },
-    "proposedDelta": null,
     "systemMetadata": {
         "lastObserved": 1638860400000,
-        "runId": "mode-test",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "mode-test"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(mode,f622b9ee725b)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "mode-test"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(mode,f622b9ee725b)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "acryl"
+                },
+                {
+                    "id": "AcrylTest"
+                },
+                {
+                    "id": "Report 1"
+                },
+                {
+                    "id": "Customer and staff"
+                },
+                {
+                    "id": "Customer Staff Table"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "mode-test"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(mode,2934237)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "mode-test"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
@@ -4132,5 +4132,65 @@
         "lastObserved": 1615443388097,
         "runId": "mongodb-test"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,mngdb.emptyCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,mngdb.firstCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,mngdb.largeCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:mongodb,mngdb.secondCollection,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "mongodb-test"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/nifi/nifi_mces_golden_cluster.json
+++ b/metadata-ingestion/tests/integration/nifi/nifi_mces_golden_cluster.json
@@ -652,5 +652,215 @@
         "lastObserved": 1638532800000,
         "runId": "nifi-test-cluster"
     }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),3ec2acd6-a0d4-3198-9066-a59fb757bc05)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),8eb5263d-017d-1000-ffff-ffff911b23aa)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),8a218b6e-e6a0-36b6-bc4b-79d202a80167)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),71bc17ed-a3bc-339a-a100-ebad434717d4)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),c5f6fc66-ffbb-3f60-9564-f2466ae32493)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),c8c73d4c-ebdd-1bee-9b46-629672cd11a0)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),8eb55aeb-017d-1000-ffff-fffff475768d)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,80820b2f-017d-1000-85cf-05f56cde9185,PROD),fed5914b-937b-37dd-89c0-b34ffbae9cf4)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:file,sftp_public_host,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:nifi,default.s3_data,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:file,sftp_public_host.temperature,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:nifi,default.sftp_files_out,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,enriched-topical-chat,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-cluster"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/nifi/nifi_mces_golden_standalone.json
+++ b/metadata-ingestion/tests/integration/nifi/nifi_mces_golden_standalone.json
@@ -227,5 +227,80 @@
         "lastObserved": 1638532800000,
         "runId": "nifi-test-standalone"
     }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(nifi,803ebb92-017d-1000-2961-4bdaa27a3ba0,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-standalone"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,803ebb92-017d-1000-2961-4bdaa27a3ba0,PROD),91d59f03-1c2b-3f3f-48bc-f89296a328bd)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-standalone"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,803ebb92-017d-1000-2961-4bdaa27a3ba0,PROD),aed63edf-e660-3f29-b56b-192cf6286889)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-standalone"
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(nifi,803ebb92-017d-1000-2961-4bdaa27a3ba0,PROD),cb7693ed-f93b-3340-3776-fe80e6283ddc)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-standalone"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,enriched-topical-chat,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638532800000,
+        "runId": "nifi-test-standalone"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/openapi/openapi_mces_golden.json
+++ b/metadata-ingestion/tests/integration/openapi/openapi_mces_golden.json
@@ -148,5 +148,35 @@
         "lastObserved": 1586847600000,
         "runId": "openapi-2020_04_14-07_00_00"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:OpenApi,test_openapi.root,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "openapi-2020_04_14-07_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:OpenApi,test_openapi.v2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "openapi-2020_04_14-07_00_00"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/powerbi/golden_test_platform_instance_ingest.json
+++ b/metadata-ingestion/tests/integration/powerbi/golden_test_platform_instance_ingest.json
@@ -779,6 +779,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:powerbi,aws-ap-south-1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:powerbi,aws-ap-south-1)"
+                },
+                {
                     "id": "demo-workspace"
                 }
             ]
@@ -884,6 +888,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:powerbi,aws-ap-south-1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:powerbi,aws-ap-south-1)"
+                },
                 {
                     "id": "demo-workspace"
                 }
@@ -1016,6 +1024,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:powerbi,aws-ap-south-1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:powerbi,aws-ap-south-1)"
+                },
                 {
                     "id": "demo-workspace"
                 }

--- a/metadata-ingestion/tests/integration/powerbi_report_server/golden_test_fail_api_ingest.json
+++ b/metadata-ingestion/tests/integration/powerbi_report_server/golden_test_fail_api_ingest.json
@@ -162,6 +162,40 @@
     }
 },
 {
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(powerbi,reports.ee56dc21-248a-4138-a446-ee5ab1fc938a)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "powerbi_report_server"
+                },
+                {
+                    "id": "server_alias"
+                },
+                {
+                    "id": "Reports"
+                },
+                {
+                    "id": "path"
+                },
+                {
+                    "id": "to"
+                },
+                {
+                    "id": "Testa"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "powerbi-report-server-test"
+    }
+},
+{
     "entityType": "corpuser",
     "entityUrn": "urn:li:corpuser:TEST_USER",
     "changeType": "UPSERT",
@@ -316,6 +350,40 @@
                 "time": 0,
                 "actor": "urn:li:corpuser:unknown"
             }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "powerbi-report-server-test"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(powerbi,reports.ee56dc21-248a-4138-a446-ee5ab1fc938d)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "powerbi_report_server"
+                },
+                {
+                    "id": "server_alias"
+                },
+                {
+                    "id": "Reports"
+                },
+                {
+                    "id": "path"
+                },
+                {
+                    "id": "to"
+                },
+                {
+                    "id": "Testd"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/powerbi_report_server/golden_test_ingest.json
+++ b/metadata-ingestion/tests/integration/powerbi_report_server/golden_test_ingest.json
@@ -162,6 +162,40 @@
     }
 },
 {
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(powerbi,reports.ee56dc21-248a-4138-a446-ee5ab1fc938a)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "powerbi_report_server"
+                },
+                {
+                    "id": "server_alias"
+                },
+                {
+                    "id": "Reports"
+                },
+                {
+                    "id": "path"
+                },
+                {
+                    "id": "to"
+                },
+                {
+                    "id": "Testa"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "powerbi-report-server-test"
+    }
+},
+{
     "entityType": "corpuser",
     "entityUrn": "urn:li:corpuser:TEST_USER",
     "changeType": "UPSERT",
@@ -305,6 +339,40 @@
                 }
             },
             "dashboardUrl": "http://host_port/Reports/powerbi/path/to/Testc"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "powerbi-report-server-test"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(powerbi,reports.ee56dc21-248a-4138-a446-ee5ab1fc938c)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "powerbi_report_server"
+                },
+                {
+                    "id": "server_alias"
+                },
+                {
+                    "id": "Reports"
+                },
+                {
+                    "id": "path"
+                },
+                {
+                    "id": "to"
+                },
+                {
+                    "id": "Testc"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -498,6 +566,40 @@
         "json": {
             "dashboardTool": "powerbi",
             "dashboardId": "powerbi.linkedin.com/dashboards/ee56dc21-248a-4138-a446-ee5ab1fc938d"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "powerbi-report-server-test"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(powerbi,reports.ee56dc21-248a-4138-a446-ee5ab1fc938d)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "powerbi_report_server"
+                },
+                {
+                    "id": "server_alias"
+                },
+                {
+                    "id": "Reports"
+                },
+                {
+                    "id": "path"
+                },
+                {
+                    "id": "to"
+                },
+                {
+                    "id": "Testd"
+                }
+            ]
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/remote/golden/remote_enricher_golden.json
+++ b/metadata-ingestion/tests/integration/remote/golden/remote_enricher_golden.json
@@ -158,5 +158,35 @@
         "lastObserved": 1629795600000,
         "runId": "remote-1"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1629795600000,
+        "runId": "remote-1"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Legacy",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Legacy"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1629795600000,
+        "runId": "remote-1"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/remote/golden/remote_lineage_golden.json
+++ b/metadata-ingestion/tests/integration/remote/golden/remote_lineage_golden.json
@@ -6,7 +6,6 @@
     "aspectName": "upstreamLineage",
     "aspect": {
         "json": {
-            "fineGrainedLineages": [],
             "upstreams": [
                 {
                     "auditStamp": {
@@ -24,7 +23,8 @@
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:kafka,topic1,DEV)",
                     "type": "TRANSFORMED"
                 }
-            ]
+            ],
+            "fineGrainedLineages": []
         }
     },
     "systemMetadata": {
@@ -39,7 +39,6 @@
     "aspectName": "upstreamLineage",
     "aspect": {
         "json": {
-            "fineGrainedLineages": [],
             "upstreams": [
                 {
                     "auditStamp": {
@@ -49,7 +48,38 @@
                     "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test.kafka.topic2,PROD)",
                     "type": "TRANSFORMED"
                 }
-            ]
+            ],
+            "fineGrainedLineages": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1629795600000,
+        "runId": "remote-3"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,topic2,DEV)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1629795600000,
+        "runId": "remote-3"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:kafka,topic3,DEV)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/s3/golden-files/local/golden_mces_file_without_extension.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/local/golden_mces_file_without_extension.json
@@ -211,7 +211,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -311,6 +316,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -415,6 +424,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -523,6 +536,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -635,6 +652,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -751,6 +772,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -871,6 +896,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -995,6 +1024,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -1124,6 +1157,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
                 },
@@ -1201,6 +1238,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"

--- a/metadata-ingestion/tests/integration/s3/golden-files/local/golden_mces_multiple_files.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/local/golden_mces_multiple_files.json
@@ -523,7 +523,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -623,6 +628,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -727,6 +736,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -835,6 +848,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -947,6 +964,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -1063,6 +1084,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -1183,6 +1208,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -1307,6 +1336,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -2664,6 +2697,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
                 },
@@ -3196,6 +3233,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -3746,6 +3787,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
                 },
@@ -3953,6 +3998,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -4457,6 +4506,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
                 },
@@ -4818,6 +4871,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"
@@ -7489,6 +7546,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:file,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0",
                     "urn": "urn:li:container:c0b6448a96b5b99a7cabec1c4bfa66c0"

--- a/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_file_without_extension.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_file_without_extension.json
@@ -211,7 +211,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -311,6 +316,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -415,6 +424,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -523,6 +536,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -636,6 +653,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
                 },
@@ -697,6 +718,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"

--- a/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_multiple_files.json
+++ b/metadata-ingestion/tests/integration/s3/golden-files/s3/golden_mces_multiple_files.json
@@ -523,7 +523,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -623,6 +628,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -727,6 +736,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -836,6 +849,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
                 },
@@ -878,6 +895,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -1062,6 +1083,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
                 },
@@ -1245,6 +1270,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
                 },
@@ -1403,6 +1432,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -1587,6 +1620,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
+                {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
                 },
@@ -1769,6 +1806,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"
@@ -2264,6 +2305,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:s3,test-platform-instance)"
+                },
                 {
                     "id": "urn:li:container:647eefb4dfda8695baf1aa0775d78689",
                     "urn": "urn:li:container:647eefb4dfda8695baf1aa0775d78689"

--- a/metadata-ingestion/tests/integration/salesforce/salesforce_mces_golden.json
+++ b/metadata-ingestion/tests/integration/salesforce/salesforce_mces_golden.json
@@ -1974,5 +1974,65 @@
         "lastObserved": 1652353200000,
         "runId": "salesforce-test"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:salesforce,Account,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1652353200000,
+        "runId": "salesforce-test"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:salesforce,Property__c,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1652353200000,
+        "runId": "salesforce-test"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:Custom",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "Custom"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1652353200000,
+        "runId": "salesforce-test"
+    }
+},
+{
+    "entityType": "tag",
+    "entityUrn": "urn:li:tag:SystemField",
+    "changeType": "UPSERT",
+    "aspectName": "tagKey",
+    "aspect": {
+        "json": {
+            "name": "SystemField"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1652353200000,
+        "runId": "salesforce-test"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/starburst-trino-usage/trino_usages_golden.json
+++ b/metadata-ingestion/tests/integration/starburst-trino-usage/trino_usages_golden.json
@@ -1,21 +1,62 @@
 [
 {
-    "auditHeader": null,
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:trino,testcatalog.testschema.testtable,PROD)",
-    "entityKeyAspect": null,
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
-        "value": "{\"timestampMillis\": 1634169600000, \"eventGranularity\": {\"unit\": \"DAY\", \"multiple\": 1}, \"partitionSpec\": {\"type\": \"FULL_TABLE\", \"partition\": \"FULL_TABLE_SNAPSHOT\"}, \"uniqueUserCount\": 1, \"totalSqlQueries\": 2, \"topSqlQueries\": [\"select * from testcatalog.testschema.testtable limit 100\"], \"userCounts\": [{\"user\": \"urn:li:corpuser:test-name\", \"count\": 2, \"userEmail\": \"test-name@acryl.io\"}], \"fieldCounts\": [{\"fieldPath\": \"column1\", \"count\": 2}, {\"fieldPath\": \"column2\", \"count\": 2}]}",
-        "contentType": "application/json"
+        "json": {
+            "timestampMillis": 1634169600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "uniqueUserCount": 1,
+            "totalSqlQueries": 2,
+            "topSqlQueries": [
+                "select * from testcatalog.testschema.testtable limit 100"
+            ],
+            "userCounts": [
+                {
+                    "user": "urn:li:corpuser:test-name",
+                    "count": 2,
+                    "userEmail": "test-name@acryl.io"
+                }
+            ],
+            "fieldCounts": [
+                {
+                    "fieldPath": "column1",
+                    "count": 2
+                },
+                {
+                    "fieldPath": "column2",
+                    "count": 2
+                }
+            ]
+        }
     },
     "systemMetadata": {
         "lastObserved": 1629795600000,
-        "runId": "test-trino-usage",
-        "registryName": null,
-        "registryVersion": null,
-        "properties": null
+        "runId": "test-trino-usage"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:trino,testcatalog.testschema.testtable,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1629795600000,
+        "runId": "test-trino-usage"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/tableau/tableau_with_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_with_platform_instance_mces_golden.json
@@ -74,7 +74,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -157,7 +162,12 @@
     "aspectName": "browsePathsV2",
     "aspect": {
         "json": {
-            "path": []
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                }
+            ]
         }
     },
     "systemMetadata": {
@@ -282,6 +292,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -431,6 +445,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 }
@@ -560,6 +578,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 }
@@ -688,6 +710,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -980,6 +1006,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -1542,6 +1572,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -2157,6 +2191,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -2667,6 +2705,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -2812,6 +2854,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -3127,6 +3173,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -3324,6 +3374,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -3827,6 +3881,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -4296,6 +4354,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -4799,6 +4861,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -5182,6 +5248,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -5544,6 +5614,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -5930,6 +6004,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -6372,6 +6450,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -6787,6 +6869,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -7117,6 +7203,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -7481,6 +7571,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -7733,6 +7827,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -8175,6 +8273,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -8511,6 +8613,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -8874,6 +8980,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -9263,6 +9373,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -9705,6 +9819,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -9894,6 +10012,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -10020,6 +10142,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -10123,6 +10249,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -10223,6 +10353,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -10338,6 +10472,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -12531,6 +12669,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -12927,6 +13069,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -13436,6 +13582,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -14682,6 +14832,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -21504,6 +21658,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -25653,6 +25811,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -31028,6 +31190,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
                 },
@@ -31441,6 +31607,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -31882,6 +32052,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -32939,6 +33113,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "Samples"
                 }
             ]
@@ -33157,6 +33335,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "urn:li:container:66fa1e14620418276c85f3b552c7ec65",
                     "urn": "urn:li:container:66fa1e14620418276c85f3b552c7ec65"
@@ -33387,6 +33569,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -33581,6 +33767,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "default"
                 },
@@ -33858,6 +34048,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -34108,6 +34302,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -34306,6 +34504,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -34491,6 +34693,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -34663,6 +34869,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -34783,6 +34993,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -34877,6 +35091,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "Samples"
                 },
                 {
@@ -34967,6 +35185,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "Samples"
                 },
@@ -35305,6 +35527,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "Samples"
                 },
@@ -36178,6 +36404,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "default"
                 },
@@ -37156,6 +37386,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "default"
                 },
@@ -38213,6 +38447,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -39126,6 +39364,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -39479,6 +39721,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "default"
                 },
@@ -40418,6 +40664,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "default"
                 },
@@ -41514,6 +41764,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -42466,6 +42720,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -42512,6 +42770,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -42555,6 +42817,10 @@
         "json": {
             "path": [
                 {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
+                {
                     "id": "default"
                 },
                 {
@@ -42596,6 +42862,10 @@
     "aspect": {
         "json": {
             "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:tableau,acryl_site1)"
+                },
                 {
                     "id": "default"
                 },

--- a/metadata-ingestion/tests/unit/sagemaker/sagemaker_mces_golden.json
+++ b/metadata-ingestion/tests/unit/sagemaker/sagemaker_mces_golden.json
@@ -1,1815 +1,2095 @@
 [
-  {
-    "auditHeader": null,
+{
     "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test-2,some-feature-1)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "TEXT",
-              "version": null,
-              "sources": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,datahub-sagemaker-outputs,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:glue,sagemaker_featurestore.test-2-123412341234,PROD)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
-        "urn": "urn:li:mlPrimaryKey:(test-2,some-feature-2)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
-              "description": null,
-              "dataType": "ORDINAL",
-              "version": null,
-              "sources": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,datahub-sagemaker-outputs,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:glue,sagemaker_featurestore.test-2-123412341234,PROD)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test-2,some-feature-3)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "CONTINUOUS",
-              "version": null,
-              "sources": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,datahub-sagemaker-outputs,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:glue,sagemaker_featurestore.test-2-123412341234,PROD)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
-        "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test-2)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
-              "customProperties": {
-                "arn": "arn:aws:sagemaker:us-west-2:123412341234:feature-group/test-2",
-                "creation_time": "2021-06-24 09:48:37.035000",
-                "status": "Created"
-              },
-              "description": "Yet another test feature group",
-              "mlFeatures": [
-                "urn:li:mlFeature:(test-2,some-feature-1)",
-                "urn:li:mlFeature:(test-2,some-feature-3)"
-              ],
-              "mlPrimaryKeys": [
-                "urn:li:mlPrimaryKey:(test-2,some-feature-2)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test-1,name)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "TEXT",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
-        "urn": "urn:li:mlPrimaryKey:(test-1,id)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
-              "description": null,
-              "dataType": "ORDINAL",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test-1,height)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "CONTINUOUS",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test-1,time)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "TEXT",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
-        "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test-1)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
-              "customProperties": {
-                "arn": "arn:aws:sagemaker:us-west-2:123412341234:feature-group/test-1",
-                "creation_time": "2021-06-23 13:58:10.264000",
-                "status": "Created"
-              },
-              "description": "First test feature group",
-              "mlFeatures": [
-                "urn:li:mlFeature:(test-1,name)",
-                "urn:li:mlFeature:(test-1,height)",
-                "urn:li:mlFeature:(test-1,time)"
-              ],
-              "mlPrimaryKeys": [
-                "urn:li:mlPrimaryKey:(test-1,id)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
-        "urn": "urn:li:mlPrimaryKey:(test,feature_1)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
-              "description": null,
-              "dataType": "TEXT",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test,feature_2)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "ORDINAL",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
-        "urn": "urn:li:mlFeature:(test,feature_3)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
-              "description": null,
-              "dataType": "CONTINUOUS",
-              "version": null,
-              "sources": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
-        "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
-              "customProperties": {
-                "arn": "arn:aws:sagemaker:us-west-2:123412341234:feature-group/test",
-                "creation_time": "2021-06-14 11:03:00.803000",
-                "status": "Created"
-              },
-              "description": null,
-              "mlFeatures": [
-                "urn:li:mlFeature:(test,feature_2)",
-                "urn:li:mlFeature:(test,feature_3)"
-              ],
-              "mlPrimaryKeys": [
-                "urn:li:mlPrimaryKey:(test,feature_1)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-input-bucket/file_txt,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://auto-ml-job-input-bucket/file.txt",
-                "datatype": "ManifestFile"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-output-bucket/file_txt,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://auto-ml-job-output-bucket/file.txt"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/input-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://compilation-job-bucket/input-config.tar.gz",
-                "framework": "TENSORFLOW",
-                "framework_version": "string"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://compilation-job-bucket/output-config.tar.gz",
-                "target_device": "lambda",
-                "target_platform": "{'Os': 'ANDROID', 'Arch': 'X86_64', 'Accelerator': 'INTEL_GRAPHICS'}"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://edge-packaging-bucket/model-artifact.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://edge-packaging-bucket/output-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/data-source.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://labeling-job/data-source.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/category-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://labeling-job/category-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-dataset.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://labeling-job/output-dataset.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://labeling-job/output-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,processing-job/input-data.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://processing-job/input-data.tar.gz",
-                "datatype": "ManifestFile",
-                "mode": "Pipe",
-                "distribution_type": "FullyReplicated",
-                "compression": "None",
-                "name": "string"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/input-dataset.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/input-dataset.tar.gz",
-                "datatype": "None",
-                "distribution_type": "FullyReplicated",
-                "attribute_names": "['string']",
-                "channel_name": "string"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/output-data.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/output-data.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/checkpoint-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/checkpoint-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-hook-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/debug-hook-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/tensorboard-output-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/tensorboard-output-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/profiler-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-rule-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/debug-rule-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-rule-config.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://training-job/profiler-rule-config.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/input-data-source.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://transform-job/input-data-source.tar.gz",
-                "datatype": "ManifestFile",
-                "compression": "None",
-                "split": "None"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-        "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/output.tar_gz,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-              "customProperties": {
-                "dataset_type": "s3",
-                "uri": "s3://transform-job/output.tar.gz"
-              },
-              "externalUrl": null,
-              "description": null,
-              "uri": null,
-              "tags": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "an-auto-ml-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "AutoMLJobName": "an-auto-ml-job",
-                "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
-                "InputDataConfig": "[{'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://auto-ml-job-input-bucket/file.txt'}}, 'CompressionType': 'None', 'TargetAttributeName': 'some-name'}]",
-                "OutputDataConfig": "{'KmsKeyId': 'some-key-id', 'S3OutputPath': 's3://auto-ml-job-output-bucket/file.txt'}",
-                "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                "AutoMLJobObjective": "{'MetricName': 'Accuracy'}",
-                "ProblemType": "BinaryClassification",
-                "AutoMLJobConfig": "{'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}, 'SecurityConfig': {'VolumeKmsKeyId': 'string', 'EnableInterContainerTrafficEncryption': True, 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}}}",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "EndTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "FailureReason": "string",
-                "PartialFailureReasons": "[{'PartialFailureMessage': 'string'}]",
-                "BestCandidate": "{'CandidateName': 'string', 'FinalAutoMLJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'Accuracy', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded', 'CandidateSteps': [{'CandidateStepType': 'AWS::SageMaker::TrainingJob', 'CandidateStepArn': 'string', 'CandidateStepName': 'string'}], 'CandidateStatus': 'Completed', 'InferenceContainers': [{'Image': 'string', 'ModelDataUrl': 's3://auto-ml-job/model-artifact.tar.gz', 'Environment': {'string': 'string'}}], 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'EndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'FailureReason': 'string', 'CandidateProperties': {'CandidateArtifactLocations': {'Explainability': 'string'}}}",
-                "AutoMLJobStatus": "Completed",
-                "AutoMLJobSecondaryStatus": "Starting",
-                "GenerateCandidateDefinitionsOnly": "True",
-                "AutoMLJobArtifacts": "{'CandidateDefinitionNotebookLocation': 'string', 'DataExplorationNotebookLocation': 'string'}",
-                "ResolvedAttributes": "{'AutoMLJobObjective': {'MetricName': 'Accuracy'}, 'ProblemType': 'BinaryClassification', 'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}}",
-                "ModelDeployConfig": "{'AutoGenerateEndpointName': True, 'EndpointName': 'string'}",
-                "ModelDeployResult": "{'EndpointName': 'string'}",
-                "jobType": "auto_ml"
-              },
-              "externalUrl": null,
-              "name": "an-auto-ml-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "COMPLETED"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/auto_ml"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-input-bucket/file_txt,PROD)"
-              ],
-              "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-output-bucket/file_txt,PROD)"
-              ],
-              "inputDatajobs": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "a-compilation-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "CompilationJobName": "a-compilation-job",
-                "CompilationJobArn": "arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job",
-                "CompilationJobStatus": "INPROGRESS",
-                "CompilationStartTime": "2015-01-01 00:00:00+00:00",
-                "CompilationEndTime": "2015-01-01 00:00:00+00:00",
-                "StoppingCondition": "{'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}",
-                "InferenceImage": "string",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "FailureReason": "string",
-                "ModelArtifacts": "{'S3ModelArtifacts': 's3://compilation-job-bucket/model-artifacts.tar.gz'}",
-                "ModelDigests": "{'ArtifactDigest': 'string'}",
-                "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                "InputConfig": "{'S3Uri': 's3://compilation-job-bucket/input-config.tar.gz', 'DataInputConfig': 'string', 'Framework': 'TENSORFLOW', 'FrameworkVersion': 'string'}",
-                "OutputConfig": "{'S3OutputLocation': 's3://compilation-job-bucket/output-config.tar.gz', 'TargetDevice': 'lambda', 'TargetPlatform': {'Os': 'ANDROID', 'Arch': 'X86_64', 'Accelerator': 'INTEL_GRAPHICS'}, 'CompilerOptions': 'string', 'KmsKeyId': 'string'}",
-                "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
-                "jobType": "compilation"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/compilation-jobs/a-compilation-job",
-              "name": "a-compilation-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "IN_PROGRESS"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/compilation"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/input-config.tar_gz,PROD)"
-              ],
-              "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)"
-              ],
-              "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "an-edge-packaging-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "EdgePackagingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job",
-                "EdgePackagingJobName": "an-edge-packaging-job",
-                "CompilationJobName": "a-compilation-job",
-                "ModelName": "the-second-model",
-                "ModelVersion": "string",
-                "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                "OutputConfig": "{'S3OutputLocation': 's3://edge-packaging-bucket/output-config.tar.gz', 'KmsKeyId': 'string', 'PresetDeploymentType': 'GreengrassV2Component', 'PresetDeploymentConfig': 'string'}",
-                "ResourceKey": "string",
-                "EdgePackagingJobStatus": "STARTING",
-                "EdgePackagingJobStatusMessage": "string",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "ModelArtifact": "s3://edge-packaging-bucket/model-artifact.tar.gz",
-                "ModelSignature": "string",
-                "PresetDeploymentOutput": "{'Type': 'GreengrassV2Component', 'Artifact': 'arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/some-artifact', 'Status': 'COMPLETED', 'StatusMessage': 'string'}",
-                "jobType": "edge_packaging"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/edge-packaging-jobs/an-edge-packaging-job",
-              "name": "an-edge-packaging-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "STARTING"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/edge_packaging"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [],
-              "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)"
-              ],
-              "inputDatajobs": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,hyper_parameter_tuning:a-hyper-parameter-tuning-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "a-hyper-parameter-tuning-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,hyper_parameter_tuning:a-hyper-parameter-tuning-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:hyper-parameter-tuning-job/a-hyper-parameter-tuning-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "HyperParameterTuningJobName": "a-hyper-parameter-tuning-job",
-                "HyperParameterTuningJobArn": "arn:aws:sagemaker:us-west-2:123412341234:hyper-parameter-tuning-job/a-hyper-parameter-tuning-job",
-                "HyperParameterTuningJobConfig": "{'Strategy': 'Bayesian', 'HyperParameterTuningJobObjective': {'Type': 'Maximize', 'MetricName': 'string'}, 'ResourceLimits': {'MaxNumberOfTrainingJobs': 123, 'MaxParallelTrainingJobs': 123}, 'ParameterRanges': {'IntegerParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'ContinuousParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'CategoricalParameterRanges': [{'Name': 'string', 'Values': ['string']}]}, 'TrainingJobEarlyStoppingType': 'Off', 'TuningJobCompletionCriteria': {'TargetObjectiveMetricValue': 1.0}}",
-                "TrainingJobDefinition": "{'DefinitionName': 'string', 'TuningObjective': {'Type': 'Maximize', 'MetricName': 'string'}, 'HyperParameterRanges': {'IntegerParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'ContinuousParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'CategoricalParameterRanges': [{'Name': 'string', 'Values': ['string']}]}, 'StaticHyperParameters': {'string': 'string'}, 'AlgorithmSpecification': {'TrainingImage': 'string', 'TrainingInputMode': 'Pipe', 'AlgorithmName': 'string', 'MetricDefinitions': [{'Name': 'string', 'Regex': 'string'}]}, 'RoleArn': 'arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole', 'InputDataConfig': [{'ChannelName': 'string', 'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://hyper-parameter-tuning-job/data-source.tar.gz', 'S3DataDistributionType': 'FullyReplicated', 'AttributeNames': ['string']}, 'FileSystemDataSource': {'FileSystemId': 'abcdefgihjklmnopqrstuvwxyz', 'FileSystemAccessMode': 'rw', 'FileSystemType': 'EFS', 'DirectoryPath': 'string'}}, 'ContentType': 'string', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode': 'Pipe', 'ShuffleConfig': {'Seed': 123}}], 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}, 'OutputDataConfig': {'KmsKeyId': 'string', 'S3OutputPath': 's3://hyper-parameter-tuning-job/data-output.tar.gz'}, 'ResourceConfig': {'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}, 'StoppingCondition': {'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}, 'EnableNetworkIsolation': True, 'EnableInterContainerTrafficEncryption': True, 'EnableManagedSpotTraining': True, 'CheckpointConfig': {'S3Uri': 's3://hyper-parameter-tuning-job/checkpoint-config.tar.gz', 'LocalPath': 'string'}, 'RetryStrategy': {'MaximumRetryAttempts': 123}}",
-                "TrainingJobDefinitions": "[{'DefinitionName': 'string', 'TuningObjective': {'Type': 'Maximize', 'MetricName': 'string'}, 'HyperParameterRanges': {'IntegerParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'ContinuousParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'CategoricalParameterRanges': [{'Name': 'string', 'Values': ['string']}]}, 'StaticHyperParameters': {'string': 'string'}, 'AlgorithmSpecification': {'TrainingImage': 'string', 'TrainingInputMode': 'Pipe', 'AlgorithmName': 'string', 'MetricDefinitions': [{'Name': 'string', 'Regex': 'string'}]}, 'RoleArn': 'arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole', 'InputDataConfig': [{'ChannelName': 'string', 'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://hyper-parameter-tuning-job/data-source.tar.gz', 'S3DataDistributionType': 'FullyReplicated', 'AttributeNames': ['string']}, 'FileSystemDataSource': {'FileSystemId': 'abcdefgihjklmnopqrstuvwxyz', 'FileSystemAccessMode': 'rw', 'FileSystemType': 'EFS', 'DirectoryPath': 'string'}}, 'ContentType': 'string', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode': 'Pipe', 'ShuffleConfig': {'Seed': 123}}], 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}, 'OutputDataConfig': {'KmsKeyId': 'string', 'S3OutputPath': 's3://hyper-parameter-tuning-job/data-output.tar.gz'}, 'ResourceConfig': {'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}, 'StoppingCondition': {'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}, 'EnableNetworkIsolation': True, 'EnableInterContainerTrafficEncryption': True, 'EnableManagedSpotTraining': True, 'CheckpointConfig': {'S3Uri': 's3://hyper-parameter-tuning-job/checkpoint-config.tar.gz', 'LocalPath': 'string'}, 'RetryStrategy': {'MaximumRetryAttempts': 123}}]",
-                "HyperParameterTuningJobStatus": "Completed",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "HyperParameterTuningEndTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "TrainingJobStatusCounters": "{'Completed': 123, 'InProgress': 123, 'RetryableError': 123, 'NonRetryableError': 123, 'Stopped': 123}",
-                "ObjectiveStatusCounters": "{'Succeeded': 123, 'Pending': 123, 'Failed': 123}",
-                "BestTrainingJob": "{'TrainingJobDefinitionName': 'string', 'TrainingJobName': 'string', 'TrainingJobArn': 'string', 'TuningJobName': 'string', 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingStartTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingEndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingJobStatus': 'InProgress', 'TunedHyperParameters': {'string': 'string'}, 'FailureReason': 'string', 'FinalHyperParameterTuningJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'string', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded'}",
-                "OverallBestTrainingJob": "{'TrainingJobDefinitionName': 'string', 'TrainingJobName': 'string', 'TrainingJobArn': 'string', 'TuningJobName': 'string', 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingStartTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingEndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingJobStatus': 'InProgress', 'TunedHyperParameters': {'string': 'string'}, 'FailureReason': 'string', 'FinalHyperParameterTuningJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'string', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded'}",
-                "WarmStartConfig": "{'ParentHyperParameterTuningJobs': [{'HyperParameterTuningJobName': 'string'}], 'WarmStartType': 'IdenticalDataAndAlgorithm'}",
-                "FailureReason": "string",
-                "jobType": "hyper_parameter_tuning"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/hyper-tuning-jobs/a-hyper-parameter-tuning-job",
-              "name": "a-hyper-parameter-tuning-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "COMPLETED"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/hyper_parameter_tuning"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [],
-              "outputDatasets": [],
-              "inputDatajobs": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "a-labeling-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "LabelingJobStatus": "Initializing",
-                "LabelCounters": "{'TotalLabeled': 123, 'HumanLabeled': 123, 'MachineLabeled': 123, 'FailedNonRetryableError': 123, 'Unlabeled': 123}",
-                "FailureReason": "string",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "JobReferenceCode": "string",
-                "LabelingJobName": "a-labeling-job",
-                "LabelingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job",
-                "LabelAttributeName": "string",
-                "InputConfig": "{'DataSource': {'S3DataSource': {'ManifestS3Uri': 's3://labeling-job/data-source.tar.gz'}, 'SnsDataSource': {'SnsTopicArn': 'string'}}, 'DataAttributes': {'ContentClassifiers': ['FreeOfPersonallyIdentifiableInformation', 'FreeOfAdultContent']}}",
-                "OutputConfig": "{'S3OutputPath': 's3://labeling-job/output-config.tar.gz', 'KmsKeyId': 'string', 'SnsTopicArn': 'string'}",
-                "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                "LabelCategoryConfigS3Uri": "s3://labeling-job/category-config.tar.gz",
-                "StoppingConditions": "{'MaxHumanLabeledObjectCount': 123, 'MaxPercentageOfInputDatasetLabeled': 123}",
-                "LabelingJobAlgorithmsConfig": "{'LabelingJobAlgorithmSpecificationArn': 'string', 'InitialActiveLearningModelArn': 'arn:aws:sagemaker:us-west-2:123412341234:labeling-job/initial-active-learning-model', 'LabelingJobResourceConfig': {'VolumeKmsKeyId': 'string'}}",
-                "HumanTaskConfig": "{'WorkteamArn': 'string', 'UiConfig': {'UiTemplateS3Uri': 's3://labeling-job/ui-config.tar.gz', 'HumanTaskUiArn': 'string'}, 'PreHumanTaskLambdaArn': 'string', 'TaskKeywords': ['string'], 'TaskTitle': 'string', 'TaskDescription': 'string', 'NumberOfHumanWorkersPerDataObject': 123, 'TaskTimeLimitInSeconds': 123, 'TaskAvailabilityLifetimeInSeconds': 123, 'MaxConcurrentTaskCount': 123, 'AnnotationConsolidationConfig': {'AnnotationConsolidationLambdaArn': 'string'}, 'PublicWorkforceTaskPrice': {'AmountInUsd': {'Dollars': 123, 'Cents': 123, 'TenthFractionsOfACent': 123}}}",
-                "Tags": "[{'Key': 'string', 'Value': 'string'}]",
-                "LabelingJobOutput": "{'OutputDatasetS3Uri': 's3://labeling-job/output-dataset.tar.gz', 'FinalActiveLearningModelArn': 'arn:aws:sagemaker:us-west-2:123412341234:labeling-job/final-active-learning-model'}",
-                "jobType": "labeling"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/labeling-jobs/a-labeling-job",
-              "name": "a-labeling-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "STARTING"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/labeling"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/category-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/data-source.tar_gz,PROD)"
-              ],
-              "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-dataset.tar_gz,PROD)"
-              ],
-              "inputDatajobs": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,processing:a-processing-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "a-processing-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,processing:a-processing-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:processing-job/a-processing-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "ProcessingJobName": "a-processing-job",
-                "ProcessingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:processing-job/a-processing-job",
-                "ProcessingInputs": "[{'InputName': 'string', 'AppManaged': True, 'S3Input': {'S3Uri': 's3://processing-job/input-data.tar.gz', 'LocalPath': 'string', 'S3DataType': 'ManifestFile', 'S3InputMode': 'Pipe', 'S3DataDistributionType': 'FullyReplicated', 'S3CompressionType': 'None'}, 'DatasetDefinition': {'AthenaDatasetDefinition': {'Catalog': 'athena-catalog', 'Database': 'athena-database', 'QueryString': 'athena-query-string', 'WorkGroup': 'athena-work-group', 'OutputS3Uri': 's3://processing-job/athena-output.tar.gz', 'KmsKeyId': 'string', 'OutputFormat': 'PARQUET', 'OutputCompression': 'GZIP'}, 'RedshiftDatasetDefinition': {'ClusterId': 'redshift-cluster', 'Database': 'redshift-database', 'DbUser': 'redshift-db-user', 'QueryString': 'redshift-query-string', 'ClusterRoleArn': 'arn:aws:sagemaker:us-west-2:123412341234:processing-job/redshift-cluster', 'OutputS3Uri': 's3://processing-job/redshift-output.tar.gz', 'KmsKeyId': 'string', 'OutputFormat': 'PARQUET', 'OutputCompression': 'None'}, 'LocalPath': 'string', 'DataDistributionType': 'FullyReplicated', 'InputMode': 'Pipe'}}]",
-                "ProcessingOutputConfig": "{'Outputs': [{'OutputName': 'string', 'S3Output': {'S3Uri': 's3://processing-job/processing-output.tar.gz', 'LocalPath': 'string', 'S3UploadMode': 'Continuous'}, 'FeatureStoreOutput': {'FeatureGroupName': 'string'}, 'AppManaged': True}], 'KmsKeyId': 'string'}",
-                "ProcessingResources": "{'ClusterConfig': {'InstanceCount': 123, 'InstanceType': 'ml.t3.medium', 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}}",
-                "StoppingCondition": "{'MaxRuntimeInSeconds': 123}",
-                "AppSpecification": "{'ImageUri': 'string', 'ContainerEntrypoint': ['string'], 'ContainerArguments': ['string']}",
-                "Environment": "{'string': 'string'}",
-                "NetworkConfig": "{'EnableInterContainerTrafficEncryption': True, 'EnableNetworkIsolation': True, 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}}",
-                "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                "ExperimentConfig": "{'ExperimentName': 'string', 'TrialName': 'string', 'TrialComponentDisplayName': 'string'}",
-                "ProcessingJobStatus": "InProgress",
-                "ExitMessage": "string",
-                "FailureReason": "string",
-                "ProcessingEndTime": "2015-01-01 00:00:00+00:00",
-                "ProcessingStartTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "MonitoringScheduleArn": "string",
-                "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
-                "TrainingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job",
-                "jobType": "processing"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/processing-jobs/a-processing-job",
-              "name": "a-processing-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "IN_PROGRESS"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/processing"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,processing-job/input-data.tar_gz,PROD)"
-              ],
-              "outputDatasets": [],
-              "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,training:a-training-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "a-training-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "TrainingJobName": "a-training-job",
-                "TrainingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job",
-                "TuningJobArn": "string",
-                "LabelingJobArn": "string",
-                "AutoMLJobArn": "string",
-                "ModelArtifacts": "{'S3ModelArtifacts': 's3://the-first-model-data-url/data.tar.gz'}",
-                "TrainingJobStatus": "InProgress",
-                "SecondaryStatus": "Starting",
-                "FailureReason": "string",
-                "HyperParameters": "{'parameter-1': 'some-value', 'parameter-2': 'another-value'}",
-                "AlgorithmSpecification": "{'TrainingImage': 'string', 'AlgorithmName': 'string', 'TrainingInputMode': 'Pipe', 'MetricDefinitions': [{'Name': 'string', 'Regex': 'string'}], 'EnableSageMakerMetricsTimeSeries': True}",
-                "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                "InputDataConfig": "[{'ChannelName': 'string', 'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://training-job/input-dataset.tar.gz', 'S3DataDistributionType': 'FullyReplicated', 'AttributeNames': ['string']}, 'FileSystemDataSource': {'FileSystemId': 'abcdefgihjklmnopqrstuvwxyz', 'FileSystemAccessMode': 'rw', 'FileSystemType': 'EFS', 'DirectoryPath': 'string'}}, 'ContentType': 'string', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode': 'Pipe', 'ShuffleConfig': {'Seed': 123}}]",
-                "OutputDataConfig": "{'KmsKeyId': 'string', 'S3OutputPath': 's3://training-job/output-data.tar.gz'}",
-                "ResourceConfig": "{'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}",
-                "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
-                "StoppingCondition": "{'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "TrainingStartTime": "2015-01-01 00:00:00+00:00",
-                "TrainingEndTime": "2015-01-01 00:00:00+00:00",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "SecondaryStatusTransitions": "[{'Status': 'Starting', 'StartTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'EndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'StatusMessage': 'string'}]",
-                "FinalMetricDataList": "[{'MetricName': 'some-metric', 'Value': 1.0, 'Timestamp': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}, {'MetricName': 'another-metric', 'Value': 1.0, 'Timestamp': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}, {'MetricName': 'some-metric', 'Value': 0.0, 'Timestamp': datetime.datetime(2014, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}]",
-                "EnableNetworkIsolation": "True",
-                "EnableInterContainerTrafficEncryption": "True",
-                "EnableManagedSpotTraining": "True",
-                "CheckpointConfig": "{'S3Uri': 's3://training-job/checkpoint-config.tar.gz', 'LocalPath': 'string'}",
-                "TrainingTimeInSeconds": "123",
-                "BillableTimeInSeconds": "123",
-                "DebugHookConfig": "{'LocalPath': 'string', 'S3OutputPath': 's3://training-job/debug-hook-config.tar.gz', 'HookParameters': {'string': 'string'}, 'CollectionConfigurations': [{'CollectionName': 'string', 'CollectionParameters': {'string': 'string'}}]}",
-                "ExperimentConfig": "{'ExperimentName': 'string', 'TrialName': 'string', 'TrialComponentDisplayName': 'string'}",
-                "DebugRuleConfigurations": "[{'RuleConfigurationName': 'string', 'LocalPath': 'string', 'S3OutputPath': 's3://training-job/debug-rule-config.tar.gz', 'RuleEvaluatorImage': 'string', 'InstanceType': 'ml.t3.medium', 'VolumeSizeInGB': 123, 'RuleParameters': {'string': 'string'}}]",
-                "TensorBoardOutputConfig": "{'LocalPath': 'string', 'S3OutputPath': 's3://training-job/tensorboard-output-config.tar.gz'}",
-                "DebugRuleEvaluationStatuses": "[{'RuleConfigurationName': 'string', 'RuleEvaluationJobArn': 'string', 'RuleEvaluationStatus': 'InProgress', 'StatusDetails': 'string', 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}]",
-                "ProfilerConfig": "{'S3OutputPath': 's3://training-job/profiler-config.tar.gz', 'ProfilingIntervalInMilliseconds': 123, 'ProfilingParameters': {'string': 'string'}}",
-                "ProfilerRuleConfigurations": "[{'RuleConfigurationName': 'string', 'LocalPath': 'string', 'S3OutputPath': 's3://training-job/profiler-rule-config.tar.gz', 'RuleEvaluatorImage': 'string', 'InstanceType': 'ml.t3.medium', 'VolumeSizeInGB': 123, 'RuleParameters': {'string': 'string'}}]",
-                "ProfilerRuleEvaluationStatuses": "[{'RuleConfigurationName': 'string', 'RuleEvaluationJobArn': 'string', 'RuleEvaluationStatus': 'InProgress', 'StatusDetails': 'string', 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}]",
-                "ProfilingStatus": "Enabled",
-                "RetryStrategy": "{'MaximumRetryAttempts': 123}",
-                "Environment": "{'string': 'string'}",
-                "jobType": "training"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/jobs/a-training-job",
-              "name": "a-training-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "IN_PROGRESS"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/training"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/input-dataset.tar_gz,PROD)"
-              ],
-              "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/checkpoint-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-hook-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-rule-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/output-data.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-rule-config.tar_gz,PROD)",
-                "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/tensorboard-output-config.tar_gz,PROD)"
-              ],
-              "inputDatajobs": []
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-        "urn": "urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-              "customProperties": {},
-              "externalUrl": null,
-              "name": "a-transform-job",
-              "description": null,
-              "project": null
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-        "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-              "customProperties": {
-                "TransformJobName": "a-transform-job",
-                "TransformJobArn": "arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job",
-                "TransformJobStatus": "InProgress",
-                "FailureReason": "string",
-                "ModelName": "the-second-model",
-                "MaxConcurrentTransforms": "123",
-                "ModelClientConfig": "{'InvocationsTimeoutInSeconds': 123, 'InvocationsMaxRetries': 123}",
-                "MaxPayloadInMB": "123",
-                "BatchStrategy": "MultiRecord",
-                "Environment": "{'string': 'string'}",
-                "TransformInput": "{'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://transform-job/input-data-source.tar.gz'}}, 'ContentType': 'string', 'CompressionType': 'None', 'SplitType': 'None'}",
-                "TransformOutput": "{'S3OutputPath': 's3://transform-job/output.tar.gz', 'Accept': 'string', 'AssembleWith': 'None', 'KmsKeyId': 'string'}",
-                "TransformResources": "{'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeKmsKeyId': 'string'}",
-                "CreationTime": "2015-01-01 00:00:00+00:00",
-                "TransformStartTime": "2015-01-01 00:00:00+00:00",
-                "TransformEndTime": "2015-01-01 00:00:00+00:00",
-                "LabelingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job",
-                "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
-                "DataProcessing": "{'InputFilter': 'string', 'OutputFilter': 'string', 'JoinSource': 'Input'}",
-                "ExperimentConfig": "{'ExperimentName': 'string', 'TrialName': 'string', 'TrialComponentDisplayName': 'string'}",
-                "jobType": "transform"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/transform-jobs/a-transform-job",
-              "name": "a-transform-job",
-              "description": null,
-              "type": {
-                "string": "SAGEMAKER"
-              },
-              "flowUrn": null,
-              "status": "IN_PROGRESS"
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/transform"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-              "inputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/input-data-source.tar_gz,PROD)"
-              ],
-              "outputDatasets": [
-                "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/output.tar_gz,PROD)"
-              ],
-              "inputDatajobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job)"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLModelDeploymentSnapshot": {
-        "urn": "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,the-first-endpoint,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLModelDeploymentProperties": {
-              "customProperties": {
-                "EndpointArn": "arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-first-endpoint",
-                "EndpointConfigName": "string",
-                "ProductionVariants": "[{'VariantName': 'string', 'DeployedImages': [{'SpecifiedImage': 'string', 'ResolvedImage': 'string', 'ResolutionTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}], 'CurrentWeight': 0.1, 'DesiredWeight': 0.1, 'CurrentInstanceCount': 123, 'DesiredInstanceCount': 123}]",
-                "DataCaptureConfig": "{'EnableCapture': True, 'CaptureStatus': 'Started', 'CurrentSamplingPercentage': 123, 'DestinationS3Uri': 'string', 'KmsKeyId': 'string'}",
-                "EndpointStatus": "InService",
-                "FailureReason": "string",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "LastDeploymentConfig": "{'BlueGreenUpdatePolicy': {'TrafficRoutingConfiguration': {'Type': 'ALL_AT_ONCE', 'WaitIntervalInSeconds': 123, 'CanarySize': {'Type': 'INSTANCE_COUNT', 'Value': 123}}, 'TerminationWaitInSeconds': 123, 'MaximumExecutionTimeoutInSeconds': 600}, 'AutoRollbackConfiguration': {'Alarms': [{'AlarmName': 'string'}]}}"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/endpoints/the-first-endpoint",
-              "description": null,
-              "createdAt": 1420070400000,
-              "version": null,
-              "status": "IN_SERVICE"
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLModelDeploymentSnapshot": {
-        "urn": "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,the-second-endpoint,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLModelDeploymentProperties": {
-              "customProperties": {
-                "EndpointArn": "arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-second-endpoint",
-                "EndpointConfigName": "string",
-                "ProductionVariants": "[{'VariantName': 'string', 'DeployedImages': [{'SpecifiedImage': 'string', 'ResolvedImage': 'string', 'ResolutionTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}], 'CurrentWeight': 0.1, 'DesiredWeight': 0.1, 'CurrentInstanceCount': 123, 'DesiredInstanceCount': 123}]",
-                "DataCaptureConfig": "{'EnableCapture': True, 'CaptureStatus': 'Started', 'CurrentSamplingPercentage': 123, 'DestinationS3Uri': 'string', 'KmsKeyId': 'string'}",
-                "EndpointStatus": "Creating",
-                "FailureReason": "string",
-                "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                "LastDeploymentConfig": "{'BlueGreenUpdatePolicy': {'TrafficRoutingConfiguration': {'Type': 'ALL_AT_ONCE', 'WaitIntervalInSeconds': 123, 'CanarySize': {'Type': 'INSTANCE_COUNT', 'Value': 123}}, 'TerminationWaitInSeconds': 123, 'MaximumExecutionTimeoutInSeconds': 600}, 'AutoRollbackConfiguration': {'Alarms': [{'AlarmName': 'string'}]}}"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/endpoints/the-second-endpoint",
-              "description": null,
-              "createdAt": 1420070400000,
-              "version": null,
-              "status": "CREATING"
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
-    "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLModelGroupSnapshot": {
-        "urn": "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLModelGroupProperties": {
-              "customProperties": {
-                "ModelPackageGroupArn": "arn:aws:sagemaker:us-west-2:123412341234:model-package-group/a-model-package-group",
-                "ModelPackageGroupDescription": "Just a model package group.",
-                "CreatedBy": "{'UserProfileArn': 'arn:aws:sagemaker:us-west-2:123412341234:user-profile/some-domain/some-user', 'UserProfileName': 'some-user', 'DomainId': 'some-domain'}",
-                "ModelPackageGroupStatus": "Completed"
-              },
-              "description": "Just a model package group.",
-              "createdAt": 1420070400000,
-              "version": null
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.Ownership": {
-              "owners": [
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test-2,some-feature-1)",
+            "aspects": [
                 {
-                  "owner": "urn:li:corpuser:some-user",
-                  "type": "DATAOWNER",
-                  "source": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "TEXT",
+                        "sources": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,datahub-sagemaker-outputs,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:glue,sagemaker_featurestore.test-2-123412341234,PROD)"
+                        ]
+                    }
                 }
-              ],
-              "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown",
-                "impersonator": null
-              }
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
+            ]
+        }
+    }
+},
+{
     "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLModelSnapshot": {
-        "urn": "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,the-first-model,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLModelProperties": {
-              "customProperties": {
-                "PrimaryContainer": "{'ContainerHostname': 'string', 'Image': '123412341234.dkr.ecr.us-west-2.amazonaws.com/the-first-model-image', 'ImageConfig': {'RepositoryAccessMode': 'Platform', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'SingleModel', 'ModelDataUrl': 's3://the-first-model-data-url/data.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Enabled'}}",
-                "Containers": "[{'ContainerHostname': 'string', 'Image': 'string', 'ImageConfig': {'RepositoryAccessMode': 'Platform', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'SingleModel', 'ModelDataUrl': 's3://training-job-2/model-artifact.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Enabled'}}]",
-                "InferenceExecutionConfig": "{'Mode': 'Serial'}",
-                "ExecutionRoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMaker-ExecutionRole-20210614T104201",
-                "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
-                "ModelArn": "arn:aws:sagemaker:us-west-2:123412341234:model/the-first-model",
-                "EnableNetworkIsolation": "True"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/models/the-first-model",
-              "description": null,
-              "date": 1420070400000,
-              "version": null,
-              "type": null,
-              "hyperParameters": null,
-              "hyperParams": [
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
+            "urn": "urn:li:mlPrimaryKey:(test-2,some-feature-2)",
+            "aspects": [
                 {
-                  "name": "parameter-1",
-                  "description": null,
-                  "value": "some-value",
-                  "createdAt": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
+                        "dataType": "ORDINAL",
+                        "sources": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,datahub-sagemaker-outputs,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:glue,sagemaker_featurestore.test-2-123412341234,PROD)"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test-2,some-feature-3)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "CONTINUOUS",
+                        "sources": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,datahub-sagemaker-outputs,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:glue,sagemaker_featurestore.test-2-123412341234,PROD)"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
+            "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test-2)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/sagemaker"
+                        ]
+                    }
                 },
                 {
-                  "name": "parameter-2",
-                  "description": null,
-                  "value": "another-value",
-                  "createdAt": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
+                        "customProperties": {
+                            "arn": "arn:aws:sagemaker:us-west-2:123412341234:feature-group/test-2",
+                            "creation_time": "2021-06-24 09:48:37.035000",
+                            "status": "Created"
+                        },
+                        "description": "Yet another test feature group",
+                        "mlFeatures": [
+                            "urn:li:mlFeature:(test-2,some-feature-1)",
+                            "urn:li:mlFeature:(test-2,some-feature-3)"
+                        ],
+                        "mlPrimaryKeys": [
+                            "urn:li:mlPrimaryKey:(test-2,some-feature-2)"
+                        ]
+                    }
                 }
-              ],
-              "trainingMetrics": [
-                {
-                  "name": "another-metric",
-                  "description": null,
-                  "value": "1.0",
-                  "createdAt": null
-                },
-                {
-                  "name": "some-metric",
-                  "description": null,
-                  "value": "1.0",
-                  "createdAt": null
-                }
-              ],
-              "onlineMetrics": null,
-              "mlFeatures": null,
-              "tags": [],
-              "deployments": [
-                "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-first-endpoint,PROD)"
-              ],
-              "trainingJobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
-              ],
-              "downstreamJobs": [],
-              "groups": [
-                "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker/a-model-package-group"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  },
-  {
-    "auditHeader": null,
+            ]
+        }
+    }
+},
+{
     "proposedSnapshot": {
-      "com.linkedin.pegasus2avro.metadata.snapshot.MLModelSnapshot": {
-        "urn": "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,the-second-model,PROD)",
-        "aspects": [
-          {
-            "com.linkedin.pegasus2avro.ml.metadata.MLModelProperties": {
-              "customProperties": {
-                "PrimaryContainer": "{'ContainerHostname': 'string', 'Image': '123412341234.dkr.ecr.us-west-2.amazonaws.com/the-second-model-image', 'ImageConfig': {'RepositoryAccessMode': 'Platform', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'MultiModel', 'ModelDataUrl': 's3://the-second-model-data-url/data.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Disabled'}}",
-                "Containers": "[{'ContainerHostname': 'string', 'Image': 'string', 'ImageConfig': {'RepositoryAccessMode': 'Vpc', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'SingleModel', 'ModelDataUrl': 's3://the-first-model-data-url/data.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Disabled'}}]",
-                "InferenceExecutionConfig": "{'Mode': 'Serial'}",
-                "ExecutionRoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMaker-ExecutionRole-20210614T104201",
-                "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
-                "ModelArn": "arn:aws:sagemaker:us-west-2:123412341234:model/the-second-model",
-                "EnableNetworkIsolation": "False"
-              },
-              "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/models/the-second-model",
-              "description": null,
-              "date": 1420070400000,
-              "version": null,
-              "type": null,
-              "hyperParameters": null,
-              "hyperParams": [
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test-1,name)",
+            "aspects": [
                 {
-                  "name": "parameter-1",
-                  "description": null,
-                  "value": "some-value",
-                  "createdAt": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "TEXT",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
+            "urn": "urn:li:mlPrimaryKey:(test-1,id)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
+                        "dataType": "ORDINAL",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test-1,height)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "CONTINUOUS",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test-1,time)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "TEXT",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
+            "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test-1)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/sagemaker"
+                        ]
+                    }
                 },
                 {
-                  "name": "parameter-2",
-                  "description": null,
-                  "value": "another-value",
-                  "createdAt": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
+                        "customProperties": {
+                            "arn": "arn:aws:sagemaker:us-west-2:123412341234:feature-group/test-1",
+                            "creation_time": "2021-06-23 13:58:10.264000",
+                            "status": "Created"
+                        },
+                        "description": "First test feature group",
+                        "mlFeatures": [
+                            "urn:li:mlFeature:(test-1,name)",
+                            "urn:li:mlFeature:(test-1,height)",
+                            "urn:li:mlFeature:(test-1,time)"
+                        ],
+                        "mlPrimaryKeys": [
+                            "urn:li:mlPrimaryKey:(test-1,id)"
+                        ]
+                    }
                 }
-              ],
-              "trainingMetrics": [
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLPrimaryKeySnapshot": {
+            "urn": "urn:li:mlPrimaryKey:(test,feature_1)",
+            "aspects": [
                 {
-                  "name": "another-metric",
-                  "description": null,
-                  "value": "1.0",
-                  "createdAt": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLPrimaryKeyProperties": {
+                        "dataType": "TEXT",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test,feature_2)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "ORDINAL",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
+            "urn": "urn:li:mlFeature:(test,feature_3)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureProperties": {
+                        "dataType": "CONTINUOUS",
+                        "sources": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureTableSnapshot": {
+            "urn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/sagemaker"
+                        ]
+                    }
                 },
                 {
-                  "name": "some-metric",
-                  "description": null,
-                  "value": "1.0",
-                  "createdAt": null
+                    "com.linkedin.pegasus2avro.ml.metadata.MLFeatureTableProperties": {
+                        "customProperties": {
+                            "arn": "arn:aws:sagemaker:us-west-2:123412341234:feature-group/test",
+                            "creation_time": "2021-06-14 11:03:00.803000",
+                            "status": "Created"
+                        },
+                        "mlFeatures": [
+                            "urn:li:mlFeature:(test,feature_2)",
+                            "urn:li:mlFeature:(test,feature_3)"
+                        ],
+                        "mlPrimaryKeys": [
+                            "urn:li:mlPrimaryKey:(test,feature_1)"
+                        ]
+                    }
                 }
-              ],
-              "onlineMetrics": null,
-              "mlFeatures": null,
-              "tags": [],
-              "deployments": [
-                "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-second-endpoint,PROD)"
-              ],
-              "trainingJobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
-              ],
-              "downstreamJobs": [
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
-                "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job)"
-              ],
-              "groups": [
-                "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)"
-              ]
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.BrowsePaths": {
-              "paths": [
-                "/sagemaker/a-model-package-group"
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "proposedDelta": null,
-    "systemMetadata": null
-  }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-input-bucket/file_txt,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://auto-ml-job-input-bucket/file.txt",
+                            "datatype": "ManifestFile"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-output-bucket/file_txt,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://auto-ml-job-output-bucket/file.txt"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/input-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://compilation-job-bucket/input-config.tar.gz",
+                            "framework": "TENSORFLOW",
+                            "framework_version": "string"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://compilation-job-bucket/output-config.tar.gz",
+                            "target_device": "lambda",
+                            "target_platform": "{'Os': 'ANDROID', 'Arch': 'X86_64', 'Accelerator': 'INTEL_GRAPHICS'}"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://edge-packaging-bucket/model-artifact.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://edge-packaging-bucket/output-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/data-source.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://labeling-job/data-source.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/category-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://labeling-job/category-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-dataset.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://labeling-job/output-dataset.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://labeling-job/output-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,processing-job/input-data.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://processing-job/input-data.tar.gz",
+                            "datatype": "ManifestFile",
+                            "mode": "Pipe",
+                            "distribution_type": "FullyReplicated",
+                            "compression": "None",
+                            "name": "string"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/input-dataset.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/input-dataset.tar.gz",
+                            "datatype": "None",
+                            "distribution_type": "FullyReplicated",
+                            "attribute_names": "['string']",
+                            "channel_name": "string"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/output-data.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/output-data.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/checkpoint-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/checkpoint-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-hook-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/debug-hook-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/tensorboard-output-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/tensorboard-output-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/profiler-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-rule-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/debug-rule-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-rule-config.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://training-job/profiler-rule-config.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/input-data-source.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://transform-job/input-data-source.tar.gz",
+                            "datatype": "ManifestFile",
+                            "compression": "None",
+                            "split": "None"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/output.tar_gz,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "dataset_type": "s3",
+                            "uri": "s3://transform-job/output.tar.gz"
+                        },
+                        "tags": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "an-auto-ml-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "AutoMLJobName": "an-auto-ml-job",
+                            "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
+                            "InputDataConfig": "[{'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://auto-ml-job-input-bucket/file.txt'}}, 'CompressionType': 'None', 'TargetAttributeName': 'some-name'}]",
+                            "OutputDataConfig": "{'KmsKeyId': 'some-key-id', 'S3OutputPath': 's3://auto-ml-job-output-bucket/file.txt'}",
+                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
+                            "AutoMLJobObjective": "{'MetricName': 'Accuracy'}",
+                            "ProblemType": "BinaryClassification",
+                            "AutoMLJobConfig": "{'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}, 'SecurityConfig': {'VolumeKmsKeyId': 'string', 'EnableInterContainerTrafficEncryption': True, 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}}}",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "EndTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "FailureReason": "string",
+                            "PartialFailureReasons": "[{'PartialFailureMessage': 'string'}]",
+                            "BestCandidate": "{'CandidateName': 'string', 'FinalAutoMLJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'Accuracy', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded', 'CandidateSteps': [{'CandidateStepType': 'AWS::SageMaker::TrainingJob', 'CandidateStepArn': 'string', 'CandidateStepName': 'string'}], 'CandidateStatus': 'Completed', 'InferenceContainers': [{'Image': 'string', 'ModelDataUrl': 's3://auto-ml-job/model-artifact.tar.gz', 'Environment': {'string': 'string'}}], 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'EndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'FailureReason': 'string', 'CandidateProperties': {'CandidateArtifactLocations': {'Explainability': 'string'}}}",
+                            "AutoMLJobStatus": "Completed",
+                            "AutoMLJobSecondaryStatus": "Starting",
+                            "GenerateCandidateDefinitionsOnly": "True",
+                            "AutoMLJobArtifacts": "{'CandidateDefinitionNotebookLocation': 'string', 'DataExplorationNotebookLocation': 'string'}",
+                            "ResolvedAttributes": "{'AutoMLJobObjective': {'MetricName': 'Accuracy'}, 'ProblemType': 'BinaryClassification', 'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}}",
+                            "ModelDeployConfig": "{'AutoGenerateEndpointName': True, 'EndpointName': 'string'}",
+                            "ModelDeployResult": "{'EndpointName': 'string'}",
+                            "jobType": "auto_ml"
+                        },
+                        "name": "an-auto-ml-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "COMPLETED"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/auto_ml"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-input-bucket/file_txt,PROD)"
+                        ],
+                        "outputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-output-bucket/file_txt,PROD)"
+                        ],
+                        "inputDatajobs": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "a-compilation-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "CompilationJobName": "a-compilation-job",
+                            "CompilationJobArn": "arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job",
+                            "CompilationJobStatus": "INPROGRESS",
+                            "CompilationStartTime": "2015-01-01 00:00:00+00:00",
+                            "CompilationEndTime": "2015-01-01 00:00:00+00:00",
+                            "StoppingCondition": "{'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}",
+                            "InferenceImage": "string",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "FailureReason": "string",
+                            "ModelArtifacts": "{'S3ModelArtifacts': 's3://compilation-job-bucket/model-artifacts.tar.gz'}",
+                            "ModelDigests": "{'ArtifactDigest': 'string'}",
+                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
+                            "InputConfig": "{'S3Uri': 's3://compilation-job-bucket/input-config.tar.gz', 'DataInputConfig': 'string', 'Framework': 'TENSORFLOW', 'FrameworkVersion': 'string'}",
+                            "OutputConfig": "{'S3OutputLocation': 's3://compilation-job-bucket/output-config.tar.gz', 'TargetDevice': 'lambda', 'TargetPlatform': {'Os': 'ANDROID', 'Arch': 'X86_64', 'Accelerator': 'INTEL_GRAPHICS'}, 'CompilerOptions': 'string', 'KmsKeyId': 'string'}",
+                            "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
+                            "jobType": "compilation"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/compilation-jobs/a-compilation-job",
+                        "name": "a-compilation-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "IN_PROGRESS"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/compilation"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/input-config.tar_gz,PROD)"
+                        ],
+                        "outputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)"
+                        ],
+                        "inputDatajobs": [
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "an-edge-packaging-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "EdgePackagingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job",
+                            "EdgePackagingJobName": "an-edge-packaging-job",
+                            "CompilationJobName": "a-compilation-job",
+                            "ModelName": "the-second-model",
+                            "ModelVersion": "string",
+                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
+                            "OutputConfig": "{'S3OutputLocation': 's3://edge-packaging-bucket/output-config.tar.gz', 'KmsKeyId': 'string', 'PresetDeploymentType': 'GreengrassV2Component', 'PresetDeploymentConfig': 'string'}",
+                            "ResourceKey": "string",
+                            "EdgePackagingJobStatus": "STARTING",
+                            "EdgePackagingJobStatusMessage": "string",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "ModelArtifact": "s3://edge-packaging-bucket/model-artifact.tar.gz",
+                            "ModelSignature": "string",
+                            "PresetDeploymentOutput": "{'Type': 'GreengrassV2Component', 'Artifact': 'arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/some-artifact', 'Status': 'COMPLETED', 'StatusMessage': 'string'}",
+                            "jobType": "edge_packaging"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/edge-packaging-jobs/an-edge-packaging-job",
+                        "name": "an-edge-packaging-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "STARTING"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/edge_packaging"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [],
+                        "outputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)"
+                        ],
+                        "inputDatajobs": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,hyper_parameter_tuning:a-hyper-parameter-tuning-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "a-hyper-parameter-tuning-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,hyper_parameter_tuning:a-hyper-parameter-tuning-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:hyper-parameter-tuning-job/a-hyper-parameter-tuning-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "HyperParameterTuningJobName": "a-hyper-parameter-tuning-job",
+                            "HyperParameterTuningJobArn": "arn:aws:sagemaker:us-west-2:123412341234:hyper-parameter-tuning-job/a-hyper-parameter-tuning-job",
+                            "HyperParameterTuningJobConfig": "{'Strategy': 'Bayesian', 'HyperParameterTuningJobObjective': {'Type': 'Maximize', 'MetricName': 'string'}, 'ResourceLimits': {'MaxNumberOfTrainingJobs': 123, 'MaxParallelTrainingJobs': 123}, 'ParameterRanges': {'IntegerParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'ContinuousParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'CategoricalParameterRanges': [{'Name': 'string', 'Values': ['string']}]}, 'TrainingJobEarlyStoppingType': 'Off', 'TuningJobCompletionCriteria': {'TargetObjectiveMetricValue': 1.0}}",
+                            "TrainingJobDefinition": "{'DefinitionName': 'string', 'TuningObjective': {'Type': 'Maximize', 'MetricName': 'string'}, 'HyperParameterRanges': {'IntegerParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'ContinuousParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'CategoricalParameterRanges': [{'Name': 'string', 'Values': ['string']}]}, 'StaticHyperParameters': {'string': 'string'}, 'AlgorithmSpecification': {'TrainingImage': 'string', 'TrainingInputMode': 'Pipe', 'AlgorithmName': 'string', 'MetricDefinitions': [{'Name': 'string', 'Regex': 'string'}]}, 'RoleArn': 'arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole', 'InputDataConfig': [{'ChannelName': 'string', 'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://hyper-parameter-tuning-job/data-source.tar.gz', 'S3DataDistributionType': 'FullyReplicated', 'AttributeNames': ['string']}, 'FileSystemDataSource': {'FileSystemId': 'abcdefgihjklmnopqrstuvwxyz', 'FileSystemAccessMode': 'rw', 'FileSystemType': 'EFS', 'DirectoryPath': 'string'}}, 'ContentType': 'string', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode': 'Pipe', 'ShuffleConfig': {'Seed': 123}}], 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}, 'OutputDataConfig': {'KmsKeyId': 'string', 'S3OutputPath': 's3://hyper-parameter-tuning-job/data-output.tar.gz'}, 'ResourceConfig': {'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}, 'StoppingCondition': {'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}, 'EnableNetworkIsolation': True, 'EnableInterContainerTrafficEncryption': True, 'EnableManagedSpotTraining': True, 'CheckpointConfig': {'S3Uri': 's3://hyper-parameter-tuning-job/checkpoint-config.tar.gz', 'LocalPath': 'string'}, 'RetryStrategy': {'MaximumRetryAttempts': 123}}",
+                            "TrainingJobDefinitions": "[{'DefinitionName': 'string', 'TuningObjective': {'Type': 'Maximize', 'MetricName': 'string'}, 'HyperParameterRanges': {'IntegerParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'ContinuousParameterRanges': [{'Name': 'string', 'MinValue': 'string', 'MaxValue': 'string', 'ScalingType': 'Auto'}], 'CategoricalParameterRanges': [{'Name': 'string', 'Values': ['string']}]}, 'StaticHyperParameters': {'string': 'string'}, 'AlgorithmSpecification': {'TrainingImage': 'string', 'TrainingInputMode': 'Pipe', 'AlgorithmName': 'string', 'MetricDefinitions': [{'Name': 'string', 'Regex': 'string'}]}, 'RoleArn': 'arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole', 'InputDataConfig': [{'ChannelName': 'string', 'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://hyper-parameter-tuning-job/data-source.tar.gz', 'S3DataDistributionType': 'FullyReplicated', 'AttributeNames': ['string']}, 'FileSystemDataSource': {'FileSystemId': 'abcdefgihjklmnopqrstuvwxyz', 'FileSystemAccessMode': 'rw', 'FileSystemType': 'EFS', 'DirectoryPath': 'string'}}, 'ContentType': 'string', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode': 'Pipe', 'ShuffleConfig': {'Seed': 123}}], 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}, 'OutputDataConfig': {'KmsKeyId': 'string', 'S3OutputPath': 's3://hyper-parameter-tuning-job/data-output.tar.gz'}, 'ResourceConfig': {'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}, 'StoppingCondition': {'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}, 'EnableNetworkIsolation': True, 'EnableInterContainerTrafficEncryption': True, 'EnableManagedSpotTraining': True, 'CheckpointConfig': {'S3Uri': 's3://hyper-parameter-tuning-job/checkpoint-config.tar.gz', 'LocalPath': 'string'}, 'RetryStrategy': {'MaximumRetryAttempts': 123}}]",
+                            "HyperParameterTuningJobStatus": "Completed",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "HyperParameterTuningEndTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "TrainingJobStatusCounters": "{'Completed': 123, 'InProgress': 123, 'RetryableError': 123, 'NonRetryableError': 123, 'Stopped': 123}",
+                            "ObjectiveStatusCounters": "{'Succeeded': 123, 'Pending': 123, 'Failed': 123}",
+                            "BestTrainingJob": "{'TrainingJobDefinitionName': 'string', 'TrainingJobName': 'string', 'TrainingJobArn': 'string', 'TuningJobName': 'string', 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingStartTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingEndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingJobStatus': 'InProgress', 'TunedHyperParameters': {'string': 'string'}, 'FailureReason': 'string', 'FinalHyperParameterTuningJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'string', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded'}",
+                            "OverallBestTrainingJob": "{'TrainingJobDefinitionName': 'string', 'TrainingJobName': 'string', 'TrainingJobArn': 'string', 'TuningJobName': 'string', 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingStartTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingEndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'TrainingJobStatus': 'InProgress', 'TunedHyperParameters': {'string': 'string'}, 'FailureReason': 'string', 'FinalHyperParameterTuningJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'string', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded'}",
+                            "WarmStartConfig": "{'ParentHyperParameterTuningJobs': [{'HyperParameterTuningJobName': 'string'}], 'WarmStartType': 'IdenticalDataAndAlgorithm'}",
+                            "FailureReason": "string",
+                            "jobType": "hyper_parameter_tuning"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/hyper-tuning-jobs/a-hyper-parameter-tuning-job",
+                        "name": "a-hyper-parameter-tuning-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "COMPLETED"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/hyper_parameter_tuning"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [],
+                        "outputDatasets": [],
+                        "inputDatajobs": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "a-labeling-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "LabelingJobStatus": "Initializing",
+                            "LabelCounters": "{'TotalLabeled': 123, 'HumanLabeled': 123, 'MachineLabeled': 123, 'FailedNonRetryableError': 123, 'Unlabeled': 123}",
+                            "FailureReason": "string",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "JobReferenceCode": "string",
+                            "LabelingJobName": "a-labeling-job",
+                            "LabelingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job",
+                            "LabelAttributeName": "string",
+                            "InputConfig": "{'DataSource': {'S3DataSource': {'ManifestS3Uri': 's3://labeling-job/data-source.tar.gz'}, 'SnsDataSource': {'SnsTopicArn': 'string'}}, 'DataAttributes': {'ContentClassifiers': ['FreeOfPersonallyIdentifiableInformation', 'FreeOfAdultContent']}}",
+                            "OutputConfig": "{'S3OutputPath': 's3://labeling-job/output-config.tar.gz', 'KmsKeyId': 'string', 'SnsTopicArn': 'string'}",
+                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
+                            "LabelCategoryConfigS3Uri": "s3://labeling-job/category-config.tar.gz",
+                            "StoppingConditions": "{'MaxHumanLabeledObjectCount': 123, 'MaxPercentageOfInputDatasetLabeled': 123}",
+                            "LabelingJobAlgorithmsConfig": "{'LabelingJobAlgorithmSpecificationArn': 'string', 'InitialActiveLearningModelArn': 'arn:aws:sagemaker:us-west-2:123412341234:labeling-job/initial-active-learning-model', 'LabelingJobResourceConfig': {'VolumeKmsKeyId': 'string'}}",
+                            "HumanTaskConfig": "{'WorkteamArn': 'string', 'UiConfig': {'UiTemplateS3Uri': 's3://labeling-job/ui-config.tar.gz', 'HumanTaskUiArn': 'string'}, 'PreHumanTaskLambdaArn': 'string', 'TaskKeywords': ['string'], 'TaskTitle': 'string', 'TaskDescription': 'string', 'NumberOfHumanWorkersPerDataObject': 123, 'TaskTimeLimitInSeconds': 123, 'TaskAvailabilityLifetimeInSeconds': 123, 'MaxConcurrentTaskCount': 123, 'AnnotationConsolidationConfig': {'AnnotationConsolidationLambdaArn': 'string'}, 'PublicWorkforceTaskPrice': {'AmountInUsd': {'Dollars': 123, 'Cents': 123, 'TenthFractionsOfACent': 123}}}",
+                            "Tags": "[{'Key': 'string', 'Value': 'string'}]",
+                            "LabelingJobOutput": "{'OutputDatasetS3Uri': 's3://labeling-job/output-dataset.tar.gz', 'FinalActiveLearningModelArn': 'arn:aws:sagemaker:us-west-2:123412341234:labeling-job/final-active-learning-model'}",
+                            "jobType": "labeling"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/labeling-jobs/a-labeling-job",
+                        "name": "a-labeling-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "STARTING"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/labeling"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/category-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/data-source.tar_gz,PROD)"
+                        ],
+                        "outputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-dataset.tar_gz,PROD)"
+                        ],
+                        "inputDatajobs": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,processing:a-processing-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "a-processing-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,processing:a-processing-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:processing-job/a-processing-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "ProcessingJobName": "a-processing-job",
+                            "ProcessingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:processing-job/a-processing-job",
+                            "ProcessingInputs": "[{'InputName': 'string', 'AppManaged': True, 'S3Input': {'S3Uri': 's3://processing-job/input-data.tar.gz', 'LocalPath': 'string', 'S3DataType': 'ManifestFile', 'S3InputMode': 'Pipe', 'S3DataDistributionType': 'FullyReplicated', 'S3CompressionType': 'None'}, 'DatasetDefinition': {'AthenaDatasetDefinition': {'Catalog': 'athena-catalog', 'Database': 'athena-database', 'QueryString': 'athena-query-string', 'WorkGroup': 'athena-work-group', 'OutputS3Uri': 's3://processing-job/athena-output.tar.gz', 'KmsKeyId': 'string', 'OutputFormat': 'PARQUET', 'OutputCompression': 'GZIP'}, 'RedshiftDatasetDefinition': {'ClusterId': 'redshift-cluster', 'Database': 'redshift-database', 'DbUser': 'redshift-db-user', 'QueryString': 'redshift-query-string', 'ClusterRoleArn': 'arn:aws:sagemaker:us-west-2:123412341234:processing-job/redshift-cluster', 'OutputS3Uri': 's3://processing-job/redshift-output.tar.gz', 'KmsKeyId': 'string', 'OutputFormat': 'PARQUET', 'OutputCompression': 'None'}, 'LocalPath': 'string', 'DataDistributionType': 'FullyReplicated', 'InputMode': 'Pipe'}}]",
+                            "ProcessingOutputConfig": "{'Outputs': [{'OutputName': 'string', 'S3Output': {'S3Uri': 's3://processing-job/processing-output.tar.gz', 'LocalPath': 'string', 'S3UploadMode': 'Continuous'}, 'FeatureStoreOutput': {'FeatureGroupName': 'string'}, 'AppManaged': True}], 'KmsKeyId': 'string'}",
+                            "ProcessingResources": "{'ClusterConfig': {'InstanceCount': 123, 'InstanceType': 'ml.t3.medium', 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}}",
+                            "StoppingCondition": "{'MaxRuntimeInSeconds': 123}",
+                            "AppSpecification": "{'ImageUri': 'string', 'ContainerEntrypoint': ['string'], 'ContainerArguments': ['string']}",
+                            "Environment": "{'string': 'string'}",
+                            "NetworkConfig": "{'EnableInterContainerTrafficEncryption': True, 'EnableNetworkIsolation': True, 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}}",
+                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
+                            "ExperimentConfig": "{'ExperimentName': 'string', 'TrialName': 'string', 'TrialComponentDisplayName': 'string'}",
+                            "ProcessingJobStatus": "InProgress",
+                            "ExitMessage": "string",
+                            "FailureReason": "string",
+                            "ProcessingEndTime": "2015-01-01 00:00:00+00:00",
+                            "ProcessingStartTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "MonitoringScheduleArn": "string",
+                            "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
+                            "TrainingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job",
+                            "jobType": "processing"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/processing-jobs/a-processing-job",
+                        "name": "a-processing-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "IN_PROGRESS"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/processing"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,processing-job/input-data.tar_gz,PROD)"
+                        ],
+                        "outputDatasets": [],
+                        "inputDatajobs": [
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,training:a-training-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "a-training-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "TrainingJobName": "a-training-job",
+                            "TrainingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job",
+                            "TuningJobArn": "string",
+                            "LabelingJobArn": "string",
+                            "AutoMLJobArn": "string",
+                            "ModelArtifacts": "{'S3ModelArtifacts': 's3://the-first-model-data-url/data.tar.gz'}",
+                            "TrainingJobStatus": "InProgress",
+                            "SecondaryStatus": "Starting",
+                            "FailureReason": "string",
+                            "HyperParameters": "{'parameter-1': 'some-value', 'parameter-2': 'another-value'}",
+                            "AlgorithmSpecification": "{'TrainingImage': 'string', 'AlgorithmName': 'string', 'TrainingInputMode': 'Pipe', 'MetricDefinitions': [{'Name': 'string', 'Regex': 'string'}], 'EnableSageMakerMetricsTimeSeries': True}",
+                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
+                            "InputDataConfig": "[{'ChannelName': 'string', 'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://training-job/input-dataset.tar.gz', 'S3DataDistributionType': 'FullyReplicated', 'AttributeNames': ['string']}, 'FileSystemDataSource': {'FileSystemId': 'abcdefgihjklmnopqrstuvwxyz', 'FileSystemAccessMode': 'rw', 'FileSystemType': 'EFS', 'DirectoryPath': 'string'}}, 'ContentType': 'string', 'CompressionType': 'None', 'RecordWrapperType': 'None', 'InputMode': 'Pipe', 'ShuffleConfig': {'Seed': 123}}]",
+                            "OutputDataConfig": "{'KmsKeyId': 'string', 'S3OutputPath': 's3://training-job/output-data.tar.gz'}",
+                            "ResourceConfig": "{'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeSizeInGB': 123, 'VolumeKmsKeyId': 'string'}",
+                            "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
+                            "StoppingCondition": "{'MaxRuntimeInSeconds': 123, 'MaxWaitTimeInSeconds': 123}",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "TrainingStartTime": "2015-01-01 00:00:00+00:00",
+                            "TrainingEndTime": "2015-01-01 00:00:00+00:00",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "SecondaryStatusTransitions": "[{'Status': 'Starting', 'StartTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'EndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'StatusMessage': 'string'}]",
+                            "FinalMetricDataList": "[{'MetricName': 'some-metric', 'Value': 1.0, 'Timestamp': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}, {'MetricName': 'another-metric', 'Value': 1.0, 'Timestamp': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}, {'MetricName': 'some-metric', 'Value': 0.0, 'Timestamp': datetime.datetime(2014, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}]",
+                            "EnableNetworkIsolation": "True",
+                            "EnableInterContainerTrafficEncryption": "True",
+                            "EnableManagedSpotTraining": "True",
+                            "CheckpointConfig": "{'S3Uri': 's3://training-job/checkpoint-config.tar.gz', 'LocalPath': 'string'}",
+                            "TrainingTimeInSeconds": "123",
+                            "BillableTimeInSeconds": "123",
+                            "DebugHookConfig": "{'LocalPath': 'string', 'S3OutputPath': 's3://training-job/debug-hook-config.tar.gz', 'HookParameters': {'string': 'string'}, 'CollectionConfigurations': [{'CollectionName': 'string', 'CollectionParameters': {'string': 'string'}}]}",
+                            "ExperimentConfig": "{'ExperimentName': 'string', 'TrialName': 'string', 'TrialComponentDisplayName': 'string'}",
+                            "DebugRuleConfigurations": "[{'RuleConfigurationName': 'string', 'LocalPath': 'string', 'S3OutputPath': 's3://training-job/debug-rule-config.tar.gz', 'RuleEvaluatorImage': 'string', 'InstanceType': 'ml.t3.medium', 'VolumeSizeInGB': 123, 'RuleParameters': {'string': 'string'}}]",
+                            "TensorBoardOutputConfig": "{'LocalPath': 'string', 'S3OutputPath': 's3://training-job/tensorboard-output-config.tar.gz'}",
+                            "DebugRuleEvaluationStatuses": "[{'RuleConfigurationName': 'string', 'RuleEvaluationJobArn': 'string', 'RuleEvaluationStatus': 'InProgress', 'StatusDetails': 'string', 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}]",
+                            "ProfilerConfig": "{'S3OutputPath': 's3://training-job/profiler-config.tar.gz', 'ProfilingIntervalInMilliseconds': 123, 'ProfilingParameters': {'string': 'string'}}",
+                            "ProfilerRuleConfigurations": "[{'RuleConfigurationName': 'string', 'LocalPath': 'string', 'S3OutputPath': 's3://training-job/profiler-rule-config.tar.gz', 'RuleEvaluatorImage': 'string', 'InstanceType': 'ml.t3.medium', 'VolumeSizeInGB': 123, 'RuleParameters': {'string': 'string'}}]",
+                            "ProfilerRuleEvaluationStatuses": "[{'RuleConfigurationName': 'string', 'RuleEvaluationJobArn': 'string', 'RuleEvaluationStatus': 'InProgress', 'StatusDetails': 'string', 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}]",
+                            "ProfilingStatus": "Enabled",
+                            "RetryStrategy": "{'MaximumRetryAttempts': 123}",
+                            "Environment": "{'string': 'string'}",
+                            "jobType": "training"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/jobs/a-training-job",
+                        "name": "a-training-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "IN_PROGRESS"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/training"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/input-dataset.tar_gz,PROD)"
+                        ],
+                        "outputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/checkpoint-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-hook-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-rule-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/output-data.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-rule-config.tar_gz,PROD)",
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/tensorboard-output-config.tar_gz,PROD)"
+                        ],
+                        "inputDatajobs": []
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+            "urn": "urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                        "customProperties": {},
+                        "name": "a-transform-job"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                        "customProperties": {
+                            "TransformJobName": "a-transform-job",
+                            "TransformJobArn": "arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job",
+                            "TransformJobStatus": "InProgress",
+                            "FailureReason": "string",
+                            "ModelName": "the-second-model",
+                            "MaxConcurrentTransforms": "123",
+                            "ModelClientConfig": "{'InvocationsTimeoutInSeconds': 123, 'InvocationsMaxRetries': 123}",
+                            "MaxPayloadInMB": "123",
+                            "BatchStrategy": "MultiRecord",
+                            "Environment": "{'string': 'string'}",
+                            "TransformInput": "{'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://transform-job/input-data-source.tar.gz'}}, 'ContentType': 'string', 'CompressionType': 'None', 'SplitType': 'None'}",
+                            "TransformOutput": "{'S3OutputPath': 's3://transform-job/output.tar.gz', 'Accept': 'string', 'AssembleWith': 'None', 'KmsKeyId': 'string'}",
+                            "TransformResources": "{'InstanceType': 'ml.m4.xlarge', 'InstanceCount': 123, 'VolumeKmsKeyId': 'string'}",
+                            "CreationTime": "2015-01-01 00:00:00+00:00",
+                            "TransformStartTime": "2015-01-01 00:00:00+00:00",
+                            "TransformEndTime": "2015-01-01 00:00:00+00:00",
+                            "LabelingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job",
+                            "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
+                            "DataProcessing": "{'InputFilter': 'string', 'OutputFilter': 'string', 'JoinSource': 'Input'}",
+                            "ExperimentConfig": "{'ExperimentName': 'string', 'TrialName': 'string', 'TrialComponentDisplayName': 'string'}",
+                            "jobType": "transform"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/transform-jobs/a-transform-job",
+                        "name": "a-transform-job",
+                        "type": {
+                            "string": "SAGEMAKER"
+                        },
+                        "status": "IN_PROGRESS"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/transform"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                        "inputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/input-data-source.tar_gz,PROD)"
+                        ],
+                        "outputDatasets": [
+                            "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/output.tar_gz,PROD)"
+                        ],
+                        "inputDatajobs": [
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job)"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLModelDeploymentSnapshot": {
+            "urn": "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,the-first-endpoint,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLModelDeploymentProperties": {
+                        "customProperties": {
+                            "EndpointArn": "arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-first-endpoint",
+                            "EndpointConfigName": "string",
+                            "ProductionVariants": "[{'VariantName': 'string', 'DeployedImages': [{'SpecifiedImage': 'string', 'ResolvedImage': 'string', 'ResolutionTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}], 'CurrentWeight': 0.1, 'DesiredWeight': 0.1, 'CurrentInstanceCount': 123, 'DesiredInstanceCount': 123}]",
+                            "DataCaptureConfig": "{'EnableCapture': True, 'CaptureStatus': 'Started', 'CurrentSamplingPercentage': 123, 'DestinationS3Uri': 'string', 'KmsKeyId': 'string'}",
+                            "EndpointStatus": "InService",
+                            "FailureReason": "string",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "LastDeploymentConfig": "{'BlueGreenUpdatePolicy': {'TrafficRoutingConfiguration': {'Type': 'ALL_AT_ONCE', 'WaitIntervalInSeconds': 123, 'CanarySize': {'Type': 'INSTANCE_COUNT', 'Value': 123}}, 'TerminationWaitInSeconds': 123, 'MaximumExecutionTimeoutInSeconds': 600}, 'AutoRollbackConfiguration': {'Alarms': [{'AlarmName': 'string'}]}}"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/endpoints/the-first-endpoint",
+                        "createdAt": 1420070400000,
+                        "status": "IN_SERVICE"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLModelDeploymentSnapshot": {
+            "urn": "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,the-second-endpoint,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLModelDeploymentProperties": {
+                        "customProperties": {
+                            "EndpointArn": "arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-second-endpoint",
+                            "EndpointConfigName": "string",
+                            "ProductionVariants": "[{'VariantName': 'string', 'DeployedImages': [{'SpecifiedImage': 'string', 'ResolvedImage': 'string', 'ResolutionTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)}], 'CurrentWeight': 0.1, 'DesiredWeight': 0.1, 'CurrentInstanceCount': 123, 'DesiredInstanceCount': 123}]",
+                            "DataCaptureConfig": "{'EnableCapture': True, 'CaptureStatus': 'Started', 'CurrentSamplingPercentage': 123, 'DestinationS3Uri': 'string', 'KmsKeyId': 'string'}",
+                            "EndpointStatus": "Creating",
+                            "FailureReason": "string",
+                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
+                            "LastDeploymentConfig": "{'BlueGreenUpdatePolicy': {'TrafficRoutingConfiguration': {'Type': 'ALL_AT_ONCE', 'WaitIntervalInSeconds': 123, 'CanarySize': {'Type': 'INSTANCE_COUNT', 'Value': 123}}, 'TerminationWaitInSeconds': 123, 'MaximumExecutionTimeoutInSeconds': 600}, 'AutoRollbackConfiguration': {'Alarms': [{'AlarmName': 'string'}]}}"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/endpoints/the-second-endpoint",
+                        "createdAt": 1420070400000,
+                        "status": "CREATING"
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLModelGroupSnapshot": {
+            "urn": "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLModelGroupProperties": {
+                        "customProperties": {
+                            "ModelPackageGroupArn": "arn:aws:sagemaker:us-west-2:123412341234:model-package-group/a-model-package-group",
+                            "ModelPackageGroupDescription": "Just a model package group.",
+                            "CreatedBy": "{'UserProfileArn': 'arn:aws:sagemaker:us-west-2:123412341234:user-profile/some-domain/some-user', 'UserProfileName': 'some-user', 'DomainId': 'some-domain'}",
+                            "ModelPackageGroupStatus": "Completed"
+                        },
+                        "description": "Just a model package group.",
+                        "createdAt": 1420070400000
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:some-user",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/sagemaker"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLModelSnapshot": {
+            "urn": "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,the-first-model,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLModelProperties": {
+                        "customProperties": {
+                            "PrimaryContainer": "{'ContainerHostname': 'string', 'Image': '123412341234.dkr.ecr.us-west-2.amazonaws.com/the-first-model-image', 'ImageConfig': {'RepositoryAccessMode': 'Platform', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'SingleModel', 'ModelDataUrl': 's3://the-first-model-data-url/data.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Enabled'}}",
+                            "Containers": "[{'ContainerHostname': 'string', 'Image': 'string', 'ImageConfig': {'RepositoryAccessMode': 'Platform', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'SingleModel', 'ModelDataUrl': 's3://training-job-2/model-artifact.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Enabled'}}]",
+                            "InferenceExecutionConfig": "{'Mode': 'Serial'}",
+                            "ExecutionRoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMaker-ExecutionRole-20210614T104201",
+                            "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
+                            "ModelArn": "arn:aws:sagemaker:us-west-2:123412341234:model/the-first-model",
+                            "EnableNetworkIsolation": "True"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/models/the-first-model",
+                        "date": 1420070400000,
+                        "hyperParams": [
+                            {
+                                "name": "parameter-1",
+                                "value": "some-value"
+                            },
+                            {
+                                "name": "parameter-2",
+                                "value": "another-value"
+                            }
+                        ],
+                        "trainingMetrics": [
+                            {
+                                "name": "another-metric",
+                                "value": "1.0"
+                            },
+                            {
+                                "name": "some-metric",
+                                "value": "1.0"
+                            }
+                        ],
+                        "tags": [],
+                        "deployments": [
+                            "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-first-endpoint,PROD)"
+                        ],
+                        "trainingJobs": [
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
+                        ],
+                        "downstreamJobs": [],
+                        "groups": [
+                            "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/sagemaker/a-model-package-group"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.MLModelSnapshot": {
+            "urn": "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,the-second-model,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.ml.metadata.MLModelProperties": {
+                        "customProperties": {
+                            "PrimaryContainer": "{'ContainerHostname': 'string', 'Image': '123412341234.dkr.ecr.us-west-2.amazonaws.com/the-second-model-image', 'ImageConfig': {'RepositoryAccessMode': 'Platform', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'MultiModel', 'ModelDataUrl': 's3://the-second-model-data-url/data.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Disabled'}}",
+                            "Containers": "[{'ContainerHostname': 'string', 'Image': 'string', 'ImageConfig': {'RepositoryAccessMode': 'Vpc', 'RepositoryAuthConfig': {'RepositoryCredentialsProviderArn': 'string'}}, 'Mode': 'SingleModel', 'ModelDataUrl': 's3://the-first-model-data-url/data.tar.gz', 'Environment': {'string': 'string'}, 'ModelPackageName': 'string', 'MultiModelConfig': {'ModelCacheSetting': 'Disabled'}}]",
+                            "InferenceExecutionConfig": "{'Mode': 'Serial'}",
+                            "ExecutionRoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMaker-ExecutionRole-20210614T104201",
+                            "VpcConfig": "{'SecurityGroupIds': ['string'], 'Subnets': ['string']}",
+                            "ModelArn": "arn:aws:sagemaker:us-west-2:123412341234:model/the-second-model",
+                            "EnableNetworkIsolation": "False"
+                        },
+                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/models/the-second-model",
+                        "date": 1420070400000,
+                        "hyperParams": [
+                            {
+                                "name": "parameter-1",
+                                "value": "some-value"
+                            },
+                            {
+                                "name": "parameter-2",
+                                "value": "another-value"
+                            }
+                        ],
+                        "trainingMetrics": [
+                            {
+                                "name": "another-metric",
+                                "value": "1.0"
+                            },
+                            {
+                                "name": "some-metric",
+                                "value": "1.0"
+                            }
+                        ],
+                        "tags": [],
+                        "deployments": [
+                            "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,arn:aws:sagemaker:us-west-2:123412341234:endpoint/the-second-endpoint,PROD)"
+                        ],
+                        "trainingJobs": [
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
+                        ],
+                        "downstreamJobs": [
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
+                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job)"
+                        ],
+                        "groups": [
+                            "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)"
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/sagemaker/a-model-package-group"
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,hyper_parameter_tuning:a-hyper-parameter-tuning-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,processing:a-processing-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,training:a-training-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataFlow",
+    "entityUrn": "urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,auto_ml:an-auto-ml-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,hyper_parameter_tuning:a-hyper-parameter-tuning-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:hyper-parameter-tuning-job/a-hyper-parameter-tuning-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,labeling:a-labeling-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:labeling-job/a-labeling-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,processing:a-processing-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:processing-job/a-processing-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataJob",
+    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-input-bucket/file_txt,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,auto-ml-job-output-bucket/file_txt,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/input-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/category-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/data-source.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/output-dataset.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,processing-job/input-data.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/checkpoint-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-hook-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/debug-rule-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/input-dataset.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/output-data.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/profiler-rule-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,training-job/tensorboard-output-config.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/input-data-source.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,transform-job/output.tar_gz,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test,feature_2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test,feature_3)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test-1,height)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test-1,name)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test-1,time)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test-2,some-feature-1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeature",
+    "entityUrn": "urn:li:mlFeature:(test-2,some-feature-3)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test-1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlFeatureTable",
+    "entityUrn": "urn:li:mlFeatureTable:(urn:li:dataPlatform:sagemaker,test-2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,the-first-model,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlModel",
+    "entityUrn": "urn:li:mlModel:(urn:li:dataPlatform:sagemaker,the-second-model,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlModelDeployment",
+    "entityUrn": "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,the-first-endpoint,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlModelDeployment",
+    "entityUrn": "urn:li:mlModelDeployment:(urn:li:dataPlatform:sagemaker,the-second-endpoint,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlModelGroup",
+    "entityUrn": "urn:li:mlModelGroup:(urn:li:dataPlatform:sagemaker,a-model-package-group,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test,feature_1)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test-1,id)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "mlPrimaryKey",
+    "entityUrn": "urn:li:mlPrimaryKey:(test-2,some-feature-2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+}
 ]


### PR DESCRIPTION
Makes the following changes:
- Passes `platform_instance` properly as per https://github.com/datahub-project/datahub/pull/8478, thanks @anshbansal!
- Remove overrides of `get_workunits` in many sources so that they run workunit processors, which will make them both (i) create status aspects and (ii) create browse paths v2
- Updates error handling around MCPDiff -- does not log warning or print trace if file contains MCEs

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
