### PR TITLE
fix(ingest/okta): fix event_loop RuntimeError with nested asyncio

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -355,7 +355,7 @@ plugins: Dict[str, Set[str]] = {
     "mysql": sql_common | {"pymysql>=1.0.2"},
     # mariadb should have same dependency as mysql
     "mariadb": sql_common | {"pymysql>=1.0.2"},
-    "okta": {"okta~=1.7.0"},
+    "okta": {"okta~=1.7.0", "nest-asyncio"},
     "oracle": sql_common | {"cx_Oracle"},
     "postgres": sql_common | {"psycopg2-binary", "GeoAlchemy2"},
     "presto": sql_common | pyhive_common | trino,

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -2,12 +2,12 @@ import asyncio
 import logging
 import re
 import urllib
-import nest_asyncio
 from collections import defaultdict
 from dataclasses import dataclass, field
 from time import sleep
 from typing import Dict, Iterable, List, Optional, Union
 
+import nest_asyncio
 from okta.client import Client as OktaClient
 from okta.exceptions import OktaAPIException
 from okta.models import Group, GroupProfile, User, UserProfile, UserStatus

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/okta.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import re
 import urllib
+import nest_asyncio
 from collections import defaultdict
 from dataclasses import dataclass, field
 from time import sleep
@@ -51,6 +52,7 @@ from datahub.metadata.schema_classes import (
 )
 
 logger = logging.getLogger(__name__)
+nest_asyncio.apply()
 
 
 class OktaConfig(StatefulIngestionConfigBase, ConfigModel):


### PR DESCRIPTION
This PR addresses [bug #8636](https://github.com/datahub-project/datahub/issues/8636). Proper fix for it depends on intended behavior of the `okta` connector - if nesting event loops is desired behavior then `nest_asyncio` should be used.

For more considerations see:
https://stackoverflow.com/questions/46827007/runtimeerror-this-event-loop-is-already-running-in-python

Fixes #8636.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
