### PR TITLE
feat(siblings): hiding non-existant siblings in FE

### DIFF
--- a/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
+++ b/datahub-web-react/src/app/entity/shared/__tests__/siblingsUtils.test.ts
@@ -195,6 +195,7 @@ const searchResultWithSiblings = [
     {
         entity: {
             urn: 'urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.raw_orders,PROD)',
+            exists: true,
             type: 'DATASET',
             name: 'cypress_project.jaffle_shop.raw_orders',
             origin: 'PROD',
@@ -328,6 +329,7 @@ const searchResultWithSiblings = [
                 siblings: [
                     {
                         urn: 'urn:li:dataset:(urn:li:dataPlatform:dbt,cypress_project.jaffle_shop.raw_orders,PROD)',
+                        exists: true,
                         type: 'DATASET',
                         platform: {
                             urn: 'urn:li:dataPlatform:dbt',
@@ -376,6 +378,7 @@ const searchResultWithSiblings = [
     {
         entity: {
             urn: 'urn:li:dataset:(urn:li:dataPlatform:dbt,cypress_project.jaffle_shop.raw_orders,PROD)',
+            exists: true,
             type: 'DATASET',
             name: 'cypress_project.jaffle_shop.raw_orders',
             origin: 'PROD',
@@ -513,6 +516,169 @@ const searchResultWithSiblings = [
     },
 ];
 
+const searchResultWithGhostSiblings = [
+    {
+        entity: {
+            urn: 'urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.raw_orders,PROD)',
+            exists: true,
+            type: 'DATASET',
+            name: 'cypress_project.jaffle_shop.raw_orders',
+            origin: 'PROD',
+            uri: null,
+            platform: {
+                urn: 'urn:li:dataPlatform:bigquery',
+                type: 'DATA_PLATFORM',
+                name: 'bigquery',
+                properties: {
+                    type: 'RELATIONAL_DB',
+                    displayName: 'BigQuery',
+                    datasetNameDelimiter: '.',
+                    logoUrl: '/assets/platforms/bigquerylogo.png',
+                    __typename: 'DataPlatformProperties',
+                },
+                displayName: null,
+                info: null,
+                __typename: 'DataPlatform',
+            },
+            dataPlatformInstance: null,
+            editableProperties: null,
+            platformNativeType: null,
+            properties: {
+                name: 'raw_orders',
+                description: null,
+                qualifiedName: null,
+                customProperties: [],
+                __typename: 'DatasetProperties',
+            },
+            ownership: null,
+            globalTags: null,
+            glossaryTerms: null,
+            subTypes: {
+                typeNames: ['table'],
+                __typename: 'SubTypes',
+            },
+            domain: null,
+            container: {
+                urn: 'urn:li:container:348c96555971d3f5c1ffd7dd2e7446cb',
+                platform: {
+                    urn: 'urn:li:dataPlatform:bigquery',
+                    type: 'DATA_PLATFORM',
+                    name: 'bigquery',
+                    properties: {
+                        type: 'RELATIONAL_DB',
+                        displayName: 'BigQuery',
+                        datasetNameDelimiter: '.',
+                        logoUrl: '/assets/platforms/bigquerylogo.png',
+                        __typename: 'DataPlatformProperties',
+                    },
+                    displayName: null,
+                    info: null,
+                    __typename: 'DataPlatform',
+                },
+                properties: {
+                    name: 'jaffle_shop',
+                    __typename: 'ContainerProperties',
+                },
+                subTypes: {
+                    typeNames: ['Dataset'],
+                    __typename: 'SubTypes',
+                },
+                deprecation: null,
+                __typename: 'Container',
+            },
+            parentContainers: {
+                count: 2,
+                containers: [
+                    {
+                        urn: 'urn:li:container:348c96555971d3f5c1ffd7dd2e7446cb',
+                        platform: {
+                            urn: 'urn:li:dataPlatform:bigquery',
+                            type: 'DATA_PLATFORM',
+                            name: 'bigquery',
+                            properties: {
+                                type: 'RELATIONAL_DB',
+                                displayName: 'BigQuery',
+                                datasetNameDelimiter: '.',
+                                logoUrl: '/assets/platforms/bigquerylogo.png',
+                                __typename: 'DataPlatformProperties',
+                            },
+                            displayName: null,
+                            info: null,
+                            __typename: 'DataPlatform',
+                        },
+                        properties: {
+                            name: 'jaffle_shop',
+                            __typename: 'ContainerProperties',
+                        },
+                        subTypes: {
+                            typeNames: ['Dataset'],
+                            __typename: 'SubTypes',
+                        },
+                        deprecation: null,
+                        __typename: 'Container',
+                    },
+                    {
+                        urn: 'urn:li:container:b5e95fce839e7d78151ed7e0a7420d84',
+                        platform: {
+                            urn: 'urn:li:dataPlatform:bigquery',
+                            type: 'DATA_PLATFORM',
+                            name: 'bigquery',
+                            properties: {
+                                type: 'RELATIONAL_DB',
+                                displayName: 'BigQuery',
+                                datasetNameDelimiter: '.',
+                                logoUrl: '/assets/platforms/bigquerylogo.png',
+                                __typename: 'DataPlatformProperties',
+                            },
+                            displayName: null,
+                            info: null,
+                            __typename: 'DataPlatform',
+                        },
+                        properties: {
+                            name: 'cypress_project',
+                            __typename: 'ContainerProperties',
+                        },
+                        subTypes: {
+                            typeNames: ['Project'],
+                            __typename: 'SubTypes',
+                        },
+                        deprecation: null,
+                        __typename: 'Container',
+                    },
+                ],
+                __typename: 'ParentContainersResult',
+            },
+            deprecation: null,
+            siblings: {
+                isPrimary: false,
+                siblings: [
+                    {
+                        urn: 'urn:li:dataset:(urn:li:dataPlatform:dbt,cypress_project.jaffle_shop.raw_orders,PROD)',
+                        exists: false,
+                        type: 'DATASET',
+                    },
+                ],
+                __typename: 'SiblingProperties',
+            },
+            __typename: 'Dataset',
+        },
+        matchedFields: [
+            {
+                name: 'name',
+                value: 'raw_orders',
+                __typename: 'MatchedField',
+            },
+            {
+                name: 'id',
+                value: 'cypress_project.jaffle_shop.raw_orders',
+                __typename: 'MatchedField',
+            },
+        ],
+        insights: [],
+        __typename: 'SearchResult',
+    },
+];
+
 describe('siblingUtils', () => {
     describe('combineEntityDataWithSiblings', () => {
         it('combines my metadata with my siblings as primary', () => {
@@ -564,6 +730,18 @@ describe('siblingUtils', () => {
             expect(result?.[0]?.matchedEntities?.[1]?.urn).toEqual(
                 'urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.raw_orders,PROD)',
             );
+
+            expect(result?.[0]?.matchedEntities).toHaveLength(2);
+        });
+
+        it('will not combine an entity with a ghost node', () => {
+            const result = combineSiblingsInSearchResults(searchResultWithGhostSiblings as any);
+
+            expect(result).toHaveLength(1);
+            expect(result?.[0]?.matchedEntities?.[0]?.urn).toEqual(
+                'urn:li:dataset:(urn:li:dataPlatform:bigquery,cypress_project.jaffle_shop.raw_orders,PROD)',
+            );
+            expect(result?.[0]?.matchedEntities).toHaveLength(1);
         });
     });
 

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarSiblingsSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarSiblingsSection.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useDataNotCombinedWithSiblings, useEntityData } from '../../../EntityContext';
 import { SidebarHeader } from './SidebarHeader';
 import { CompactEntityNameList } from '../../../../../recommendations/renderer/component/CompactEntityNameList';
-import { Entity } from '../../../../../../types.generated';
+import { Dataset, Entity } from '../../../../../../types.generated';
 import { SEPARATE_SIBLINGS_URL_PARAM, stripSiblingsFromEntity, useIsSeparateSiblingsMode } from '../../../siblingUtils';
 import { GetDatasetQuery } from '../../../../../../graphql/dataset.generated';
 
@@ -36,14 +36,22 @@ export const SidebarSiblingsSection = () => {
     const siblingEntities = entityData?.siblings?.siblings || [];
     const entityDataWithoutSiblings = stripSiblingsFromEntity(dataNotCombinedWithSiblings.dataset);
 
-    const allSiblingsInGroup = [...siblingEntities, entityDataWithoutSiblings] as Entity[];
+    const allSiblingsInGroup = [...siblingEntities, entityDataWithoutSiblings] as Dataset[];
+
+    const allSiblingsInGroupThatExist = allSiblingsInGroup.filter((sibling) => sibling.exists);
+
+    // you are always going to be in the sibling group, so if the sibling group is just you do not render.
+    // The less than case is likely not neccessary but just there as a safety case for unexpected scenarios
+    if (allSiblingsInGroupThatExist.length <= 1) {
+        return <></>;
+    }
 
     return (
         <div>
             <SidebarHeader title="Composed Of" />
             <EntityListContainer>
                 <CompactEntityNameList
-                    entities={allSiblingsInGroup}
+                    entities={allSiblingsInGroupThatExist}
                     linkUrlParams={{ [SEPARATE_SIBLINGS_URL_PARAM]: true }}
                     showTooltips
                 />

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -2,7 +2,7 @@ import merge from 'deepmerge';
 import { unionBy, keyBy, values } from 'lodash';
 import { useLocation } from 'react-router-dom';
 import * as QueryString from 'query-string';
-import { Entity, MatchedField, Maybe, SiblingProperties } from '../../../types.generated';
+import { Dataset, Entity, MatchedField, Maybe, SiblingProperties } from '../../../types.generated';
 
 export function stripSiblingsFromEntity(entity: any) {
     return {
@@ -235,6 +235,11 @@ export function combineSiblingsInSearchResults(
             combinedResult.matchedEntities = entity.siblings.isPrimary
                 ? [stripSiblingsFromEntity(entity), ...entity.siblings.siblings]
                 : [...entity.siblings.siblings, stripSiblingsFromEntity(entity)];
+
+            combinedResult.matchedEntities = combinedResult.matchedEntities.filter(
+                (resultToFilter) => (resultToFilter as Dataset).exists,
+            );
+
             siblingUrns.forEach((urn) => {
                 siblingsToPair[urn] = combinedResult;
             });

--- a/datahub-web-react/src/app/search/SearchResultList.tsx
+++ b/datahub-web-react/src/app/search/SearchResultList.tsx
@@ -151,7 +151,9 @@ export const SearchResultList = ({
                             )}
                             {entityRegistry.renderSearchResult(item.entity.type, item)}
                         </ListItem>
-                        {item.matchedEntities && item.matchedEntities.length > 0 && (
+                        {/* an entity is always going to be inserted in the sibling group, so if the sibling group is just one do not 
+                        render. */}
+                        {item.matchedEntities && item.matchedEntities.length > 1 && (
                             <SiblingResultContainer className="test-search-result-sibling-section">
                                 <CompactEntityNameList
                                     linkUrlParams={{ [SEPARATE_SIBLINGS_URL_PARAM]: true }}

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -25,7 +25,6 @@ query getDataProfiles($urn: String!, $limit: Int, $startTime: Long, $endTime: Lo
 
 query getDataset($urn: String!) {
     dataset(urn: $urn) {
-        exists
         ...nonSiblingDatasetFields
         siblings {
             isPrimary
@@ -40,6 +39,7 @@ query getDataset($urn: String!) {
 
 fragment nonSiblingDatasetFields on Dataset {
     ...nonRecursiveDatasetFields
+    exists
     deprecation {
         actor
         deprecated

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -254,6 +254,7 @@ fragment searchResultFields on Entity {
     urn
     type
     ... on Dataset {
+        exists
         name
         origin
         uri
@@ -305,6 +306,7 @@ fragment searchResultFields on Entity {
                 urn
                 type
                 ... on Dataset {
+                    exists
                     platform {
                         ...platformFields
                     }


### PR DESCRIPTION
We should treat ghost siblings same as ghost lineage edges- hide them! This is in anticipation of our snowflake-shares-as-siblings work which may introduce ghost sibling edges if shares are done to external accounts.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
