### PR TITLE
feat(ci): use docker registry cache

### DIFF
--- a/.github/actions/docker-custom-build-and-push/action.yml
+++ b/.github/actions/docker-custom-build-and-push/action.yml
@@ -49,7 +49,7 @@ runs:
         # add git short SHA as Docker tag
         tag-custom: ${{ inputs.tags }}
         tag-custom-only: true
-    
+
     # Code for testing the build when not pushing to Docker Hub.
     - name: Build and Load image for testing (if not publishing)
       uses: docker/build-push-action@v3
@@ -64,12 +64,14 @@ runs:
         tags: ${{ steps.docker_meta.outputs.tags }}
         load: true
         push: false
+        cache-from: type=registry,ref=${{ steps.docker_meta.outputs.tags }}
+        cache-to: type=inline
     - name: Upload image locally for testing (if not publishing)
       uses: ishworkh/docker-image-artifact-upload@v1
       if: ${{ inputs.publish != 'true' }}
       with:
         image: ${{ steps.docker_meta.outputs.tags }}
-    
+
     # Code for building multi-platform images and pushing to Docker Hub.
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
@@ -93,5 +95,7 @@ runs:
         build-args: ${{ inputs.build-args }}
         tags: ${{ steps.docker_meta.outputs.tags }}
         push: true
+        cache-from: type=registry,ref=${{ steps.docker_meta.outputs.tags }}
+        cache-to: type=inline
 
     # TODO add code for vuln scanning?


### PR DESCRIPTION
This seems to shave off a few minutes per Docker build.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
