### PR TITLE
feat(ingest/business-glossary): support related entity ingestion in glossary config

### DIFF
--- a/metadata-ingestion/docs/sources/business-glossary/datahub-business-glossary.md
+++ b/metadata-ingestion/docs/sources/business-glossary/datahub-business-glossary.md
@@ -64,7 +64,9 @@ Example **GlossaryTerm**:
   knowledge_links:                                                          # (optional) a list of **KnowledgeCard** related to this term. These appear as links on the glossary node's page
     - url: "https://en.wikipedia.org/wiki/Address"
       label: Wiki link
-  domain: "urn:li:domain:Logistics"                                            # (optional) domain name or domain urn
+  domain: "urn:li:domain:Logistics"                                         # (optional) domain name or domain urn
+  related_entities:                                                         # (optional) a list of urns for related entities
+    - "urn:li:dataset:related_dataset"
 ```
 
 To see how these all work together, check out this comprehensive example business glossary file below:

--- a/metadata-ingestion/tests/integration/business-glossary/business_glossary.yml
+++ b/metadata-ingestion/tests/integration/business-glossary/business_glossary.yml
@@ -72,3 +72,5 @@ nodes:
     terms:
       - name: CSAT %
         description: Customer Satisfaction Score
+        related_entities:
+          - "urn:li:dataset:abc"

--- a/metadata-ingestion/tests/integration/business-glossary/glossary_events_auto_id_golden.json
+++ b/metadata-ingestion/tests/integration/business-glossary/glossary_events_auto_id_golden.json
@@ -764,5 +764,44 @@
         "lastObserved": 1586847600000,
         "runId": "datahub-business-glossary-2020_04_14-07_00_00"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:abc",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "datahub-business-glossary-2020_04_14-07_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:abc",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "auditStamp": {
+                "actor": "urn:li:corpuser:datahub",
+                "message": "ingestion bot",
+                "time": 1586847600000
+            },
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:4faf1eed790370f65942f2998a7993d6"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "datahub-business-glossary-2020_04_14-07_00_00"
+    }
 }
 ]

--- a/metadata-ingestion/tests/integration/business-glossary/glossary_events_golden.json
+++ b/metadata-ingestion/tests/integration/business-glossary/glossary_events_golden.json
@@ -764,5 +764,44 @@
         "lastObserved": 1586847600000,
         "runId": "datahub-business-glossary-2020_04_14-07_00_00"
     }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:abc",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "datahub-business-glossary-2020_04_14-07_00_00"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:abc",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "auditStamp": {
+                "actor": "urn:li:corpuser:datahub",
+                "message": "ingestion bot",
+                "time": 1586847600000
+            },
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:4faf1eed790370f65942f2998a7993d6"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1586847600000,
+        "runId": "datahub-business-glossary-2020_04_14-07_00_00"
+    }
 }
 ]


### PR DESCRIPTION
Support tagging related entities during business-glossary ingestion. 

(As opposed to either tagging manually via the UI or in a separate source)


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
~- [ ] Links to related issues (if applicable)~
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
~- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)~
