### PR TITLE
feat(cli): fix upload ingest cli endpoint

### DIFF
--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -282,11 +282,13 @@ def deploy(
         "urn": urn,
         "name": name,
         "type": pipeline_config["source"]["type"],
-        "schedule": {"interval": schedule, "timezone": time_zone},
         "recipe": json.dumps(pipeline_config),
         "executorId": executor_id,
         "version": cli_version,
     }
+
+    if schedule is not None:
+        variables["schedule"] = {"interval": schedule, "timezone": time_zone}
 
     if urn:
         if not datahub_graph.exists(urn):
@@ -331,6 +333,7 @@ def deploy(
                 $version: String) {
 
                 createIngestionSource(input: {
+                    name: $name,
                     type: $type,
                     schedule: $schedule,
                     config: {


### PR DESCRIPTION
Corrects graphQL query for uploading an ingestion recipe for the first time. Also removes the schedule parameter as the input when it is not specified.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
