### PR TITLE
fix(siblings): space icons out

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
@@ -14,6 +14,7 @@ import ParentNodesView, {
 
 const LogoIcon = styled.span`
     display: flex;
+    gap: 4px;
     margin-right: 8px;
 `;
 

--- a/datahub-web-react/src/app/search/autoComplete/AutoCompleteEntity.tsx
+++ b/datahub-web-react/src/app/search/autoComplete/AutoCompleteEntity.tsx
@@ -20,6 +20,7 @@ const AutoCompleteEntityWrapper = styled.div`
 
 const IconsContainer = styled.div`
     display: flex;
+    gap: 4px;
 `;
 
 const ContentWrapper = styled.div`


### PR DESCRIPTION
A couple of notes for this PR:
* Search cards suffered from the same icon spacing issue as the new siblings autocomplete that was shown at town hall. The reason it was missed is that dbt/bigquery combo look fine together due to the unique design of those icons.
* I remember why I didn't reuse the search card logo component. It's currently a bit of tangled up component handling a lot of different icon rendering scenarios for different props (entityLogoComponent, platformLogoUrl, platformLogoUrls) and digging in and consolidating all of that would've taken more time than I had available for this project. For another day I suppose!

Search card after:
<img width="878" alt="Screenshot 2023-08-31 at 4 59 29 PM" src="https://github.com/datahub-project/datahub/assets/2107911/fb300502-56f7-4649-a3b9-bb4222eca458">

Autocomplete after:
<img width="668" alt="Screenshot 2023-08-31 at 4 59 36 PM" src="https://github.com/datahub-project/datahub/assets/2107911/c64b2b78-4a3f-4474-b626-2f0e944b21ae">

---

Autocomplete before:
<img width="674" alt="Screenshot 2023-08-31 at 4 57 26 PM" src="https://github.com/datahub-project/datahub/assets/2107911/72641013-7566-4cec-a9df-9a5f7dff0d9c">

Search card before:
<img width="1252" alt="Screenshot 2023-08-31 at 4 57 19 PM" src="https://github.com/datahub-project/datahub/assets/2107911/7b653808-22b2-4510-bbe9-1aa6fd3ef9e1">