### PR TITLE
Fix glossary_navigation.js

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
@@ -20,8 +20,7 @@ describe("glossary sidebar navigation test", () => {
         cy.waitTextVisible("No documentation yet");
         cy.openThreeDotDropdown();
         cy.clickOptionWithText("Move");
-        cy.get('[role="dialog"] [data-icon="close-circle"]').click({force: true});
-        cy.get('[role="dialog"]').contains(glossaryTermGroup).click();
+        cy.get('[role="dialog"]').contains(glossaryTermGroup).click({force: true});
         cy.get('[role="dialog"]').contains(glossaryTermGroup).should("be.visible");
         cy.get("button").contains("Move").click();
         cy.waitTextVisible("Moved Glossary Term!");
@@ -33,8 +32,7 @@ describe("glossary sidebar navigation test", () => {
         cy.clickOptionWithText(glossaryTermGroup);
         cy.openThreeDotDropdown();
         cy.clickOptionWithText("Move");
-        cy.get('[role="dialog"] [data-icon="close-circle"]').click({force: true});
-        cy.get('[role="dialog"]').contains(glossaryParentGroup).click();
+        cy.get('[role="dialog"]').contains(glossaryParentGroup).click({force: true});
         cy.get('[role="dialog"]').contains(glossaryParentGroup).should("be.visible");
         cy.get("button").contains("Move").click();
         cy.waitTextVisible("Moved Term Group!");


### PR DESCRIPTION
This should fix the flaky glossary_navigation.js Cypress test
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
