### PR TITLE
feat(evals): add config-driven eval framework for context intelligence agents

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnerResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnerResolver.java
@@ -2,14 +2,11 @@ package com.linkedin.datahub.graphql.resolvers.mutate;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.CorpuserUrn;
-
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.AddOwnerInput;
-import com.linkedin.datahub.graphql.generated.OwnerEntityType;
 import com.linkedin.datahub.graphql.generated.OwnerInput;
-import com.linkedin.datahub.graphql.generated.OwnershipType;
 import com.linkedin.datahub.graphql.generated.ResourceRefInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.metadata.entity.EntityService;
@@ -20,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
-import static com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils.*;
 
 
 @Slf4j
@@ -37,10 +33,10 @@ public class AddOwnerResolver implements DataFetcher<CompletableFuture<Boolean>>
     OwnerInput.Builder ownerInputBuilder = OwnerInput.builder();
     ownerInputBuilder.setOwnerUrn(input.getOwnerUrn());
     ownerInputBuilder.setOwnerEntityType(input.getOwnerEntityType());
-    if(input.getType() != null) {
+    if (input.getType() != null) {
       ownerInputBuilder.setType(input.getType());
     }
-    if(input.getOwnershipTypeUrn() != null) {
+    if (input.getOwnershipTypeUrn() != null) {
       ownerInputBuilder.setOwnershipTypeUrn(input.getOwnershipTypeUrn());
     }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnersResolver.java
@@ -39,7 +39,7 @@ public class AddOwnersResolver implements DataFetcher<CompletableFuture<Boolean>
         throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
       }
 
-      OwnerUtils.validateAddInput(
+      OwnerUtils.validateAddOwnerInput(
           owners,
           targetUrn,
           _entityService

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddOwnersResolver.java
@@ -53,8 +53,7 @@ public class BatchAddOwnersResolver implements DataFetcher<CompletableFuture<Boo
 
   private void validateOwners(List<OwnerInput> owners) {
     for (OwnerInput ownerInput : owners) {
-      OwnerUtils.validateOwner(UrnUtils.getUrn(ownerInput.getOwnerUrn()), ownerInput.getOwnerEntityType(),
-          UrnUtils.getUrn(ownerInput.getOwnershipTypeUrn()), _entityService);
+      OwnerUtils.validateOwner(ownerInput, _entityService);
     }
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -75,7 +75,7 @@ public class OwnerUtils {
         Constants.OWNERSHIP_ASPECT_NAME, entityService,
         new Ownership());
     for (OwnerInput input : owners) {
-      addOwner(ownershipAspect, UrnUtils.getUrn(input.getOwnerUrn()), ownershipType, UrnUtils.getUrn(input.getOwnershipTypeUrn()));
+      addOwner(ownershipAspect, UrnUtils.getUrn(input.getOwnerUrn()), input.getType(), UrnUtils.getUrn(input.getOwnershipTypeUrn()));
     }
     return buildMetadataChangeProposalWithUrn(resourceUrn, Constants.OWNERSHIP_ASPECT_NAME, ownershipAspect);
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -50,7 +50,7 @@ public class OwnerUtils {
   ) {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
     for (ResourceRefInput resource : resources) {
-      changes.add(buildAddOwnersProposal(owners, UrnUtils.getUrn(resource.getResourceUrn()), actor, entityService));
+      changes.add(buildAddOwnersProposal(owners, UrnUtils.getUrn(resource.getResourceUrn()), entityService));
     }
     EntityUtils.ingestChangeProposals(changes, entityService, actor, false);
   }
@@ -69,13 +69,13 @@ public class OwnerUtils {
   }
 
 
-  private static MetadataChangeProposal buildAddOwnersProposal(List<OwnerInput> owners, Urn resourceUrn, Urn actor, EntityService entityService) {
+  static MetadataChangeProposal buildAddOwnersProposal(List<OwnerInput> owners, Urn resourceUrn, EntityService entityService) {
     Ownership ownershipAspect = (Ownership) EntityUtils.getAspectFromEntity(
         resourceUrn.toString(),
         Constants.OWNERSHIP_ASPECT_NAME, entityService,
         new Ownership());
     for (OwnerInput input : owners) {
-      addOwner(ownershipAspect, UrnUtils.getUrn(input.getOwnerUrn()), input.getType(), UrnUtils.getUrn(input.getOwnershipTypeUrn()));
+      addOwner(ownershipAspect, UrnUtils.getUrn(input.getOwnerUrn()), ownershipType, UrnUtils.getUrn(input.getOwnershipTypeUrn()));
     }
     return buildMetadataChangeProposalWithUrn(resourceUrn, Constants.OWNERSHIP_ASPECT_NAME, ownershipAspect);
   }
@@ -181,18 +181,13 @@ public class OwnerUtils {
         orPrivilegeGroups);
   }
 
-  public static Boolean validateAddInput(
+  public static Boolean validateAddOwnerInput(
       List<OwnerInput> owners,
       Urn resourceUrn,
       EntityService entityService
   ) {
     for (OwnerInput owner : owners) {
-      boolean result = validateAddInput(
-          UrnUtils.getUrn(owner.getOwnerUrn()),
-          owner.getOwnershipTypeUrn(),
-          owner.getOwnerEntityType(),
-          resourceUrn,
-          entityService);
+      boolean result = validateAddOwnerInput(owner, resourceUrn, entityService);
       if (!result) {
         return false;
       }
@@ -200,44 +195,29 @@ public class OwnerUtils {
     return true;
   }
 
-  public static Boolean validateAddInput(
-      Urn ownerUrn,
-      String ownershipEntityUrn,
-      OwnerEntityType ownerEntityType,
+  public static Boolean validateAddOwnerInput(
+      OwnerInput owner,
       Urn resourceUrn,
       EntityService entityService
   ) {
-
-    if (OwnerEntityType.CORP_GROUP.equals(ownerEntityType) && !Constants.CORP_GROUP_ENTITY_NAME.equals(ownerUrn.getEntityType())) {
-      throw new IllegalArgumentException(String.format("Failed to change ownership for resource %s. Expected a corp group urn.", resourceUrn));
-    }
-
-    if (OwnerEntityType.CORP_USER.equals(ownerEntityType) && !Constants.CORP_USER_ENTITY_NAME.equals(ownerUrn.getEntityType())) {
-      throw new IllegalArgumentException(String.format("Failed to change ownership for resource %s. Expected a corp user urn.", resourceUrn));
-    }
 
     if (!entityService.exists(resourceUrn)) {
       throw new IllegalArgumentException(String.format("Failed to change ownership for resource %s. Resource does not exist.", resourceUrn));
     }
 
-    if (!entityService.exists(ownerUrn)) {
-      throw new IllegalArgumentException(String.format("Failed to change ownership for resource %s. Owner %s does not exist.", resourceUrn, ownerUrn));
-    }
-
-    if (ownershipEntityUrn != null && !entityService.exists(UrnUtils.getUrn(ownershipEntityUrn))) {
-      throw new IllegalArgumentException(String.format("Failed to change ownership type for resource %s. Ownership Type "
-          + "%s does not exist.", resourceUrn, ownershipEntityUrn));
-    }
+    validateOwner(owner, entityService);
 
     return true;
   }
 
   public static void validateOwner(
-      Urn ownerUrn,
-      OwnerEntityType ownerEntityType,
-      Urn ownershipEntityUrn,
+      OwnerInput owner,
       EntityService entityService
   ) {
+
+    OwnerEntityType ownerEntityType = owner.getOwnerEntityType();
+    Urn ownerUrn = UrnUtils.getUrn(owner.getOwnerUrn());
+
     if (OwnerEntityType.CORP_GROUP.equals(ownerEntityType) && !Constants.CORP_GROUP_ENTITY_NAME.equals(ownerUrn.getEntityType())) {
       throw new IllegalArgumentException(
           String.format("Failed to change ownership for resource(s). Expected a corp group urn, found %s", ownerUrn));
@@ -252,9 +232,14 @@ public class OwnerUtils {
       throw new IllegalArgumentException(String.format("Failed to change ownership for resource(s). Owner with urn %s does not exist.", ownerUrn));
     }
 
-    if (!entityService.exists(ownershipEntityUrn)) {
-      throw new IllegalArgumentException(String.format("Failed to change ownership for resource(s). Ownership type with "
-          + "urn %s does not exist.", ownershipEntityUrn));
+    if (owner.getOwnershipTypeUrn() != null && !entityService.exists(UrnUtils.getUrn(owner.getOwnershipTypeUrn()))) {
+      throw new IllegalArgumentException(String.format("Failed to change ownership for resource(s). Custom Ownership type with "
+          + "urn %s does not exist.", owner.getOwnershipTypeUrn()));
+    }
+
+    if (owner.getType() == null && owner.getOwnershipTypeUrn() == null) {
+      throw new IllegalArgumentException("Failed to change ownership for resource(s). Expected either "
+          + "type or ownershipTypeUrn to be specified.");
     }
   }
 
@@ -269,11 +254,11 @@ public class OwnerUtils {
   }
 
   public static void addCreatorAsOwner(
-    QueryContext context,
-    String urn,
-    OwnerEntityType ownerEntityType,
-    OwnershipType ownershipType,
-    EntityService entityService) {
+      QueryContext context,
+      String urn,
+      OwnerEntityType ownerEntityType,
+      OwnershipType ownershipType,
+      EntityService entityService) {
     try {
       Urn actorUrn = CorpuserUrn.createFromString(context.getActorUrn());
       String ownershipTypeUrn = mapOwnershipTypeToEntity(ownershipType.name());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.owner;
 
 import com.google.common.collect.ImmutableList;
+import com.linkedin.common.*;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -28,6 +29,7 @@ public class AddOwnersResolverTest {
   private static final String TEST_ENTITY_URN = "urn:li:dataset:(urn:li:dataPlatform:mysql,my-test,PROD)";
   private static final String TEST_OWNER_1_URN = "urn:li:corpuser:test-id-1";
   private static final String TEST_OWNER_2_URN = "urn:li:corpuser:test-id-2";
+  private static final String TEST_OWNER_3_URN = "urn:li:corpGroup:test-id-3";
 
   @Test
   public void testGetSuccessNoExistingOwners() throws Exception {
@@ -75,33 +77,41 @@ public class AddOwnersResolverTest {
   }
 
   @Test
-  public void testGetSuccessExistingOwners() throws Exception {
+  public void testGetSuccessExistingOwnerNewType() throws Exception {
     EntityService mockService = getMockEntityService();
 
+    com.linkedin.common.Ownership oldOwnership = new Ownership().setOwners(new OwnerArray(
+            ImmutableList.of(new Owner()
+                    .setOwner(UrnUtils.getUrn(TEST_OWNER_1_URN))
+                    .setType(com.linkedin.common.OwnershipType.NONE)
+                    .setSource(new OwnershipSource().setType(OwnershipSourceType.MANUAL))
+            )));
+
     Mockito.when(mockService.getAspect(
-        Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
-        Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-        Mockito.eq(0L)))
-        .thenReturn(null);
+                    Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                    Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
+                    Mockito.eq(0L)))
+            .thenReturn(oldOwnership);
 
     Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
     Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_2_URN))).thenReturn(true);
 
     Mockito.when(mockService.exists(Urn.createFromString(
-            OwnerUtils.mapOwnershipTypeToEntity(com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name()))))
-        .thenReturn(true);
+                    OwnerUtils.mapOwnershipTypeToEntity(com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name()))))
+            .thenReturn(true);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+
     AddOwnersInput input = new AddOwnersInput(ImmutableList.of(
-        new OwnerInput(TEST_OWNER_1_URN, OwnerEntityType.CORP_USER, OwnershipType.TECHNICAL_OWNER,
-            OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.TECHNICAL_OWNER.name())),
-        new OwnerInput(TEST_OWNER_2_URN, OwnerEntityType.CORP_USER, OwnershipType.TECHNICAL_OWNER,
-            OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.TECHNICAL_OWNER.name()))
+            OwnerInput.builder()
+                    .setOwnerUrn(TEST_OWNER_1_URN)
+                    .setOwnershipTypeUrn(OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.TECHNICAL_OWNER.name()))
+                    .setOwnerEntityType(OwnerEntityType.CORP_USER)
+                    .build()
     ), TEST_ENTITY_URN);
     Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
@@ -111,11 +121,126 @@ public class AddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1)).exists(
-        Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN))
+            Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN))
+    );
+  }
+
+  @Test
+  public void testGetSuccessDeprecatedTypeToOwnershipType() throws Exception {
+    EntityService mockService = getMockEntityService();
+
+    com.linkedin.common.Ownership oldOwnership = new Ownership().setOwners(new OwnerArray(
+            ImmutableList.of(new Owner()
+                    .setOwner(UrnUtils.getUrn(TEST_OWNER_1_URN))
+                    .setType(com.linkedin.common.OwnershipType.TECHNICAL_OWNER)
+                    .setSource(new OwnershipSource().setType(OwnershipSourceType.MANUAL))
+            )));
+
+    Mockito.when(mockService.getAspect(
+                    Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                    Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
+                    Mockito.eq(0L)))
+            .thenReturn(oldOwnership);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
+
+    Mockito.when(mockService.exists(Urn.createFromString(
+                    OwnerUtils.mapOwnershipTypeToEntity(com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name()))))
+            .thenReturn(true);
+
+    AddOwnersResolver resolver = new AddOwnersResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+
+    AddOwnersInput input = new AddOwnersInput(ImmutableList.of(OwnerInput.builder()
+                    .setOwnerUrn(TEST_OWNER_1_URN)
+                    .setOwnershipTypeUrn(OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.TECHNICAL_OWNER.name()))
+                    .setOwnerEntityType(OwnerEntityType.CORP_USER)
+                    .build()
+    ), TEST_ENTITY_URN);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    assertTrue(resolver.get(mockEnv).get());
+
+    // Unable to easily validate exact payload due to the injected timestamp
+    verifyIngestProposal(mockService, 1);
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+            Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN))
+    );
+  }
+
+  @Test
+  public void testGetSuccessMultipleOwnerTypes() throws Exception {
+    EntityService mockService = getMockEntityService();
+
+    com.linkedin.common.Ownership oldOwnership = new Ownership().setOwners(new OwnerArray(
+            ImmutableList.of(new Owner()
+                    .setOwner(UrnUtils.getUrn(TEST_OWNER_1_URN))
+                    .setType(com.linkedin.common.OwnershipType.NONE)
+                    .setSource(new OwnershipSource().setType(OwnershipSourceType.MANUAL))
+            )));
+
+    Mockito.when(mockService.getAspect(
+                    Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                    Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
+                    Mockito.eq(0L)))
+            .thenReturn(oldOwnership);
+
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_3_URN))).thenReturn(true);
+
+    Mockito.when(mockService.exists(Urn.createFromString(
+                    OwnerUtils.mapOwnershipTypeToEntity(com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER.name()))))
+            .thenReturn(true);
+    Mockito.when(mockService.exists(Urn.createFromString(
+                    OwnerUtils.mapOwnershipTypeToEntity(com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER.name()))))
+            .thenReturn(true);
+
+    AddOwnersResolver resolver = new AddOwnersResolver(mockService);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+
+    AddOwnersInput input = new AddOwnersInput(ImmutableList.of(OwnerInput.builder()
+                    .setOwnerUrn(TEST_OWNER_1_URN)
+                    .setOwnershipTypeUrn(OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.TECHNICAL_OWNER.name()))
+                    .setOwnerEntityType(OwnerEntityType.CORP_USER)
+                    .build(),
+            OwnerInput.builder()
+                    .setOwnerUrn(TEST_OWNER_2_URN)
+                    .setOwnershipTypeUrn(OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.BUSINESS_OWNER.name()))
+                    .setOwnerEntityType(OwnerEntityType.CORP_USER)
+                    .build(),
+            OwnerInput.builder()
+                    .setOwnerUrn(TEST_OWNER_3_URN)
+                    .setOwnershipTypeUrn(OwnerUtils.mapOwnershipTypeToEntity(OwnershipType.TECHNICAL_OWNER.name()))
+                    .setOwnerEntityType(OwnerEntityType.CORP_GROUP)
+                    .build()
+    ), TEST_ENTITY_URN);
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+    assertTrue(resolver.get(mockEnv).get());
+
+    // Unable to easily validate exact payload due to the injected timestamp
+    verifyIngestProposal(mockService, 1);
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+            Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN))
     );
 
     Mockito.verify(mockService, Mockito.times(1)).exists(
-        Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN))
+            Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN))
+    );
+
+    Mockito.verify(mockService, Mockito.times(1)).exists(
+            Mockito.eq(Urn.createFromString(TEST_OWNER_3_URN))
     );
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
@@ -1,8 +1,12 @@
 package com.linkedin.datahub.graphql.resolvers.owner;
 
 import com.google.common.collect.ImmutableList;
