### PR TITLE
fix(kafka-setup): replace usage of confluent docker utils

### DIFF
--- a/docker/kafka-setup/Dockerfile
+++ b/docker/kafka-setup/Dockerfile
@@ -16,8 +16,7 @@ ENV KAFKA_VERSION 3.4.1
 ENV SCALA_VERSION 2.13
 
 # Set the classpath for JARs required by `cub`
-ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
-
+ENV CUB_CLASSPATH='/usr/share/java/cp-base-new/*'
 LABEL name="kafka" version=${KAFKA_VERSION}
 
 RUN apk add --no-cache bash coreutils
@@ -31,10 +30,6 @@ RUN mkdir -p /opt \
   && mv /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka \
   && adduser -DH -s /sbin/nologin kafka \
   && chown -R kafka: /opt/kafka \
-  && echo "===> Installing python packages ..."  \
-  && pip install --no-cache-dir --upgrade pip wheel setuptools \
-  && pip install jinja2 requests \
-  && pip install "Cython<3.0" "PyYAML<6" --no-build-isolation \
   && rm -rf /tmp/* \
   && apk del --purge .build-deps
 

--- a/docker/kafka-setup/kafka-setup.sh
+++ b/docker/kafka-setup/kafka-setup.sh
@@ -50,7 +50,11 @@ if [[ -n "$KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS" ]]; then
 fi
 
 # cub kafka-ready -c $CONNECTION_PROPERTIES_PATH -b $KAFKA_BOOTSTRAP_SERVER 1 180
-. kafka-ready.sh
+java -cp "$CUB_CLASSPATH" \
+  -Dlog4j.configuration=file:/etc/cp-base-new/log4j.properties \
+  io.confluent.admin.utils.cli.KafkaReadyCommand 1 180000 \
+  --config $CONNECTION_PROPERTIES_PATH \
+  -b $KAFKA_BOOTSTRAP_SERVER
 
 ############################################################
 # Start Topic Creation Logic


### PR DESCRIPTION
Confluent has recently removed their GitHub repo for the `confluent-docker-utils` package for a short period of time, which was causing the build of the `kafka-setup` image to fail.

I noticed `cub.check_kafka_health` seems to be the only function we use from the package. By extracting the logic of the function as an equivalent `java` command, we can drop the dependency on `confluent-docker-utils` so the image is slimmer and the build will be more robust.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
