### PR TITLE
Glossary Navigation Cypress test

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
@@ -1,6 +1,6 @@
 const glossaryTerm = "CypressGlosssaryNavigationTerm";
 const glossaryTermGroup = "CypressGlosssaryNavigationGroup";
-const glossaryParentGroup = "CypressGlosssaryGroup";
+const glossaryParentGroup = "Cypress";
 
 describe("glossary sidebar navigation test", () => {
     it("create term and term parent group, move and delete term group", () => {
@@ -8,10 +8,14 @@ describe("glossary sidebar navigation test", () => {
         cy.loginWithCredentials();
         cy.goToGlossaryList();
         cy.clickOptionWithText("Add Term Group");
-        cy.addViaModal(glossaryTermGroup, "Create Term Group");
+        cy.waitTextVisible("Create Term Group");
+        cy.get(".ant-input-affix-wrapper > input[type='text']").first().type(glossaryTermGroup);
+        cy.get(".ant-modal-footer > button:last-child").click();
         cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).should("be.visible");
         cy.clickOptionWithText("Add Term");
-        cy.addViaModal(glossaryTerm, "Create Glossary Term");
+        cy.waitTextVisible("Create Glossary Term");
+        cy.get(".ant-input-affix-wrapper > input[type='text']").first().type(glossaryTerm);
+        cy.get(".ant-modal-footer > button:last-child").click();
         cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTerm).click();
         cy.waitTextVisible("No documentation yet");
         cy.openThreeDotDropdown();

--- a/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
@@ -1,0 +1,57 @@
+const glossaryTerm = "CypressGlosssaryNavigationTerm";
+const glossaryTermGroup = "CypressGlosssaryNavigationGroup";
+const glossaryParentGroup = "CypressGlosssaryGroup";
+
+describe("glossary sidebar navigation test", () => {
+    it("create term and term parent group, move and delete term group", () => {
+        //create a new term group and term, move term to the group
+        cy.loginWithCredentials();
+        cy.goToGlossaryList();
+        cy.clickOptionWithText("Add Term Group");
+        cy.addViaAffixModal(glossaryTermGroup, "Create Term Group");
+        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).should("be.visible");
+        cy.clickOptionWithText("Add Term");
+        cy.addViaAffixModal(glossaryTerm, "Create Glossary Term");
+        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTerm).click();
+        cy.waitTextVisible("No documentation yet");
+        cy.openThreeDotDropdown();
+        cy.clickOptionWithText("Move");
+        cy.get('[role="dialog"] [data-icon="close-circle"]').click({force: true});
+        cy.get('[role="dialog"]').contains(glossaryTermGroup).click();
+        cy.get('[role="dialog"]').contains(glossaryTermGroup).should("be.visible");
+        cy.get("button").contains("Move").click();
+        cy.waitTextVisible("Moved Glossary Term!");
+        //ensure the new term is under the parent term group in the navigation sidebar
+        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).click();
+        cy.get('*[class^="GlossaryEntitiesList"]').contains(glossaryTerm).should("be.visible");
+        cy.get('*[class^="GlossaryBrowser"] [aria-label="down"]').click().wait(1000);
+        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTerm).should("not.exist");
+        //move a term group from the root level to be under a parent term group
+        cy.goToGlossaryList();
+        cy.clickOptionWithText(glossaryTermGroup);
+        cy.openThreeDotDropdown();
+        cy.clickOptionWithText("Move");
+        cy.get('[role="dialog"] [data-icon="close-circle"]').click({force: true});
+        cy.get('[role="dialog"]').contains(glossaryParentGroup).click();
+        cy.get('[role="dialog"]').contains(glossaryParentGroup).should("be.visible");
+        cy.get("button").contains("Move").click();
+        cy.waitTextVisible("Moved Term Group!");
+        //ensure it is no longer on the sidebar navigator at the top level but shows up under the new parent
+        cy.get('*[class^="GlossaryBrowser"] [aria-label="down"]').click().wait(1000);
+        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).should("not.exist");
+        //delete a term group
+        cy.goToGlossaryList();
+        cy.clickOptionWithText(glossaryParentGroup);
+        cy.clickOptionWithText(glossaryTermGroup);
+        cy.clickOptionWithText(glossaryTerm).wait(3000);
+        cy.deleteFromDropdown();
+        cy.waitTextVisible("Deleted Glossary Term!");
+        cy.clickOptionWithText(glossaryParentGroup);
+        cy.clickOptionWithText(glossaryTermGroup).wait(3000);
+        cy.deleteFromDropdown();
+        cy.waitTextVisible("Deleted Term Group!");
+        //ensure it is no longer in the sidebar navigator
+        cy.ensureTextNotPresent(glossaryTerm);
+        cy.ensureTextNotPresent(glossaryTermGroup);
+    });
+});

--- a/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
@@ -8,10 +8,10 @@ describe("glossary sidebar navigation test", () => {
         cy.loginWithCredentials();
         cy.goToGlossaryList();
         cy.clickOptionWithText("Add Term Group");
-        cy.addViaAffixModal(glossaryTermGroup, "Create Term Group");
+        cy.addViaModal(glossaryTermGroup, "Create Term Group");
         cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).should("be.visible");
         cy.clickOptionWithText("Add Term");
-        cy.addViaAffixModal(glossaryTerm, "Create Glossary Term");
+        cy.addViaModal(glossaryTerm, "Create Glossary Term");
         cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTerm).click();
         cy.waitTextVisible("No documentation yet");
         cy.openThreeDotDropdown();


### PR DESCRIPTION
Test steps:
1. create a new term group and term, move term to the group
2. ensure the new term is under the parent term group in the navigation sidebar
3. move a term group from the root level to be under a parent
4. ensure it is no longer on the sidebar navigator at the top level but shows up under the new parent
5. delete a term group
6. ensure it is no longer in the sidebar navigator

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
