### PR TITLE
Allow frontend to use http proxy

### DIFF
--- a/docker/datahub-frontend/start.sh
+++ b/docker/datahub-frontend/start.sh
@@ -26,6 +26,21 @@ if [[ ! -z ${SSL_TRUSTSTORE_PASSWORD:-} ]]; then
   TRUSTSTORE_PASSWORD="-Djavax.net.ssl.trustStorePassword=$SSL_TRUSTSTORE_PASSWORD"
 fi
 
+HTTP_PROXY=""
+if [[ ! -z ${HTTP_PROXY_HOST:-} ]] && [[ ! -z ${HTTP_PROXY_PORT:-} ]]; then
+  HTTP_PROXY="-Dhttp.proxyHost=$HTTP_PROXY_HOST -Dhttp.proxyPort=$HTTP_PROXY_PORT"
+fi
+
+HTTPS_PROXY=""
+if [[ ! -z ${HTTPS_PROXY_HOST:-} ]] && [[ ! -z ${HTTPS_PROXY_PORT:-} ]]; then
+  HTTPS_PROXY="-Dhttps.proxyHost=$HTTPS_PROXY_HOST -Dhttps.proxyPort=$HTTPS_PROXY_PORT"
+fi
+
+NO_PROXY=""
+if [[ ! -z ${HTTP_NON_PROXY_HOSTS:-} ]]; then
+  NO_PROXY="-Dhttp.nonProxyHosts='$HTTP_NON_PROXY_HOSTS'"
+fi
+
 # make sure there is no whitespace at the beginning and the end of 
 # this string
 export JAVA_OPTS="-Xms512m \
@@ -37,6 +52,7 @@ export JAVA_OPTS="-Xms512m \
    -Dlogback.debug=false \
    ${PROMETHEUS_AGENT:-} ${OTEL_AGENT:-} \
    ${TRUSTSTORE_FILE:-} ${TRUSTSTORE_TYPE:-} ${TRUSTSTORE_PASSWORD:-} \
+   ${HTTP_PROXY:-} ${HTTPS_PROXY:-} ${NO_PROXY:-} \
    -Dpidfile.path=/dev/null"
 
 exec ./datahub-frontend/bin/datahub-frontend

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -160,6 +160,7 @@ module.exports = {
                     "docs/authentication/guides/sso/configure-oidc-react-google",
                     "docs/authentication/guides/sso/configure-oidc-react-okta",
                     "docs/authentication/guides/sso/configure-oidc-react-azure",
+                    "docs/authentication/guides/sso/configure-oidc-behind-proxy",
                   ],
                 },
               ],

--- a/docs/authentication/guides/sso/configure-oidc-behind-proxy.md
+++ b/docs/authentication/guides/sso/configure-oidc-behind-proxy.md
@@ -1,0 +1,64 @@
+# Configuring Frontend to use a Proxy when communicating with SSO Provider
+*Authored on 22/08/2023*
+
+The `datahub-frontend-react` server can be configured to use an http proxy when retrieving the openid-configuration. 
+This can be needed if your infrastructure is locked down and disallows connectivity by default, using proxies for fine-grained egress control. 
+
+## Configure http proxy and non proxy hosts
+
+To do this, you will need to pass a set of environment variables to the datahub-frontend-react container (e.g. in the `docker-compose.yml` file or your kubernetes manifest).
+
+```
+HTTP_PROXY_HOST=host of your http proxy
+HTTP_PROXY_PORT=port of your http proxy
+HTTPS_PROXY_HOST=host of your http(s) proxy used for https connections (often the same as the http proxy)
+HTTPS_PROXY_PORT=port of your http(s) proxy used for https connections (often the same as the http proxy)
+HTTP_NON_PROXY_HOSTS=localhost|datahub-gms (or any other hosts that you would like to bypass the proxy for, delimited by pipe)
+```
+
+## Optional: provide custom truststore
+If your upstream proxy performs SSL termination to inspect traffic, this will result in different (self-signed) certificates for HTTPS connections. 
+The default truststore used in the `datahub-frontend-react` docker image will not trust these kinds of connections.
+To address this, you can copy or mount your own truststore (provided by the proxy or network administrators) into the docker container.
+
+Depending on your setup, you have a few options to achieve this:
+
+### Make truststore available in the frontend
+
+#### Option a) Build frontend docker image with your own truststore included
+
+To build a custom image for your frontend, with the certificates built-in, you can use the official frontend image as a base, then copy in your required files.
+
+Example Dockerfile:
+
+```dockerfile
+FROM linkedin/datahub-frontend-react:<version>
+COPY /truststore-directory /certificates
+```
+
+Building this Dockerfile will result in your own custom docker image on your local machine. 
+You will then be able to tag it, publish it to your own registry, etc. 
+
+#### Option b) Mount truststore from your host machine using a docker volume
+
+Adapt your docker-compose.yml to include a new volume mount in the `datahub-frontend-react` container
+
+```docker
+  datahub-frontend-react:
+    # ...
+    volumes:
+      # ...
+      - /truststore-directory:/certificates
+```
+
+### Reference new truststore 
+
+Add the following environment values to the `datahub-frontend-react` container:
+
+```
+SSL_TRUSTSTORE_FILE=path/to/truststore.jks (e.g. /certificates)
+SSL_TRUSTSTORE_TYPE=jks
+SSL_TRUSTSTORE_PASSWORD=MyTruststorePassword
+```
+
+Once these steps are done, your frontend container will use the new truststore when validating SSL/HTTPS connections.


### PR DESCRIPTION
Hi all,

following a discussion on [Slack](https://datahubspace.slack.com/archives/C029A3M079U/p1689679171836099), I would like to propose the following changes to datahub:

> Allow passing of environment variables to the `datahub-frontend-react` container to make it use a proxy when connecting to external services (namely OIDC providers).

This is my first PR here, so please let me know if I missed anything. I believe the PR checklist is fulfilled, but maybe I missed something else? Happy to change anything not up-to-par!

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
