### PR TITLE
fix(index): Do not override the search analyzer for ngram fields

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/MappingsBuilder.java
@@ -121,8 +121,7 @@ public class MappingsBuilder {
             String analyzerName = entry.getValue();
             subFields.put(fieldName, ImmutableMap.of(
                 TYPE, TEXT,
-                ANALYZER, analyzerName,
-                SEARCH_ANALYZER, analyzerName
+                ANALYZER, analyzerName
             ));
           }
         }


### PR DESCRIPTION
Using the same analyzer for the index and search is already the default: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-analyzer.html
`By default, queries will use the analyzer defined in the field mapping`

So, no need to specify it explicitly, and doing so causes the system update job to detect a difference between the field as exists in ES and the defined mapping when there isn't one.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
