### PR TITLE
fix(mysql-setup): quote database name

### DIFF
--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -1,6 +1,6 @@
 -- create datahub database
-CREATE DATABASE IF NOT EXISTS DATAHUB_DB_NAME CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-USE DATAHUB_DB_NAME;
+CREATE DATABASE IF NOT EXISTS `DATAHUB_DB_NAME` CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+USE `DATAHUB_DB_NAME`;
 
 -- create metadata aspect table
 create table if not exists metadata_aspect_v2 (


### PR DESCRIPTION
Some database names are only accepted if quoted. See [Schema Object Names](https://dev.mysql.com/doc/refman/8.0/en/identifiers.html) in the MySQL documentation for background. This changes the init SQL file to always quote the database name.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
