### PR TITLE
docs(development.md): Minor grammatical error

### DIFF
--- a/docs/docker/development.md
+++ b/docs/docker/development.md
@@ -20,7 +20,7 @@ We highly recommend you just invoke `./gradlew quickstartDebug` task.
 This task is defined in `docker/build.gradle` and executes the following steps:
 
 1. Builds all required artifacts to run DataHub. This includes both application code such as the GMS war, the frontend
-distribution zip which contains javascript, as wel as secondary support docker containers.
+distribution zip which contains javascript, as well as secondary support docker containers.
  
 1. Locally builds Docker images with the expected `debug` tag required by the docker compose files.
 


### PR DESCRIPTION
(docs) Using Docker Images During Development: Minor grammatical error

### It is missing an L

![image](https://github.com/PauloGoncalvesLima/datahub/assets/18203100/5854ab0c-fb0e-491c-9eb4-ac892ebba174)

### Proposed changes

![image](https://github.com/PauloGoncalvesLima/datahub/assets/18203100/786d6ae2-89c3-4e12-8fb9-e5efa528b3a1)

### Location
https://datahubproject.io/docs/docker/development/

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
