### PR TITLE
feat(graphql) Support exists operator in GraphQL Search API

### DIFF
--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -443,6 +443,11 @@ enum FilterOperator {
   * Represent the relation: String field is one of the array values to, e.g. name in ["Profile", "Event"]
   """
   IN
+
+  """
+  Represents the relation: The field exists. If the field is an array, the field is either not present or empty.
+  """
+  EXISTS
 }
 
 """


### PR DESCRIPTION
## Summary

Tiny PR for adding the exists operator to GraphQL API. This was confirmed to work locally, because we already support this in Condition.pdl on the Elasticsearch backend. 

Tested queries:

```
query searchAcrossEntities {
  searchAcrossEntities(input:{
    types: [MONITOR],
    start: 0,
    count: 20,
    query: "*",
    orFilters: [
    {
      and: [
        { field: "executorId", condition: EXISTS }
      ]
    }
    ]
  }) {
    total
    start
   	searchResults {
      entity {
        ...on Monitor {
          urn
        }
      }
    }
  }
```

## Status

Ready for review 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
