### PR TITLE
feat(graphql): support filtering based on greater than/less than criteria

### DIFF
--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -458,6 +458,26 @@ enum FilterOperator {
   Represents the relation: The field exists. If the field is an array, the field is either not present or empty.
   """
   EXISTS
+
+  """
+  Represent the relation greater than, e.g. ownerCount > 5
+  """
+  GREATER_THAN
+
+  """
+   Represent the relation greater than or equal to, e.g. ownerCount >= 5
+  """
+  GREATER_THAN_OR_EQUAL_TO
+
+  """
+  Represent the relation less than, e.g. ownerCount < 3
+  """
+  LESS_THAN
+
+  """
+  Represent the relation less than or equal to, e.g. ownerCount <= 3
+  """
+  LESS_THAN_OR_EQUAL_TO
 }
 
 """


### PR DESCRIPTION
Example usage:
```
{
  searchAcrossEntities
(
    input: {types: [], query: "*", orFilters: 
[{and: [{field: "<numeric property>", condition: GREATER_THAN, values:["400"], negated: false}]}]}
) {
  searchResults {
    entity {
      urn,
      type
    }
  } 
  }
}
```

This PR is so short because the condition is parsed from GraphQL using Condition.valueOf:
https://github.com/datahub-project/datahub/blob/a8f0080c08b5c816f0dae9d3bef07ea00220541e/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java#L177

And these already exist as conditions:
https://github.com/datahub-project/datahub/blob/a8f0080c08b5c816f0dae9d3bef07ea00220541e/metadata-models/src/main/pegasus/com/linkedin/metadata/query/filter/Condition.pdl#L4

So, simply add them as options in the GraphQL API to support filtering by them
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
