### PR TITLE
fix(ingest): drop `wrap_aspect_as_workunit` method

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mcp_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp_builder.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 from typing import Any, Dict, Iterable, List, Optional, TypeVar
 
-from deprecated import deprecated
 from pydantic.fields import Field
 from pydantic.main import BaseModel
 
@@ -30,7 +29,6 @@ from datahub.metadata.schema_classes import (
     StatusClass,
     SubTypesClass,
     TagAssociationClass,
-    _Aspect,
 )
 
 
@@ -174,23 +172,6 @@ def add_tags_to_entity_wu(
             tags=[TagAssociationClass(f"urn:li:tag:{tag}") for tag in tags]
         ),
     ).as_workunit()
-
-
-@deprecated("use MetadataChangeProposalWrapper(...).as_workunit() instead")
-def wrap_aspect_as_workunit(
-    entityName: str,
-    entityUrn: str,
-    aspectName: str,
-    aspect: _Aspect,
-) -> MetadataWorkUnit:
-    wu = MetadataWorkUnit(
-        id=f"{aspectName}-for-{entityUrn}",
-        mcp=MetadataChangeProposalWrapper(
-            entityUrn=entityUrn,
-            aspect=aspect,
-        ),
-    )
-    return wu
 
 
 def gen_containers(


### PR DESCRIPTION
It's been deprecated for 8 months.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
