### PR TITLE
fix(metadata-io) fix issue 8740 Most Popular, Recently Viewed and Recen…

### DIFF
--- a/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/AppEndEvent.java
+++ b/metadata-integration/java/spark-lineage/src/main/java/datahub/spark/model/AppEndEvent.java
@@ -3,8 +3,9 @@ package datahub.spark.model;
 import com.linkedin.common.urn.DataFlowUrn;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datajob.DataFlowInfo;
+import com.linkedin.common.Status;
 import datahub.event.MetadataChangeProposalWrapper;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.ToString;
@@ -23,6 +24,8 @@ public class AppEndEvent extends LineageEvent {
 
   @Override
   public List<MetadataChangeProposalWrapper> asMetadataEvents() {
+    ArrayList<MetadataChangeProposalWrapper> mcps = new ArrayList<MetadataChangeProposalWrapper>();
+
     DataFlowUrn flowUrn = LineageUtils.flowUrn(getMaster(), getAppName());
 
     StringMap customProps = start.customProps();
@@ -30,7 +33,14 @@ public class AppEndEvent extends LineageEvent {
 
     DataFlowInfo flowInfo = new DataFlowInfo().setName(getAppName()).setCustomProperties(customProps);
 
-    return Collections.singletonList(MetadataChangeProposalWrapper.create(
+    mcps.add(MetadataChangeProposalWrapper.create(
         b -> b.entityType("dataFlow").entityUrn(flowUrn).upsert().aspect(flowInfo)));
+
+    // set remove status to false to avoid null status
+    Status statusInfo = new Status().setRemoved(false);
+    mcps.add(MetadataChangeProposalWrapper.create(
+        b -> b.entityType("dataFlow").entityUrn(flowUrn).upsert().aspect(statusInfo).aspectName("status")));
+
+    return mcps;
   }
 }

--- a/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/TestSparkJobsLineage.java
+++ b/metadata-integration/java/spark-lineage/src/test/java/datahub/spark/TestSparkJobsLineage.java
@@ -76,7 +76,7 @@ public class TestSparkJobsLineage {
 
   private static final String MASTER = "local";
 
-  private static final int N = 3; // num of GMS requests per spark job
+  private static final int N = 4; // num of GMS requests per spark job
 
   private static final int MOCK_PORT = PortFactory.findFreePort();
   private static final int GMS_PORT = MOCK_GMS ? MOCK_PORT : 8080;

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
@@ -167,4 +167,27 @@ public class EntityUtils {
       return false;
     }
   }
+
+  /**
+   * Check if entity is not existed ('exists' is false or not exist in database)
+   */
+  public static boolean checkIfNotExists(EntityService entityService, Urn entityUrn) {
+    try {
+
+      if (!entityService.exists(entityUrn)) {
+        return true;
+      }
+
+      EnvelopedAspect statusAspect =
+          entityService.getLatestEnvelopedAspect(entityUrn.getEntityType(), entityUrn, "exists");
+      if (statusAspect == null) {
+        return false;
+      } else {
+        return statusAspect.getValue().data().containsValue("false");
+      }
+    } catch (Exception e) {
+      log.error("Error while checking if {} is not existed", entityUrn, e);
+      return true;
+    }
+  }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
@@ -139,7 +139,7 @@ public class MostPopularSource implements RecommendationSource {
 
   private Optional<RecommendationContent> buildContent(@Nonnull String entityUrn) {
     Urn entity = UrnUtils.getUrn(entityUrn);
-    if (EntityUtils.checkIfRemoved(_entityService, entity) || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
+    if (EntityUtils.checkIfNotExists(_entityService,entity) || EntityUtils.checkIfRemoved(_entityService, entity) || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
       return Optional.empty();
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyEditedSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyEditedSource.java
@@ -142,7 +142,7 @@ public class RecentlyEditedSource implements RecommendationSource {
 
   private Optional<RecommendationContent> buildContent(@Nonnull String entityUrn) {
     Urn entity = UrnUtils.getUrn(entityUrn);
-    if (EntityUtils.checkIfRemoved(_entityService, entity) || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
+    if (EntityUtils.checkIfNotExists(_entityService,entity) || EntityUtils.checkIfRemoved(_entityService, entity) || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
       return Optional.empty();
     }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyViewedSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyViewedSource.java
@@ -144,7 +144,7 @@ public class RecentlyViewedSource implements RecommendationSource {
 
   private Optional<RecommendationContent> buildContent(@Nonnull String entityUrn) {
     Urn entity = UrnUtils.getUrn(entityUrn);
-    if (EntityUtils.checkIfRemoved(_entityService, entity) || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
+    if (EntityUtils.checkIfNotExists(_entityService,entity) || EntityUtils.checkIfRemoved(_entityService, entity) || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
Fix issue 8740. Most Popular, Recently Viewed and Recently Edited display entities that hard deleted via CLI


_Within this PR, I also fix  an issue related with spark-lineage that defaulting the 'Removed' flag status of spark ingested datajobs or dataflows to 'false' instead of null._

Please kindly check if i have missed anything for this PR since this is my first contribution to the repository. 

## Checklist

- [✓] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [✓] Links to related issues (if applicable) [https://github.com/datahub-project/datahub/issues/8740](url)
- [✓] Tests for the changes have been added/updated (if applicable)
- [X ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [X] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
