### PR TITLE
fix(sql-parser): convert platform instance to lowercase when building table urns

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlglot_lineage.py
@@ -344,8 +344,12 @@ class SchemaResolver(Closeable):
         table_name = ".".join(
             filter(None, [table.database, table.db_schema, table.table])
         )
+
+        platform_instance = self.platform_instance
+
         if lower:
             table_name = table_name.lower()
+            platform_instance = platform_instance.lower()
 
         if self.platform == "bigquery":
             # Normalize shard numbers and other BigQuery weirdness.
@@ -356,7 +360,7 @@ class SchemaResolver(Closeable):
 
         urn = make_dataset_urn_with_platform_instance(
             platform=self.platform,
-            platform_instance=self.platform_instance,
+            platform_instance=platform_instance,
             env=self.env,
             name=table_name,
         )

--- a/metadata-ingestion/src/datahub/utilities/sqlglot_lineage.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlglot_lineage.py
@@ -349,7 +349,7 @@ class SchemaResolver(Closeable):
 
         if lower:
             table_name = table_name.lower()
-            platform_instance = platform_instance.lower()
+            platform_instance = platform_instance.lower() if platform_instance else None
 
         if self.platform == "bigquery":
             # Normalize shard numbers and other BigQuery weirdness.

--- a/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_schemaresolver.py
@@ -1,0 +1,33 @@
+from datahub.utilities.sqlglot_lineage import SchemaResolver, _TableName
+
+
+def test_get_urn_for_table_lowercase():
+    schema_resolver = SchemaResolver(
+        platform="mssql",
+        platform_instance="Uppercased-Instance",
+        env="PROD",
+        graph=None,
+    )
+
+    table = _TableName(database="Database", db_schema="DataSet", table="Table")
+
+    assert (
+        schema_resolver.get_urn_for_table(table=table, lower=True)
+        == "urn:li:dataset:(urn:li:dataPlatform:mssql,uppercased-instance.database.dataset.table,PROD)"
+    )
+
+
+def test_get_urn_for_table_not_lower_should_keep_capital_letters():
+    schema_resolver = SchemaResolver(
+        platform="mssql",
+        platform_instance="Uppercased-Instance",
+        env="PROD",
+        graph=None,
+    )
+
+    table = _TableName(database="Database", db_schema="DataSet", table="Table")
+
+    assert (
+        schema_resolver.get_urn_for_table(table=table, lower=False)
+        == "urn:li:dataset:(urn:li:dataPlatform:mssql,Uppercased-Instance.Database.DataSet.Table,PROD)"
+    )


### PR DESCRIPTION
A naive approach for fixing #9172. I simply transform the platform instance to lower case when required.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable): Fixes #9172. 
- [X] Tests for the changes have been added/updated (if applicable)