### PR TITLE
build: increase gradle retries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,16 @@ org.gradle.caching=false
 # Increase gradle JVM memory to 3GB to allow tests to run locally
 org.gradle.jvmargs=-Xmx3000m
 # Increase retries to 5 (from default of 3) and increase interval from 125ms to 1s.
+# Based on this thread https://github.com/gradle/gradle/issues/4629, it's unclear
+# if we should be using systemProp or not.  We're using both for now.
 org.gradle.internal.repository.max.retries=5
 org.gradle.internal.repository.max.tentatives=5
 org.gradle.internal.repository.initial.backoff=1000
+systemProp.org.gradle.internal.http.connectionTimeout=120000
+systemProp.org.gradle.internal.http.socketTimeout=120000
+systemProp.org.gradle.internal.repository.max.retries=5
+systemProp.org.gradle.internal.repository.max.tentatives=5
+systemProp.org.gradle.internal.repository.initial.backoff=1000
 
 # Needed to publish to Nexus from a sub-module
 gnsp.disableApplyOnlyOnRootProjectEnforcement=true


### PR DESCRIPTION
Honestly not sure what the right options are here, so just trying some things out.

See a lot of issues in CI https://github.com/datahub-project/datahub/actions/runs/6631594104/job/18015463615?pr=9061

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
