### PR TITLE
feat(kafka): meta-mapping for labels from Avro schemas on Kafka ingest

### DIFF
--- a/metadata-ingestion/docs/sources/kafka/kafka.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka.md
@@ -214,5 +214,5 @@ config:
         tag: "pii"
 ```
 
-The underlying implementation is similar to [dbt meta mapping](../dbt/dbt.md#dbt-meta-automated-mappings), which has more detailed examples that can be used for reference.
+The underlying implementation is similar to [dbt meta mapping](https://datahubproject.io/docs/generated/ingestion/sources/dbt#dbt-meta-automated-mappings), which has more detailed examples that can be used for reference.
 

--- a/metadata-ingestion/docs/sources/kafka/kafka.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka.md
@@ -130,3 +130,89 @@ message MessageWithMap {
   repeated Map1Entry map_1 = 1;
 }
 ```
+
+### Embedding DataHub metadata in schemas with meta mapping
+
+:::note
+Meta mapping is currently only available for Avro schemas
+:::
+
+Avro schemas are permitted to have additional attributes not defined by the
+specification as arbitrary metadata. A common pattern is to utilize this for
+business metadata. The Kafka source has the ability to transform this directly
+into DataHub Owners, Tags and Terms.
+
+#### Simple tags
+
+If you simply have a list of tags embedded into an Avro schema (either at the top-level or for an individual field), you can use the `schema_tags_field` config.
+
+Example Avro schema:
+
+```json
+{
+  "name": "sampleRecord",
+  "type": "record",
+  "tags": ["tag1", "tag2"],
+  "fields": [{
+    "name": "field_1",
+    "type": "string",
+    "tags": ["tag3", "tag4"]
+  }]
+}
+```
+
+The name of the field containing a list of tags can be configured with the `schema_tags_field` property:
+
+```yaml
+config:
+  schema_tags_field: tags
+```
+
+#### meta mapping
+
+You can also map specific Avro fields into Owners, Tags and Terms using meta
+mapping.
+
+Example Avro schema:
+
+```json
+{
+  "name": "sampleRecord",
+  "type": "record",
+  "owning_team": "@Data-Science",
+  "data_tier": "Bronze",
+  "fields": [{
+    "name": "field_1",
+    "type": "string",
+    "gdpr": {
+      "pii": true
+    }
+  }]
+}
+```
+
+This can be mapped to DataHub metadata with `meta_mapping` config:
+
+```yaml
+config:
+  meta_mapping:
+    owning_team:
+      match: "^@(.*)"
+      operation: "add_owner"
+      config:
+        owner_type: group
+    data_tier:
+      match: "Bronze|Silver|Gold"
+      operation: "add_term"
+      config:
+        term: "{{ $match }}"
+  field_meta_mapping:
+    gdpr.pii:
+      match: true
+      operation: "add_tag"
+      config:
+        tag: "pii"
+```
+
+The underlying implementation is similar to [dbt meta mapping](../dbt/dbt.md#dbt-meta-automated-mappings), which has more detailed examples that can be used for reference.
+

--- a/metadata-ingestion/docs/sources/kafka/kafka.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka.md
@@ -131,7 +131,7 @@ message MessageWithMap {
 }
 ```
 
-### Embedding DataHub metadata in schemas with meta mapping
+### Enriching DataHub metadata with automated meta mapping
 
 :::note
 Meta mapping is currently only available for Avro schemas

--- a/metadata-ingestion/docs/sources/kafka/kafka.md
+++ b/metadata-ingestion/docs/sources/kafka/kafka.md
@@ -137,10 +137,7 @@ message MessageWithMap {
 Meta mapping is currently only available for Avro schemas
 :::
 
-Avro schemas are permitted to have additional attributes not defined by the
-specification as arbitrary metadata. A common pattern is to utilize this for
-business metadata. The Kafka source has the ability to transform this directly
-into DataHub Owners, Tags and Terms.
+Avro schemas are permitted to have additional attributes not defined by the specification as arbitrary metadata. A common pattern is to utilize this for business metadata. The Kafka source has the ability to transform this directly into DataHub Owners, Tags and Terms.
 
 #### Simple tags
 

--- a/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
+++ b/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Type, Union
 
 import avro.schema
 
+from datahub.emitter import mce_builder
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
     ArrayTypeClass,
     BooleanTypeClass,
@@ -22,6 +23,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
     UnionTypeClass,
 )
 from datahub.metadata.schema_classes import GlobalTagsClass, TagAssociationClass
+from datahub.utilities.mapping import Constants, OperationProcessor
 
 """A helper file for Avro schema -> MCE schema transformations"""
 
@@ -98,7 +100,14 @@ class AvroToMceSchemaConverter:
         "uuid": StringTypeClass,
     }
 
-    def __init__(self, is_key_schema: bool, default_nullable: bool = False) -> None:
+    def __init__(
+        self,
+        is_key_schema: bool,
+        default_nullable: bool = False,
+        meta_mapping_processor: Optional[OperationProcessor] = None,
+        schema_tags_field: Optional[str] = None,
+        tag_prefix: Optional[str] = None,
+    ) -> None:
         # Tracks the prefix name stack for nested name generation.
         self._prefix_name_stack: PrefixNameStack = [self.version_string]
         # Tracks the fields on the current path.
@@ -112,6 +121,10 @@ class AvroToMceSchemaConverter:
         if is_key_schema:
             # Helps maintain backwards-compatibility. Annotation for any field that is part of key-schema.
             self._prefix_name_stack.append("[key=True]")
+        # Meta mapping
+        self._meta_mapping_processor = meta_mapping_processor
+        self._schema_tags_field = schema_tags_field
+        self._tag_prefix = tag_prefix
         # Map of avro schema type to the conversion handler
         self._avro_type_to_mce_converter_map: Dict[
             avro.schema.Schema,
@@ -251,12 +264,18 @@ class AvroToMceSchemaConverter:
             converter: "AvroToMceSchemaConverter",
             description: Optional[str] = None,
             default_value: Optional[str] = None,
+            meta_mapping_processor: Optional[OperationProcessor] = None,
+            schema_tags_field: Optional[str] = None,
+            tag_prefix: Optional[str] = None,
         ):
             self._schema = schema
             self._actual_schema = actual_schema
             self._converter = converter
             self._description = description
             self._default_value = default_value
+            self._meta_mapping_processor = meta_mapping_processor
+            self._schema_tags_field = schema_tags_field
+            self._tag_prefix = tag_prefix
 
         def __enter__(self):
             type_annotation = self._converter._get_type_annotation(self._actual_schema)
@@ -317,7 +336,23 @@ class AvroToMceSchemaConverter:
                 merged_props.update(self._schema.other_props)
                 merged_props.update(schema.other_props)
 
-                tags = None
+                # Parse meta_mapping
+                meta_aspects: Dict[str, Any] = {}
+                if self._meta_mapping_processor:
+                    meta_aspects = self._meta_mapping_processor.process(merged_props)
+
+                tags = []
+                if self._schema_tags_field:
+                    for tag in merged_props.get(self._schema_tags_field, []):
+                        tags.append(self._tag_prefix + tag)
+
+                meta_tags_aspect = meta_aspects.get(Constants.ADD_TAG_OPERATION)
+                if meta_tags_aspect:
+                    tags += [
+                        tag_association.tag[len("urn:li:tag:") :]
+                        for tag_association in meta_tags_aspect.tags
+                    ]
+
                 if "deprecated" in merged_props:
                     description = (
                         f"<span style=\"color:red\">DEPRECATED: {merged_props['deprecated']}</span>\n"
@@ -325,9 +360,17 @@ class AvroToMceSchemaConverter:
                         if description
                         else ""
                     )
-                    tags = GlobalTagsClass(
-                        tags=[TagAssociationClass(tag="urn:li:tag:Deprecated")]
-                    )
+                    tags += [
+                        GlobalTagsClass(
+                            tags=[TagAssociationClass(tag="urn:li:tag:Deprecated")]
+                        )
+                    ]
+
+                tags_aspect = None
+                if tags:
+                    tags_aspect = mce_builder.make_global_tag_aspect_with_tag_list(tags)
+
+                meta_terms_aspect = meta_aspects.get(Constants.ADD_TERM_OPERATION)
 
                 logical_type_name: Optional[str] = (
                     # logicalType nested inside type
@@ -349,7 +392,8 @@ class AvroToMceSchemaConverter:
                     recursive=False,
                     nullable=self._converter._is_nullable(schema),
                     isPartOfKey=self._converter._is_key_schema,
-                    globalTags=tags,
+                    globalTags=tags_aspect,
+                    glossaryTerms=meta_terms_aspect,
                     jsonProps=json.dumps(merged_props) if merged_props else None,
                 )
                 yield field
@@ -423,6 +467,9 @@ class AvroToMceSchemaConverter:
             self,
             description,
             last_field_schema.default,
+            self._meta_mapping_processor,
+            self._schema_tags_field,
+            self._tag_prefix,
         ) as f_emit:
             yield from f_emit.emit()
 
@@ -447,7 +494,12 @@ class AvroToMceSchemaConverter:
         actual_schema = self._get_underlying_type_if_option_as_union(schema, schema)
 
         with AvroToMceSchemaConverter.SchemaFieldEmissionContextManager(
-            schema, actual_schema, self
+            schema,
+            actual_schema,
+            self,
+            meta_mapping_processor=self._meta_mapping_processor,
+            schema_tags_field=self._schema_tags_field,
+            tag_prefix=self._tag_prefix,
         ) as fe_schema:
             if isinstance(
                 actual_schema,
@@ -478,7 +530,12 @@ class AvroToMceSchemaConverter:
     ) -> Generator[SchemaField, None, None]:
         """Handles generation of MCE SchemaFields for non-nested AVRO types."""
         with AvroToMceSchemaConverter.SchemaFieldEmissionContextManager(
-            schema, schema, self
+            schema,
+            schema,
+            self,
+            meta_mapping_processor=self._meta_mapping_processor,
+            schema_tags_field=self._schema_tags_field,
+            tag_prefix=self._tag_prefix,
         ) as non_nested_emitter:
             yield from non_nested_emitter.emit()
 
@@ -496,9 +553,12 @@ class AvroToMceSchemaConverter:
     @classmethod
     def to_mce_fields(
         cls,
-        avro_schema_string: str,
+        avro_schema: avro.schema.Schema,
         is_key_schema: bool,
         default_nullable: bool = False,
+        meta_mapping_processor: Optional[OperationProcessor] = None,
+        schema_tags_field: Optional[str] = None,
+        tag_prefix: Optional[str] = None,
     ) -> Generator[SchemaField, None, None]:
         """
         Converts a key or value type AVRO schema string to appropriate MCE SchemaFields.
@@ -506,8 +566,14 @@ class AvroToMceSchemaConverter:
         :param is_key_schema: True if it is a key-schema.
         :return: An MCE SchemaField generator.
         """
-        avro_schema = avro.schema.parse(avro_schema_string)
-        converter = cls(is_key_schema, default_nullable)
+        # avro_schema = avro.schema.parse(avro_schema)
+        converter = cls(
+            is_key_schema,
+            default_nullable,
+            meta_mapping_processor,
+            schema_tags_field,
+            tag_prefix,
+        )
         yield from converter._to_mce_fields(avro_schema)
 
 
@@ -516,28 +582,40 @@ class AvroToMceSchemaConverter:
 
 
 def avro_schema_to_mce_fields(
-    avro_schema_string: str,
+    avro_schema: Union[avro.schema.Schema, str],
     is_key_schema: bool = False,
     default_nullable: bool = False,
+    meta_mapping_processor: Optional[OperationProcessor] = None,
+    schema_tags_field: Optional[str] = None,
+    tag_prefix: Optional[str] = None,
     swallow_exceptions: bool = True,
 ) -> List[SchemaField]:
     """
     Converts an avro schema into schema fields compatible with MCE.
-    :param avro_schema_string: String representation of the AVRO schema.
+    :param avro_schema: AVRO schema, either as a string or as an avro.schema.Schema object.
     :param is_key_schema: True if it is a key-schema. Default is False (value-schema).
     :param swallow_exceptions: True if the caller wants exceptions to be suppressed
+    :param action_processor: Optional OperationProcessor to be used for meta mappings
     :return: The list of MCE compatible SchemaFields.
     """
 
     try:
+        if isinstance(avro_schema, str):
+            avro_schema = avro.schema.parse(avro_schema)
+
         return list(
             AvroToMceSchemaConverter.to_mce_fields(
-                avro_schema_string, is_key_schema, default_nullable
+                avro_schema,
+                is_key_schema,
+                default_nullable,
+                meta_mapping_processor,
+                schema_tags_field,
+                tag_prefix,
             )
         )
     except Exception:
         if swallow_exceptions:
-            logger.exception(f"Failed to parse {avro_schema_string} into mce fields.")
+            logger.exception(f"Failed to parse {avro_schema} into mce fields.")
             return []
         else:
             raise

--- a/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
+++ b/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
@@ -22,7 +22,6 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
     TimeTypeClass,
     UnionTypeClass,
 )
-from datahub.metadata.schema_classes import GlobalTagsClass, TagAssociationClass
 from datahub.utilities.mapping import Constants, OperationProcessor
 
 """A helper file for Avro schema -> MCE schema transformations"""
@@ -341,7 +340,7 @@ class AvroToMceSchemaConverter:
                 if self._meta_mapping_processor:
                     meta_aspects = self._meta_mapping_processor.process(merged_props)
 
-                tags = []
+                tags: List[Any] = []
                 if self._schema_tags_field:
                     for tag in merged_props.get(self._schema_tags_field, []):
                         tags.append(self._tag_prefix + tag)
@@ -360,11 +359,7 @@ class AvroToMceSchemaConverter:
                         if description
                         else ""
                     )
-                    tags += [
-                        GlobalTagsClass(
-                            tags=[TagAssociationClass(tag="urn:li:tag:Deprecated")]
-                        )
-                    ]
+                    tags.append("Deprecated")
 
                 tags_aspect = None
                 if tags:

--- a/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
@@ -2,18 +2,17 @@ import json
 import logging
 from dataclasses import dataclass
 from hashlib import md5
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 import avro.schema
-import confluent_kafka
 import jsonref
 from confluent_kafka.schema_registry.schema_registry_client import (
     RegisteredSchema,
     Schema,
     SchemaReference,
+    SchemaRegistryClient,
 )
 
-from datahub.emitter import mce_builder
 from datahub.ingestion.extractor import protobuf_util, schema_util
 from datahub.ingestion.extractor.json_schema_util import JsonSchemaTranslator
 from datahub.ingestion.extractor.protobuf_util import ProtobufSchema
@@ -24,8 +23,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
     SchemaField,
     SchemaMetadata,
 )
-from datahub.metadata.schema_classes import DatasetPropertiesClass
-from datahub.utilities.mapping import Constants, OperationProcessor
+from datahub.utilities.mapping import OperationProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -49,14 +47,11 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
     ) -> None:
         self.source_config: KafkaSourceConfig = source_config
         self.report: KafkaSourceReport = report
-        # Use the fully qualified name for SchemaRegistryClient to make it mock patchable for testing.
-        self.schema_registry_client = (
-            confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient(
-                {
-                    "url": source_config.connection.schema_registry_url,
-                    **source_config.connection.schema_registry_config,
-                }
-            )
+        self.schema_registry_client = SchemaRegistryClient(
+            {
+                "url": source_config.connection.schema_registry_url,
+                **source_config.connection.schema_registry_config,
+            }
         )
         self.known_schema_registry_subjects: List[str] = []
         try:
@@ -66,12 +61,6 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
         except Exception as e:
             logger.warning(f"Failed to get subjects from schema registry: {e}")
 
-        self.meta_processor = OperationProcessor(
-            self.source_config.meta_mapping,
-            self.source_config.tag_prefix,
-            "SOURCE_CONTROL",
-            self.source_config.strip_user_ids_from_email,
-        )
         self.field_meta_processor = OperationProcessor(
             self.source_config.field_meta_mapping,
             self.source_config.tag_prefix,
@@ -407,46 +396,6 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
         key_schema, key_fields = self._get_schema_and_fields(
             topic=topic, is_key_schema=True
         )  # type:Tuple[Optional[Schema], List[SchemaField]]
-
-        meta_aspects: Dict[str, Any] = {}
-        description = None
-        all_tags: List[str] = []
-
-        if schema is not None:
-            if schema.schema_type == "AVRO":
-                cleaned_str: str = self.get_schema_str_replace_confluent_ref_avro(
-                    schema
-                )
-                avro_schema = avro.schema.parse(cleaned_str)
-                meta_aspects = self.meta_processor.process(avro_schema.other_props)
-                description = avro_schema.doc
-                for tag in avro_schema.other_props.get(
-                    self.source_config.schema_tags_field, []
-                ):
-                    all_tags.append(self.source_config.tag_prefix + tag)
-            elif schema.schema_type == "PROTOBUF":
-                pass  # not implemented
-
-        aspects: List[Any] = []
-        aspects.append(DatasetPropertiesClass(description=description))
-
-        meta_owners_aspects = meta_aspects.get(Constants.ADD_OWNER_OPERATION)
-        if meta_owners_aspects:
-            aspects.append(meta_owners_aspects)
-
-        meta_terms_aspect = meta_aspects.get(Constants.ADD_TERM_OPERATION)
-        if meta_terms_aspect:
-            aspects.append(meta_terms_aspect)
-
-        # Create the tags aspect
-        meta_tags_aspect = meta_aspects.get(Constants.ADD_TAG_OPERATION)
-        if meta_tags_aspect:
-            all_tags += [
-                tag_association.tag[len("urn:li:tag:") :]
-                for tag_association in meta_tags_aspect.tags
-            ]
-        if all_tags:
-            aspects.append(mce_builder.make_global_tag_aspect_with_tag_list(all_tags))
 
         # Create the schemaMetadata aspect.
         if schema is not None or key_schema is not None:

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -89,6 +89,29 @@ class KafkaSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin):
         default="datahub.ingestion.source.confluent_schema_registry.ConfluentSchemaRegistry",
         description="The fully qualified implementation class(custom) that implements the KafkaSchemaRegistryBase interface.",
     )
+    schema_tags_field = pydantic.Field(
+        default="tags",
+        description="The field name in the schema metadata that contains the tags to be added to the dataset.",
+    )
+    enable_meta_mapping = pydantic.Field(
+        default=True,
+        description="When enabled, applies the mappings that are defined through the meta_mapping directives.",
+    )
+    meta_mapping: Dict = pydantic.Field(
+        default={},
+        description="mapping rules that will be executed against top-level schema properties. Refer to the section below on meta automated mappings.",
+    )
+    field_meta_mapping: Dict = pydantic.Field(
+        default={},
+        description="mapping rules that will be executed against field-level schema properties. Refer to the section below on meta automated mappings.",
+    )
+    strip_user_ids_from_email: bool = pydantic.Field(
+        default=False,
+        description="Whether or not to strip email id while adding owners using meta mappings.",
+    )
+    tag_prefix: str = pydantic.Field(
+        default="kafka:", description="Prefix added to tags during ingestion."
+    )
     ignore_warnings_on_schema_type: bool = pydantic.Field(
         default=False,
         description="Disables warnings reported for non-AVRO/Protobuf value or key schemas if set.",

--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -269,7 +269,7 @@ def get_schema_fields_for_hive_column(
             hive_column_name=hive_column_name, hive_column_type=hive_column_type
         )
         schema_fields = avro_schema_to_mce_fields(
-            avro_schema_string=json.dumps(avro_schema_json),
+            avro_schema=json.dumps(avro_schema_json),
             default_nullable=default_nullable,
             swallow_exceptions=False,
         )

--- a/metadata-ingestion/tests/integration/kafka/kafka_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka/kafka_mces_golden.json
@@ -80,6 +80,13 @@
                         "name": "key_topic",
                         "tags": []
                     }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/prod/kafka/key_topic"
+                        ]
+                    }
                 }
             ]
         }
@@ -239,6 +246,13 @@
                         "name": "key_value_topic",
                         "description": "Value schema for kafka topic",
                         "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/prod/kafka/key_value_topic"
+                        ]
                     }
                 }
             ]
@@ -404,6 +418,13 @@
                         "name": "value_topic",
                         "description": "Value schema for kafka topic",
                         "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
+                        "paths": [
+                            "/prod/kafka/value_topic"
+                        ]
                     }
                 }
             ]

--- a/metadata-ingestion/tests/integration/kafka/kafka_mces_golden.json
+++ b/metadata-ingestion/tests/integration/kafka/kafka_mces_golden.json
@@ -80,13 +80,6 @@
                         "name": "key_topic",
                         "tags": []
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
-                        "paths": [
-                            "/prod/kafka/key_topic"
-                        ]
-                    }
                 }
             ]
         }
@@ -246,13 +239,6 @@
                         "name": "key_value_topic",
                         "description": "Value schema for kafka topic",
                         "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
-                        "paths": [
-                            "/prod/kafka/key_value_topic"
-                        ]
                     }
                 }
             ]
@@ -418,13 +404,6 @@
                         "name": "value_topic",
                         "description": "Value schema for kafka topic",
                         "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
-                        "paths": [
-                            "/prod/kafka/value_topic"
-                        ]
                     }
                 }
             ]

--- a/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
+++ b/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
@@ -1,4 +1,8 @@
+import json
 import unittest
+from hashlib import md5
+from itertools import chain
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 from confluent_kafka.schema_registry.schema_registry_client import (
@@ -9,6 +13,14 @@ from confluent_kafka.schema_registry.schema_registry_client import (
 
 from datahub.ingestion.source.confluent_schema_registry import ConfluentSchemaRegistry
 from datahub.ingestion.source.kafka import KafkaSourceConfig, KafkaSourceReport
+from datahub.metadata.schema_classes import (
+    DatasetPropertiesClass,
+    GlobalTagsClass,
+    GlossaryTermsClass,
+    KafkaSchemaClass,
+    OwnershipClass,
+    SchemaMetadataClass,
+)
 
 
 class ConfluentSchemaRegistryTest(unittest.TestCase):
@@ -121,6 +133,237 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
             assert schema_str == ConfluentSchemaRegistry._compact_schema(
                 schema_str_final
             )
+
+    def test_get_schema_metadata_uses_get_aspects_from_schema(self):
+        """Check that get_schema_metadata remains implemented although deprecated."""
+        kafka_source_config = KafkaSourceConfig.parse_obj(
+            {
+                "connection": {
+                    "bootstrap": "localhost:9092",
+                    "schema_registry_url": "http://localhost:8081",
+                },
+            }
+        )
+        confluent_schema_registry = ConfluentSchemaRegistry.create(
+            kafka_source_config, KafkaSourceReport()
+        )
+
+        schema_metadata_aspect = SchemaMetadataClass(
+            schemaName="test",
+            platform="urn:li:platform:test",
+            version=0,
+            hash="test hash",
+            platformSchema=KafkaSchemaClass("test scheama"),
+            fields=[],
+        )
+
+        def new_get_aspects_from_schema(topic: str, platform_urn: str) -> List[Any]:
+            return [DatasetPropertiesClass(name="test"), schema_metadata_aspect]
+
+        with patch.object(
+            confluent_schema_registry,
+            "get_schema_metadata",
+            new_get_aspects_from_schema,
+        ):
+
+            aspects = confluent_schema_registry.get_schema_metadata(
+                topic="test", platform_urn="urn:li:platform:test"
+            )
+
+            # aspects_schema_metaclass = [
+            #     aspect for aspect in aspects if isinstance(aspect, SchemaMetadataClass)
+            # ][0]
+
+            if isinstance(aspects, SchemaMetadataClass):
+                assert aspects == schema_metadata_aspect
+
+    @patch(
+        "datahub.ingestion.source.confluent_schema_registry.confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient",
+        autospec=True,
+    )
+    def test_get_aspects_from_schema_avro(self, mock_schema_registry_client):
+        key_schema_str = json.dumps(
+            {
+                "type": "record",
+                "name": "Topic1Key",
+                "namespace": "test.acryl",
+                "fields": [{"name": "t1key", "type": "string"}],
+            }
+        )
+        value_schema_str = json.dumps(
+            {
+                "type": "record",
+                "name": "TestTopic1Val",
+                "doc": "test dataset description",
+                "owner": "@test-team",
+                "tags": ["tag1", "tag2"],
+                "has_tag3": True,
+                "has_term1": True,
+                "namespace": "test.acryl",
+                "fields": [
+                    {
+                        "name": "field1",
+                        "type": "string",
+                        "doc": "field1 description",
+                        "tags": ["tag1", "tag2"],
+                        "has_tag3": True,
+                        "has_term1": True,
+                    }
+                ],
+            }
+        )
+
+        topic_subject_schema_map: Dict[
+            str, Tuple[RegisteredSchema, RegisteredSchema]
+        ] = {
+            # TopicNameStrategy is used for subject
+            "topic1": (
+                RegisteredSchema(
+                    schema_id="schema_id_2",
+                    schema=Schema(
+                        schema_str=key_schema_str,
+                        schema_type="AVRO",
+                    ),
+                    subject="topic1-key",
+                    version=1,
+                ),
+                RegisteredSchema(
+                    schema_id="schema_id_1",
+                    schema=Schema(
+                        schema_str=value_schema_str,
+                        schema_type="AVRO",
+                    ),
+                    subject="topic1-value",
+                    version=1,
+                ),
+            ),
+        }
+
+        # Mock the schema registry client
+        # - mock get_subjects: all subjects in topic_subject_schema_map
+        mock_schema_registry_client.return_value.get_subjects.return_value = [
+            v.subject for v in chain(*topic_subject_schema_map.values())
+        ]
+
+        # - mock get_latest_version
+        def mock_get_latest_version(subject_name: str) -> Optional[RegisteredSchema]:
+            for registered_schema in chain(*topic_subject_schema_map.values()):
+                if registered_schema.subject == subject_name:
+                    return registered_schema
+            return None
+
+        mock_schema_registry_client.return_value.get_latest_version = (
+            mock_get_latest_version
+        )
+
+        kafka_source_config = KafkaSourceConfig.parse_obj(
+            {
+                "connection": {
+                    "bootstrap": "localhost:9092",
+                    "schema_registry_url": "http://localhost:8081",
+                },
+                "meta_mapping": {
+                    "owner": {
+                        "match": "^@(.*)",
+                        "operation": "add_owner",
+                        "config": {
+                            "owner_type": "group",
+                        },
+                    },
+                    "has_tag3": {
+                        "match": True,
+                        "operation": "add_tag",
+                        "config": {
+                            "tag": "tag3",
+                        },
+                    },
+                    "has_term1": {
+                        "match": True,
+                        "operation": "add_term",
+                        "config": {
+                            "term": "term1",
+                        },
+                    },
+                },
+                "field_meta_mapping": {
+                    "has_tag3": {
+                        "match": True,
+                        "operation": "add_tag",
+                        "config": {
+                            "tag": "tag3",
+                        },
+                    },
+                    "has_term1": {
+                        "match": True,
+                        "operation": "add_term",
+                        "config": {
+                            "term": "term1",
+                        },
+                    },
+                },
+            }
+        )
+        confluent_schema_registry = ConfluentSchemaRegistry.create(
+            kafka_source_config, KafkaSourceReport()
+        )
+
+        aspects = confluent_schema_registry.get_schema_metadata(
+            topic="topic1", platform_urn="urn:li:platform:test"
+        )
+
+        # Check dataset properties aspect
+        if isinstance(aspects, DatasetPropertiesClass):
+            dataset_properties_aspect = aspects
+            assert dataset_properties_aspect.description == "test dataset description"
+
+        # Check owners aspect
+        if isinstance(aspects, OwnershipClass):
+            owners_aspect = aspects
+            assert owners_aspect.owners[0].owner == "urn:li:corpGroup:test-team"
+
+        # Check terms aspects
+        if isinstance(aspects, GlossaryTermsClass):
+            terms_aspect = aspects
+            terms_assoc_values = {term_assoc.urn for term_assoc in terms_aspect.terms}
+            assert terms_assoc_values == {"urn:li:glossaryTerm:term1"}
+
+        # Check tags aspect
+        if isinstance(aspects, GlobalTagsClass):
+            tags_aspect = aspects
+            tags_assoc_values = {tag_assoc.tag for tag_assoc in tags_aspect.tags}
+            # Should include tags from `schema_tags_field` and meta_mapping
+            assert tags_assoc_values == {
+                "urn:li:tag:kafka:tag1",
+                "urn:li:tag:kafka:tag2",
+                "urn:li:tag:kafka:tag3",
+            }
+
+        # Check schema metadata aspect
+        if isinstance(aspects, SchemaMetadataClass):
+            schema_metadata_aspect: SchemaMetadataClass = aspects
+            assert schema_metadata_aspect.schemaName == "topic1"
+            assert schema_metadata_aspect.platform == "urn:li:platform:test"
+            assert (
+                schema_metadata_aspect.hash
+                == md5((value_schema_str + key_schema_str).encode()).hexdigest()
+            )
+            assert isinstance(schema_metadata_aspect.platformSchema, KafkaSchemaClass)
+            assert (
+                schema_metadata_aspect.platformSchema.documentSchema == value_schema_str
+            )
+            assert len(schema_metadata_aspect.fields) == 2
+            field = schema_metadata_aspect.fields[1]  # the value field
+
+        assert isinstance(field.globalTags, GlobalTagsClass)
+        fieldTags = {tag_assoc.tag for tag_assoc in field.globalTags.tags}
+        assert fieldTags == {
+            "urn:li:tag:kafka:tag1",
+            "urn:li:tag:kafka:tag2",
+            "urn:li:tag:kafka:tag3",
+        }
+        assert isinstance(field.glossaryTerms, GlossaryTermsClass)
+        fieldTerms = {term_assoc.urn for term_assoc in field.glossaryTerms.terms}
+        assert fieldTerms == {"urn:li:glossaryTerm:term1"}
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
+++ b/metadata-ingestion/tests/unit/test_confluent_schema_registry.py
@@ -178,7 +178,7 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
                 assert aspects == schema_metadata_aspect
 
     @patch(
-        "datahub.ingestion.source.confluent_schema_registry.confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient",
+        "datahub.ingestion.source.confluent_schema_registry.SchemaRegistryClient",
         autospec=True,
     )
     def test_get_aspects_from_schema_avro(self, mock_schema_registry_client):
@@ -307,6 +307,7 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
             kafka_source_config, KafkaSourceReport()
         )
 
+        aspects: Optional[SchemaMetadataClass]
         aspects = confluent_schema_registry.get_schema_metadata(
             topic="topic1", platform_urn="urn:li:platform:test"
         )
@@ -354,16 +355,16 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
             assert len(schema_metadata_aspect.fields) == 2
             field = schema_metadata_aspect.fields[1]  # the value field
 
-        assert isinstance(field.globalTags, GlobalTagsClass)
-        fieldTags = {tag_assoc.tag for tag_assoc in field.globalTags.tags}
-        assert fieldTags == {
-            "urn:li:tag:kafka:tag1",
-            "urn:li:tag:kafka:tag2",
-            "urn:li:tag:kafka:tag3",
-        }
-        assert isinstance(field.glossaryTerms, GlossaryTermsClass)
-        fieldTerms = {term_assoc.urn for term_assoc in field.glossaryTerms.terms}
-        assert fieldTerms == {"urn:li:glossaryTerm:term1"}
+            assert isinstance(field.globalTags, GlobalTagsClass)
+            fieldTags = {tag_assoc.tag for tag_assoc in field.globalTags.tags}
+            assert fieldTags == {
+                "urn:li:tag:kafka:tag1",
+                "urn:li:tag:kafka:tag2",
+                "urn:li:tag:kafka:tag3",
+            }
+            assert isinstance(field.glossaryTerms, GlossaryTermsClass)
+            fieldTerms = {term_assoc.urn for term_assoc in field.glossaryTerms.terms}
+            assert fieldTerms == {"urn:li:glossaryTerm:term1"}
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -12,6 +12,8 @@ from datahub.emitter.mce_builder import (
     make_dataplatform_instance_urn,
     make_dataset_urn,
     make_dataset_urn_with_platform_instance,
+    make_glossary_terms_aspect_from_urn_list,
+    make_ownership_aspect_from_urn_list,
 )
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -20,6 +22,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.schema_classes import (
     BrowsePathsClass,
     DataPlatformInstanceClass,
+    DatasetPropertiesClass,
     KafkaSchemaClass,
     SchemaMetadataClass,
 )
@@ -209,7 +212,7 @@ def test_close(mock_kafka, mock_admin_client):
 
 
 @patch(
-    "datahub.ingestion.source.confluent_schema_registry.SchemaRegistryClient",
+    "datahub.ingestion.source.kafka.confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient",
     autospec=True,
 )
 @patch("datahub.ingestion.source.kafka.confluent_kafka.Consumer", autospec=True)
@@ -390,7 +393,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
     ],
 )
 @patch(
-    "datahub.ingestion.source.confluent_schema_registry.SchemaRegistryClient",
+    "datahub.ingestion.source.kafka.confluent_kafka.schema_registry.schema_registry_client.SchemaRegistryClient",
     autospec=True,
 )
 @patch("datahub.ingestion.source.kafka.confluent_kafka.Consumer", autospec=True)
@@ -521,3 +524,53 @@ def test_kafka_source_succeeds_with_describe_configs_error(
     mock_admin_client_instance.describe_configs.assert_called_once()
 
     assert len(workunits) == 2
+
+
+@patch("datahub.ingestion.source.kafka.KafkaSource.create_schema_registry")
+@patch("datahub.ingestion.source.kafka.confluent_kafka.Consumer", autospec=True)
+def test_kafka_source_uses_aspects_from_schema(mock_kafka, mock_create_schema_registry):
+    mock_kafka_instance = mock_kafka.return_value
+    mock_cluster_metadata = MagicMock()
+    mock_cluster_metadata.topics = {"test": None, "foobar": None, "bazbaz": None}
+    mock_kafka_instance.list_topics.return_value = mock_cluster_metadata
+
+    ctx = PipelineContext(run_id="test1")
+    kafka_source = KafkaSource.create(
+        {
+            "topic_patterns": {"allow": ["test"]},
+            "connection": {"bootstrap": "localhost:9092"},
+        },
+        ctx,
+    )
+
+    meta_aspects = [
+        make_ownership_aspect_from_urn_list(["urn:li:corpuser:test_user"], "AUDIT"),
+        make_glossary_terms_aspect_from_urn_list(["urn:li:glossaryTerm:testt"]),
+    ]
+
+    mock_create_schema_registry.return_value.get_aspects_from_schema.return_value = [
+        DatasetPropertiesClass(
+            description="test description",
+        ),
+        *meta_aspects,
+    ]
+
+    workunits = [w for w in kafka_source.get_workunits()]
+    assert len(workunits) == 2
+
+    assert isinstance(workunits[0].metadata, MetadataChangeEvent)
+    mce = workunits[0].metadata
+
+    # Assert the DatasetProperties aspect is present and contains proprties from from the topic and the schema
+
+    if isinstance(mce.proposedSnapshot.aspects, DatasetPropertiesClass):
+        dataset_properties = mce.proposedSnapshot.aspects
+
+        assert dataset_properties.name == "test"
+        assert dataset_properties.description == "test description"
+
+    """
+    # Assert the other aspects from the schema are present
+    for aspect in meta_aspects:
+        assert aspect in mce.proposedSnapshot.aspects
+    """

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -227,7 +227,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
             RegisteredSchema(
                 schema_id="schema_id_2",
                 schema=Schema(
-                    schema_str='{"type":"record", "name":"Topic1Key", "namespace": "test.acryl", "fields": [{"name":"t1key", "type": "string"}]}',
+                    schema_str='{"type":"record", "name":"Topic1Key", "namespace": "test.acryl", "fields": [{"name":"t1key", "type": "string","doc": "field1 description", "tags": ["tag1", "tag2"],"has_tag3": True,"has_term1": True,}]}',
                     schema_type="AVRO",
                 ),
                 subject="topic1-key",
@@ -236,7 +236,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
             RegisteredSchema(
                 schema_id="schema_id_1",
                 schema=Schema(
-                    schema_str='{"type":"record", "name":"Topic1Value", "namespace": "test.acryl", "fields": [{"name":"t1value", "type": "string"}]}',
+                    schema_str='{"type":"record", "name":"Topic1Value", "namespace": "test.acryl", "fields": [{"name":"t1value", "type": "string","doc": "field1 description", "tags": ["tag1", "tag2"],"has_tag3": True,"has_term1": True,}]}',
                     schema_type="AVRO",
                 ),
                 subject="topic1-value",
@@ -248,7 +248,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
             RegisteredSchema(
                 schema_id="schema_id_3",
                 schema=Schema(
-                    schema_str='{"type":"record", "name":"Topic2Key", "namespace": "test.acryl", "fields": [{"name":"t2key", "type": "string"}]}',
+                    schema_str='{"type":"record", "name":"Topic2Key", "namespace": "test.acryl", "fields": [{"name":"t2key", "type": "string","doc": "field1 description", "tags": ["tag1", "tag2"],"has_tag3": True,"has_term1": True,}]}',
                     schema_type="AVRO",
                 ),
                 subject="test.acryl.Topic2Key",
@@ -257,7 +257,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
             RegisteredSchema(
                 schema_id="schema_id_4",
                 schema=Schema(
-                    schema_str='{"type":"record", "name":"Topic2Value", "namespace": "test.acryl", "fields": [{"name":"t2value", "type": "string"}]}',
+                    schema_str='{"type":"record", "name":"Topic2Value", "namespace": "test.acryl", "fields": [{"name":"t2value", "type": "string","doc": "field1 description", "tags": ["tag1", "tag2"],"has_tag3": True,"has_term1": True,}]}',
                     schema_type="AVRO",
                 ),
                 subject="test.acryl.Topic2Value",
@@ -269,7 +269,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
             RegisteredSchema(
                 schema_id="schema_id_4",
                 schema=Schema(
-                    schema_str='{"type":"record", "name":"Topic3Key", "namespace": "test.acryl", "fields": [{"name":"t3key", "type": "string"}]}',
+                    schema_str='{"type":"record", "name":"Topic3Key", "namespace": "test.acryl", "fields": [{"name":"t3key", "type": "string","doc": "field1 description", "tags": ["tag1", "tag2"],"has_tag3": True,"has_term1": True,}]}',
                     schema_type="AVRO",
                 ),
                 subject="topic3-test.acryl.Topic3Key-key",
@@ -278,7 +278,7 @@ def test_kafka_source_workunits_schema_registry_subject_name_strategies(
             RegisteredSchema(
                 schema_id="schema_id_5",
                 schema=Schema(
-                    schema_str='{"type":"record", "name":"Topic3Value", "namespace": "test.acryl", "fields": [{"name":"t3value", "type": "string"}]}',
+                    schema_str='{"type":"record", "name":"Topic3Value", "namespace": "test.acryl", "fields": [{"name":"t3value", "type": "string","doc": "field1 description", "tags": ["tag1", "tag2"],"has_tag3": True,"has_term1": True,}]}',
                     schema_type="AVRO",
                 ),
                 subject="topic3-test.acryl.Topic3Value-value",


### PR DESCRIPTION
Integrating this old PR: https://github.com/datahub-project/datahub/pull/7381/files as per current code.

Since Avro permits non-spec field/value pairs, a common pattern is to use this to embed business metadata. Being able to map this directly to DataHub's Owners, Tags, and Terms allows metadata to be kept closer to source, avoiding the need for Data Producers to configure transformers.


## Mapping an Avro list-of-strings to DataHub Tags

Consider the following Avro schema:
```
{
  "name": "sampleRecord",
  "type": "record",
  "tags": ["tag1", "tag2"],
  "fields": [{
    "name": "field_1",
    "type": "string",
    "tags": ["tag3", "tag4"]
  }]
}
```
The following new config allows this to be ingested as DataHub tags:
```
config:
  schema_tags_field: tags
  tag_prefix: kafka
  
```
These config values are currently the default (so they wouldn't actually be needed).

Maybe it would make more sense for the default value of `schema_tags_field` to be something like `_datahub_tags`?

Field-level tags do not automatically become Dataset-level tags.

## Meta-mapping implementation

I've re-used the meta-mapping implementation that already exists for dbt (with a small extension to support referencing nested fields).

Consider the following Avro schema:
```
{
  "name": "sampleRecord",
  "type": "record",
  "owning_team": "@Data-Science",
  "data_tier": "Bronze",
  "fields": [{
    "name": "field_1",
    "type": "string",
    "gdpr": {
      "pii": true
    }
  }]
}
```
This can now be mapped to DataHub metadata with the following config:
```
config:
  meta_mapping:
    owning_team:
      match: "^@(.*)"
      operation: "add_owner"
      config:
        owner_type: group
    data_tier:
      match: "Bronze|Silver|Gold"
      operation: "add_term"
      config:
        term: "{{ $match }}"
  field_meta_mapping:
    gdpr.pii:
      match: true
      operation: "add_tag"
      config:
        tag: "pii"
```

Note the ability to reference nested fields.


Implementation

The implementation is mostly just re-using the OperationProcessor created for the dbt source. Otherwise:

`ConfluentSchemaRegistry(KafkaSchemaRegistryBase)` to support returned multiple Aspects. The original method for backward compatibility.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
