### PR TITLE
feat(ingest/metabase): detect source table for cards sourced from other cards

### DIFF
--- a/metadata-ingestion/tests/integration/metabase/metabase_mces_golden.json
+++ b/metadata-ingestion/tests/integration/metabase/metabase_mces_golden.json
@@ -117,6 +117,61 @@
 },
 {
     "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot": {
+            "urn": "urn:li:chart:(metabase,3)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.chart.ChartInfo": {
+                        "customProperties": {
+                            "Metrics": "Distinct values of order_number, Sum of nominal_total",
+                            "Filters": "['time-interval', ['field', 'completed_at', {'base-type': 'type/DateTimeWithTZ'}], -8, 'day', {'include-current': False}]",
+                            "Dimensions": "completed_at"
+                        },
+                        "title": "Question with data from other question",
+                        "description": "",
+                        "lastModified": {
+                            "created": {
+                                "time": 1685628119636,
+                                "actor": "urn:li:corpuser:john.doe@example.com"
+                            },
+                            "lastModified": {
+                                "time": 1685628119636,
+                                "actor": "urn:li:corpuser:john.doe@example.com"
+                            }
+                        },
+                        "chartUrl": "http://localhost:3000/card/3",
+                        "inputs": [
+                            {
+                                "string": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-data.public.payment,PROD)"
+                            }
+                        ],
+                        "type": "TABLE"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:admin@metabase.com",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1636614000000,
+        "runId": "metabase-test"
+    }
+},
+{
+    "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot": {
             "urn": "urn:li:dashboard:(metabase,1)",
             "aspects": [
@@ -183,6 +238,21 @@
 {
     "entityType": "chart",
     "entityUrn": "urn:li:chart:(metabase,2)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1636614000000,
+        "runId": "metabase-test"
+    }
+},
+{
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(metabase,3)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/metabase/setup/card.json
+++ b/metadata-ingestion/tests/integration/metabase/setup/card.json
@@ -304,4 +304,196 @@
   "favorite": false,
   "created_at": "2021-12-13T17:48:37.102",
   "public_uuid": null
+}, {
+    "description": null,
+    "archived": false,
+    "collection_position": null,
+    "table_id": null,
+    "result_metadata": [
+        {
+            "name": "completed_at",
+            "display_name": "completed_at",
+            "base_type": "type/Date",
+            "special_type": null,
+            "field_ref": [
+                "field",
+                "completed_at",
+                {
+                    "base-type": "type/DateTimeWithTZ",
+                    "temporal-unit": "day"
+                }
+            ],
+            "unit": "day",
+            "fingerprint": {
+                "global": {
+                    "distinct-count": 1916,
+                    "nil%": 0.0385
+                }
+            }
+        },
+        {
+            "name": "count",
+            "display_name": "Distinct values of order_number",
+            "base_type": "type/BigInteger",
+            "special_type": "type/Quantity",
+            "field_ref": [
+                "aggregation",
+                0
+            ],
+            "fingerprint": {
+                "global": {
+                    "distinct-count": 8,
+                    "nil%": 0.0
+                },
+                "type": {
+                    "type/Number": {
+                        "min": 44098.0,
+                        "q1": 46911.0,
+                        "q3": 51276.0,
+                        "max": 52228.0,
+                        "sd": 2797.3306887357558,
+                        "avg": 48557.125
+                    }
+                }
+            }
+        },
+        {
+            "name": "sum",
+            "display_name": "Sum of nominal_total",
+            "base_type": "type/Float",
+            "special_type": null,
+            "field_ref": [
+                "aggregation",
+                1
+            ],
+            "fingerprint": {
+                "global": {
+                    "distinct-count": 8,
+                    "nil%": 0.0
+                },
+                "type": {
+                    "type/Number": {
+                        "min": 1.256807007034278E8,
+                        "q1": 1.277180884245776E8,
+                        "q3": 1.4257821803491282E8,
+                        "max": 1.4887777502074698E8,
+                        "sd": 8966928.163419789,
+                        "avg": 1.3526486656272435E8
+                    }
+                }
+            }
+        }
+    ],
+    "creator": {
+        "email": "john.doe@example.com",
+        "first_name": "John",
+        "last_login": "2023-08-03T09:33:25.157021Z",
+        "is_qbnewb": false,
+        "is_superuser": false,
+        "id": 1,
+        "last_name": "Doe",
+        "date_joined": "2020-07-13T07:29:31.805765Z",
+        "common_name": "John Doe"
+    },
+    "can_write": true,
+    "database_id": 2,
+    "enable_embedding": false,
+    "collection_id": 1135,
+    "query_type": "query",
+    "name": "Question with data from other question",
+    "last_query_start": null,
+    "dashboard_count": 1,
+    "average_query_time": null,
+    "creator_id": 31337,
+    "moderation_reviews": [],
+    "updated_at": "2023-06-01T14:01:59.592811Z",
+    "made_public_by_id": null,
+    "embedding_params": null,
+    "cache_ttl": null,
+    "dataset_query": {
+        "database": 2,
+        "query": {
+            "source-table": "card__1",
+            "filter": [
+                "time-interval",
+                [
+                    "field",
+                    "completed_at",
+                    {
+                        "base-type": "type/DateTimeWithTZ"
+                    }
+                ],
+                -8,
+                "day",
+                {
+                    "include-current": false
+                }
+            ],
+            "aggregation": [
+                [
+                    "distinct",
+                    [
+                        "field",
+                        "order_number",
+                        {
+                            "base-type": "type/Text"
+                        }
+                    ]
+                ],
+                [
+                    "sum",
+                    [
+                        "field",
+                        "nominal_total",
+                        {
+                            "base-type": "type/Float"
+                        }
+                    ]
+                ]
+            ],
+            "breakout": [
+                [
+                    "field",
+                    "completed_at",
+                    {
+                        "base-type": "type/DateTimeWithTZ",
+                        "temporal-unit": "day"
+                    }
+                ]
+            ]
+        },
+        "type": "query"
+    },
+    "id": 3,
+    "parameter_mappings": null,
+    "display": "table",
+    "entity_id": null,
+    "collection_preview": true,
+    "last-edit-info": {
+        "id": 1,
+        "email": "john.doe@example.com",
+        "first_name": "John",
+        "last_name": "Doe",
+        "timestamp": "2023-06-01T14:01:59.636581Z"
+    },
+    "visualization_settings": {},
+    "collection": {
+        "authority_level": null,
+        "description": null,
+        "archived": false,
+        "slug": "group",
+        "color": "#509EE3",
+        "name": "Group",
+        "personal_owner_id": null,
+        "id": 1135,
+        "entity_id": null,
+        "location": "/3/373/",
+        "namespace": null,
+        "created_at": "2020-07-17T19:28:39.513365Z"
+    },
+    "parameters": null,
+    "dataset": false,
+    "created_at": "2020-07-17T19:28:39.513365Z",
+    "parameter_usage_count": 0,
+    "public_uuid": null
 }]

--- a/metadata-ingestion/tests/integration/metabase/setup/card_3.json
+++ b/metadata-ingestion/tests/integration/metabase/setup/card_3.json
@@ -1,0 +1,193 @@
+{
+    "description": null,
+    "archived": false,
+    "collection_position": null,
+    "table_id": null,
+    "result_metadata": [
+        {
+            "name": "completed_at",
+            "display_name": "completed_at",
+            "base_type": "type/Date",
+            "special_type": null,
+            "field_ref": [
+                "field",
+                "completed_at",
+                {
+                    "base-type": "type/DateTimeWithTZ",
+                    "temporal-unit": "day"
+                }
+            ],
+            "unit": "day",
+            "fingerprint": {
+                "global": {
+                    "distinct-count": 1916,
+                    "nil%": 0.0385
+                }
+            }
+        },
+        {
+            "name": "count",
+            "display_name": "Distinct values of order_number",
+            "base_type": "type/BigInteger",
+            "special_type": "type/Quantity",
+            "field_ref": [
+                "aggregation",
+                0
+            ],
+            "fingerprint": {
+                "global": {
+                    "distinct-count": 8,
+                    "nil%": 0.0
+                },
+                "type": {
+                    "type/Number": {
+                        "min": 44098.0,
+                        "q1": 46911.0,
+                        "q3": 51276.0,
+                        "max": 52228.0,
+                        "sd": 2797.3306887357558,
+                        "avg": 48557.125
+                    }
+                }
+            }
+        },
+        {
+            "name": "sum",
+            "display_name": "Sum of nominal_total",
+            "base_type": "type/Float",
+            "special_type": null,
+            "field_ref": [
+                "aggregation",
+                1
+            ],
+            "fingerprint": {
+                "global": {
+                    "distinct-count": 8,
+                    "nil%": 0.0
+                },
+                "type": {
+                    "type/Number": {
+                        "min": 1.256807007034278E8,
+                        "q1": 1.277180884245776E8,
+                        "q3": 1.4257821803491282E8,
+                        "max": 1.4887777502074698E8,
+                        "sd": 8966928.163419789,
+                        "avg": 1.3526486656272435E8
+                    }
+                }
+            }
+        }
+    ],
+    "creator": {
+        "email": "john.doe@example.com",
+        "first_name": "John",
+        "last_login": "2023-08-03T09:33:25.157021Z",
+        "is_qbnewb": false,
+        "is_superuser": false,
+        "id": 1,
+        "last_name": "Doe",
+        "date_joined": "2020-07-13T07:29:31.805765Z",
+        "common_name": "John Doe"
+    },
+    "can_write": true,
+    "database_id": 2,
+    "enable_embedding": false,
+    "collection_id": 1135,
+    "query_type": "query",
+    "name": "Question with data from other question",
+    "last_query_start": null,
+    "dashboard_count": 1,
+    "average_query_time": null,
+    "creator_id": 1,
+    "moderation_reviews": [],
+    "updated_at": "2023-06-01T14:01:59.592811Z",
+    "made_public_by_id": null,
+    "embedding_params": null,
+    "cache_ttl": null,
+    "dataset_query": {
+        "database": 2,
+        "query": {
+            "source-table": "card__1",
+            "filter": [
+                "time-interval",
+                [
+                    "field",
+                    "completed_at",
+                    {
+                        "base-type": "type/DateTimeWithTZ"
+                    }
+                ],
+                -8,
+                "day",
+                {
+                    "include-current": false
+                }
+            ],
+            "aggregation": [
+                [
+                    "distinct",
+                    [
+                        "field",
+                        "order_number",
+                        {
+                            "base-type": "type/Text"
+                        }
+                    ]
+                ],
+                [
+                    "sum",
+                    [
+                        "field",
+                        "nominal_total",
+                        {
+                            "base-type": "type/Float"
+                        }
+                    ]
+                ]
+            ],
+            "breakout": [
+                [
+                    "field",
+                    "completed_at",
+                    {
+                        "base-type": "type/DateTimeWithTZ",
+                        "temporal-unit": "day"
+                    }
+                ]
+            ]
+        },
+        "type": "query"
+    },
+    "id": 3,
+    "parameter_mappings": null,
+    "display": "table",
+    "entity_id": null,
+    "collection_preview": true,
+    "last-edit-info": {
+        "id": 1,
+        "email": "john.doe@example.com",
+        "first_name": "John",
+        "last_name": "Doe",
+        "timestamp": "2023-06-01T14:01:59.636581Z"
+    },
+    "visualization_settings": {},
+    "collection": {
+        "authority_level": null,
+        "description": null,
+        "archived": false,
+        "slug": "group",
+        "color": "#509EE3",
+        "name": "Group",
+        "personal_owner_id": null,
+        "id": 1135,
+        "entity_id": null,
+        "location": "/3/373/",
+        "namespace": null,
+        "created_at": "2020-07-17T19:28:39.513365Z"
+    },
+    "parameters": null,
+    "dataset": false,
+    "created_at": "2020-07-17T19:28:39.513365Z",
+    "parameter_usage_count": 0,
+    "public_uuid": null
+}

--- a/metadata-ingestion/tests/integration/metabase/test_metabase.py
+++ b/metadata-ingestion/tests/integration/metabase/test_metabase.py
@@ -23,6 +23,7 @@ JSON_RESPONSE_MAP = {
     "http://localhost:3000/api/card/1": "card_1.json",
     "http://localhost:3000/api/card/2": "card_2.json",
     "http://localhost:3000/api/table/21": "table_21.json",
+    "http://localhost:3000/api/card/3": "card_3.json",
 }
 
 RESPONSE_ERROR_LIST = ["http://localhost:3000/api/dashboard"]


### PR DESCRIPTION
Metabase question (datahub Card) may not query database table directly but rather use another question as source. The change makes ingestion to attempt finding the source database table from source question in recursive manner.

Example API response for questions getting data from other question results:
```
{
. . .
    "dataset_query": {
        "database": 42,
        "query": {
            "source-table": "card__31337",
            "filter": [
. . .
            ],
            "aggregation": [
. . .
            ],
            "breakout": [
. . .
            ]
        },
        "type": "query"
    },
    "id": 123
. . .
}
```

The proposed patch is trying to resolve source database and tables recursively from Metabase question specified as data source for target question. Recursion depth is statically limited.

Retrieving question (Card) information by its ID from Metabase API has been moved to method to ease re-use of this retrieval.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
