### PR TITLE
feat(ingest/snowflake): tables from snowflake shares as siblings

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -267,7 +267,7 @@ class SnowflakeV2Config(
 
         # Check: same database from some platform instance as inbound and outbound
         other_platform_instance_databases: Sequence[SnowflakeDatabaseDataHubId] = [
-            db for db in inbound_shares_map.values()
+            db for db in set(inbound_shares_map.values())
         ] + [db for dbs in outbound_shares_map.values() for db in dbs]
 
         for other_instance_db in other_platform_instance_databases:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -138,7 +138,7 @@ class SnowflakeV2Config(
         default=None,
         description="Required if the current account has created any outbound snowflake shares and there is at least one consumer account in which database is created from such share."
         " If specified, connector creates siblings relationship between current account's database tables and all database tables created in consumer accounts from the share including current account's database."
-        " Map of database name X -> list of (platform instance of snowflake consumer account who've created database from share, name of database created from share) for all shares created from database name X.",
+        " Map of database name D -> list of (platform instance of snowflake consumer account who've created database from share, name of database created from share) for all shares created from database name D.",
     )
 
     @validator("include_column_lineage")
@@ -253,7 +253,7 @@ class SnowflakeV2Config(
         ):
             raise ValueError(
                 "Current `platform_instance` can not be present as any database in `outbound_shares_map`."
-                "Self-sharing not supported in Snowflake. Please check your configuration."
+                "Self-sharing is not supported in Snowflake. Please check your configuration."
             )
 
         # Check: platform_instance should be present
@@ -267,7 +267,10 @@ class SnowflakeV2Config(
 
         # Check: same database from some platform instance as inbound and outbound
         other_platform_instance_databases: Sequence[SnowflakeDatabaseDataHubId] = [
-            db for db in set(inbound_shares_map.values())
+            db
+            for db in set(
+                inbound_shares_map.values()
+            )  # using set as multiple inbound shares may be present from same original database
         ] + [db for dbs in outbound_shares_map.values() for db in dbs]
 
         for other_instance_db in other_platform_instance_databases:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -8,9 +8,15 @@ from typing import Dict, List, Optional
 import pandas as pd
 from snowflake.connector import SnowflakeConnection
 
+from datahub.configuration.pattern_utils import is_schema_allowed
 from datahub.ingestion.source.snowflake.constants import SnowflakeObjectDomain
+from datahub.ingestion.source.snowflake.snowflake_config import SnowflakeV2Config
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
-from datahub.ingestion.source.snowflake.snowflake_utils import SnowflakeQueryMixin
+from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
+from datahub.ingestion.source.snowflake.snowflake_utils import (
+    SnowflakeCommonMixin,
+    SnowflakeQueryMixin,
+)
 from datahub.ingestion.source.sql.sql_generic import BaseColumn, BaseTable, BaseView
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -177,8 +183,10 @@ class _SnowflakeTagCache:
         )
 
 
-class SnowflakeDataDictionary(SnowflakeQueryMixin):
-    def __init__(self) -> None:
+class SnowflakeDataDictionary(SnowflakeQueryMixin, SnowflakeCommonMixin):
+    def __init__(self, config: SnowflakeV2Config, report: SnowflakeV2Report) -> None:
+        self.config = config
+        self.report = report
         self.logger = logger
         self.connection: Optional[SnowflakeConnection] = None
 
@@ -221,7 +229,11 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
                 last_altered=database["LAST_ALTERED"],
                 comment=database["COMMENT"],
             )
-            databases.append(snowflake_db)
+            self.report.report_entity_scanned(snowflake_db.name, "database")
+            if not self.config.database_pattern.allowed(snowflake_db.name):
+                self.report.report_dropped(f"{snowflake_db.name}.*")
+            else:
+                databases.append(snowflake_db)
 
         return databases
 
@@ -239,7 +251,16 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
                 last_altered=schema["LAST_ALTERED"],
                 comment=schema["COMMENT"],
             )
-            snowflake_schemas.append(snowflake_schema)
+            self.report.report_entity_scanned(snowflake_schema.name, "schema")
+            if not is_schema_allowed(
+                self.config.schema_pattern,
+                snowflake_schema.name,
+                db_name,
+                self.config.match_fully_qualified_names,
+            ):
+                self.report.report_dropped(f"{db_name}.{snowflake_schema.name}.*")
+            else:
+                snowflake_schemas.append(snowflake_schema)
         return snowflake_schemas
 
     @lru_cache(maxsize=1)
