### PR TITLE
feat(policy): enable support for 10k+ policies

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/ListPoliciesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/policy/ListPoliciesResolver.java
@@ -40,23 +40,15 @@ public class ListPoliciesResolver implements DataFetcher<CompletableFuture<ListP
       final Integer count = input.getCount() == null ? DEFAULT_COUNT : input.getCount();
       final String query = input.getQuery() == null ? DEFAULT_QUERY : input.getQuery();
 
-      return CompletableFuture.supplyAsync(() -> {
-        try {
-          // First, get all policy Urns.
-          final PolicyFetcher.PolicyFetchResult policyFetchResult =
-              _policyFetcher.fetchPolicies(start, count, query, context.getAuthentication());
-
-          // Now that we have entities we can bind this to a result.
-          final ListPoliciesResult result = new ListPoliciesResult();
-          result.setStart(start);
-          result.setCount(count);
-          result.setTotal(policyFetchResult.getTotal());
-          result.setPolicies(mapEntities(policyFetchResult.getPolicies()));
-          return result;
-        } catch (Exception e) {
-          throw new RuntimeException("Failed to list policies", e);
-        }
-      });
+      return _policyFetcher.fetchPolicies(start, query, count, context.getAuthentication())
+              .thenApply(policyFetchResult -> {
+                final ListPoliciesResult result = new ListPoliciesResult();
+                result.setStart(start);
+                result.setCount(count);
+                result.setTotal(policyFetchResult.getTotal());
+                result.setPolicies(mapEntities(policyFetchResult.getPolicies()));
+                return result;
+              });
     }
     throw new AuthorizationException("Unauthorized to perform this action. Please contact your DataHub administrator.");
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -381,7 +381,7 @@ public class JavaEntityClient implements EntityClient {
     @Nonnull
     @Override
     public ScrollResult scrollAcrossEntities(@Nonnull List<String> entities, @Nonnull String input,
-        @Nullable Filter filter, @Nullable String scrollId, @Nonnull String keepAlive, int count,
+        @Nullable Filter filter, @Nullable String scrollId, @Nullable String keepAlive, int count,
         @Nullable SearchFlags searchFlags, @Nonnull Authentication authentication)
         throws RemoteInvocationException {
         final SearchFlags finalFlags = searchFlags != null ? searchFlags : new SearchFlags().setFulltext(true);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
@@ -147,15 +147,23 @@ public class SearchService {
     return result;
   }
 
+  /**
+   * If no entities are provided, fallback to the list of non-empty entities
+   * @param inputEntities the requested entities
+   * @return some entities to search
+   */
   private List<String> getEntitiesToSearch(@Nonnull List<String> inputEntities) {
     List<String> nonEmptyEntities;
     List<String> lowercaseEntities = inputEntities.stream().map(String::toLowerCase).collect(Collectors.toList());
-    try (Timer.Context ignored = MetricUtils.timer(this.getClass(), "getNonEmptyEntities").time()) {
-      nonEmptyEntities = _entityDocCountCache.getNonEmptyEntities();
+
+    if (lowercaseEntities.isEmpty()) {
+      try (Timer.Context ignored = MetricUtils.timer(this.getClass(), "getNonEmptyEntities").time()) {
+        nonEmptyEntities = _entityDocCountCache.getNonEmptyEntities();
+      }
+    } else {
+      nonEmptyEntities = lowercaseEntities;
     }
-    if (!inputEntities.isEmpty()) {
-      nonEmptyEntities = nonEmptyEntities.stream().filter(lowercaseEntities::contains).collect(Collectors.toList());
-    }
+
     return nonEmptyEntities;
   }
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyFetcher.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyFetcher.java
@@ -8,8 +8,8 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.query.filter.SortOrder;
+import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchEntity;
-import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.policy.DataHubPolicyInfo;
 import com.linkedin.r2.RemoteInvocationException;
 import java.net.URISyntaxException;
@@ -18,10 +18,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
 
 import static com.linkedin.metadata.Constants.DATAHUB_POLICY_INFO_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.POLICY_ENTITY_NAME;
@@ -38,22 +41,53 @@ public class PolicyFetcher {
   private static final SortCriterion POLICY_SORT_CRITERION =
       new SortCriterion().setField("lastUpdatedTimestamp").setOrder(SortOrder.DESCENDING);
 
-  public PolicyFetchResult fetchPolicies(int start, int count, Authentication authentication)
-      throws RemoteInvocationException, URISyntaxException {
-    return fetchPolicies(start, count, "", authentication);
+  /**
+   * This is to provide a scroll implementation using the start/count api. It is not efficient
+   * and the scroll native functions should be used instead. This does fix a failure to fetch
+   * policies when deep pagination happens where there are >10k policies.
+   * Exists primarily to prevent breaking change to the graphql api.
+   */
+  @Deprecated
+  public CompletableFuture<PolicyFetchResult> fetchPolicies(int start, String query, int count, Authentication authentication) {
+    return CompletableFuture.supplyAsync(() -> {
+      try {
+        PolicyFetchResult result = PolicyFetchResult.EMPTY;
+        String scrollId = "";
+        int fetchedResults = 0;
+
+        while (PolicyFetchResult.EMPTY.equals(result) && scrollId != null) {
+          PolicyFetchResult tmpResult = fetchPolicies(query, count, scrollId.isEmpty() ? null : scrollId, authentication);
+          fetchedResults += tmpResult.getPolicies().size();
+          scrollId = tmpResult.getScrollId();
+          if (fetchedResults > start) {
+            result = tmpResult;
+          }
+        }
+
+        return result;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to list policies", e);
+      }
+    });
   }
 
-  public PolicyFetchResult fetchPolicies(int start, int count, String query, Authentication authentication)
+  public PolicyFetchResult fetchPolicies(int count, @Nullable String scrollId, Authentication authentication)
+          throws RemoteInvocationException, URISyntaxException {
+    return fetchPolicies("", count, scrollId, authentication);
+  }
+
+  public PolicyFetchResult fetchPolicies(String query, int count, @Nullable String scrollId, Authentication authentication)
       throws RemoteInvocationException, URISyntaxException {
-    log.debug(String.format("Batch fetching policies. start: %s, count: %s ", start, count));
-    // First fetch all policy urns from start - start + count
-    SearchResult result =
-        _entityClient.search(POLICY_ENTITY_NAME, query, null, POLICY_SORT_CRITERION, start, count, authentication,
-            new SearchFlags().setFulltext(true));
+    log.debug(String.format("Batch fetching policies. count: %s, scroll: %s", count, scrollId));
+
+    // First fetch all policy urns
+    ScrollResult result = _entityClient.scrollAcrossEntities(List.of(POLICY_ENTITY_NAME), query, null, scrollId,
+            null, count, new SearchFlags().setSkipCache(true).setSkipAggregates(true)
+                    .setSkipHighlighting(true).setFulltext(true), authentication);
     List<Urn> policyUrns = result.getEntities().stream().map(SearchEntity::getEntity).collect(Collectors.toList());
 
     if (policyUrns.isEmpty()) {
-      return new PolicyFetchResult(Collections.emptyList(), 0);
+      return PolicyFetchResult.EMPTY;
     }
 
     // Fetch DataHubPolicyInfo aspects for each urn
@@ -64,7 +98,7 @@ public class PolicyFetcher {
         .filter(Objects::nonNull)
         .map(this::extractPolicy)
         .filter(Objects::nonNull)
-        .collect(Collectors.toList()), result.getNumEntities());
+        .collect(Collectors.toList()), result.getNumEntities(), result.getScrollId());
   }
 
   private Policy extractPolicy(EntityResponse entityResponse) {
@@ -82,6 +116,10 @@ public class PolicyFetcher {
   public static class PolicyFetchResult {
     List<Policy> policies;
     int total;
+    @Nullable
+    String scrollId;
+
+    public static final PolicyFetchResult EMPTY = new PolicyFetchResult(Collections.emptyList(), 0, null);
   }
 
   @Value

--- a/metadata-service/configuration/src/main/resources/application.yml
+++ b/metadata-service/configuration/src/main/resources/application.yml
@@ -39,6 +39,7 @@ authorization:
   defaultAuthorizer:
     enabled: ${AUTH_POLICIES_ENABLED:true}
     cacheRefreshIntervalSecs: ${POLICY_CACHE_REFRESH_INTERVAL_SECONDS:120}
+    cachePolicyFetchSize: ${POLICY_CACHE_FETCH_SIZE:1000}
   # Enables authorization of reads, writes, and deletes on REST APIs. Defaults to false for backwards compatibility, but should become true down the road
   restApiAuthorization: ${REST_API_AUTHORIZATION_ENABLED:false}
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubAuthorizerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/DataHubAuthorizerFactory.java
@@ -32,6 +32,9 @@ public class DataHubAuthorizerFactory {
   @Value("${authorization.defaultAuthorizer.cacheRefreshIntervalSecs}")
   private Integer policyCacheRefreshIntervalSeconds;
 
+  @Value("${authorization.defaultAuthorizer.cachePolicyFetchSize}")
+  private Integer policyCacheFetchSize;
+
   @Value("${authorization.defaultAuthorizer.enabled:true}")
   private Boolean policiesEnabled;
 
@@ -44,6 +47,6 @@ public class DataHubAuthorizerFactory {
         : DataHubAuthorizer.AuthorizationMode.ALLOW_ALL;
 
     return new DataHubAuthorizer(systemAuthentication, entityClient, 10,
-        policyCacheRefreshIntervalSeconds, mode);
+        policyCacheRefreshIntervalSeconds, mode, policyCacheFetchSize);
   }
 }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -241,7 +241,7 @@ public interface EntityClient {
    */
   @Nonnull
   ScrollResult scrollAcrossEntities(@Nonnull List<String> entities, @Nonnull String input,
-      @Nullable Filter filter, @Nullable String scrollId, @Nonnull String keepAlive, int count, @Nullable SearchFlags searchFlags,
+      @Nullable Filter filter, @Nullable String scrollId, @Nullable String keepAlive, int count, @Nullable SearchFlags searchFlags,
       @Nonnull Authentication authentication)
       throws RemoteInvocationException;
 

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -482,11 +482,11 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   @Nonnull
   @Override
   public ScrollResult scrollAcrossEntities(@Nonnull List<String> entities, @Nonnull String input,
-      @Nullable Filter filter, @Nullable String scrollId, @Nonnull String keepAlive, int count,
+      @Nullable Filter filter, @Nullable String scrollId, @Nullable String keepAlive, int count,
       @Nullable SearchFlags searchFlags, @Nonnull Authentication authentication)
       throws RemoteInvocationException {
     final EntitiesDoScrollAcrossEntitiesRequestBuilder requestBuilder =
-        ENTITIES_REQUEST_BUILDERS.actionScrollAcrossEntities().inputParam(input).countParam(count).keepAliveParam(keepAlive);
+        ENTITIES_REQUEST_BUILDERS.actionScrollAcrossEntities().inputParam(input).countParam(count);
 
     if (entities != null) {
       requestBuilder.entitiesParam(new StringArray(entities));
@@ -499,6 +499,9 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     }
     if (searchFlags != null) {
       requestBuilder.searchFlagsParam(searchFlags);
+    }
+    if (keepAlive != null) {
+      requestBuilder.keepAliveParam(keepAlive);
     }
 
     return sendClientRequest(requestBuilder, authentication).getEntity();

--- a/smoke-test/tests/cypress/cypress/e2e/settings/managing_groups.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settings/managing_groups.js
@@ -81,7 +81,7 @@ describe("create and manage group", () => {
         cy.focused().type(expected_name);
         cy.get(".ant-select-item-option").contains(expected_name, { matchCase: false }).click();
         cy.focused().blur();
-        cy.contains(expected_name).should("have.length", 1);
+        cy.contains(expected_name, { matchCase: false }).should("have.length", 1);
         cy.get('[role="dialog"] button').contains("Done").click();
         cy.waitTextVisible("Owners Added");
         cy.contains(expected_name, { matchCase: false }).should("be.visible");


### PR DESCRIPTION
Fetching policies was previously limited to 30 policy pages. This PR increases to 1000 by default. Secondly, moving to the scroll API which performs better with deep pagination in the 10k+ policy counts.

The graphql API changes are not included so we're forced to stay compatible with the current start/offset and count by paginating in the background when needed for the UI.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