-import com.linkedin.common.*;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Owner;
+import com.linkedin.common.OwnerArray;
+import com.linkedin.common.Ownership;
+import com.linkedin.common.OwnershipSource;
+import com.linkedin.common.OwnershipSourceType;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;


### PR DESCRIPTION
## Summary

Adds a full eval harness for context intelligence agents (Ask DataHub, Analytics Agent, Cortex Agents) and direct LLM baselines. The framework is YAML-driven: define prompts, assertions, runner backend, and optional SQL executor in config — then `python -m evals.run --config <yaml>` orchestrates parallel runs, scores results, and writes structured output.

## Motivation

We need a repeatable, config-driven way to evaluate and compare our text-to-SQL and chatbot agents across prompt sets, runner backends, and scoring criteria. Before this PR, evaluation was ad-hoc scripts with no structured assertion model, no cost tracking, and no way to A/B test runners on the same prompt set.

## Changes Overview

### New: Eval Engine (`evals/engine.py`)
- Loads prompts from YAML, filters by ID/tag/instance, runs prompts in parallel via `ThreadPoolExecutor`
- Scores results with a two-layer assertion model (global + per-prompt overrides)
- Writes incremental `results.jsonl`, `summary.json`, `debug.log`, and `judge_traces/`
- Tracks per-prompt agent + judge token cost with cache-aware Bedrock usage
- AWS credential pre-check (STS probe) to fail fast on expired SSO tokens
- Stale-timeout enforcement, idempotent finalization, non-empty output-dir guard

