### PR TITLE
feat(ui) Make certain things disabled if read only mode is enabled

### DIFF
--- a/datahub-web-react/src/app/domain/nestedDomains/ManageDomainsPageV2.tsx
+++ b/datahub-web-react/src/app/domain/nestedDomains/ManageDomainsPageV2.tsx
@@ -17,6 +17,7 @@ const PageWrapper = styled.div`
     flex: 1;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
 `;
 
 const Header = styled.div`

--- a/datahub-web-react/src/app/entity/user/UserEditProfileModal.tsx
+++ b/datahub-web-react/src/app/entity/user/UserEditProfileModal.tsx
@@ -138,6 +138,7 @@ export default function UserEditProfileModal({ visible, onClose, onSave, editMod
                         placeholder="John Smith"
                         value={data.name}
                         onChange={(event) => setData({ ...data, name: event.target.value })}
+                        disabled={readOnlyModeEnabled}
                     />
                 </Form.Item>
                 <Form.Item
@@ -150,6 +151,7 @@ export default function UserEditProfileModal({ visible, onClose, onSave, editMod
                         placeholder="Data Analyst"
                         value={data.title}
                         onChange={(event) => setData({ ...data, title: event.target.value })}
+                        disabled={readOnlyModeEnabled}
                     />
                 </Form.Item>
                 <Tooltip
@@ -180,6 +182,7 @@ export default function UserEditProfileModal({ visible, onClose, onSave, editMod
                         placeholder="Product Engineering"
                         value={data.team}
                         onChange={(event) => setData({ ...data, team: event.target.value })}
+                        disabled={readOnlyModeEnabled}
                     />
                 </Form.Item>
                 <Form.Item
@@ -203,6 +206,7 @@ export default function UserEditProfileModal({ visible, onClose, onSave, editMod
                         placeholder="john.smith@example.com"
                         value={data.email}
                         onChange={(event) => setData({ ...data, email: event.target.value })}
+                        disabled={readOnlyModeEnabled}
                     />
                 </Form.Item>
                 <Form.Item
@@ -215,6 +219,7 @@ export default function UserEditProfileModal({ visible, onClose, onSave, editMod
                         placeholder="john_smith"
                         value={data.slack}
                         onChange={(event) => setData({ ...data, slack: event.target.value })}
+                        disabled={readOnlyModeEnabled}
                     />
                 </Form.Item>
                 <Form.Item
@@ -236,6 +241,7 @@ export default function UserEditProfileModal({ visible, onClose, onSave, editMod
                         placeholder="444-999-9999"
                         value={data.phone}
                         onChange={(event) => setData({ ...data, phone: event.target.value })}
+                        disabled={readOnlyModeEnabled}
                     />
                 </Form.Item>
             </Form>

--- a/datahub-web-react/src/app/settings/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settings/SettingsPage.tsx
@@ -89,12 +89,13 @@ export const SettingsPage = () => {
     const isPoliciesEnabled = config?.policiesConfig.enabled;
     const isIdentityManagementEnabled = config?.identityManagementConfig.enabled;
     const isViewsEnabled = config?.viewsConfig.enabled;
+    const { readOnlyModeEnabled } = config.featureFlags;
 
     const showPolicies = (isPoliciesEnabled && me && me?.platformPrivileges?.managePolicies) || false;
     const showUsersGroups = (isIdentityManagementEnabled && me && me?.platformPrivileges?.manageIdentities) || false;
     const showViews = isViewsEnabled || false;
     const showOwnershipTypes = me && me?.platformPrivileges?.manageOwnershipTypes;
-    const showHomePagePosts = me && me?.platformPrivileges?.manageGlobalAnnouncements;
+    const showHomePagePosts = me && me?.platformPrivileges?.manageGlobalAnnouncements && !readOnlyModeEnabled;
 
     return (
         <PageContainer>


### PR DESCRIPTION
Disables a few more things if the read only mode is enabled (specifically on the demo site)

Also fixes a styling issue on the manage domains page.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
