### PR TITLE
feat(glossary): add ability to clone glossary term(name and documentation) from term profile menu

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
@@ -65,7 +65,12 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                 useEntityQuery={useGetGlossaryTermQuery as any}
                 headerActionItems={new Set([EntityActionItem.BATCH_ADD_GLOSSARY_TERM])}
                 headerDropdownItems={
-                    new Set([EntityMenuItems.UPDATE_DEPRECATION, EntityMenuItems.MOVE, EntityMenuItems.DELETE])
+                    new Set([
+                        EntityMenuItems.UPDATE_DEPRECATION,
+                        EntityMenuItems.CLONE,
+                        EntityMenuItems.MOVE,
+                        EntityMenuItems.DELETE,
+                    ])
                 }
                 isNameEditable
                 hideBrowseBar

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/CreateGlossaryEntityModal.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components/macro';
 import { EditOutlined } from '@ant-design/icons';
 import { message, Button, Input, Modal, Typography, Form, Collapse } from 'antd';
 import DOMPurify from 'dompurify';
+import { useHistory } from 'react-router';
 import {
     useCreateGlossaryTermMutation,
     useCreateGlossaryNodeMutation,
@@ -16,6 +17,7 @@ import DescriptionModal from '../components/legacy/DescriptionModal';
 import { validateCustomUrnId } from '../../../shared/textUtil';
 import { useGlossaryEntityData } from '../GlossaryEntityContext';
 import { getGlossaryRootToUpdate, updateGlossarySidebar } from '../../../glossary/utils';
+import { getEntityPath } from '../containers/profile/utils';
 
 const StyledItem = styled(Form.Item)`
     margin-bottom: 0;
@@ -33,6 +35,7 @@ interface Props {
     entityType: EntityType;
     onClose: () => void;
     refetchData?: () => void;
+    clone?: boolean;
 }
 
 function CreateGlossaryEntityModal(props: Props) {
@@ -43,14 +46,30 @@ function CreateGlossaryEntityModal(props: Props) {
     const entityRegistry = useEntityRegistry();
     const [stagedId, setStagedId] = useState<string | undefined>(undefined);
     const [stagedName, setStagedName] = useState('');
-    const [selectedParentUrn, setSelectedParentUrn] = useState(entityData.urn);
+    const [selectedParentUrn, setSelectedParentUrn] = useState<string>(props.clone ? '' : entityData.urn);
     const [documentation, setDocumentation] = useState('');
     const [isDocumentationModalVisible, setIsDocumentationModalVisible] = useState(false);
     const [createButtonDisabled, setCreateButtonDisabled] = useState(true);
     const refetch = useRefetch();
+    const history = useHistory();
 
     const [createGlossaryTermMutation] = useCreateGlossaryTermMutation();
     const [createGlossaryNodeMutation] = useCreateGlossaryNodeMutation();
+
+    useEffect(() => {
+        if (props.clone && entityData.entityData) {
+            const { properties } = entityData.entityData;
+
+            if (properties?.name) {
+                setStagedName(properties.name);
+                form.setFieldValue('name', properties.name);
+            }
+
+            if (properties?.description) {
+                setDocumentation(properties.description);
+            }
+        }
+    }, [props.clone, entityData.entityData, form]);
 
     function createGlossaryEntity() {
         const mutation =
@@ -67,7 +86,7 @@ function CreateGlossaryEntityModal(props: Props) {
                 },
             },
         })
-            .then(() => {
+            .then((res) => {
                 message.loading({ content: 'Updating...', duration: 2 });
                 setTimeout(() => {
                     analytics.event({
@@ -82,11 +101,20 @@ function CreateGlossaryEntityModal(props: Props) {
                     refetch();
                     if (isInGlossaryContext) {
                         // either refresh this current glossary node or the root nodes or root terms
-                        const nodeToUpdate = entityData?.urn || getGlossaryRootToUpdate(entityType);
+                        const nodeToUpdate = props.clone
+                            ? getGlossaryRootToUpdate(entityType)
+                            : entityData?.urn || getGlossaryRootToUpdate(entityType);
                         updateGlossarySidebar([nodeToUpdate], urnsToUpdate, setUrnsToUpdate);
                     }
                     if (refetchData) {
                         refetchData();
+                    }
+                    if (props.clone) {
+                        const redirectUrn =
+                            entityType === EntityType.GlossaryTerm
+                                ? res.data?.createGlossaryTerm
+                                : res.data?.createGlossaryNode;
+                        history.push(getEntityPath(entityType, redirectUrn, entityRegistry, false, false));
                     }
                 }, 2000);
             })

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/EntityDropdown.tsx
@@ -9,6 +9,7 @@ import {
     LinkOutlined,
     MoreOutlined,
     PlusOutlined,
+    CopyOutlined,
 } from '@ant-design/icons';
 import { Redirect } from 'react-router';
 import { EntityType } from '../../../../types.generated';
@@ -32,6 +33,7 @@ export enum EntityMenuItems {
     ADD_TERM_GROUP,
     DELETE,
     MOVE,
+    CLONE,
 }
 
 export const MenuIcon = styled(MoreOutlined)<{ fontSize?: number }>`
@@ -107,6 +109,7 @@ function EntityDropdown(props: Props) {
 
     const [isCreateTermModalVisible, setIsCreateTermModalVisible] = useState(false);
     const [isCreateNodeModalVisible, setIsCreateNodeModalVisible] = useState(false);
+    const [isCloneEntityModalVisible, setIsCloneEntityModalVisible] = useState<boolean>(false);
     const [isDeprecationModalVisible, setIsDeprecationModalVisible] = useState(false);
     const [isMoveModalVisible, setIsMoveModalVisible] = useState(false);
 
@@ -197,10 +200,21 @@ function EntityDropdown(props: Props) {
                                 </MenuItem>
                             </StyledMenuItem>
                         )}
+                        {menuItems.has(EntityMenuItems.CLONE) && (
+                            <StyledMenuItem
+                                key="4"
+                                disabled={!entityData?.privileges?.canManageEntity}
+                                onClick={() => setIsCloneEntityModalVisible(true)}
+                            >
+                                <MenuItem>
+                                    <CopyOutlined /> &nbsp;Clone
+                                </MenuItem>
+                            </StyledMenuItem>
+                        )}
                         {!isDomainMoveHidden && menuItems.has(EntityMenuItems.MOVE) && (
                             <StyledMenuItem
                                 data-testid="entity-menu-move-button"
-                                key="4"
+                                key="5"
                                 disabled={isMoveDisabled(entityType, entityData, me.platformPrivileges)}
                                 onClick={() => setIsMoveModalVisible(true)}
                             >
@@ -211,7 +225,7 @@ function EntityDropdown(props: Props) {
                         )}
                         {menuItems.has(EntityMenuItems.DELETE) && (
                             <StyledMenuItem
-                                key="5"
+                                key="6"
                                 disabled={isDeleteDisabled(entityType, entityData, me.platformPrivileges)}
                                 onClick={onDeleteEntity}
                             >
@@ -248,6 +262,14 @@ function EntityDropdown(props: Props) {
                     entityType={EntityType.GlossaryNode}
                     onClose={() => setIsCreateNodeModalVisible(false)}
                     refetchData={refetchForNodes}
+                />
+            )}
+            {isCloneEntityModalVisible && (
+                <CreateGlossaryEntityModal
+                    entityType={entityType}
+                    onClose={() => setIsCloneEntityModalVisible(false)}
+                    refetchData={entityType === EntityType.GlossaryTerm ? refetchForTerms : refetchForNodes}
+                    clone
                 />
             )}
             {isDeprecationModalVisible && (

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -69,6 +69,7 @@ export type GenericEntityProperties = {
     type?: EntityType;
     name?: Maybe<string>;
     properties?: Maybe<{
+        name?: Maybe<string>;
         description?: Maybe<string>;
         qualifiedName?: Maybe<string>;
         sourceUrl?: Maybe<string>;


### PR DESCRIPTION
Add ability to clone Glossary Term by using "Clone" button in term's profile menu. After cloning, user is redirected to new entity's profile page.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

![clone-term](https://github.com/datahub-project/datahub/assets/38855943/aaf69b42-f9c4-48a6-893f-172c8e9d9246)