### PR TITLE
docs: minor fix on versioning navbar and dropdown

### DIFF
--- a/docs-website/src/pages/docs/_components/SearchBar/index.jsx
+++ b/docs-website/src/pages/docs/_components/SearchBar/index.jsx
@@ -18,8 +18,8 @@ import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 import { usePluralForm, useEvent } from "@docusaurus/theme-common";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { useAllDocsData } from "@docusaurus/plugin-content-docs/client";
-import { useSearchQueryString } from '@docusaurus/theme-common';
-import {useTitleFormatter} from '@docusaurus/theme-common/internal';
+import { useSearchQueryString } from "@docusaurus/theme-common";
+import { useTitleFormatter } from "@docusaurus/theme-common/internal";
 import Translate, { translate } from "@docusaurus/Translate";
 import styles from "./search.module.scss";
 
@@ -48,7 +48,7 @@ function useDocsSearchVersionsHelpers() {
   // docsPluginId -> versionName map
   const [searchVersions, setSearchVersions] = useState(() => {
     return Object.entries(allDocsData).reduce((acc, [pluginId, pluginData]) => {
-      return { ...acc, [pluginId]: pluginData.versions[0].name };
+      return { ...acc, [pluginId]: pluginData.versions?.[1].name };
     }, {});
   });
 
@@ -70,11 +70,11 @@ const SearchVersionSelectList = ({ docsSearchVersionsHelpers }) => {
   const versionedPluginEntries = Object.entries(docsSearchVersionsHelpers.allDocsData)
     // Do not show a version select for unversioned docs plugin instances
     .filter(([, docsData]) => docsData.versions.length > 1);
-
   return (
-    <div className={clsx("col", "col--3", "padding-left--none", styles.searchVersionColumn)}>
+    <>
       {versionedPluginEntries.map(([pluginId, docsData]) => {
         const labelPrefix = versionedPluginEntries.length > 1 ? `${pluginId}: ` : "";
+
         return (
           <select
             key={pluginId}
@@ -88,7 +88,7 @@ const SearchVersionSelectList = ({ docsSearchVersionsHelpers }) => {
           </select>
         );
       })}
-    </div>
+    </>
   );
 };
 
@@ -274,46 +274,41 @@ function SearchBar() {
   return (
     <div className="DocSearch row">
       <div className="col col--offset-3 col--6">
-        <form onSubmit={(e) => e.preventDefault()} className={styles.searchForm}>
-          <input
-            type="search"
-            name="q"
-            className={styles.searchQueryInput}
-            placeholder={translate({
-              id: "theme.SearchPage.inputPlaceholder",
-              message: "Search the docs",
-              description: "The placeholder for search page input",
-            })}
-            aria-label={translate({
-              id: "theme.SearchPage.inputLabel",
-              message: "Search",
-              description: "The ARIA label for search page input",
-            })}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            value={searchQuery}
-            autoComplete="off"
-            autoFocus
-          />
-          <svg width="20" height="20" className={clsx("DocSearch-Search-Icon", styles.searchIcon)} viewBox="0 0 20 20">
-            <path
-              d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z"
-              stroke="currentColor"
-              fill="none"
-              fillRule="evenodd"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            ></path>
-          </svg>
-        </form>
-        {docsSearchVersionsHelpers.versioningEnabled && (
-          <SearchVersionSelectList
-            docsSearchVersionsHelpers={docsSearchVersionsHelpers}
-          />
-        )}
-        <div className={styles.searchResultsColumn}>
-          {!!searchResultState.totalResults &&
-            documentsFoundPlural(searchResultState.totalResults)}
+        <div className={styles.searchHeader}>
+          <form onSubmit={(e) => e.preventDefault()} className={styles.searchForm}>
+            <input
+              type="search"
+              name="q"
+              className={styles.searchQueryInput}
+              placeholder={translate({
+                id: "theme.SearchPage.inputPlaceholder",
+                message: "Search the docs",
+                description: "The placeholder for search page input",
+              })}
+              aria-label={translate({
+                id: "theme.SearchPage.inputLabel",
+                message: "Search",
+                description: "The ARIA label for search page input",
+              })}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              value={searchQuery}
+              autoComplete="off"
+              autoFocus
+            />
+            <svg width="20" height="20" className={clsx("DocSearch-Search-Icon", styles.searchIcon)} viewBox="0 0 20 20">
+              <path
+                d="M14.386 14.386l4.0877 4.0877-4.0877-4.0877c-2.9418 2.9419-7.7115 2.9419-10.6533 0-2.9419-2.9418-2.9419-7.7115 0-10.6533 2.9418-2.9419 7.7115-2.9419 10.6533 0 2.9419 2.9418 2.9419 7.7115 0 10.6533z"
+                stroke="currentColor"
+                fill="none"
+                fillRule="evenodd"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              ></path>
+            </svg>
+          </form>
+          {docsSearchVersionsHelpers.versioningEnabled && <SearchVersionSelectList docsSearchVersionsHelpers={docsSearchVersionsHelpers} />}
         </div>
+        <div className={styles.searchResultsColumn}>{!!searchResultState.totalResults && documentsFoundPlural(searchResultState.totalResults)}</div>
 
         {searchResultState.items.length > 0 ? (
           <main>

--- a/docs-website/src/pages/docs/_components/SearchBar/search.module.scss
+++ b/docs-website/src/pages/docs/_components/SearchBar/search.module.scss
@@ -5,9 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+.searchHeader {
+  display: flex;
+  gap: 0.8rem;
+}
+
 .searchForm {
   position: relative;
-
+  flex: 1;
   &:focus + svg {
     color: red;
   }
@@ -23,11 +28,16 @@
 
 .searchQueryInput {
   padding: 0.8rem 0.8rem 0.8rem 3rem;
+  width: 100%;
 }
 
 .searchVersionInput {
-  padding: 0.8rem 2rem 0.8rem 2rem;
-  text-align: center;
+  padding: 0.8rem 2rem 0.8rem 0.8rem;
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 0.6rem center;
+  background-size: 1em;
 }
 
 .searchQueryInput,
@@ -36,14 +46,13 @@
   border-style: solid;
   border-color: transparent;
   font: var(--ifm-font-size-base) var(--ifm-font-family-base);
-  width: 100%;
-  background: var(--docsearch-searchbox-background);
+  background-color: var(--docsearch-searchbox-background);
   color: var(--docsearch-text-color);
   margin-bottom: 0.5rem;
   transition: border var(--ifm-transition-fast) ease;
 
   &:focus {
-    background: var(--ifm-background-color);
+    background-color: var(--ifm-background-color);
 
     + svg {
       color: var(--docsearch-primary-color);
@@ -99,11 +108,6 @@
 }
 
 @media only screen and (max-width: 996px) {
-  .searchVersionColumn {
-    max-width: 40% !important;
-    margin: auto;
-  }
-
   .searchResultsColumn {
     max-width: 60% !important;
   }
@@ -129,7 +133,6 @@
 .searchVersionColumn {
   margin: auto;
 }
-
 
 .loadingSpinner {
   width: 3rem;

--- a/docs-website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/docs-website/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,70 @@
+import React from "react";
+import { useVersions, useActiveDocContext } from "@docusaurus/plugin-content-docs/client";
+import { useDocsPreferredVersion } from "@docusaurus/theme-common";
+import { useDocsVersionCandidates } from "@docusaurus/theme-common/internal";
+import { translate } from "@docusaurus/Translate";
+import { useLocation } from "@docusaurus/router";
+import DefaultNavbarItem from "@theme/NavbarItem/DefaultNavbarItem";
+import DropdownNavbarItem from "@theme/NavbarItem/DropdownNavbarItem";
+const getVersionMainDoc = (version) => version.docs.find((doc) => doc.id === version.mainDocId);
+export default function DocsVersionDropdownNavbarItem({
+  mobile,
+  docsPluginId,
+  dropdownActiveClassDisabled,
+  dropdownItemsBefore,
+  dropdownItemsAfter,
+  ...props
+}) {
+  const { search, hash } = useLocation();
+  const activeDocContext = useActiveDocContext(docsPluginId);
+  const versions = useVersions(docsPluginId);
+  const { savePreferredVersionName } = useDocsPreferredVersion(docsPluginId);
+  const versionLinks = versions.map((version) => {
+    // We try to link to the same doc, in another version
+    // When not possible, fallback to the "main doc" of the version
+    const versionDoc = activeDocContext.alternateDocVersions[version.name] ?? getVersionMainDoc(version);
+    return {
+      label: version.label,
+      // preserve ?search#hash suffix on version switches
+      to: `${versionDoc.path}${search}${hash}`,
+      isActive: () => version === activeDocContext.activeVersion,
+      onClick: () => savePreferredVersionName(version.name),
+    };
+  });
+  const items = [...dropdownItemsBefore, ...versionLinks, ...dropdownItemsAfter];
+  const dropdownVersion = useDocsVersionCandidates(docsPluginId)[0];
+  // Mobile dropdown is handled a bit differently
+  const dropdownLabel =
+    mobile && items.length > 1
+      ? translate({
+          id: "theme.navbar.mobileVersionsDropdown.label",
+          message: "Versions",
+          description: "The label for the navbar versions dropdown on mobile view",
+        })
+      : dropdownVersion.label;
+  const dropdownTo = mobile && items.length > 1 ? undefined : getVersionMainDoc(dropdownVersion).path;
+  // We don't want to render a version dropdown with 0 or 1 item. If we build
+  // the site with a single docs version (onlyIncludeVersions: ['1.0.0']),
+  // We'd rather render a button instead of a dropdown
+  if (items.length <= 1) {
+    return (
+      <DefaultNavbarItem
+        {...props}
+        mobile={mobile}
+        label={dropdownLabel}
+        to={dropdownTo}
+        isActive={dropdownActiveClassDisabled ? () => false : undefined}
+      />
+    );
+  }
+  return (
+    <DropdownNavbarItem
+      {...props}
+      mobile={mobile}
+      label={dropdownLabel}
+      to={false} // This component is Swizzled to disable the link here
+      items={items}
+      isActive={dropdownActiveClassDisabled ? () => false : undefined}
+    />
+  );
+}


### PR DESCRIPTION
A couple of fixes for the docs website versioning:
1. Swizzles the `DocsVersionDropdownNavbarItem` component in order to disable the link on the primary nav item. Clicking the version nav item now just opens the dropdown instead of linking anywhere.
2. Changes the default selected version in the search dropdown on the docs homepage. Since the docs homepage is actually a custom page and not versioned, we can't know the selected version as there is none. The active version displayed in the nav will always be the `latest` version. So we just select the second version available in the dropdown by default instead of the first. May need to revisit when another version is added to confirm. Styles for version dropdown also updated to make it look nicer.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
