### PR TITLE
fix(java) Update DataProductMapper to always return a name

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataproduct/mappers/DataProductMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataproduct/mappers/DataProductMapper.java
@@ -50,7 +50,8 @@ public class DataProductMapper implements ModelMapper<EntityResponse, DataProduc
 
     EnvelopedAspectMap aspectMap = entityResponse.getAspects();
     MappingHelper<DataProduct> mappingHelper = new MappingHelper<>(aspectMap, result);
-    mappingHelper.mapToResult(DATA_PRODUCT_PROPERTIES_ASPECT_NAME, this::mapDataProductProperties);
+    mappingHelper.mapToResult(DATA_PRODUCT_PROPERTIES_ASPECT_NAME, (dataProduct, dataMap) ->
+        mapDataProductProperties(dataProduct, dataMap, entityUrn));
     mappingHelper.mapToResult(GLOBAL_TAGS_ASPECT_NAME, (dataProduct, dataMap) ->
         dataProduct.setTags(GlobalTagsMapper.map(new GlobalTags(dataMap), entityUrn)));
     mappingHelper.mapToResult(GLOSSARY_TERMS_ASPECT_NAME, (dataProduct, dataMap) ->
@@ -65,11 +66,12 @@ public class DataProductMapper implements ModelMapper<EntityResponse, DataProduc
     return result;
   }
 
-  private void mapDataProductProperties(@Nonnull DataProduct dataProduct, @Nonnull DataMap dataMap) {
+  private void mapDataProductProperties(@Nonnull DataProduct dataProduct, @Nonnull DataMap dataMap, @Nonnull Urn urn) {
     DataProductProperties dataProductProperties = new DataProductProperties(dataMap);
     com.linkedin.datahub.graphql.generated.DataProductProperties properties = new com.linkedin.datahub.graphql.generated.DataProductProperties();
 
-    properties.setName(dataProductProperties.getName());
+    String name = dataProductProperties.hasName() ? dataProductProperties.getName() : urn.getId();
+    properties.setName(name);
     properties.setDescription(dataProductProperties.getDescription());
     if (dataProductProperties.hasExternalUrl()) {
       properties.setExternalUrl(dataProductProperties.getExternalUrl().toString());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataproduct/mappers/DataProductMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataproduct/mappers/DataProductMapper.java
@@ -70,7 +70,7 @@ public class DataProductMapper implements ModelMapper<EntityResponse, DataProduc
     DataProductProperties dataProductProperties = new DataProductProperties(dataMap);
     com.linkedin.datahub.graphql.generated.DataProductProperties properties = new com.linkedin.datahub.graphql.generated.DataProductProperties();
 
-    String name = dataProductProperties.hasName() ? dataProductProperties.getName() : urn.getId();
+    final String name = dataProductProperties.hasName() ? dataProductProperties.getName() : urn.getId();
     properties.setName(name);
     properties.setDescription(dataProductProperties.getDescription());
     if (dataProductProperties.hasExternalUrl()) {


### PR DESCRIPTION
If someone creates a Data Product without a name (not possible through the UI but is possible in the model) we need to return something for the name and not null since graphql and the frontend are always expecting it. If we get in this weird situation, just return the ID of the urn instead.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
