### PR TITLE
add dependency level to scrollAcrossLineage search results

### DIFF
--- a/datahub-web-react/src/graphql/scroll.graphql
+++ b/datahub-web-react/src/graphql/scroll.graphql
@@ -408,6 +408,7 @@ fragment downloadScrollAcrossLineageResult on ScrollAcrossLineageResults {
     count
     total
     searchResults {
+        degree
         entity {
             ...downloadSearchResults
         }


### PR DESCRIPTION
Now when you download the lineage csv, there is a `level of dependency` column listing the degree.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
<img width="831" alt="Screenshot 2023-10-13 at 5 33 30 PM" src="https://github.com/datahub-project/datahub/assets/98533600/e0080d73-6cab-4889-99ba-b8a2cd9a8495">
