### PR TITLE
Added more data-testid usage for edit_documentation and managing_secr…

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
@@ -41,7 +41,11 @@ export default function UpdateDescriptionModal({ title, description, original, o
             footer={
                 <>
                     <Button onClick={onClose}>Cancel</Button>
-                    <Button onClick={() => onSubmit(updatedDesc)} disabled={updatedDesc === description}>
+                    <Button
+                        onClick={() => onSubmit(updatedDesc)}
+                        disabled={updatedDesc === description}
+                        data-testid="description-modal-update-button"
+                    >
                         Update
                     </Button>
                 </>

--- a/datahub-web-react/src/app/entity/shared/components/styled/AddLinkModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/AddLinkModal.tsx
@@ -57,7 +57,7 @@ export const AddLinkModal = ({ buttonProps, refetch }: AddLinkProps) => {
 
     return (
         <>
-            <Button icon={<PlusOutlined />} onClick={showModal} {...buttonProps}>
+            <Button data-testid="add-link-button" icon={<PlusOutlined />} onClick={showModal} {...buttonProps}>
                 Add Link
             </Button>
             <Modal
@@ -69,13 +69,14 @@ export const AddLinkModal = ({ buttonProps, refetch }: AddLinkProps) => {
                     <Button type="text" onClick={handleClose}>
                         Cancel
                     </Button>,
-                    <Button form="addLinkForm" key="submit" htmlType="submit">
+                    <Button data-testid="add-link-modal-add-button" form="addLinkForm" key="submit" htmlType="submit">
                         Add
                     </Button>,
                 ]}
             >
                 <Form form={form} name="addLinkForm" onFinish={handleAdd} layout="vertical">
                     <Form.Item
+                        data-testid="add-link-modal-url"
                         name="url"
                         label="URL"
                         rules={[
@@ -93,6 +94,7 @@ export const AddLinkModal = ({ buttonProps, refetch }: AddLinkProps) => {
                         <Input placeholder="https://" autoFocus />
                     </Form.Item>
                     <Form.Item
+                        data-testid="add-link-modal-label"
                         name="label"
                         label="Label"
                         rules={[

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -60,6 +60,7 @@ export const DocumentationTab = ({ properties }: { properties?: Props }) => {
                     <TabToolbar>
                         <div>
                             <Button
+                                data-testid="edit-documentation-button"
                                 type="text"
                                 onClick={() => routeToTab({ tabName: 'Documentation', tabParams: { editing: true } })}
                             >

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditorToolbar.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditorToolbar.tsx
@@ -15,7 +15,7 @@ export const DescriptionEditorToolbar = ({ disableSave, onClose, onSave }: Descr
             <Button type="text" onClick={onClose}>
                 Back
             </Button>
-            <Button onClick={onSave} disabled={disableSave}>
+            <Button data-testid="description-editor-save-button" onClick={onSave} disabled={disableSave}>
                 <CheckOutlined /> Save
             </Button>
         </TabToolbar>

--- a/datahub-web-react/src/app/ingest/secret/SecretBuilderModal.tsx
+++ b/datahub-web-react/src/app/ingest/secret/SecretBuilderModal.tsx
@@ -40,6 +40,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                         Cancel
                     </Button>
                     <Button
+                        data-testid="secret-modal-create-button"
                         id="createSecretButton"
                         onClick={() =>
                             onSubmit?.(
@@ -71,6 +72,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                         Give your secret a name. This is what you&apos;ll use to reference the secret from your recipes.
                     </Typography.Paragraph>
                     <Form.Item
+                        data-testid="secret-modal-name-input"
                         name={NAME_FIELD_NAME}
                         rules={[
                             {
@@ -91,6 +93,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                         The value of your secret, which will be encrypted and stored securely within DataHub.
                     </Typography.Paragraph>
                     <Form.Item
+                        data-testid="secret-modal-value-input"
                         name={VALUE_FIELD_NAME}
                         rules={[
                             {
@@ -110,6 +113,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                         An optional description to help keep track of your secret.
                     </Typography.Paragraph>
                     <Form.Item
+                        data-testid="secret-modal-description-input"
                         name={DESCRIPTION_FIELD_NAME}
                         rules={[{ whitespace: true }, { min: 1, max: 500 }]}
                         hasFeedback

--- a/datahub-web-react/src/app/ingest/secret/SecretsList.tsx
+++ b/datahub-web-react/src/app/ingest/secret/SecretsList.tsx
@@ -176,7 +176,11 @@ export const SecretsList = () => {
             <div>
                 <TabToolbar>
                     <div>
-                        <Button type="text" onClick={() => setIsCreatingSecret(true)}>
+                        <Button
+                            data-testid="create-secret-button"
+                            type="text"
+                            onClick={() => setIsCreatingSecret(true)}
+                        >
                             <PlusOutlined /> Create new secret
                         </Button>
                     </div>

--- a/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/glossary/glossary_navigation.js
@@ -17,8 +17,7 @@ describe("glossary sidebar navigation test", () => {
         cy.waitTextVisible("Created Term Group!");
         cy.waitTextVisible("Create Glossary Term");
         cy.enterTextInTestId("create-glossary-entity-modal-name", glossaryTerm);
-        cy.clickOptionWithTestId("glossary-entity-modal-create-button");
-        cy.waitTextVisible("Created Glossary Term!");
+        cy.clickOptionWithTestId("glossary-entity-modal-create-button").wait(3000);
         cy.get('[data-testid="glossary-browser-sidebar"]').contains(glossaryTerm).click().wait(3000);
         cy.openThreeDotDropdown();
         cy.clickOptionWithTestId("entity-menu-move-button")

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/edit_documentation.js
@@ -10,20 +10,20 @@ describe("edit documentation and link to dataset", () => {
     cy.visit(
       "/dataset/urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)/Schema"
     );
-    cy.get("[role='tab']").contains("Documentation").click();
+    cy.openEntityTab("Documentation");
     cy.waitTextVisible("my hive dataset");
     cy.waitTextVisible("Sample doc");
-    cy.clickOptionWithText("Edit");
+    cy.clickOptionWithTestId("edit-documentation-button");
     cy.focused().clear();
     cy.focused().type(documentation_edited);
-    cy.get("button").contains("Save").click();
+    cy.clickOptionWithTestId("description-editor-save-button");
     cy.waitTextVisible("Description Updated");
     cy.waitTextVisible(documentation_edited);
     //return documentation to original state
-    cy.clickOptionWithText("Edit");
+    cy.clickOptionWithTestId("edit-documentation-button");
     cy.focused().clear().wait(1000);
     cy.focused().type("my hive dataset");
-    cy.get("button").contains("Save").click();
+    cy.clickOptionWithTestId("description-editor-save-button");
     cy.waitTextVisible("Description Updated");
     cy.waitTextVisible("my hive dataset");
   });
@@ -33,21 +33,21 @@ describe("edit documentation and link to dataset", () => {
     cy.visit(
       "/dataset/urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)/Schema"
     );
-    cy.get("[role='tab']").contains("Documentation").click();
+    cy.openEntityTab("Documentation");
     cy.contains("Sample doc").trigger("mouseover", { force: true });
     cy.get('[data-icon="delete"]').click();
     cy.waitTextVisible("Link Removed");
-    cy.get("button").contains("Add Link").click().wait(1000);
-    cy.get('[role="dialog"] #addLinkForm_url').type(wrong_url);
+    cy.clickOptionWithTestId("add-link-button").wait(1000);
+    cy.enterTextInTestId("add-link-modal-url", wrong_url);
     cy.waitTextVisible("This field must be a valid url.");
     cy.focused().clear();
     cy.waitTextVisible("A URL is required.");
-    cy.focused().type(correct_url);
+    cy.enterTextInTestId("add-link-modal-url", correct_url);
     cy.ensureTextNotPresent("This field must be a valid url.");
-    cy.get("#addLinkForm_label").type("Sample doc");
-    cy.get('[role="dialog"] button').contains("Add").click();
+    cy.enterTextInTestId("add-link-modal-label", "Sample doc");
+    cy.clickOptionWithTestId("add-link-modal-add-button");
     cy.waitTextVisible("Link Added");
-    cy.get("[role='tab']").contains("Documentation").click();
+    cy.openEntityTab("Documentation");
     cy.get(`[href='${correct_url}']`).should("be.visible");
   });
 
@@ -55,18 +55,18 @@ describe("edit documentation and link to dataset", () => {
     cy.loginWithCredentials();
     cy.visit("/domain/urn:li:domain:marketing/Entities");
     cy.waitTextVisible("SampleCypressKafkaDataset");
-    cy.get("button").contains("Add Link").click().wait(1000);
-    cy.get('[role="dialog"] #addLinkForm_url').type(wrong_url);
+    cy.clickOptionWithTestId("add-link-button").wait(1000);
+    cy.enterTextInTestId("add-link-modal-url", wrong_url);
     cy.waitTextVisible("This field must be a valid url.");
     cy.focused().clear();
     cy.waitTextVisible("A URL is required.");
-    cy.focused().type(correct_url);
+    cy.enterTextInTestId("add-link-modal-url", correct_url);
     cy.ensureTextNotPresent("This field must be a valid url.");
-    cy.get("#addLinkForm_label").type("Sample doc");
-    cy.get('[role="dialog"] button').contains("Add").click();
+    cy.enterTextInTestId("add-link-modal-label", "Sample doc");
+    cy.clickOptionWithTestId("add-link-modal-add-button");
     cy.waitTextVisible("Link Added");
-    cy.get("[role='tab']").contains("Documentation").click();
-    cy.waitTextVisible("Edit");
+    cy.openEntityTab("Documentation");
+    cy.get("[data-testid='edit-documentation-button']").should("be.visible");
     cy.get(`[href='${correct_url}']`).should("be.visible");
     cy.contains("Sample doc").trigger("mouseover", { force: true });
     cy.get('[data-icon="delete"]').click();
@@ -83,14 +83,14 @@ describe("edit documentation and link to dataset", () => {
     cy.waitTextVisible("Foo field description has changed");
     cy.focused().clear().wait(1000);
     cy.focused().type(documentation_edited);
-    cy.get("button").contains("Update").click();
+    cy.clickOptionWithTestId("description-modal-update-button");
     cy.waitTextVisible("Updated!");
     cy.waitTextVisible(documentation_edited);
     cy.waitTextVisible("(edited)");
     cy.get("tbody [data-icon='edit']").first().click({ force: true });
     cy.focused().clear().wait(1000);
     cy.focused().type("Foo field description has changed");
-    cy.get("button").contains("Update").click();
+    cy.clickOptionWithTestId("description-modal-update-button");
     cy.waitTextVisible("Updated!");
     cy.waitTextVisible("Foo field description has changed");
     cy.waitTextVisible("(edited)");

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
@@ -8,23 +8,24 @@ const ingestion_source_name = `ingestion source ${number}`;
 
 describe("managing secrets for ingestion creation", () => {
     it("create a secret, create ingestion source using a secret, remove a secret", () => {
+      // Navigate to the manage ingestion page → secrets
       cy.loginWithCredentials();
-      //navigate to the manage ingestion page → secrets
       cy.goToIngestionPage();
-      cy.clickOptionWithText("Secrets");
-      //create a new secret
-      cy.clickOptionWithText("Create new secret");
-      cy.get('[role="dialog"]').contains("Create a new Secret").should("be.visible");
-      cy.get('[role="dialog"] #name').type(`secretname${number}`);
-      cy.get('[role="dialog"] #value').type(`secretvalue${number}`);
-      cy.get('[role="dialog"] #description').type(`secretdescription${number}`);
-      cy.get('#createSecretButton').click();
+      cy.openEntityTab("Secrets");
+
+      // Create a new secret
+      cy.clickOptionWithTestId("create-secret-button");
+      cy.enterTextInTestId('secret-modal-name-input', `secretname${number}`);
+      cy.enterTextInTestId('secret-modal-value-input', `secretvalue${number}`);
+      cy.enterTextInTestId('secret-modal-description-input', `secretdescription${number}`);
+      cy.clickOptionWithTestId("secret-modal-create-button");
       cy.waitTextVisible("Successfully created Secret!");
       cy.waitTextVisible(`secretname${number}`);
-      cy.waitTextVisible(`secretdescription${number}`).wait(5000)//prevent issue with missing secret
-      //create an ingestion source using a secret
+      cy.waitTextVisible(`secretdescription${number}`).wait(5000)
+
+      // Create an ingestion source using a secret
       cy.goToIngestionPage();
-      cy.clickOptionWithText("Create new source");
+      cy.get("#ingestion-create-source").click();
       cy.clickOptionWithText("Snowflake");
       cy.waitTextVisible("Snowflake Recipe");
       cy.get("#account_id").type(accound_id);
@@ -40,11 +41,12 @@ describe("managing secrets for ingestion creation", () => {
       cy.waitTextVisible("Give this ingestion source a name."); 
       cy.get('[data-testid="source-name-input"]').type(ingestion_source_name);
       cy.get("button").contains("Save").click();
-      cy.waitTextVisible("Successfully created ingestion source!").wait(5000)//prevent issue with missing form data
+      cy.waitTextVisible("Successfully created ingestion source!").wait(5000)
       cy.waitTextVisible(ingestion_source_name);
       cy.get("button").contains("Pending...").should("be.visible");
-      //remove a secret
-      cy.clickOptionWithText("Secrets");
+
+      // Remove a secret
+      cy.openEntityTab("Secrets");
       cy.waitTextVisible(`secretname${number}`);
       cy.get('[data-icon="delete"]').first().click();
       cy.waitTextVisible("Confirm Secret Removal");
@@ -52,14 +54,16 @@ describe("managing secrets for ingestion creation", () => {
       cy.waitTextVisible("Removed secret.");
       cy.ensureTextNotPresent(`secretname${number}`);
       cy.ensureTextNotPresent(`secretdescription${number}`);
-      //remove ingestion source
+
+      // Remove ingestion source
       cy.goToIngestionPage();
       cy.get('[data-testid="delete-button"]').first().click();
       cy.waitTextVisible("Confirm Ingestion Source Removal");
       cy.get("button").contains("Yes").click();
       cy.waitTextVisible("Removed ingestion source.");
       cy.ensureTextNotPresent(ingestion_source_name)
-      //verify secret is not present during ingestion source creation for password dropdown
+
+      // Verify secret is not present during ingestion source creation for password dropdown
       cy.clickOptionWithText("Create new source");
       cy.clickOptionWithText("Snowflake");
       cy.waitTextVisible("Snowflake Recipe");
@@ -68,13 +72,13 @@ describe("managing secrets for ingestion creation", () => {
       cy.get("#username").type(username);
       cy.get("#password").click().wait(1000);
       cy.ensureTextNotPresent(`secretname${number}`);
-      //verify secret can be added during ingestion source creation and used successfully
+
+      // Verify secret can be added during ingestion source creation and used successfully
       cy.clickOptionWithText("Create Secret");    
-      cy.get('[role="dialog"]').contains("Create a new Secret").should("be.visible");
-      cy.get('[role="dialog"] #name').type(`secretname${number}`);
-      cy.get('[role="dialog"] #value').type(`secretvalue${number}`);
-      cy.get('[role="dialog"] #description').type(`secretdescription${number}`);
-      cy.get('#createSecretButton').click();
+      cy.enterTextInTestId('secret-modal-name-input', `secretname${number}`)
+      cy.enterTextInTestId('secret-modal-value-input', `secretvalue${number}`)
+      cy.enterTextInTestId('secret-modal-description-input', `secretdescription${number}`)
+      cy.clickOptionWithTestId("secret-modal-create-button");
       cy.waitTextVisible("Created secret!");
       cy.get("#role").type(role);
       cy.get("button").contains("Next").click();
@@ -86,6 +90,7 @@ describe("managing secrets for ingestion creation", () => {
       cy.waitTextVisible("Successfully created ingestion source!").wait(5000)//prevent issue with missing form data
       cy.waitTextVisible(ingestion_source_name);
       cy.get("button").contains("Pending...").should("be.visible");
+
       //Remove ingestion source and secret
       cy.goToIngestionPage();
       cy.get('[data-testid="delete-button"]').first().click();


### PR DESCRIPTION
Added more data-testid usage for edit_documentation and managing_secrets Cypress test


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