### New: Config System (`evals/config.py`)
- Pydantic models for the full eval YAML schema with discriminated-union runner configs
- `${ENV_VAR}` expansion with strict unresolved-var detection
- CLI `--override key=value` for dotted-path config overrides
- `skip_assertion_types` for run-wide off-switch of whole assertion categories
- `merge_assertions()` for global + per-prompt assertion composition

### New: 11 Assertion Types (`evals/checks.py`)
`not_empty`, `contains`, `not_contains`, `regex_match`, `regex_not_match`, `min_value`, `max_value`, `llm_judge`, `tool_calls`, `sql_syntax`, `exec_match`

### New: Template-Driven LLM Judge (`evals/judges/`)
- **`default`**: Legacy binary PASS/FAIL judge for chatbot response-guidelines
- **`text_to_sql_v1`**: FLEX/FLASK-aligned per-criterion 1–3 scoring (entity, filters, aggregation, anti_patterns, narrative) with deterministic verdict derivation (PASS/BORDERLINE/FAIL). Mandatory criterion-by-criterion CoT, structured JSON output, equivalent-path procedure, bias guards
- Slot resolver (`judges/slots.py`) wires runtime context (response, generated SQL, reference SQL, exec_match outcomes) into template placeholders
- `diskcache` memoization keyed on rendered prompt + model + max_tokens

