### PR TITLE
fix(ingest): Add client_certificate_path for rest client cert instead of ca_certif…

### DIFF
--- a/docs-website/genJsonSchema/gen_json_schema.py
+++ b/docs-website/genJsonSchema/gen_json_schema.py
@@ -55,8 +55,12 @@ def get_base() -> Any:
                 "properties": {
                     "ca_certificate_path": {
                         "type": "string",
-                        "description": "Path to CA certificate for HTTPS communications.",
+                        "description": "Path to server's CA certificate for verification of HTTPS communications",
                     },
+                    "client_certificate_path": {
+                        "type": "string",
+                        "descritption": "Path to client's CA certificate for HTTPS communications",
+                    }
                     "max_threads": {
                         "type": "number",
                         "description": "Experimental: Max parallelism for REST API calls",

--- a/docs-website/genJsonSchema/gen_json_schema.py
+++ b/docs-website/genJsonSchema/gen_json_schema.py
@@ -60,7 +60,7 @@ def get_base() -> Any:
                     "client_certificate_path": {
                         "type": "string",
                         "descritption": "Path to client's CA certificate for HTTPS communications",
-                    }
+                    },
                     "max_threads": {
                         "type": "number",
                         "description": "Experimental: Max parallelism for REST API calls",

--- a/metadata-ingestion/sink_docs/datahub.md
+++ b/metadata-ingestion/sink_docs/datahub.md
@@ -65,7 +65,8 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `token`                    |          |                      | Bearer token used for authentication.                                                              |
 | `extra_headers`            |          |                      | Extra headers which will be added to the request.                                                  |
 | `max_threads`              |          | `15`                 | Experimental: Max parallelism for REST API calls                                                   |
-| `ca_certificate_path`      |          |                      | Path to CA certificate for HTTPS communications                                                    |
+| `ca_certificate_path`      |          |                      | Path to server's CA certificate for verification of HTTPS communications                                                    |
+| `client_certificate_path`      |          |                      | Path to client's CA certificate for HTTPS communications                                                    |
 | `disable_ssl_verification` |          | false                | Disable ssl certificate validation                                                                 |
 
 ## DataHub Kafka

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -62,6 +62,7 @@ class DataHubRestEmitter(Closeable):
         retry_max_times: Optional[int] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         ca_certificate_path: Optional[str] = None,
+        client_certificate_path: Optional[str] = None,
         disable_ssl_verification: bool = False,
     ):
         if not gms_server:
@@ -88,8 +89,11 @@ class DataHubRestEmitter(Closeable):
         if extra_headers:
             self._session.headers.update(extra_headers)
 
+        if client_certificate_path:
+            self._session.cert = client_certificate_path
+
         if ca_certificate_path:
-            self._session.cert = ca_certificate_path
+            self._session.verify = ca_certificate_path
 
         if disable_ssl_verification:
             self._session.verify = False

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -62,6 +62,7 @@ class DatahubClientConfig(ConfigModel):
     retry_max_times: Optional[int] = None
     extra_headers: Optional[Dict[str, str]] = None
     ca_certificate_path: Optional[str] = None
+    client_certificate_path: Optional[str] = None
     disable_ssl_verification: bool = False
 
 
@@ -122,6 +123,7 @@ class DataHubGraph(DatahubRestEmitter):
             retry_max_times=self.config.retry_max_times,
             extra_headers=self.config.extra_headers,
             ca_certificate_path=self.config.ca_certificate_path,
+            client_certificate_path=self.config.client_certificate_path,
             disable_ssl_verification=self.config.disable_ssl_verification,
         )
         self.test_connection()

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -100,6 +100,7 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
             retry_max_times=self.config.retry_max_times,
             extra_headers=self.config.extra_headers,
             ca_certificate_path=self.config.ca_certificate_path,
+            client_certificate_path=self.config.client_certificate_path,
             disable_ssl_verification=self.config.disable_ssl_verification,
         )
         try:


### PR DESCRIPTION
…icate_path

Prior to v10.0.3, we are passing server side certificate in the ca_certificate_path and this is used for ssl verification. With the PR - https://github.com/datahub-project/datahub/pull/7978, this has been changed to cert (client certificate) and this causes ssl handshake failure. 

The proposal in this PR is to use a new parameter for client_certificate_path for client certificate and reset old parameter as verify for server cert verification.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
