### PR TITLE
fix(usage): Update index lifecycle policy to not delete old datahub usage events

### DIFF
--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
@@ -3,7 +3,7 @@
     "policy_id": "PREFIXdatahub_usage_event_policy",
     "description": "Datahub Usage Event Policy",
     "default_state": "Rollover",
-    "schema_version": 2,
+    "schema_version": 3,
     "states": [
       {
         "name": "Rollover",
@@ -29,22 +29,6 @@
         "actions": [
           {
             "read_only": {}
-          }
-        ],
-        "transitions": [
-          {
-            "state_name": "Delete",
-            "conditions": {
-              "min_index_age": "60d"
-            }
-          }
-        ]
-      },
-      {
-        "name": "Delete",
-        "actions": [
-          {
-            "delete": {}
           }
         ],
         "transitions": []

--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/policy.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/policy.json
@@ -7,12 +7,6 @@
             "max_age": "7d"
           }
         }
-      },
-      "delete": {
-        "min_age": "60d",
-        "actions": {
-          "delete": {}
-        }
       }
     }
   }


### PR DESCRIPTION
The UI can display up to 1 year of history, so we should not delete events after 60 days. 


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