### New: 4 Runner Backends (`evals/runners/`)
| Runner | What it does |
|--------|-------------|
| `agent` | Runs prompts through Ask DataHub agents (auto/fast/research) via `DataHubClient` |
| `analytics_agent` | Runs prompts through the Analytics Agent's LangGraph ReAct agent in-process |
| `cortex_agent` | Streams one-shot runs through Snowflake Cortex Agents REST API |
| `llm` | Sends prompts directly to Bedrock (baseline, no tools) |

All share a `RunnerBackend` ABC that handles the event-queue protocol, timing, and error wrapping — subclasses implement only `_execute()`.

### New: SQL Executors (`evals/executors/`)
- **`local`**: sqlglot syntax/lint checks, no DB connection
- **`snowflake`**: Full execution + DataFrame result comparison. JWT and legacy-JSON auth. SQL injection guard (`_reject_if_mutating` keyword allowlist), thread-safe connection, session-level read-only intent

### New: Supporting Tools
- **`replay_judge.py`**: Re-run only the LLM judge against frozen `results.jsonl` — iterate on judge prompts without paying agent cost
- **`lint_response_guidelines.py`**: Lint that every `response_guidelines` block conforms to the canonical `text_to_sql_v1` schema
- **`mlflow_publisher.py`**: Publish eval results to MLflow (config, metrics, artifacts). Credential redaction for sensitive config keys
- **Shared history utilities** (`runners/history.py`): `ChatHistory`-compatible JSON builder for tool-call traces across runners

