### PR TITLE
fix(browsepathv2): default browse path with empty space

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
@@ -142,7 +142,7 @@ public class BrowsePathV2Utils {
     BrowsePathEntryArray browsePathEntries = new BrowsePathEntryArray();
     if (datasetName.contains(delimiter.toString())) {
       final List<String> datasetNamePathParts = Arrays.stream(datasetName.split(Pattern.quote(delimiter.toString())))
-              .filter((name)-> !name.isEmpty())
+              .filter((name) -> !name.isEmpty())
               .collect(Collectors.toList());
       // Omit the name from the path.
       datasetNamePathParts.subList(0, datasetNamePathParts.size() - 1).forEach((part -> {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathV2Utils.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.linkedin.metadata.Constants.CONTAINER_ASPECT_NAME;
 
@@ -140,7 +141,9 @@ public class BrowsePathV2Utils {
   private static BrowsePathEntryArray getDefaultDatasetPathEntries(@Nonnull final String datasetName, @Nonnull final Character delimiter) {
     BrowsePathEntryArray browsePathEntries = new BrowsePathEntryArray();
     if (datasetName.contains(delimiter.toString())) {
-      final List<String> datasetNamePathParts = Arrays.asList(datasetName.split(Pattern.quote(delimiter.toString())));
+      final List<String> datasetNamePathParts = Arrays.stream(datasetName.split(Pattern.quote(delimiter.toString())))
+              .filter((name)-> !name.isEmpty())
+              .collect(Collectors.toList());
       // Omit the name from the path.
       datasetNamePathParts.subList(0, datasetNamePathParts.size() - 1).forEach((part -> {
         browsePathEntries.add(createBrowsePathEntry(part, null));


### PR DESCRIPTION
Noticed this for elasticsearch indices where names started with `.`
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
