### PR TITLE
fix(ingest): make user_urn and group_urn generation consider user and…

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -180,20 +180,20 @@ def assertion_urn_to_key(assertion_urn: str) -> Optional[AssertionKeyClass]:
 
 def make_user_urn(username: str) -> str:
     """
-    Makes a user urn if the input is not a user urn already
+    Makes a user urn if the input is not a user or group urn already
     """
     return (
         f"urn:li:corpuser:{username}"
-        if not username.startswith("urn:li:corpuser:")
+        if not username.startswith(("urn:li:corpuser:", "urn:li:corpGroup:"))
         else username
     )
 
 
 def make_group_urn(groupname: str) -> str:
     """
-    Makes a group urn if the input is not a group urn already
+    Makes a group urn if the input is not a user or group urn already
     """
-    if groupname and groupname.startswith("urn:li:corpGroup:"):
+    if groupname and groupname.startswith(("urn:li:corpGroup:", "urn:li:corpuser:")):
         return groupname
     else:
         return f"urn:li:corpGroup:{groupname}"


### PR DESCRIPTION
… group urn prefixes

User and Group urn generation helpers need to take into account all "Identity" urns to avoid double prefixing.

e.g. 
make_user_urn("urn:li:corpGroup:foo")  should return `urn:li:corpGroup:foo`


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