### Modified: Production Code (small, backward-compatible)
- **`gen_ai/bedrock.py`**: Added `BedrockUsage` dataclass and `call_bedrock_llm_with_usage()` wrapper to expose token counts (including cache_read/cache_creation) without changing the existing `call_bedrock_llm() -> str` contract
- **`gen_ai/model_config.py`**: Added `CLAUDE_46_SONNET` to `BedrockModel` and `ModelIdentifier` enums
- **`observability/cost.py`**: Added pricing entries for Claude Sonnet 4.6 and Haiku 4.5
- **`chat/agents/data_catalog_agent.py`**: Added optional `include_mutation_tools` and `extra_tools` params to agent factory functions (defaults preserve existing behavior)

## Testing

6 test files covering key regression scenarios:
- `test_check_tool_calls.py` — `values` enforcement, rich-match + bare-name composition, preamble forwarding
- `test_extract_json_from_markdown.py` — JSON extraction from multi-fence LLM responses (locked in fix for 3 real ERROR verdicts)
- `test_judge_model_resolution.py` — `BedrockModel` enum resolution, strict unknown-name rejection
- `test_prompts_loader.py` — List-form and dict-form YAML loading
- `test_skip_assertion_types.py` — Run-wide type skipping at the `score_result` seam
- `test_skip_preserves_slot_visibility.py` — Skipped assertions stay visible to sibling slot resolvers

## Impact Assessment

- **Affected components**: New `evals/` package (dev-only, not imported at service runtime). Small additions to `bedrock.py`, `model_config.py`, `cost.py`, `data_catalog_agent.py`
- **Breaking changes**: None — all production API signatures are backward-compatible (new params have defaults)
- **Risk level**: Low — the eval framework is a dev tool; production changes are additive

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md)
- [x] Tests for the changes have been added/updated
- [x] No breaking changes to existing functionality