### PR TITLE
fix(ingest/bigquery): show report in output

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -24,7 +24,7 @@ class BigQuerySchemaApiPerfReport(Report):
     get_columns_for_dataset: PerfTimer = field(default_factory=PerfTimer)
     get_tables_for_dataset = PerfTimer()
     list_tables = PerfTimer()
-    get_views_for_dataset = PerfTimer()
+    get_views_for_dataset: PerfTimer = field(default_factory=PerfTimer)
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -22,8 +22,8 @@ class BigQuerySchemaApiPerfReport(Report):
     list_projects: PerfTimer = field(default_factory=PerfTimer)
     list_datasets: PerfTimer = field(default_factory=PerfTimer)
     get_columns_for_dataset: PerfTimer = field(default_factory=PerfTimer)
-    get_tables_for_dataset = PerfTimer()
-    list_tables = PerfTimer()
+    get_tables_for_dataset: PerfTimer = field(default_factory=PerfTimer)
+    list_tables: PerfTimer = field(default_factory=PerfTimer)
     get_views_for_dataset: PerfTimer = field(default_factory=PerfTimer)
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -19,9 +19,9 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 @dataclass
 class BigQuerySchemaApiPerfReport(Report):
-    list_projects = PerfTimer()
-    list_datasets = PerfTimer()
-    get_columns_for_dataset = PerfTimer()
+    list_projects: PerfTimer = field(default_factory=PerfTimer)
+    list_datasets: PerfTimer = field(default_factory=PerfTimer)
+    get_columns_for_dataset: PerfTimer = field(default_factory=PerfTimer)
     get_tables_for_dataset = PerfTimer()
     list_tables = PerfTimer()
     get_views_for_dataset = PerfTimer()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -29,8 +29,8 @@ class BigQuerySchemaApiPerfReport(Report):
 
 @dataclass
 class BigQueryAuditLogApiPerfReport(Report):
-    get_exported_log_entries = PerfTimer()
-    list_log_entries = PerfTimer()
+    get_exported_log_entries: PerfTimer = field(default_factory=PerfTimer)
+    list_log_entries: PerfTimer = field(default_factory=PerfTimer)
 
 
 @dataclass

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -27,6 +27,7 @@ class BigQuerySchemaApiPerfReport(Report):
     get_views_for_dataset = PerfTimer()
 
 
+@dataclass
 class BigQueryAuditLogApiPerfReport(Report):
     get_exported_log_entries = PerfTimer()
     list_log_entries = PerfTimer()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -17,6 +17,7 @@ from datahub.utilities.stats_collections import TopKDict, int_top_k_dict
 logger: logging.Logger = logging.getLogger(__name__)
 
 
+@dataclass
 class BigQuerySchemaApiPerfReport(Report):
     list_projects = PerfTimer()
     list_datasets = PerfTimer()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_report.py
@@ -6,6 +6,7 @@ from typing import Counter, Dict, List, Optional
 
 import pydantic
 
+from datahub.ingestion.api.report import Report
 from datahub.ingestion.source.sql.sql_generic_profiler import ProfilingSqlReport
 from datahub.ingestion.source_report.ingestion_stage import IngestionStageReport
 from datahub.ingestion.source_report.time_window import BaseTimeWindowReport
@@ -16,7 +17,7 @@ from datahub.utilities.stats_collections import TopKDict, int_top_k_dict
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-class BigQuerySchemaApiPerfReport:
+class BigQuerySchemaApiPerfReport(Report):
     list_projects = PerfTimer()
     list_datasets = PerfTimer()
     get_columns_for_dataset = PerfTimer()
@@ -25,7 +26,7 @@ class BigQuerySchemaApiPerfReport:
     get_views_for_dataset = PerfTimer()
 
 
-class BigQueryAuditLogApiPerfReport:
+class BigQueryAuditLogApiPerfReport(Report):
     get_exported_log_entries = PerfTimer()
     list_log_entries = PerfTimer()
 


### PR DESCRIPTION
Follow up on https://github.com/datahub-project/datahub/pull/8626.

The report currently shows the object refs:

```
 'schema_api_perf': '<datahub.ingestion.source.bigquery_v2.bigquery_report.BigQuerySchemaApiPerfReport object at 0x7f27859c5ba0>',
 'audit_log_api_perf': '<datahub.ingestion.source.bigquery_v2.bigquery_report.BigQueryAuditLogApiPerfReport object at 0x7f27859c5bd0>',
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
