### PR TITLE
chore(kafka): update kafka library dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
   ext.slf4jVersion = '1.7.36'
   ext.logbackClassic = '1.2.12'
   ext.hadoop3Version = '3.3.5'
-  ext.kafkaVersion = '2.3.0'
+  ext.kafkaVersion = '5.5.15'
   ext.hazelcastVersion = '5.3.1'
   ext.ebeanVersion = '12.16.1'
 
@@ -136,9 +136,9 @@ project.ext.externalDependency = [
     'junitJupiterParams': "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion",
     'junitJupiterEngine': "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion",
     // avro-serde includes dependencies for `kafka-avro-serializer` `kafka-schema-registry-client` and `avro`
-    'kafkaAvroSerde': 'io.confluent:kafka-streams-avro-serde:5.5.1',
-    'kafkaAvroSerializer': 'io.confluent:kafka-avro-serializer:5.1.4',
-    'kafkaClients': "org.apache.kafka:kafka-clients:$kafkaVersion",
+    'kafkaAvroSerde': "io.confluent:kafka-streams-avro-serde:$kafkaVersion",
+    'kafkaAvroSerializer': "io.confluent:kafka-avro-serializer:$kafkaVersion",
+    'kafkaClients': "org.apache.kafka:kafka-clients:$kafkaVersion-ccs",
     'snappy': 'org.xerial.snappy:snappy-java:1.1.10.3',
     'logbackClassic': "ch.qos.logback:logback-classic:$logbackClassic",
     'slf4jApi': "org.slf4j:slf4j-api:$slf4jVersion",

--- a/datahub-upgrade/build.gradle
+++ b/datahub-upgrade/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   // mock internal schema registry
   implementation externalDependency.kafkaAvroSerde
   implementation externalDependency.kafkaAvroSerializer
-  implementation "org.apache.kafka:kafka_2.12:$kafkaVersion"
+  implementation "org.apache.kafka:kafka_2.12:$kafkaVersion-ccs"
 
   implementation externalDependency.slf4jApi
   compileOnly externalDependency.lombok

--- a/metadata-integration/java/datahub-client/build.gradle
+++ b/metadata-integration/java/datahub-client/build.gradle
@@ -129,6 +129,7 @@ shadowJar {
   relocate 'common.message', 'datahub.shaded.common.message'
   relocate 'org.glassfish', 'datahub.shaded.org.glassfish'
   relocate 'ch.randelshofer', 'datahub.shaded.ch.randelshofer'
+  relocate 'org.yaml', 'datahub.shaded.org.yaml'
 
   finalizedBy checkShadowJar
 }

--- a/metadata-jobs/mae-consumer/build.gradle
+++ b/metadata-jobs/mae-consumer/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     implementation externalDependency.elasticSearchRest
     implementation externalDependency.kafkaAvroSerde
+    implementation externalDependency.javaxInject
     implementation externalDependency.protobuf
     implementation externalDependency.neo4jJavaDriver
 


### PR DESCRIPTION
It was found that for most modules we were using the confluent ccs licensed kafka library. This makes it consistent and avoids a vulnerability problem with the apache lib. A few transitive dependencies changed requiring a javax import and a snakeyaml relocation (both were present previously).

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