@@ -261,17 +282,25 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         for table in cur:
             if table["TABLE_SCHEMA"] not in tables:
                 tables[table["TABLE_SCHEMA"]] = []
-            tables[table["TABLE_SCHEMA"]].append(
-                SnowflakeTable(
-                    name=table["TABLE_NAME"],
-                    created=table["CREATED"],
-                    last_altered=table["LAST_ALTERED"],
-                    size_in_bytes=table["BYTES"],
-                    rows_count=table["ROW_COUNT"],
-                    comment=table["COMMENT"],
-                    clustering_key=table["CLUSTERING_KEY"],
-                )
+
+            table_identifier = self.get_dataset_identifier(
+                table["TABLE_NAME"], table["TABLE_SCHEMA"], db_name
             )
+            self.report.report_entity_scanned(table_identifier)
+            if not self.config.table_pattern.allowed(table_identifier):
+                self.report.report_dropped(table_identifier)
+            else:
+                tables[table["TABLE_SCHEMA"]].append(
+                    SnowflakeTable(
+                        name=table["TABLE_NAME"],
+                        created=table["CREATED"],
+                        last_altered=table["LAST_ALTERED"],
+                        size_in_bytes=table["BYTES"],
+                        rows_count=table["ROW_COUNT"],
+                        comment=table["COMMENT"],
+                        clustering_key=table["CLUSTERING_KEY"],
+                    )
+                )
         return tables
 
     def get_tables_for_schema(
@@ -284,17 +313,24 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         )
 
         for table in cur:
-            tables.append(
-                SnowflakeTable(
-                    name=table["TABLE_NAME"],
-                    created=table["CREATED"],
-                    last_altered=table["LAST_ALTERED"],
-                    size_in_bytes=table["BYTES"],
-                    rows_count=table["ROW_COUNT"],
-                    comment=table["COMMENT"],
-                    clustering_key=table["CLUSTERING_KEY"],
-                )
+            table_identifier = self.get_dataset_identifier(
+                table["TABLE_NAME"], schema_name, db_name
             )
+            self.report.report_entity_scanned(table_identifier)
+            if not self.config.table_pattern.allowed(table_identifier):
+                self.report.report_dropped(table_identifier)
+            else:
+                tables.append(
+                    SnowflakeTable(
+                        name=table["TABLE_NAME"],
+                        created=table["CREATED"],
+                        last_altered=table["LAST_ALTERED"],
+                        size_in_bytes=table["BYTES"],
+                        rows_count=table["ROW_COUNT"],
+                        comment=table["COMMENT"],
+                        clustering_key=table["CLUSTERING_KEY"],
+                    )
+                )
         return tables
 
     @lru_cache(maxsize=1)
@@ -314,18 +350,27 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
         for table in cur:
             if table["schema_name"] not in views:
                 views[table["schema_name"]] = []
-            views[table["schema_name"]].append(
-                SnowflakeView(
-                    name=table["name"],
-                    created=table["created_on"],
-                    # last_altered=table["last_altered"],
-                    comment=table["comment"],
-                    view_definition=table["text"],
-                    last_altered=table["created_on"],
-                    materialized=table.get("is_materialized", "false").lower()
-                    == "true",
-                )
+            view_name = self.get_dataset_identifier(
+                table["name"], table["schema_name"], db_name
             )
+
+            self.report.report_entity_scanned(view_name, "view")
+
+            if not self.config.view_pattern.allowed(view_name):
+                self.report.report_dropped(view_name)
+            else:
+                views[table["schema_name"]].append(
+                    SnowflakeView(
+                        name=table["name"],
+                        created=table["created_on"],
+                        # last_altered=table["last_altered"],
+                        comment=table["comment"],
+                        view_definition=table["text"],
+                        last_altered=table["created_on"],
+                        materialized=table.get("is_materialized", "false").lower()
+                        == "true",
+                    )
+                )
         return views
 
     def get_views_for_schema(
@@ -335,16 +380,23 @@ class SnowflakeDataDictionary(SnowflakeQueryMixin):
 
         cur = self.query(SnowflakeQuery.show_views_for_schema(schema_name, db_name))
         for table in cur:
-            views.append(
-                SnowflakeView(
-                    name=table["name"],
-                    created=table["created_on"],
-                    # last_altered=table["last_altered"],
-                    comment=table["comment"],
-                    view_definition=table["text"],
-                    last_altered=table["created_on"],
+            view_name = self.get_dataset_identifier(table["name"], schema_name, db_name)
+
+            self.report.report_entity_scanned(view_name, "view")
+
+            if not self.config.view_pattern.allowed(view_name):
+                self.report.report_dropped(view_name)
+            else:
+                views.append(
+                    SnowflakeView(
+                        name=table["name"],
+                        created=table["created_on"],
+                        # last_altered=table["last_altered"],
+                        comment=table["comment"],
+                        view_definition=table["text"],
+                        last_altered=table["created_on"],
+                    )
                 )
-            )
         return views
 
     @lru_cache(maxsize=1)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_shares.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_shares.py
@@ -54,6 +54,12 @@ class SnowflakeSharesHandler(SnowflakeCommonMixin):
 
             for schema in db.schemas:
                 for table_name in schema.tables + schema.views:
+                    # TODO: If this is outbound database,
+                    # 1. attempt listing shares using `show shares` to identify name of share associated with this database (cache query result).
+                    # 2. if corresponding share is listed, then run `show grants to share <share_name>` to identify exact tables, views included in share.
+                    # 3. emit siblings only for the objects listed above.
+                    # This will work only if the configured role has accountadmin role access OR is owner of share.
+                    # Otherwise ghost nodes will be shown in "Composed Of" section for tables/views in original database which are not granted to share.
                     yield from self.get_siblings(
                         db.name,
                         schema.name,
@@ -130,8 +136,6 @@ class SnowflakeSharesHandler(SnowflakeCommonMixin):
             )
             for sibling_db in sibling_databases
         ]
-
-        sibling_urns.append(urn)
 
         yield MetadataChangeProposalWrapper(
             entityUrn=urn, aspect=Siblings(primary=primary, siblings=sibling_urns)

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_shares.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_shares.py
@@ -59,7 +59,7 @@ class SnowflakeSharesHandler(SnowflakeCommonMixin):
                     # 2. if corresponding share is listed, then run `show grants to share <share_name>` to identify exact tables, views included in share.
                     # 3. emit siblings only for the objects listed above.
                     # This will work only if the configured role has accountadmin role access OR is owner of share.
-                    # Otherwise ghost nodes will be shown in "Composed Of" section for tables/views in original database which are not granted to share.
+                    # Otherwise ghost nodes may be shown in "Composed Of" section for tables/views in original database which are not granted to share.
                     yield from self.get_siblings(
                         db.name,
                         schema.name,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_shares.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_shares.py
@@ -1,0 +1,134 @@
+import logging
+from typing import Callable, Iterable, List
+
+from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.snowflake.snowflake_config import (
+    SnowflakeDatabaseDataHubId,
+    SnowflakeV2Config,
+)
+from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
+from datahub.ingestion.source.snowflake.snowflake_schema import SnowflakeDatabase
+from datahub.ingestion.source.snowflake.snowflake_utils import SnowflakeCommonMixin
+from datahub.metadata.com.linkedin.pegasus2avro.common import Siblings
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
+    DatasetLineageType,
+    Upstream,
+    UpstreamLineage,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class SnowflakeSharesHandler(SnowflakeCommonMixin):
+    def __init__(
+        self,
+        config: SnowflakeV2Config,
+        report: SnowflakeV2Report,
+        dataset_urn_builder: Callable[[str], str],
+    ) -> None:
+        self.config = config
+        self.report = report
+        self.logger = logger
+        self.dataset_urn_builder = dataset_urn_builder
+
+    def get_workunits(
+        self, databases: List[SnowflakeDatabase]
+    ) -> Iterable[MetadataWorkUnit]:
+        for db in databases:
+            inbound = (
+                self.config.inbound_shares_map.get(db.name)
+                if self.config.inbound_shares_map
+                and db.name in self.config.inbound_shares_map
+                else None
+            )
+            outbounds = (
+                self.config.outbound_shares_map.get(db.name)
+                if self.config.outbound_shares_map
+                and db.name in self.config.outbound_shares_map
+                else None
+            )
+            sibling_dbs: List[SnowflakeDatabaseDataHubId]
+            if inbound:
+                sibling_dbs = [inbound]
+            elif outbounds:
+                sibling_dbs = outbounds
+            else:
+                continue
+            # TODO: pydantic validator to check that database key in inbound_shares_map is not present in outbound_shares_map
+            # TODO: logger statements and exception handling
+            for schema in db.schemas:
+                for table_name in schema.tables:
+                    yield from self.get_siblings(
+                        db.name,
+                        schema.name,
+                        table_name,
+                        True if outbounds else False,
+                        sibling_dbs,
+                    )
+
+                    if inbound:
+                        # TODO: Should this be governed by any config flag ? Should this be part of lineage_extractor ?
+                        yield self.get_upstream_lineage_with_primary_sibling(
+                            db.name, schema.name, table_name, inbound
+                        )
+
+    def get_siblings(
+        self,
+        database_name: str,
+        schema_name: str,
+        table_name: str,
+        primary: bool,
+        sibling_databases: List[SnowflakeDatabaseDataHubId],
+    ) -> Iterable[MetadataWorkUnit]:
+        if not sibling_databases:
+            return
+        dataset_identifier = self.get_dataset_identifier(
+            table_name, schema_name, database_name
+        )
+        urn = self.dataset_urn_builder(dataset_identifier)
+
+        sibling_urns = [
+            make_dataset_urn_with_platform_instance(
+                self.platform,
+                self.get_dataset_identifier(
+                    table_name, schema_name, sibling_db.database_name
+                ),
+                sibling_db.platform_instance,
+            )
+            for sibling_db in sibling_databases
+        ]
+
+        sibling_urns.append(urn)
+
+        yield MetadataChangeProposalWrapper(
+            entityUrn=urn, aspect=Siblings(primary=primary, siblings=sibling_urns)
+        ).as_workunit()
+
+    def get_upstream_lineage_with_primary_sibling(
+        self,
+        database_name: str,
+        schema_name: str,
+        table_name: str,
+        primary_sibling_db: SnowflakeDatabaseDataHubId,
+    ) -> MetadataWorkUnit:
+        dataset_identifier = self.get_dataset_identifier(
+            table_name, schema_name, database_name
+        )
+        urn = self.dataset_urn_builder(dataset_identifier)
+
+        upstream_urn = make_dataset_urn_with_platform_instance(
+            self.platform,
+            self.get_dataset_identifier(
+                table_name, schema_name, primary_sibling_db.database_name
+            ),
+            primary_sibling_db.platform_instance,
+        )
+
+        return MetadataChangeProposalWrapper(
+            entityUrn=urn,
+            aspect=UpstreamLineage(
+                upstreams=[Upstream(dataset=upstream_urn, type=DatasetLineageType.COPY)]
+            ),
+        ).as_workunit()

--- a/metadata-ingestion/tests/unit/test_snowflake_shares.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_shares.py
@@ -1,0 +1,359 @@
+from typing import List
+
+import pytest
+
+from datahub.emitter.mce_builder import make_dataset_urn_with_platform_instance
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.source.snowflake.snowflake_config import (
+    SnowflakeDatabaseDataHubId,
+    SnowflakeV2Config,
+)
+from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
+from datahub.ingestion.source.snowflake.snowflake_schema import (
+    SnowflakeDatabase,
+    SnowflakeSchema,
+)
+from datahub.ingestion.source.snowflake.snowflake_shares import SnowflakeSharesHandler
+from datahub.metadata.com.linkedin.pegasus2avro.common import Siblings
+from datahub.metadata.com.linkedin.pegasus2avro.dataset import UpstreamLineage
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeProposal
+
+
+@pytest.fixture(scope="module")
+def snowflake_databases() -> List[SnowflakeDatabase]:
+    return [
+        SnowflakeDatabase(
+            name="db1",
+            created=None,
+            comment=None,
+            last_altered=None,
+            schemas=[
+                SnowflakeSchema(
+                    name="schema11",
+                    created=None,
+                    comment=None,
+                    last_altered=None,
+                    tables=["table111", "table112"],
+                    views=["view111"],
+                ),
+                SnowflakeSchema(
+                    name="schema12",
+                    created=None,
+                    comment=None,
+                    last_altered=None,
+                    tables=["table121", "table122"],
+                    views=["view121"],
+                ),
+            ],
+        ),
+        SnowflakeDatabase(
+            name="db2",
+            created=None,
+            comment=None,
+            last_altered=None,
+            schemas=[
+                SnowflakeSchema(
+                    name="schema21",
+                    created=None,
+                    comment=None,
+                    last_altered=None,
+                    tables=["table211", "table212"],
+                    views=["view211"],
+                ),
+                SnowflakeSchema(
+                    name="schema22",
+                    created=None,
+                    comment=None,
+                    last_altered=None,
+                    tables=["table221", "table222"],
+                    views=["view221"],
+                ),
+            ],
+        ),
+        SnowflakeDatabase(
+            name="db3",
+            created=None,
+            comment=None,
+            last_altered=None,
+            schemas=[
+                SnowflakeSchema(
+                    name="schema31",
+                    created=None,
+                    comment=None,
+                    last_altered=None,
+                    tables=["table311", "table312"],
+                    views=["view311"],
+                )
+            ],
+        ),
+    ]
+
+
+def make_snowflake_urn(table_name, instance_name=None):
+    return make_dataset_urn_with_platform_instance(
+        "snowflake", table_name, instance_name
+    )
+
+
+def test_snowflake_shares_workunit_no_shares(
+    snowflake_databases: List[SnowflakeDatabase],
+) -> None:
+    config = SnowflakeV2Config(account_id="abc12345", platform_instance="instance1")
+
+    report = SnowflakeV2Report()
+    shares_handler = SnowflakeSharesHandler(
+        config, report, lambda x: make_snowflake_urn(x)
+    )
+
+    wus = list(shares_handler.get_workunits(snowflake_databases))
+
+    assert len(wus) == 0
+
+
+def test_same_database_inbound_and_outbound_invalid_config() -> None:
+    with pytest.raises(ValueError):
+        SnowflakeV2Config(
+            account_id="abc12345",
+            platform_instance="instance1",
+            inbound_shares_map={
+                "db1": SnowflakeDatabaseDataHubId(
+                    database_name="original_db1", platform_instance="instance2"
+                )
+            },
+            outbound_shares_map={
+                "db1": [
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2_from_share", platform_instance="instance2"
+                    ),
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2", platform_instance="instance3"
+                    ),
+                ]
+            },
+        )
+
+
+def test_current_platform_instance_inbound_and_outbound_invalid() -> None:
+    with pytest.raises(ValueError):
+        SnowflakeV2Config(
+            account_id="abc12345",
+            platform_instance="instance1",
+            inbound_shares_map={
+                "db1": SnowflakeDatabaseDataHubId(
+                    database_name="db2", platform_instance="instance1"
+                )
+            },
+            outbound_shares_map={
+                "db2": [
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2_from_share", platform_instance="instance2"
+                    ),
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2", platform_instance="instance3"
+                    ),
+                ]
+            },
+        )
+
+    with pytest.raises(ValueError):
+        SnowflakeV2Config(
+            account_id="abc12345",
+            platform_instance="instance1",
+            inbound_shares_map={
+                "db1": SnowflakeDatabaseDataHubId(
+                    database_name="db2", platform_instance="instance2"
+                )
+            },
+            outbound_shares_map={
+                "db2": [
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2_from_share", platform_instance="instance2"
+                    ),
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2", platform_instance="instance1"
+                    ),
+                ]
+            },
+        )
+
+
+def test_another_instance_database_inbound_and_outbound_invalid() -> None:
+    with pytest.raises(ValueError):
+        SnowflakeV2Config(
+            account_id="abc12345",
+            platform_instance="instance1",
+            inbound_shares_map={
+                "db1": SnowflakeDatabaseDataHubId(
+                    database_name="db2", platform_instance="instance3"
+                )
+            },
+            outbound_shares_map={
+                "db2": [
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2_from_share", platform_instance="instance2"
+                    ),
+                    SnowflakeDatabaseDataHubId(
+                        database_name="db2", platform_instance="instance3"
+                    ),
+                ]
+            },
+        )
+
+
+def test_snowflake_shares_workunit_inbound_share(
+    snowflake_databases: List[SnowflakeDatabase],
+) -> None:
+    config = SnowflakeV2Config(
+        account_id="abc12345",
+        platform_instance="instance1",
+        inbound_shares_map={
+            "db1": SnowflakeDatabaseDataHubId(
+                database_name="original_db1", platform_instance="instance2"
+            )
+        },
+    )
+
+    report = SnowflakeV2Report()
+    shares_handler = SnowflakeSharesHandler(
+        config, report, lambda x: make_snowflake_urn(x, "instance1")
+    )
+
+    wus = list(shares_handler.get_workunits(snowflake_databases))
+
+    # 2 schemas - 2 tables and 1 view in each schema making total 6 datasets
+    # Hence 6 Sibling and 6 upstreamLineage aspects
+    assert len(wus) == 12
+    upstream_lineage_aspect_entity_urns = set()
+    sibling_aspect_entity_urns = set()
+
+    for wu in wus:
+        assert isinstance(
+            wu.metadata, (MetadataChangeProposal, MetadataChangeProposalWrapper)
+        )
+        if wu.metadata.aspectName == "upstreamLineage":
+            upstream_aspect = wu.get_aspect_of_type(UpstreamLineage)
+            assert upstream_aspect is not None
+            upstream_lineage_aspect_entity_urns.add(wu.get_urn())
+            assert len(upstream_aspect.upstreams) == 1
+            assert upstream_aspect.upstreams[0].dataset == wu.get_urn().replace(
+                "instance1.db1", "instance2.original_db1"
+            )
+        else:
+            siblings_aspect = wu.get_aspect_of_type(Siblings)
+            assert siblings_aspect is not None
+            sibling_aspect_entity_urns.add(wu.get_urn())
+            assert len(siblings_aspect.siblings) == 2  # upstream and itself
+            assert siblings_aspect.siblings == [
+                wu.get_urn().replace("instance1.db1", "instance2.original_db1"),
+                wu.get_urn(),
+            ]
+
+    assert len(upstream_lineage_aspect_entity_urns) == 6
+    assert len(sibling_aspect_entity_urns) == 6
+
+
+def test_snowflake_shares_workunit_outbound_share(
+    snowflake_databases: List[SnowflakeDatabase],
+) -> None:
+    config = SnowflakeV2Config(
+        account_id="abc12345",
+        platform_instance="instance1",
+        outbound_shares_map={
+            "db2": [
+                SnowflakeDatabaseDataHubId(
+                    database_name="db2_from_share", platform_instance="instance2"
+                ),
+                SnowflakeDatabaseDataHubId(
+                    database_name="db2", platform_instance="instance3"
+                ),
+            ]
+        },
+    )
+
+    report = SnowflakeV2Report()
+    shares_handler = SnowflakeSharesHandler(
+        config, report, lambda x: make_snowflake_urn(x, "instance1")
+    )
+
+    wus = list(shares_handler.get_workunits(snowflake_databases))
+
+    # 2 schemas - 2 tables and 1 view in each schema making total 6 datasets
+    # Hence 6 Sibling aspects
+    assert len(wus) == 6
+    entity_urns = set()
+
+    for wu in wus:
+        siblings_aspect = wu.get_aspect_of_type(Siblings)
+        assert siblings_aspect is not None
+        entity_urns.add(wu.get_urn())
+        assert len(siblings_aspect.siblings) == 3  # 2 consumers and itself
+        assert siblings_aspect.siblings == [
+            wu.get_urn().replace("instance1.db2", "instance2.db2_from_share"),
+            wu.get_urn().replace("instance1.db2", "instance3.db2"),
+            wu.get_urn(),
+        ]
+
+    assert len((entity_urns)) == 6
+
+
+def test_snowflake_shares_workunit_inbound_and_outbound_share(
+    snowflake_databases: List[SnowflakeDatabase],
+) -> None:
+    config = SnowflakeV2Config(
+        account_id="abc12345",
+        platform_instance="instance1",
+        inbound_shares_map={
+            "db1": SnowflakeDatabaseDataHubId(
+                database_name="original_db1", platform_instance="instance2"
+            )
+        },
+        outbound_shares_map={
+            "db2": [
+                SnowflakeDatabaseDataHubId(
+                    database_name="db2_from_share", platform_instance="instance2"
+                ),
+                SnowflakeDatabaseDataHubId(
+                    database_name="db2", platform_instance="instance3"
+                ),
+            ]
+        },
+    )
+
+    report = SnowflakeV2Report()
+    shares_handler = SnowflakeSharesHandler(
+        config, report, lambda x: make_snowflake_urn(x, "instance1")
+    )
+
+    wus = list(shares_handler.get_workunits(snowflake_databases))
+
+    # 6 Sibling and 6 upstreamLineage aspects for db1 tables
+    # 6 Sibling aspects for db2 tables
+    assert len(wus) == 18
+
+    for wu in wus:
+        assert isinstance(
+            wu.metadata, (MetadataChangeProposal, MetadataChangeProposalWrapper)
+        )
+        if wu.metadata.aspectName == "upstreamLineage":
+            upstream_aspect = wu.get_aspect_of_type(UpstreamLineage)
+            assert upstream_aspect is not None
+            assert len(upstream_aspect.upstreams) == 1
+            assert upstream_aspect.upstreams[0].dataset == wu.get_urn().replace(
+                "instance1.db1", "instance2.original_db1"
+            )
+        else:
+            siblings_aspect = wu.get_aspect_of_type(Siblings)
+            assert siblings_aspect is not None
+            if "db1" in wu.get_urn():
+                assert len(siblings_aspect.siblings) == 2  # upstream and itself
+                assert siblings_aspect.siblings == [
+                    wu.get_urn().replace("instance1.db1", "instance2.original_db1"),
+                    wu.get_urn(),
+                ]
+            else:
+                assert len(siblings_aspect.siblings) == 3  # 2 consumers and itself
+                assert siblings_aspect.siblings == [
+                    wu.get_urn().replace("instance1.db2", "instance2.db2_from_share"),
+                    wu.get_urn().replace("instance1.db2", "instance3.db2"),
+                    wu.get_urn(),
+                ]

