### PR TITLE
fix(elasticsearch): fix elasticsearch-setup for dropped 000001 index

### DIFF
--- a/docker/elasticsearch-setup/create-indices.sh
+++ b/docker/elasticsearch-setup/create-indices.sh
@@ -129,7 +129,7 @@ function create_datahub_usage_event_aws_elasticsearch() {
   if [ $USAGE_EVENT_STATUS -eq 200 ]; then
     USAGE_EVENT_DEFINITION=$(curl "${CURL_ARGS[@]}" "$ELASTICSEARCH_URL/${PREFIX}datahub_usage_event")
     # the definition is expected to contain "datahub_usage_event-000001" string
-    if [[ $USAGE_EVENT_DEFINITION != *"datahub_usage_event-$INDEX_SUFFIX"* ]]; then
+    if [[ $USAGE_EVENT_DEFINITION != *"datahub_usage_event-"* ]]; then
       # ... if it doesn't, we need to drop it
       echo -e "\n>>> deleting invalid datahub_usage_event ..."
       curl "${CURL_ARGS[@]}" -XDELETE "$ELASTICSEARCH_URL/${PREFIX}datahub_usage_event"


### PR DESCRIPTION
In old index management policies, old indices could be dropped. The setup script assumes the index is always present. Adjusting the logic slightly to not rely on the 000001 index specifically. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
