### PR TITLE
fix: expand the stats row in search preview cards

### DIFF
--- a/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/shared/DashboardStatsSummary.tsx
@@ -11,6 +11,9 @@ import ExpandingStat from '../../dataset/shared/ExpandingStat';
 
 const StatText = styled.span`
     color: ${ANTD_GRAY[8]};
+    @media (min-width: 1024px) {
+        width: 100%;
+        white-space: nowrap;
 `;
 
 const HelpIcon = styled(QuestionCircleOutlined)`

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -12,6 +12,9 @@ import ExpandingStat from './ExpandingStat';
 
 const StatText = styled.span<{ color: string }>`
     color: ${(props) => props.color};
+    @media (min-width: 1160px) {
+        width: 100%;
+        white-space: nowrap;
 `;
 
 const PopoverContent = styled.div`
@@ -47,6 +50,7 @@ export const DatasetStatsSummary = ({
     const statsViews = [
         !!rowCount && (
             <ExpandingStat
+                renderCss={false}
                 disabled={isTooltipMode || !needsFormatting(rowCount)}
                 render={(isExpanded) => (
                     <StatText color={displayedColor}>

--- a/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/DatasetStatsSummary.tsx
@@ -50,7 +50,6 @@ export const DatasetStatsSummary = ({
     const statsViews = [
         !!rowCount && (
             <ExpandingStat
-                renderCss={false}
                 disabled={isTooltipMode || !needsFormatting(rowCount)}
                 render={(isExpanded) => (
                     <StatText color={displayedColor}>

--- a/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
@@ -1,18 +1,20 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; width: string }>`
-    overflow: hidden;
-    white-space: nowrap;
-    width: ${(props) => props.width};
+const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; width: string; renderCss: boolean }>`
+    overflow: ${(props) => props.renderCss && 'hidden'};
+    white-space: ${(props) => props.renderCss && 'nowrap'};
+    max-width: ${(props) => (!props.renderCss ? '100%' : props.width)};
     transition: width 250ms ease;
 `;
 
 const ExpandingStat = ({
     disabled = false,
     render,
+    renderCss = true,
 }: {
     disabled?: boolean;
+    renderCss?: boolean;
     render: (isExpanded: boolean) => ReactNode;
 }) => {
     const contentRef = useRef<HTMLSpanElement>(null);
@@ -34,6 +36,7 @@ const ExpandingStat = ({
 
     return (
         <ExpandingStatContainer
+            renderCss={renderCss}
             disabled={disabled}
             expanded={isExpanded}
             width={width}

--- a/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
+++ b/datahub-web-react/src/app/entity/dataset/shared/ExpandingStat.tsx
@@ -1,20 +1,17 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
-const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; width: string; renderCss: boolean }>`
-    overflow: ${(props) => props.renderCss && 'hidden'};
-    white-space: ${(props) => props.renderCss && 'nowrap'};
-    max-width: ${(props) => (!props.renderCss ? '100%' : props.width)};
+const ExpandingStatContainer = styled.span<{ disabled: boolean; expanded: boolean; width: string }>`
+    max-width: 100%;
     transition: width 250ms ease;
 `;
 
 const ExpandingStat = ({
     disabled = false,
     render,
-    renderCss = true,
 }: {
     disabled?: boolean;
-    renderCss?: boolean;
+
     render: (isExpanded: boolean) => ReactNode;
 }) => {
     const contentRef = useRef<HTMLSpanElement>(null);
@@ -36,7 +33,6 @@ const ExpandingStat = ({
 
     return (
         <ExpandingStatContainer
-            renderCss={renderCss}
             disabled={disabled}
             expanded={isExpanded}
             width={width}


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)- https://linear.app/acryl-data/issue/OBS-187/expand-the-stats-row-in-search-preview-cards
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