--- a/metadata-ingestion/tests/unit/test_snowflake_shares.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_shares.py
@@ -242,10 +242,9 @@ def test_snowflake_shares_workunit_inbound_share(
             siblings_aspect = wu.get_aspect_of_type(Siblings)
             assert siblings_aspect is not None
             sibling_aspect_entity_urns.add(wu.get_urn())
-            assert len(siblings_aspect.siblings) == 2  # upstream and itself
+            assert len(siblings_aspect.siblings) == 1
             assert siblings_aspect.siblings == [
-                wu.get_urn().replace("instance1.db1", "instance2.original_db1"),
-                wu.get_urn(),
+                wu.get_urn().replace("instance1.db1", "instance2.original_db1")
             ]
 
     assert len(upstream_lineage_aspect_entity_urns) == 6
@@ -286,11 +285,10 @@ def test_snowflake_shares_workunit_outbound_share(
         siblings_aspect = wu.get_aspect_of_type(Siblings)
         assert siblings_aspect is not None
         entity_urns.add(wu.get_urn())
-        assert len(siblings_aspect.siblings) == 3  # 2 consumers and itself
+        assert len(siblings_aspect.siblings) == 2
         assert siblings_aspect.siblings == [
             wu.get_urn().replace("instance1.db2", "instance2.db2_from_share"),
             wu.get_urn().replace("instance1.db2", "instance3.db2"),
-            wu.get_urn(),
         ]
 
     assert len((entity_urns)) == 6
@@ -345,15 +343,13 @@ def test_snowflake_shares_workunit_inbound_and_outbound_share(
             siblings_aspect = wu.get_aspect_of_type(Siblings)
             assert siblings_aspect is not None
             if "db1" in wu.get_urn():
-                assert len(siblings_aspect.siblings) == 2  # upstream and itself
+                assert len(siblings_aspect.siblings) == 1
                 assert siblings_aspect.siblings == [
-                    wu.get_urn().replace("instance1.db1", "instance2.original_db1"),
-                    wu.get_urn(),
+                    wu.get_urn().replace("instance1.db1", "instance2.original_db1")
                 ]
             else:
-                assert len(siblings_aspect.siblings) == 3  # 2 consumers and itself
+                assert len(siblings_aspect.siblings) == 2
                 assert siblings_aspect.siblings == [
                     wu.get_urn().replace("instance1.db2", "instance2.db2_from_share"),
                     wu.get_urn().replace("instance1.db2", "instance3.db2"),
-                    wu.get_urn(),
                 ]


### PR DESCRIPTION
1. Introduce new configurations `inbound_shares_map` and `outbound_shares_map`  - to declare databases created using and from shares and corresponding snowflake platform instances. 
2. Emit upstreamLineage and siblings aspect for linked tables/views in such shared databases.
3. Push down allow deny pattern filtering near query execution - inside snowflake_schema module
4. Add documentation around snowflake shares and corresponding configuration example
5. Unit tests for snowflake shares code

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
