### PR TITLE
fix(ui): Simplify background color for Entity Health Status popover

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHealthPopover.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHealthPopover.tsx
@@ -46,8 +46,6 @@ const StyledDivider = styled(Divider)`
     }
 `;
 
-const popoverStyle = { backgroundColor: '#262626' };
-
 type Props = {
     health: Health[];
     baseUrl: string;
@@ -72,7 +70,7 @@ export const EntityHealthPopover = ({ health, baseUrl, children }: Props) => {
                     ))}
                 </>
             }
-            overlayStyle={popoverStyle}
+            color="#262626"
             placement="right"
             zIndex={10000000}
         >


### PR DESCRIPTION
## Summary

Tiny change which ensures the entire popover, including the arrow, is a consistent color.

## Status

Ready for review

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
