### PR TITLE
fix(frontend): Fix"Logout with OIDC not working"

### DIFF
--- a/datahub-frontend/app/controllers/CentralLogoutController.java
+++ b/datahub-frontend/app/controllers/CentralLogoutController.java
@@ -16,7 +16,8 @@ import java.nio.charset.StandardCharsets;
  */
 @Slf4j
 public class CentralLogoutController extends LogoutController {
-  private static final String DEFAULT_BASE_URL_PATH = "/login";
+  private static final String AUTH_URL_CONFIG_PATH = "/login";
+  private static final String DEFAULT_BASE_URL_PATH = "/";
   private static Boolean _isOidcEnabled = false;
 
   @Inject
@@ -36,8 +37,7 @@ public class CentralLogoutController extends LogoutController {
   public Result executeLogout(Http.Request request) {
     if (_isOidcEnabled) {
       try {
-        return Results.redirect(DEFAULT_BASE_URL_PATH)
-                .removingFromSession(request);
+        return logout(request).toCompletableFuture().get().withNewSession();
       } catch (Exception e) {
         log.error("Caught exception while attempting to perform SSO logout! It's likely that SSO integration is mis-configured.", e);
         return redirect(
@@ -47,7 +47,7 @@ public class CentralLogoutController extends LogoutController {
         .withNewSession();
       }
     }
-    return Results.redirect(DEFAULT_BASE_URL_PATH)
+    return Results.redirect(AUTH_URL_CONFIG_PATH)
             .withNewSession();
   }
 }


### PR DESCRIPTION
The logout action used to clear the session but did not trigger SSO to deactivate the token. Therefore, when the session was cleared, the user remained logged into the system.
Fixed issue #8369

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
