### PR TITLE
feat(siblings): dont show multiple platform icons if the siblings are ghost nodes

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/utils.ts
@@ -60,7 +60,7 @@ export function getDataForEntityType<T>({
         };
     }
 
-    if (anyEntityData?.siblings?.siblings?.length > 0 && !isHideSiblingMode) {
+    if (anyEntityData?.siblings?.siblings?.filter((sibling) => sibling.exists).length > 0 && !isHideSiblingMode) {
         const genericSiblingProperties: GenericEntityProperties[] = anyEntityData?.siblings?.siblings?.map((sibling) =>
             getDataForEntityType({ data: sibling, getOverrideProperties: () => ({}) }),
         );

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -251,6 +251,9 @@ fragment lineageFields on EntityWithRelationships {
             siblings {
                 urn
                 type
+                ... on Dataset {
+                    exists
+                }
                 ...lineageNodeProperties
             }
         }
@@ -369,6 +372,9 @@ query getEntityLineage(
                 siblings {
                     urn
                     type
+                    ... on Dataset {
+                        exists
+                    }
                     ...lineageNodeProperties
                 }
             }


### PR DESCRIPTION
Following up on https://github.com/datahub-project/datahub/pull/8528, gives platform icons a similar UX to the other ways ghost siblings are hidden.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
