### PR TITLE
fix(ingest/bigquery): Do not check profiling eligibility if table level only

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -61,6 +61,7 @@ class BigQueryV2Report(ProfilingSqlReport):
     partition_info: Dict[str, str] = field(default_factory=TopKDict)
     profile_table_selection_criteria: Dict[str, str] = field(default_factory=TopKDict)
     selected_profile_tables: Dict[str, List[str]] = field(default_factory=TopKDict)
+    profiling_skipped_no_column_count: LossyList = field(default_factory=LossyList)
     invalid_partition_ids: Dict[str, str] = field(default_factory=TopKDict)
     allow_pattern: Optional[str] = None
     deny_pattern: Optional[str] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/profiler.py
@@ -240,7 +240,7 @@ WHERE
         dataset_name = BigqueryTableIdentifier(
             project_id=project, dataset=dataset, table=table.name
         ).get_table_name()
-        if not self.is_dataset_eligible_for_profiling(
+        if not profile_table_level_only and not self.is_dataset_eligible_for_profiling(
             dataset_name, table.last_altered, table.size_in_bytes, table.rows_count
         ):
             profile_table_level_only = True
@@ -248,6 +248,7 @@ WHERE
 
         if not table.column_count:
             skip_profiling = True
+            self.report.profiling_skipped_no_column_count.append(dataset_name)
 
         if skip_profiling:
             if self.config.profiling.report_dropped_profiles:


### PR DESCRIPTION
Also adds counter for when we skip tables because we're missing column count

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
