### PR TITLE
fix:Settings tab should have 2 scrollable sections

### DIFF
--- a/datahub-web-react/src/app/entity/ownership/ManageOwnership.tsx
+++ b/datahub-web-react/src/app/entity/ownership/ManageOwnership.tsx
@@ -21,7 +21,7 @@ const PageTitle = styled(Typography.Title)`
 `;
 
 const ListContainer = styled.div`
-    height: calc(100% - 120px);
+    height: calc(100% - 11vh);
 `;
 
 /**

--- a/datahub-web-react/src/app/entity/ownership/ManageOwnership.tsx
+++ b/datahub-web-react/src/app/entity/ownership/ManageOwnership.tsx
@@ -20,7 +20,9 @@ const PageTitle = styled(Typography.Title)`
     }
 `;
 
-const ListContainer = styled.div``;
+const ListContainer = styled.div`
+    height: calc(100% - 120px);
+`;
 
 /**
  * Component used for displaying the 'Manage Ownership' experience.

--- a/datahub-web-react/src/app/entity/ownership/table/OwnershipTable.tsx
+++ b/datahub-web-react/src/app/entity/ownership/table/OwnershipTable.tsx
@@ -55,6 +55,10 @@ export const OwnershipTable = ({ ownershipTypes, setIsOpen, setOwnershipType, re
                 emptyText: <Empty description="No Ownership Types found!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
             }}
             pagination={false}
+            style={{
+                height: 'calc(100% - 30px)',
+                overflow: 'auto',
+            }}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/ownership/table/OwnershipTable.tsx
+++ b/datahub-web-react/src/app/entity/ownership/table/OwnershipTable.tsx
@@ -56,7 +56,6 @@ export const OwnershipTable = ({ ownershipTypes, setIsOpen, setOwnershipType, re
             }}
             pagination={false}
             style={{
-                height: 'calc(100% - 30px)',
                 overflow: 'auto',
             }}
         />

--- a/datahub-web-react/src/app/entity/view/ManageViews.tsx
+++ b/datahub-web-react/src/app/entity/view/ManageViews.tsx
@@ -21,7 +21,7 @@ const PageTitle = styled(Typography.Title)`
 `;
 
 const ListContainer = styled.div`
-    height: calc(100% - 120px);
+    height: calc(100% - 11vh);
 `;
 
 /**

--- a/datahub-web-react/src/app/entity/view/ManageViews.tsx
+++ b/datahub-web-react/src/app/entity/view/ManageViews.tsx
@@ -20,7 +20,9 @@ const PageTitle = styled(Typography.Title)`
     }
 `;
 
-const ListContainer = styled.div``;
+const ListContainer = styled.div`
+    height: calc(100% - 120px);
+`;
 
 /**
  * Component used for displaying the 'Manage Views' experience.

--- a/datahub-web-react/src/app/entity/view/ViewsTable.tsx
+++ b/datahub-web-react/src/app/entity/view/ViewsTable.tsx
@@ -56,6 +56,10 @@ export const ViewsTable = ({ views, onEditView }: ViewsTableProps) => {
                 emptyText: <Empty description="No Views found!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
             }}
             pagination={false}
+            style={{
+                height: 'calc(100% - 30px)',
+                overflow: 'auto',
+            }}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/view/ViewsTable.tsx
+++ b/datahub-web-react/src/app/entity/view/ViewsTable.tsx
@@ -57,7 +57,6 @@ export const ViewsTable = ({ views, onEditView }: ViewsTableProps) => {
             }}
             pagination={false}
             style={{
-                height: 'calc(100% - 30px)',
                 overflow: 'auto',
             }}
         />

--- a/datahub-web-react/src/app/identity/ManageIdentities.tsx
+++ b/datahub-web-react/src/app/identity/ManageIdentities.tsx
@@ -27,7 +27,7 @@ const Content = styled.div`
         margin: 0;
     }
     color: #262626;
-    height: calc(100vh - 60px);
+    height: calc(100% - 60px);
 
     &&& .ant-tabs > .ant-tabs-nav .ant-tabs-nav-wrap {
         padding-left: 28px;

--- a/datahub-web-react/src/app/identity/ManageIdentities.tsx
+++ b/datahub-web-react/src/app/identity/ManageIdentities.tsx
@@ -27,7 +27,7 @@ const Content = styled.div`
         margin: 0;
     }
     color: #262626;
-    height: calc(100% - 60px);
+    height: calc(100% - 11vh);
 
     &&& .ant-tabs > .ant-tabs-nav .ant-tabs-nav-wrap {
         padding-left: 28px;

--- a/datahub-web-react/src/app/identity/group/GroupList.tsx
+++ b/datahub-web-react/src/app/identity/group/GroupList.tsx
@@ -18,12 +18,12 @@ import { OnboardingTour } from '../../onboarding/OnboardingTour';
 import { addGroupToListGroupsCache, DEFAULT_GROUP_LIST_PAGE_SIZE, removeGroupFromListGroupsCache } from './cacheUtils';
 
 const GroupContainer = styled.div`
-    height: 100%;
+    height: calc(100% - 6vh);
 `;
 
 const GroupStyledList = styled(List)`
     &&& {
-        height: calc(100% - 85px);
+        height: calc(100% - 11vh);
         width: 100%;
         border-color: ${(props) => props.theme.styles['border-color-base']};
         overflow: auto;

--- a/datahub-web-react/src/app/identity/group/GroupList.tsx
+++ b/datahub-web-react/src/app/identity/group/GroupList.tsx
@@ -17,12 +17,16 @@ import { GROUPS_CREATE_GROUP_ID, GROUPS_INTRO_ID } from '../../onboarding/config
 import { OnboardingTour } from '../../onboarding/OnboardingTour';
 import { addGroupToListGroupsCache, DEFAULT_GROUP_LIST_PAGE_SIZE, removeGroupFromListGroupsCache } from './cacheUtils';
 
-const GroupContainer = styled.div``;
+const GroupContainer = styled.div`
+    height: 100%;
+`;
 
 const GroupStyledList = styled(List)`
     &&& {
+        height: calc(100% - 85px);
         width: 100%;
         border-color: ${(props) => props.theme.styles['border-color-base']};
+        overflow: auto;
     }
 `;
 

--- a/datahub-web-react/src/app/identity/user/UserList.tsx
+++ b/datahub-web-react/src/app/identity/user/UserList.tsx
@@ -26,12 +26,12 @@ import { DEFAULT_USER_LIST_PAGE_SIZE, removeUserFromListUsersCache } from './cac
 import { useUserContext } from '../../context/useUserContext';
 
 const UserContainer = styled.div`
-    height: 100%;
+    height: calc(100% - 6vh);
 `;
 
 const UserStyledList = styled(List)`
     &&& {
-        height: calc(100% - 85px);
+        height: calc(100% - 11vh);
         overflow: auto;
         width: 100%;
         border-color: ${(props) => props.theme.styles['border-color-base']};

--- a/datahub-web-react/src/app/identity/user/UserList.tsx
+++ b/datahub-web-react/src/app/identity/user/UserList.tsx
@@ -25,10 +25,14 @@ import { useUpdateEducationStepIdsAllowlist } from '../../onboarding/useUpdateEd
 import { DEFAULT_USER_LIST_PAGE_SIZE, removeUserFromListUsersCache } from './cacheUtils';
 import { useUserContext } from '../../context/useUserContext';
 
-const UserContainer = styled.div``;
+const UserContainer = styled.div`
+    height: 100%;
+`;
 
 const UserStyledList = styled(List)`
     &&& {
+        height: calc(100% - 85px);
+        overflow: auto;
         width: 100%;
         border-color: ${(props) => props.theme.styles['border-color-base']};
     }

--- a/datahub-web-react/src/app/permissions/ManagePermissions.tsx
+++ b/datahub-web-react/src/app/permissions/ManagePermissions.tsx
@@ -27,7 +27,7 @@ const Content = styled.div`
         margin: 0;
     }
     color: #262626;
-    height: calc(100vh - 60px);
+    height: calc(100% - 60px);
 
     &&& .ant-tabs > .ant-tabs-nav .ant-tabs-nav-wrap {
         padding-left: 28px;

--- a/datahub-web-react/src/app/permissions/ManagePermissions.tsx
+++ b/datahub-web-react/src/app/permissions/ManagePermissions.tsx
@@ -27,7 +27,7 @@ const Content = styled.div`
         margin: 0;
     }
     color: #262626;
-    height: calc(100% - 60px);
+    height: calc(100% - 11vh);
 
     &&& .ant-tabs > .ant-tabs-nav .ant-tabs-nav-wrap {
         padding-left: 28px;

--- a/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
+++ b/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
@@ -39,7 +39,7 @@ import { POLICIES_CREATE_POLICY_ID, POLICIES_INTRO_ID } from '../../onboarding/c
 import { OnboardingTour } from '../../onboarding/OnboardingTour';
 
 const SourceContainer = styled.div`
-    height: calc(100% - 40px);
+    height: 100%;
 `;
 
 const PaginationContainer = styled.div`
@@ -77,7 +77,7 @@ const EditPolicyButton = styled(Button)`
 
 const PageContainer = styled.div`
     width: 100%;
-    height: 100%;
+    height: calc(100% - 11vh);
 `;
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -493,7 +493,7 @@ export const ManagePolicies = () => {
                     }}
                     pagination={false}
                     style={{
-                        height: 'calc(100% - 30px)',
+                        height: 'calc(100% - 46px)',
                         overflow: 'auto',
                     }}
                 />

--- a/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
+++ b/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
@@ -38,7 +38,9 @@ import analytics, { EventType } from '../../analytics';
 import { POLICIES_CREATE_POLICY_ID, POLICIES_INTRO_ID } from '../../onboarding/config/PoliciesOnboardingConfig';
 import { OnboardingTour } from '../../onboarding/OnboardingTour';
 
-const SourceContainer = styled.div``;
+const SourceContainer = styled.div`
+    height: calc(100% - 40px);
+`;
 
 const PaginationContainer = styled.div`
     display: flex;
@@ -73,8 +75,9 @@ const EditPolicyButton = styled(Button)`
     margin-right: 16px;
 `;
 
-const PageContainer = styled.span`
+const PageContainer = styled.div`
     width: 100%;
+    height: 100%;
 `;
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -489,6 +492,10 @@ export const ManagePolicies = () => {
                         emptyText: <Empty description="No Policies!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
                     }}
                     pagination={false}
+                    style={{
+                        height: 'calc(100% - 30px)',
+                        overflow: 'auto',
+                    }}
                 />
             </SourceContainer>
             <PaginationContainer>

--- a/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
+++ b/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
@@ -22,7 +22,7 @@ import { ROLES_INTRO_ID } from '../../onboarding/config/RolesOnboardingConfig';
 import { clearUserListCache } from '../../identity/user/cacheUtils';
 
 const SourceContainer = styled.div`
-    height: calc(100% - 40px);
+    height: 100%;
 `;
 
 const PaginationContainer = styled.div`
@@ -37,7 +37,7 @@ const RoleName = styled.span`
 
 const PageContainer = styled.div`
     width: 100%;
-    height: 100%;
+    height: calc(100% - 11vh);
 `;
 
 const ActionsContainer = styled.div`
@@ -265,7 +265,7 @@ export const ManageRoles = () => {
                     }}
                     pagination={false}
                     style={{
-                        height: 'calc(100% - 30px)',
+                        height: 'calc(100% - 46px)',
                         overflow: 'auto',
                     }}
                 />

--- a/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
+++ b/datahub-web-react/src/app/permissions/roles/ManageRoles.tsx
@@ -21,7 +21,9 @@ import { OnboardingTour } from '../../onboarding/OnboardingTour';
 import { ROLES_INTRO_ID } from '../../onboarding/config/RolesOnboardingConfig';
 import { clearUserListCache } from '../../identity/user/cacheUtils';
 
-const SourceContainer = styled.div``;
+const SourceContainer = styled.div`
+    height: calc(100% - 40px);
+`;
 
 const PaginationContainer = styled.div`
     display: flex;
@@ -33,8 +35,9 @@ const RoleName = styled.span`
     font-weight: 700;
 `;
 
-const PageContainer = styled.span`
+const PageContainer = styled.div`
     width: 100%;
+    height: 100%;
 `;
 
 const ActionsContainer = styled.div`
@@ -261,6 +264,10 @@ export const ManageRoles = () => {
                         emptyText: <Empty description="No Roles!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
                     }}
                     pagination={false}
+                    style={{
+                        height: 'calc(100% - 30px)',
+                        overflow: 'auto',
+                    }}
                 />
             </SourceContainer>
             <PaginationContainer>

--- a/datahub-web-react/src/app/search/SearchablePage.tsx
+++ b/datahub-web-react/src/app/search/SearchablePage.tsx
@@ -18,16 +18,6 @@ import { useQuickFiltersContext } from '../../providers/QuickFiltersContext';
 import { useUserContext } from '../context/useUserContext';
 import { useSelectedSortOption } from './context/SearchContext';
 
-const styles = {
-    children: {
-        flex: '1',
-        marginTop: 60,
-        display: 'flex',
-        flexDirection: 'column' as const,
-        maxHeight: 'calc(100vh - 60px)',
-    },
-};
-
 interface Props extends React.PropsWithChildren<any> {
     onSearch?: (query: string, type?: EntityType) => void;
     onAutoComplete?: (query: string) => void;
@@ -138,7 +128,16 @@ export const SearchablePage = ({ onSearch, onAutoComplete, children }: Props) =>
                 authenticatedUserPictureLink={user?.editableProperties?.pictureLink}
                 entityRegistry={entityRegistry}
             />
-            <div style={styles.children}>{children}</div>
+            <div
+                style={{
+                    maxHeight: 'calc(100vh - 60px)',
+                    position: 'absolute',
+                    inset: '60px 0px 0px',
+                    overflowY: 'auto',
+                }}
+            >
+                {children}
+            </div>
         </>
     );
 };

--- a/datahub-web-react/src/app/settings/AccessTokens.tsx
+++ b/datahub-web-react/src/app/settings/AccessTokens.tsx
@@ -272,7 +272,7 @@ export const AccessTokens = () => {
                 }}
                 pagination={false}
                 style={{
-                    height: 'calc(100% - 365px)',
+                    height: 'calc(100% - 45vh)',
                     overflow: 'auto',
                 }}
             />

--- a/datahub-web-react/src/app/settings/AccessTokens.tsx
+++ b/datahub-web-react/src/app/settings/AccessTokens.tsx
@@ -21,6 +21,7 @@ const SourceContainer = styled.div`
     padding-top: 20px;
     padding-right: 40px;
     padding-left: 40px;
+    height: 100%;
 `;
 
 const TokensContainer = styled.div`
@@ -270,6 +271,10 @@ export const AccessTokens = () => {
                     emptyText: <Empty description="No Access Tokens!" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
                 }}
                 pagination={false}
+                style={{
+                    height: 'calc(100% - 365px)',
+                    overflow: 'auto',
+                }}
             />
             <PaginationContainer>
                 <Pagination

--- a/datahub-web-react/src/app/settings/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settings/SettingsPage.tsx
@@ -24,11 +24,12 @@ import ManagePosts from './posts/ManagePosts';
 
 const PageContainer = styled.div`
     display: flex;
+    height: calc(100% - 60px);
 `;
 
 const SettingsBarContainer = styled.div`
     padding-top: 20px;
-    min-height: 100vh;
+    height: calc(100vh - 60px);
     border-right: 1px solid ${ANTD_GRAY[5]};
 `;
 
@@ -108,7 +109,13 @@ export const SettingsPage = () => {
                 <Menu
                     selectable={false}
                     mode="inline"
-                    style={{ width: 256, marginTop: 8 }}
+                    style={{
+                        width: 256,
+                        marginTop: 8,
+                        height: 'calc(100% - 120px)',
+                        overflowX: 'hidden',
+                        overflowY: 'auto',
+                    }}
                     selectedKeys={[activePath]}
                     onClick={(newPath) => {
                         history.replace(`${url}/${newPath.key}`);

--- a/datahub-web-react/src/app/settings/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settings/SettingsPage.tsx
@@ -112,7 +112,7 @@ export const SettingsPage = () => {
                     style={{
                         width: 256,
                         marginTop: 8,
-                        height: 'calc(100% - 120px)',
+                        height: 'calc(100% - 11vh)',
                         overflowX: 'hidden',
                         overflowY: 'auto',
                     }}

--- a/datahub-web-react/src/app/settings/posts/ManagePosts.tsx
+++ b/datahub-web-react/src/app/settings/posts/ManagePosts.tsx
@@ -21,7 +21,9 @@ const PageTitle = styled(Typography.Title)`
     }
 `;
 
-const ListContainer = styled.div``;
+const ListContainer = styled.div`
+    height: calc(100% - 120px);
+`;
 
 export default function ManagePosts() {
     return (

--- a/datahub-web-react/src/app/settings/posts/ManagePosts.tsx
+++ b/datahub-web-react/src/app/settings/posts/ManagePosts.tsx
@@ -22,7 +22,7 @@ const PageTitle = styled(Typography.Title)`
 `;
 
 const ListContainer = styled.div`
-    height: calc(100% - 120px);
+    height: calc(100% - 11vh);
 `;
 
 export default function ManagePosts() {

--- a/datahub-web-react/src/app/settings/posts/PostsList.tsx
+++ b/datahub-web-react/src/app/settings/posts/PostsList.tsx
@@ -17,7 +17,9 @@ import { SearchBar } from '../../search/SearchBar';
 import { StyledTable } from '../../entity/shared/components/styled/StyledTable';
 import { POST_TYPE_TO_DISPLAY_TEXT } from './constants';
 
-const PostsContainer = styled.div``;
+const PostsContainer = styled.div`
+    height: 100%;
+`;
 
 export const PostsPaginationContainer = styled.div`
     display: flex;
@@ -155,6 +157,10 @@ export const PostList = () => {
                     rowKey="urn"
                     pagination={false}
                     locale={{ emptyText: <Empty description="No posts!" image={Empty.PRESENTED_IMAGE_SIMPLE} /> }}
+                    style={{
+                        height: 'calc(100% - 30px)',
+                        overflow: 'auto',
+                    }}
                 />
                 {totalPosts > pageSize && (
                     <PostsPaginationContainer>

--- a/datahub-web-react/src/app/settings/posts/PostsList.tsx
+++ b/datahub-web-react/src/app/settings/posts/PostsList.tsx
@@ -158,7 +158,7 @@ export const PostList = () => {
                     pagination={false}
                     locale={{ emptyText: <Empty description="No posts!" image={Empty.PRESENTED_IMAGE_SIMPLE} /> }}
                     style={{
-                        height: 'calc(100% - 30px)',
+                        height: 'calc(100% - 6vh)',
                         overflow: 'auto',
                     }}
                 />

--- a/datahub-web-react/src/app/shared/RoutedTabs.tsx
+++ b/datahub-web-react/src/app/shared/RoutedTabs.tsx
@@ -3,6 +3,7 @@ import { Route, Switch, useRouteMatch, useLocation } from 'react-router-dom';
 import { Redirect, useHistory } from 'react-router';
 import { Tabs } from 'antd';
 import { TabsProps } from 'antd/lib/tabs';
+import styled from 'styled-components';
 
 const { TabPane } = Tabs;
 
@@ -32,8 +33,13 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
     const splitPathName = trimmedPathName.split('/');
     const providedPath = splitPathName[splitPathName.length - 1];
     const activePath = subRoutes.includes(providedPath) ? providedPath : defaultPath.replace('/', '');
+
+    const PaginationContainer = styled.div`
+        height: calc(100% - 80px);
+    `;
+
     return (
-        <div>
+        <PaginationContainer>
             <Tabs
                 defaultActiveKey={activePath}
                 activeKey={activePath}
@@ -62,6 +68,6 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
                     />
                 ))}
             </Switch>
-        </div>
+        </PaginationContainer>
     );
 };

--- a/datahub-web-react/src/app/shared/RoutedTabs.tsx
+++ b/datahub-web-react/src/app/shared/RoutedTabs.tsx
@@ -35,7 +35,7 @@ export const RoutedTabs = ({ defaultPath, tabs, onTabChange, ...props }: Props) 
     const activePath = subRoutes.includes(providedPath) ? providedPath : defaultPath.replace('/', '');
 
     const PaginationContainer = styled.div`
-        height: calc(100% - 80px);
+        height: 100%;
     `;
 
     return (


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)- https://linear.app/acryl-data/issue/PRD-742/settings-tab-should-have-2-scrollable-sections
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
