### PR TITLE
feat(search): Allow aggregating on facets that are not explicitly part of default filter set

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/AggregationQueryBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/AggregationQueryBuilder.java
@@ -21,13 +21,15 @@ import static com.linkedin.metadata.utils.SearchUtil.*;
 public class AggregationQueryBuilder {
 
   private final SearchConfiguration _configs;
-  private final Set<String> _facetFields;
+  private final Set<String> _defaultFacetFields;
+  private final Set<String> _allFacetFields;
 
   public AggregationQueryBuilder(
       @Nonnull final SearchConfiguration configs,
       @Nonnull final List<SearchableAnnotation> annotations) {
     this._configs = Objects.requireNonNull(configs, "configs must not be null");
-    this._facetFields = getFacetFields(annotations);
+    this._defaultFacetFields = getDefaultFacetFields(annotations);
+    this._allFacetFields = getAllFacetFields(annotations);
   }
 
   /**
@@ -44,19 +46,28 @@ public class AggregationQueryBuilder {
     final Set<String> facetsToAggregate;
     if (facets != null) {
       facets.stream().filter(f -> !isValidAggregate(f)).forEach(facet -> {
-        log.warn(String.format("Provided facet for search filter aggregations that doesn't exist. Provided: %s; Available: %s", facet, _facetFields));
+        log.warn(String.format("Requested facet for search filter aggregations that isn't part of the default filters. Provided: %s; Available: %s", facet,
+            _defaultFacetFields));
       });
       facetsToAggregate = facets.stream().filter(this::isValidAggregate).collect(Collectors.toSet());
     } else {
-      facetsToAggregate = _facetFields;
+      facetsToAggregate = _defaultFacetFields;
     }
     return facetsToAggregate.stream().map(this::facetToAggregationBuilder).collect(Collectors.toList());
   }
 
 
-  private Set<String> getFacetFields(final List<SearchableAnnotation> annotations) {
+  private Set<String> getDefaultFacetFields(final List<SearchableAnnotation> annotations) {
     Set<String> facets = annotations.stream()
-        .flatMap(annotation -> getFacetFieldsFromAnnotation(annotation).stream())
+        .flatMap(annotation -> getDefaultFacetFieldsFromAnnotation(annotation).stream())
+        .collect(Collectors.toSet());
+    facets.add(INDEX_VIRTUAL_FIELD);
+    return facets;
+  }
+
+  private Set<String> getAllFacetFields(final List<SearchableAnnotation> annotations) {
+    Set<String> facets = annotations.stream()
+        .flatMap(annotation -> getAllFacetFieldsFromAnnotation(annotation).stream())
         .collect(Collectors.toSet());
     facets.add(INDEX_VIRTUAL_FIELD);
     return facets;
@@ -64,7 +75,7 @@ public class AggregationQueryBuilder {
 
   private boolean isValidAggregate(final String inputFacet) {
     Set<String> facets = Set.of(inputFacet.split(AGGREGATION_SEPARATOR_CHAR));
-    return facets.size() > 0 && _facetFields.containsAll(facets);
+    return facets.size() > 0 && _allFacetFields.containsAll(facets);
   }
 
   private AggregationBuilder facetToAggregationBuilder(final String inputFacet) {
@@ -97,12 +108,21 @@ public class AggregationQueryBuilder {
     return ESUtils.toKeywordField(facet, false);
   }
 
-  List<String> getFacetFieldsFromAnnotation(final SearchableAnnotation annotation) {
+  List<String> getDefaultFacetFieldsFromAnnotation(final SearchableAnnotation annotation) {
     final List<String> facetsFromAnnotation = new ArrayList<>();
     if (annotation.isAddToFilters()) {
       facetsFromAnnotation.add(annotation.getFieldName());
     }
     if (annotation.isAddHasValuesToFilters() && annotation.getHasValuesFieldName().isPresent()) {
+      facetsFromAnnotation.add(annotation.getHasValuesFieldName().get());
+    }
+    return facetsFromAnnotation;
+  }
+
+  List<String> getAllFacetFieldsFromAnnotation(final SearchableAnnotation annotation) {
+    final List<String> facetsFromAnnotation = new ArrayList<>();
+    facetsFromAnnotation.add(annotation.getFieldName());
+    if (annotation.getHasValuesFieldName().isPresent()) {
       facetsFromAnnotation.add(annotation.getHasValuesFieldName().get());
     }
     return facetsFromAnnotation;

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/AggregationQueryBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/query/request/AggregationQueryBuilderTest.java
@@ -1,11 +1,14 @@
 package com.linkedin.metadata.search.elasticsearch.query.request;
 
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.metadata.config.search.SearchConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -14,7 +17,7 @@ import org.testng.annotations.Test;
 public class AggregationQueryBuilderTest {
 
   @Test
-  public void testGetAggregationsHasFields() {
+  public void testGetDefaultAggregationsHasFields() {
 
     SearchableAnnotation annotation = new SearchableAnnotation(
         "test",
@@ -43,7 +46,7 @@ public class AggregationQueryBuilderTest {
   }
 
   @Test
-  public void testGetAggregationsFields() {
+  public void testGetDefaultAggregationsFields() {
 
     SearchableAnnotation annotation = new SearchableAnnotation(
         "test",
@@ -69,5 +72,59 @@ public class AggregationQueryBuilderTest {
     List<AggregationBuilder> aggs = builder.getAggregations();
 
     Assert.assertTrue(aggs.stream().anyMatch(agg -> agg.getName().equals("test")));
+  }
+
+  @Test
+  public void testGetSpecificAggregationsHasFields() {
+
+    SearchableAnnotation annotation1 = new SearchableAnnotation(
+        "test1",
+        SearchableAnnotation.FieldType.KEYWORD,
+        true,
+        true,
+        false,
+        false,
+        Optional.empty(),
+        Optional.of("Has Test"),
+        1.0,
+        Optional.of("hasTest1"),
+        Optional.empty(),
+        Collections.emptyMap()
+    );
+
+    SearchableAnnotation annotation2 = new SearchableAnnotation(
+        "test2",
+        SearchableAnnotation.FieldType.KEYWORD,
+        true,
+        true,
+        false,
+        false,
+        Optional.of("Test Filter"),
+        Optional.empty(),
+        1.0,
+        Optional.empty(),
+        Optional.empty(),
+        Collections.emptyMap()
+    );
+
+    SearchConfiguration config = new SearchConfiguration();
+    config.setMaxTermBucketSize(25);
+
+    AggregationQueryBuilder builder = new AggregationQueryBuilder(
+        config, ImmutableList.of(annotation1, annotation2));
+
+    // Case 1: Ask for fields that should exist.
+    List<AggregationBuilder> aggs = builder.getAggregations(
+        ImmutableList.of("test1", "test2", "hasTest1")
+    );
+    Assert.assertEquals(aggs.size(), 3);
+    Set<String> facets = aggs.stream().map(AggregationBuilder::getName).collect(Collectors.toSet());
+    Assert.assertEquals(ImmutableSet.of("test1", "test2", "hasTest1"), facets);
+
+    // Case 2: Ask for fields that should NOT exist.
+    aggs = builder.getAggregations(
+        ImmutableList.of("hasTest2")
+    );
+    Assert.assertEquals(aggs.size(), 0);
   }
 }


### PR DESCRIPTION
## Summary

aggregateAcrossEntities endpoint should allow for arbitrary aggregation on any index fields that are valid. This PR enables that behavior, removing a filter that is used when custom facets are provided which requires that the facet is marked as "addToFilters" in the searchable annotation, which really should be used for providing the _default_ set of facets that are generated when none are explicitly requested.


## Status

Ready for review

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
