### PR TITLE
fix(ingest/kafka): use SchemaReference properties instead of dict access

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
@@ -113,7 +113,7 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
             schema_seen = set()
         schema_str = self._compact_schema(schema.schema_str)
         for schema_ref in schema.references:
-            ref_subject = schema_ref["subject"]
+            ref_subject = schema_ref.subject
             if ref_subject in schema_seen:
                 continue
 
@@ -132,7 +132,7 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
             # Replace only external type references with the reference schema recursively.
             # NOTE: The type pattern is dependent on _compact_schema.
             avro_type_kwd = '"type"'
-            ref_name = schema_ref["name"]
+            ref_name = schema_ref.name
             # Try by name first
             pattern_to_replace = f'{avro_type_kwd}:"{ref_name}"'
             if pattern_to_replace not in schema_str:
@@ -164,7 +164,7 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
 
         schema_ref: SchemaReference
         for schema_ref in schema.references:
-            ref_subject: str = schema_ref["subject"]
+            ref_subject: str = schema_ref.subject
             if ref_subject in schema_seen:
                 continue
             reference_schema: RegisteredSchema = (
@@ -173,7 +173,7 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
             schema_seen.add(ref_subject)
             all_schemas.append(
                 ProtobufSchema(
-                    name=schema_ref["name"], content=reference_schema.schema.schema_str
+                    name=schema_ref.name, content=reference_schema.schema.schema_str
                 )
             )
         return all_schemas
@@ -192,19 +192,19 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
 
         schema_ref: SchemaReference
         for schema_ref in schema.references:
-            ref_subject: str = schema_ref["subject"]
+            ref_subject: str = schema_ref.subject
             if ref_subject in schema_seen:
                 continue
             reference_schema: RegisteredSchema = (
                 self.schema_registry_client.get_version(
-                    subject_name=ref_subject, version=schema_ref["version"]
+                    subject_name=ref_subject, version=schema_ref.version
                 )
             )
             schema_seen.add(ref_subject)
             all_schemas.extend(
                 self.get_schemas_from_confluent_ref_json(
                     reference_schema.schema,
-                    name=schema_ref["name"],
+                    name=schema_ref.name,
                     subject=ref_subject,
                     schema_seen=schema_seen,
                 )

--- a/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
+++ b/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from confluent_kafka.schema_registry.schema_registry_client import (
     RegisteredSchema,
     Schema,
+    SchemaReference,
 )
 
 from datahub.ingestion.source.confluent_schema_registry import ConfluentSchemaRegistry
@@ -90,7 +91,9 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
                     schema_str=schema_str_orig,
                     schema_type="AVRO",
                     references=[
-                        dict(name="TestTopic1", subject="schema_subject_1", version=1)
+                        SchemaReference(
+                            name="TestTopic1", subject="schema_subject_1", version=1
+                        )
                     ],
                 )
             )
@@ -109,7 +112,9 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
                     schema_str=schema_str_orig,
                     schema_type="AVRO",
                     references=[
-                        dict(name="schema_subject_1", subject="TestTopic1", version=1)
+                        SchemaReference(
+                            name="schema_subject_1", subject="TestTopic1", version=1
+                        )
                     ],
                 )
             )


### PR DESCRIPTION
Fixes #8366.

`schema_ref`:`SchemaReference`, was treated like a dictionary.

After update, now schema references attributes are accessible by 
`SchemaReference` properties instead of dictionary subscription.

e.g. `schema_ref.name` ,  `schema_ref.version` , `schema_ref.subject`


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
