### PR TITLE
feat(slack-help-button): added feature flag configurable slack help b…

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -15,6 +15,7 @@ public class FeatureFlags {
   private boolean showBrowseV2 = false;
   private PreProcessHooks preProcessHooks;
   private boolean showAcrylInfo = false;
+  private boolean showSlackHelpButton = true;
   private boolean showAccessManagement = false;
   private boolean nestedDomainsEnabled = false;
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -171,6 +171,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
       .setReadOnlyModeEnabled(_featureFlags.isReadOnlyModeEnabled())
       .setShowBrowseV2(_featureFlags.isShowBrowseV2())
       .setShowAcrylInfo(_featureFlags.isShowAcrylInfo())
+      .setShowSlackHelpButton(_featureFlags.isShowSlackHelpButton())
       .setShowAccessManagement(_featureFlags.isShowAccessManagement())
       .setNestedDomainsEnabled(_featureFlags.isNestedDomainsEnabled())
       .build();

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -443,6 +443,11 @@ type FeatureFlagsConfig {
   showAcrylInfo: Boolean!
 
   """
+  Whether we should show the Slack Help Button on the Home Page.
+  """
+  showSlackHelpButton: Boolean!
+
+  """
   Whether we should show AccessManagement tab in the datahub UI.
   """
   showAccessManagement: Boolean!

--- a/datahub-web-react/src/app/entity/shared/components/styled/SlackButton.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/SlackButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { SlackOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+import { Button } from 'antd';
+
+const StyledButton = styled(Button)`
+    padding: 8px;
+    font-size: 14px;
+    margin-left: 18px;
+`;
+
+export default function SlackButton() {
+    const slackChannelLink = 'http://slack.datahubproject.io';
+
+    return (
+        <StyledButton type="primary" href={slackChannelLink} target="_blank" rel="noopener noreferrer">
+            <SlackOutlined />
+            Live Help
+        </StyledButton>
+    );
+}

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -16,7 +16,7 @@ import { EntityType, FacetFilterInput } from '../../types.generated';
 import analytics, { EventType } from '../analytics';
 import { HeaderLinks } from '../shared/admin/HeaderLinks';
 import { ANTD_GRAY } from '../entity/shared/constants';
-import { useAppConfig, useIsShowAcrylInfoEnabled } from '../useAppConfig';
+import { useAppConfig, useIsShowAcrylInfoEnabled, useIsShowSlackHelpButtonEnabled } from '../useAppConfig';
 import { DEFAULT_APP_CONFIG } from '../../appConfigContext';
 import { HOME_PAGE_SEARCH_BAR_ID } from '../onboarding/config/HomePageOnboardingConfig';
 import { useQuickFiltersContext } from '../../providers/QuickFiltersContext';
@@ -24,6 +24,7 @@ import { getAutoCompleteInputFromQuickFilter } from '../search/utils/filterUtils
 import { useUserContext } from '../context/useUserContext';
 import AcrylDemoBanner from './AcrylDemoBanner';
 import DemoButton from '../entity/shared/components/styled/DemoButton';
+import SlackButton from '../entity/shared/components/styled/SlackButton';
 
 const Background = styled.div`
     width: 100%;
@@ -150,6 +151,7 @@ export const HomePageHeader = () => {
     const [newSuggestionData, setNewSuggestionData] = useState<GetAutoCompleteMultipleResultsQuery | undefined>();
     const { selectedQuickFilter } = useQuickFiltersContext();
     const showAcrylInfo = useIsShowAcrylInfoEnabled();
+    const showSlackHelpButton = useIsShowSlackHelpButtonEnabled();
     const { user } = userContext;
     const viewUrn = userContext.localState?.selectedViewUrn;
     const viewsEnabled = appConfig.config?.viewsConfig?.enabled || false;
@@ -248,6 +250,7 @@ export const HomePageHeader = () => {
                         name={(user && entityRegistry.getDisplayName(EntityType.CorpUser, user)) || undefined}
                     />
                     {showAcrylInfo && <DemoButton />}
+                    {showSlackHelpButton && <SlackButton />}
                 </NavGroup>
             </Row>
             <HeaderContainer>

--- a/datahub-web-react/src/app/useAppConfig.ts
+++ b/datahub-web-react/src/app/useAppConfig.ts
@@ -13,6 +13,11 @@ export function useIsShowAcrylInfoEnabled() {
     return appConfig.config.featureFlags.showAcrylInfo;
 }
 
+export function useIsShowSlackHelpButtonEnabled() {
+    const appConfig = useAppConfig();
+    return appConfig.config.featureFlags.showSlackHelpButton;
+}
+
 export function useIsNestedDomainsEnabled() {
     const appConfig = useAppConfig();
     return appConfig.config.featureFlags.nestedDomainsEnabled;

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -48,6 +48,7 @@ export const DEFAULT_APP_CONFIG = {
         showSearchFiltersV2: true,
         showBrowseV2: true,
         showAcrylInfo: false,
+        showSlackHelpButton: true,
         showAccessManagement: false,
         nestedDomainsEnabled: true,
     },

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -63,6 +63,7 @@ query appConfig {
             showSearchFiltersV2
             showBrowseV2
             showAcrylInfo
+            showSlackHelpButton
             showAccessManagement
             nestedDomainsEnabled
         }

--- a/metadata-service/configuration/src/main/resources/application.yml
+++ b/metadata-service/configuration/src/main/resources/application.yml
@@ -300,6 +300,7 @@ featureFlags:
   preProcessHooks:
     uiEnabled: ${PRE_PROCESS_HOOKS_UI_ENABLED:true} # Circumvents Kafka for processing index updates for UI changes sourced from GraphQL to avoid processing delays
   showAcrylInfo: ${SHOW_ACRYL_INFO:false} # Show different CTAs within DataHub around moving to Managed DataHub. Set to true for the demo site.
+  showSlackHelpButton: ${SHOW_SLACK_HELP_BUTTON:true} # Show the Slack help button that redirects to slack.datahubproject.io. Default to true for OSS.
   nestedDomainsEnabled: ${NESTED_DOMAINS_ENABLED:true} # Enables the nested Domains feature that allows users to have sub-Domains. If this is off, Domains appear "flat" again
 
 entityChangeEvents:


### PR DESCRIPTION
## Description
In this PR, I added a Slack Help button on the Home Page (top right). The button redirects the user to Datahub's Slack channel on press. There are changes on the server, there's a new feature flag `showSlackHelpButton`, that defaults to true by default. Setting the flag to false will remove the Slack Button.

![Screenshot 2023-10-04 at 3 29 56 PM](https://github.com/datahub-project/datahub/assets/7741894/0846c1c0-ec4d-4ee8-b529-08770fa82a03)

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
