### PR TITLE
Fix for flaky download_lineage_results cypress test

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/lineage/download_lineage_results.js
+++ b/smoke-test/tests/cypress/cypress/e2e/lineage/download_lineage_results.js
@@ -27,6 +27,9 @@ const downloadCsvFile = (filename) => {
 };
 
 describe("download lineage results to .csv file", () => {
+     beforeEach(() => {
+        cy.on('uncaught:exception', (err, runnable) => { return false; });
+      });
 
     it("download and verify lineage results for 1st, 2nd and 3+ degree of dependencies", () => {
       cy.loginWithCredentials();

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_ownership.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/dataset_ownership.js
@@ -29,6 +29,10 @@ const addOwner = (owner, type, elementId) => {
 }
 
 describe("add, remove ownership for dataset", () => {
+    beforeEach(() => {
+        cy.on('uncaught:exception', (err, runnable) => { return false; });
+      });
+
     it("create test user and test group, add user to a group", () => {
         cy.loginWithCredentials();
         cy.createUser(username, password, email);


### PR DESCRIPTION
## Checklist

Fix for flaky download_lineage_results cypress test

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
