### PR TITLE
fix(settings/views): enable common user to delete their own views

### DIFF
--- a/datahub-web-react/src/app/entity/view/ViewsList.tsx
+++ b/datahub-web-react/src/app/entity/view/ViewsList.tsx
@@ -117,7 +117,7 @@ export const ViewsList = () => {
                     entityRegistry={entityRegistry}
                 />
             </TabToolbar>
-            <ViewsTable views={views} onEditView={onClickEditView} />
+            <ViewsTable views={views} onEditView={onClickEditView} isOwnedByUser />
             {totalViews >= pageSize && (
                 <PaginationContainer>
                     <StyledPagination

--- a/datahub-web-react/src/app/entity/view/ViewsTable.tsx
+++ b/datahub-web-react/src/app/entity/view/ViewsTable.tsx
@@ -7,12 +7,13 @@ import { DataHubView } from '../../../types.generated';
 type ViewsTableProps = {
     views: DataHubView[];
     onEditView: (urn) => void;
+    isOwnedByUser?: boolean;
 };
 
 /**
  * This component renders a table of Views.
  */
-export const ViewsTable = ({ views, onEditView }: ViewsTableProps) => {
+export const ViewsTable = ({ views, onEditView, isOwnedByUser }: ViewsTableProps) => {
     const tableColumns = [
         {
             title: 'Name',
@@ -36,7 +37,7 @@ export const ViewsTable = ({ views, onEditView }: ViewsTableProps) => {
             title: '',
             dataIndex: '',
             key: 'x',
-            render: (record) => <ActionsColumn record={record} />,
+            render: (record) => <ActionsColumn record={record} isOwnedByUser={!!isOwnedByUser} />,
         },
     ];
 

--- a/datahub-web-react/src/app/entity/view/select/ViewsTableColumns.tsx
+++ b/datahub-web-react/src/app/entity/view/select/ViewsTableColumns.tsx
@@ -81,12 +81,13 @@ export function ViewTypeColumn({ viewType }: ViewTypeColumnProps) {
 
 type ActionColumnProps = {
     record: any;
+    isOwnedByUser: boolean;
 };
 
-export function ActionsColumn({ record }: ActionColumnProps) {
+export function ActionsColumn({ record, isOwnedByUser }: ActionColumnProps) {
     return (
         <ActionButtonsContainer>
-            <ViewDropdownMenu view={record} visible />
+            <ViewDropdownMenu view={record} isOwnedByUser={isOwnedByUser} visible />
         </ActionButtonsContainer>
     );
 }


### PR DESCRIPTION
## Contextualisation

Currently, common users are unable to delete their own views via the [Manage Views page](https://demo.datahubproject.io/settings/views) because they miss the `MANAGE_GLOBAL_VIEWS` platform privilege. In this PR, since the data in this page is from the `useListMyViewsQuery`, we pass a static `isOwnedByUser=true`, and add the property down to the component that needs it.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
