### PR TITLE
fix(ingest/bigquery): Add config option to create DataPlatformInstance, default off

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -15,6 +15,9 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 - #8300: Clickhouse source now inherited from TwoTierSQLAlchemy. In old way we have platform_instance -> container -> co
   container db (None) -> container schema and now we have platform_instance -> container database.
 - #8300: Added `uri_opts` argument; now we can add any options for clickhouse client.
+- #8659: BigQuery ingestion no longer creates DataPlatformInstance aspects by default.
+  This will only affect users that were depending on this aspect for custom functionality,
+  and can be enabled via the `include_data_platform_instance` config option.
 
 ## 0.10.5
 

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -428,7 +428,9 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
     ) -> MetadataWorkUnit:
         aspect = DataPlatformInstanceClass(
             platform=make_data_platform_urn(self.platform),
-            instance=make_dataplatform_instance_urn(self.platform, project_id),
+            instance=make_dataplatform_instance_urn(self.platform, project_id)
+            if self.config.include_data_platform_instance
+            else None,
         )
         return MetadataChangeProposalWrapper(
             entityUrn=dataset_urn, aspect=aspect

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_config.py
@@ -81,6 +81,13 @@ class BigQueryV2Config(
         description="Whether to populate BigQuery Console url to Datasets/Tables",
     )
 
+    include_data_platform_instance: bool = Field(
+        default=False,
+        description="Whether to create a DataPlatformInstance aspect, equal to the BigQuery project id."
+        " If enabled, will cause redundancy in the browse path for BigQuery entities in the UI,"
+        " because the project id is represented as the top-level container.",
+    )
+
     debug_include_full_payloads: bool = Field(
         default=False,
         description="Include full payload into events. It is only for debugging and internal use.",

--- a/metadata-ingestion/tests/integration/bigquery_v2/test_bigquery.py
+++ b/metadata-ingestion/tests/integration/bigquery_v2/test_bigquery.py
@@ -61,6 +61,7 @@ def test_bigquery_v2_ingest(
         "project_ids": ["project-id-1"],
         "include_usage_statistics": False,
         "include_table_lineage": False,
+        "include_data_platform_instance": True,
     }
 
     pipeline_config_dict: Dict[str, Any] = {

--- a/metadata-ingestion/tests/unit/test_bigquery_source.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_source.py
@@ -138,18 +138,31 @@ def test_get_dataplatform_instance_aspect_returns_project_id():
         f"urn:li:dataPlatformInstance:(urn:li:dataPlatform:bigquery,{project_id})"
     )
 
-    config = BigQueryV2Config.parse_obj({})
+    config = BigQueryV2Config.parse_obj({"include_data_platform_instance": True})
     source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
 
     data_platform_instance = source.get_dataplatform_instance_aspect(
         "urn:li:test", project_id
     )
-
     metadata = data_platform_instance.get_metadata()["metadata"]
 
     assert data_platform_instance is not None
     assert metadata.aspectName == "dataPlatformInstance"
     assert metadata.aspect.instance == expected_instance
+
+
+def test_get_dataplatform_instance_default_no_instance():
+    config = BigQueryV2Config.parse_obj({})
+    source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
+
+    data_platform_instance = source.get_dataplatform_instance_aspect(
+        "urn:li:test", None
+    )
+    metadata = data_platform_instance.get_metadata()["metadata"]
+
+    assert data_platform_instance is not None
+    assert metadata.aspectName == "dataPlatformInstance"
+    assert metadata.aspect.instance is None
 
 
 @patch("google.cloud.bigquery.client.Client")

--- a/metadata-ingestion/tests/unit/test_bigquery_source.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_source.py
@@ -156,7 +156,7 @@ def test_get_dataplatform_instance_default_no_instance():
     source = BigqueryV2Source(config=config, ctx=PipelineContext(run_id="test"))
 
     data_platform_instance = source.get_dataplatform_instance_aspect(
-        "urn:li:test", None
+        "urn:li:test", "project_id"
     )
     metadata = data_platform_instance.get_metadata()["metadata"]
 


### PR DESCRIPTION
The data platform instance results in redundancy in the UI browse path for bigquery entities, which is confusing some users. We keep the option to create the DPI aspect for users who want it

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
