### PR TITLE
fix: bad lineage link in `LineageGraphOnboardingConfig.tsx`

### DIFF
--- a/datahub-web-react/src/app/onboarding/config/LineageGraphOnboardingConfig.tsx
+++ b/datahub-web-react/src/app/onboarding/config/LineageGraphOnboardingConfig.tsx
@@ -23,7 +23,7 @@ export const LineageGraphOnboardingConfig: OnboardingStep[] = [
                     <a
                         target="_blank"
                         rel="noreferrer noopener"
-                        href="https://datahubproject.io/docs/lineage/lineage-feature-guide/"
+                        href="https://datahubproject.io/docs/generated/lineage/lineage-feature-guide/"
                     >
                         here.
                     </a>


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

This PR updates the frontend lineage link in `LineageGraphOnboardingConfig.tsx` component to the new lineage docs location made in #8899. 




