### PR TITLE
Fix for edit_documentation and glossary_navigation cypress tests

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
@@ -28,8 +28,6 @@ describe("glossary sidebar navigation test", () => {
         //ensure the new term is under the parent term group in the navigation sidebar
         cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).click();
         cy.get('*[class^="GlossaryEntitiesList"]').contains(glossaryTerm).should("be.visible");
-        cy.get('*[class^="GlossaryBrowser"] [aria-label="down"]').click().wait(1000);
-        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTerm).should("not.exist");
         //move a term group from the root level to be under a parent term group
         cy.goToGlossaryList();
         cy.clickOptionWithText(glossaryTermGroup);
@@ -41,8 +39,8 @@ describe("glossary sidebar navigation test", () => {
         cy.get("button").contains("Move").click();
         cy.waitTextVisible("Moved Term Group!");
         //ensure it is no longer on the sidebar navigator at the top level but shows up under the new parent
-        cy.get('*[class^="GlossaryBrowser"] [aria-label="down"]').click().wait(1000);
-        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryTermGroup).should("not.exist");
+        cy.get('*[class^="GlossaryBrowser"]').contains(glossaryParentGroup).click();
+        cy.get('*[class^="GlossaryEntitiesList"]').contains(glossaryTermGroup).should("be.visible");
         //delete a term group
         cy.goToGlossaryList();
         cy.clickOptionWithText(glossaryParentGroup);

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
@@ -37,8 +37,8 @@ describe("edit documentation and link to dataset", () => {
     cy.contains("Sample doc").trigger("mouseover", { force: true });
     cy.get('[data-icon="delete"]').click();
     cy.waitTextVisible("Link Removed");
-    cy.get("button").contains("Add Link").click();
-    cy.get("#addLinkForm_url").type(wrong_url);
+    cy.get("button").contains("Add Link").click().wait(1000);
+    cy.get('[role="dialog"] #addLinkForm_url').type(wrong_url);
     cy.waitTextVisible("This field must be a valid url.");
     cy.focused().clear();
     cy.waitTextVisible("A URL is required.");
@@ -54,9 +54,9 @@ describe("edit documentation and link to dataset", () => {
   it("open test domain page, remove and add dataset link", () => {
     cy.loginWithCredentials();
     cy.visit("/domain/urn:li:domain:marketing/Entities");
-    cy.get("[role='tab']").contains("Documentation").click();
-    cy.get("button").contains("Add Link").click();
-    cy.get("#addLinkForm_url").type(wrong_url);
+    cy.waitTextVisible("SampleCypressKafkaDataset");
+    cy.get("button").contains("Add Link").click().wait(1000);
+    cy.get('[role="dialog"] #addLinkForm_url').type(wrong_url);
     cy.waitTextVisible("This field must be a valid url.");
     cy.focused().clear();
     cy.waitTextVisible("A URL is required.");
@@ -66,6 +66,7 @@ describe("edit documentation and link to dataset", () => {
     cy.get('[role="dialog"] button').contains("Add").click();
     cy.waitTextVisible("Link Added");
     cy.get("[role='tab']").contains("Documentation").click();
+    cy.waitTextVisible("Edit");
     cy.get(`[href='${correct_url}']`).should("be.visible");
     cy.contains("Sample doc").trigger("mouseover", { force: true });
     cy.get('[data-icon="delete"]').click();


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
