### PR TITLE
fix(docs): remove link-checker from CI

### DIFF
--- a/docs-website/markdown-link-check-config.json
+++ b/docs-website/markdown-link-check-config.json
@@ -1,50 +1,41 @@
 {
   "ignorePatterns": [
     {
-    "pattern": "^http://demo\\.datahubproject\\.io"
+      "pattern": "^https?://demo\\.datahubproject\\.io"
     },
     {
-    "pattern": "^http://localhost"
+      "pattern": "^http://localhost"
     },
     {
-    "pattern": "^http://www.famfamfam.com"
+      "pattern": "^/docs"
     },
     {
-    "pattern": "^http://www.linkedin.com"
+      "pattern": "^/integrations"
     },
     {
-    "pattern": "\\.md$"
+      "pattern": "^https?://www.linkedin.com"
     },
     {
-    "pattern":"\\.json$"
+      "pattern": "\\.md(#.*)?$"
     },
     {
-    "pattern":"\\.txt$"
+      "pattern": "\\.json$"
     },
     {
-    "pattern": "\\.java$"
+      "pattern": "\\.txt$"
     },
     {
-    "pattern": "\\.md#.*$"
+      "pattern": "\\.java$"
     },
     {
-    "pattern": "^https://oauth2.googleapis.com/token"
+      "pattern": "^https://oauth2.googleapis.com/token"
     },
     {
-    "pattern": "^https://login.microsoftonline.com/common/oauth2/na$"
+      "pattern": "^https://login.microsoftonline.com/common/oauth2/na$"
     },
     {
-    "pattern": "#v(\\d+)-(\\d+)-(\\d+)"
-    },
-    {
-    "pattern": "^https://github.com/mohdsiddique$"
-    },
-    {
-    "pattern": "^https://github.com/2x$"
-    },
-    {
-    "pattern": "^https://github.com/datahub-project/datahub/assets/15873986/2f47d033-6c2b-483a-951d-e6d6b807f0d0%22%3E$"
+      "pattern": "^https://github.com/datahub-project/datahub/assets/15873986/2f47d033-6c2b-483a-951d-e6d6b807f0d0%22%3E$"
     }
   ],
-  "aliveStatusCodes": [200, 206, 0, 999, 400, 401, 403]
+  "aliveStatusCodes": [200, 206, 0, 999]
 }

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -17,8 +17,10 @@
     "generate": "rm -rf genDocs genStatic && mkdir genDocs genStatic && yarn _generate-docs && mv docs/* genDocs/ && rmdir docs",
     "generate-rsync": "mkdir -p genDocs genStatic && yarn _generate-docs && rsync -v --checksum -r -h -i --delete docs/ genDocs && rm -rf docs",
     "lint": "prettier -w generateDocsDir.ts sidebars.js src/pages/index.js",
-    "lint-check": "prettier -l generateDocsDir.ts sidebars.js src/pages/index.js && find ./genDocs -name \\*.md -not -path \"./genDocs/python-sdk/models.md\" -print0 | xargs -0 -n1 markdown-link-check -p -q -c markdown-link-check-config.json",
-    "lint-fix": "prettier --write generateDocsDir.ts sidebars.js src/pages/index.js"
+    "lint-check": "prettier -l generateDocsDir.ts sidebars.js src/pages/index.js",
+    "lint-fix": "prettier --write generateDocsDir.ts sidebars.js src/pages/index.js",
+    "_list-link-check-files": "find ./genDocs -name '*.md' -not \\( -path './genDocs/python-sdk/*' -o -path './genDocs/releases.md' \\)",
+    "check-links": "yarn run -s _list-link-check-files -print0 | xargs -0 -n1 -t markdown-link-check -q -c markdown-link-check-config.json"
   },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",


### PR DESCRIPTION
It had too many false positives, so can't be a blocking step in CI. However, it was still super useful so we'll just need to manually run it every now and then.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
