### PR TITLE
fix(setup): create index consistently

### DIFF
--- a/docker/mariadb/init.sql
+++ b/docker/mariadb/init.sql
@@ -11,7 +11,7 @@ create table metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-create index timeIndex ON metadata_aspect_v2 (createdon);
+create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
 
 insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) values(
   'urn:li:corpuser:datahub',

--- a/docker/mariadb/init.sql
+++ b/docker/mariadb/init.sql
@@ -11,7 +11,7 @@ create table metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
 
 insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) values(
   'urn:li:corpuser:datahub',
@@ -30,4 +30,4 @@ insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, creat
 );
 
 
-drop table if exists metadata_index;
+DROP TABLE IF EXISTS metadata_index;

--- a/docker/mariadb/init.sql
+++ b/docker/mariadb/init.sql
@@ -11,7 +11,7 @@ create table metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX timeIndex ON metadata_aspect_v2 (createdon);
 
 insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) values(
   'urn:li:corpuser:datahub',

--- a/docker/mariadb/init.sql
+++ b/docker/mariadb/init.sql
@@ -28,3 +28,6 @@ insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, creat
   now(),
   'urn:li:corpuser:__datahub_system'
 );
+
+
+drop table if exists metadata_index;

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -15,7 +15,7 @@ create table if not exists metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
 
 -- create default records for datahub user if not exists
 DROP TABLE if exists temp_metadata_aspect_v2;
@@ -42,4 +42,4 @@ WHERE NOT EXISTS (SELECT * from metadata_aspect_v2);
 DROP TABLE temp_metadata_aspect_v2;
 
 
-drop table if exists metadata_index;
+DROP TABLE IF EXISTS metadata_index;

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -12,9 +12,10 @@ create table if not exists metadata_aspect_v2 (
   createdon                     datetime(6) not null,
   createdby                     varchar(255) not null,
   createdfor                    varchar(255),
-  constraint pk_metadata_aspect_v2 primary key (urn,aspect,version),
-  INDEX timeIndex (createdon)
+  constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
+
+create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
 
 -- create default records for datahub user if not exists
 DROP TABLE if exists temp_metadata_aspect_v2;

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -40,3 +40,6 @@ INSERT INTO metadata_aspect_v2
 SELECT * FROM temp_metadata_aspect_v2
 WHERE NOT EXISTS (SELECT * from metadata_aspect_v2);
 DROP TABLE temp_metadata_aspect_v2;
+
+
+drop table if exists metadata_index;

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -15,7 +15,7 @@ create table if not exists metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX timeIndex ON metadata_aspect_v2 (createdon);
 
 -- create default records for datahub user if not exists
 DROP TABLE if exists temp_metadata_aspect_v2;

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -28,3 +28,6 @@ INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, creat
   now(),
   'urn:li:corpuser:__datahub_system'
 );
+
+
+drop table if exists metadata_index;

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
-create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
 
 INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) VALUES(
   'urn:li:corpuser:datahub',
@@ -30,4 +30,4 @@ INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, creat
 );
 
 
-drop table if exists metadata_index;
+DROP TABLE IF EXISTS metadata_index;

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -8,9 +8,10 @@ CREATE TABLE metadata_aspect_v2 (
   createdon                     datetime(6) NOT NULL,
   createdby                     VARCHAR(255) NOT NULL,
   createdfor                    VARCHAR(255),
-  constraint pk_metadata_aspect_v2 primary key (urn,aspect,version),
-  INDEX timeIndex (createdon)
+  constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
 
 INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) VALUES(
   'urn:li:corpuser:datahub',

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
-CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX timeIndex ON metadata_aspect_v2 (createdon);
 
 INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) VALUES(
   'urn:li:corpuser:datahub',

--- a/docker/postgres-setup/init.sql
+++ b/docker/postgres-setup/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (
   CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn, aspect, version)
 );
 
-create index timeIndex ON metadata_aspect_v2 (createdon);
+create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
 
 -- create default records for datahub user if not exists
 CREATE TEMP TABLE temp_metadata_aspect_v2 AS TABLE metadata_aspect_v2;

--- a/docker/postgres-setup/init.sql
+++ b/docker/postgres-setup/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (
   CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn, aspect, version)
 );
 
-create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
 
 -- create default records for datahub user if not exists
 CREATE TEMP TABLE temp_metadata_aspect_v2 AS TABLE metadata_aspect_v2;
@@ -37,4 +37,4 @@ WHERE NOT EXISTS (SELECT * from metadata_aspect_v2);
 DROP TABLE temp_metadata_aspect_v2;
 
 
-drop table if exists metadata_index;
+DROP TABLE IF EXISTS metadata_index;

--- a/docker/postgres-setup/init.sql
+++ b/docker/postgres-setup/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS metadata_aspect_v2 (
   CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn, aspect, version)
 );
 
-CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX timeIndex ON metadata_aspect_v2 (createdon);
 
 -- create default records for datahub user if not exists
 CREATE TEMP TABLE temp_metadata_aspect_v2 AS TABLE metadata_aspect_v2;

--- a/docker/postgres-setup/init.sql
+++ b/docker/postgres-setup/init.sql
@@ -35,3 +35,6 @@ INSERT INTO metadata_aspect_v2
 SELECT * FROM temp_metadata_aspect_v2
 WHERE NOT EXISTS (SELECT * from metadata_aspect_v2);
 DROP TABLE temp_metadata_aspect_v2;
+
+
+drop table if exists metadata_index;

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -11,7 +11,7 @@ create table metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-create index timeIndex ON metadata_aspect_v2 (createdon);
+create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
 
 insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) values(
   'urn:li:corpuser:datahub',

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -11,7 +11,7 @@ create table metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-create index if not exists timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
 
 insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) values(
   'urn:li:corpuser:datahub',
@@ -30,4 +30,4 @@ insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, creat
 );
 
 
-drop table if exists metadata_index;
+DROP TABLE IF EXISTS metadata_index;

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -11,7 +11,7 @@ create table metadata_aspect_v2 (
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version)
 );
 
-CREATE INDEX IF NOT EXISTS timeIndex ON metadata_aspect_v2 (createdon);
+CREATE INDEX timeIndex ON metadata_aspect_v2 (createdon);
 
 insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) values(
   'urn:li:corpuser:datahub',

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -28,3 +28,6 @@ insert into metadata_aspect_v2 (urn, aspect, version, metadata, createdon, creat
   now(),
   'urn:li:corpuser:__datahub_system'
 );
+
+
+drop table if exists metadata_index;


### PR DESCRIPTION
Fixes
- takes care of the cases of existing deployments where this index would not have been created for `mysql` deployments.
- takes care of the case where we try to create index where one was already present
- https://github.com/datahub-project/datahub/pull/8253 removed a legacy table from being created but existing deployments would have that lying around. This cleans that up

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
