### PR TITLE
feat(lineage): add field description to tooltip in lineage visualisation

### DIFF
--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -183,6 +183,7 @@ export default class EntityRegistry {
                 fineGrainedLineages,
                 siblings: genericEntityProperties?.siblings,
                 schemaMetadata: genericEntityProperties?.schemaMetadata,
+                editableSchemaMetadata: genericEntityProperties?.editableSchemaMetadata,
                 inputFields: genericEntityProperties?.inputFields,
                 canEditLineage: genericEntityProperties?.privileges?.canEditLineage,
             } as FetchedEntity) || undefined

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/utils/utils.ts
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/utils/utils.ts
@@ -6,6 +6,7 @@ import {
     EditableSchemaMetadataUpdate,
     SchemaField,
     PlatformSchema,
+    Maybe,
 } from '../../../../../../types.generated';
 import { convertTagsForUpdate } from '../../../../../shared/tags/utils/convertTagsForUpdate';
 import { SchemaDiffSummary } from '../components/SchemaVersionSummary';
@@ -66,6 +67,17 @@ export function downgradeV2FieldPath(fieldPath?: string | null) {
 
 export function pathMatchesNewPath(fieldPathA?: string | null, fieldPathB?: string | null) {
     return fieldPathA === fieldPathB || fieldPathA === downgradeV2FieldPath(fieldPathB);
+}
+
+export function getFieldRelevantDescription(
+    field: SchemaField,
+    editableSchemaMetadata: Maybe<EditableSchemaMetadata> | undefined,
+): Maybe<string> | undefined {
+    const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
+        (candidateEditableFieldInfo) => pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, field.fieldPath),
+    );
+
+    return relevantEditableFieldInfo?.description ?? field.description;
 }
 
 // group schema fields by fieldPath and grouping for hierarchy in schema table

--- a/datahub-web-react/src/app/lineage/ColumnNode.tsx
+++ b/datahub-web-react/src/app/lineage/ColumnNode.tsx
@@ -9,6 +9,7 @@ import { ANTD_GRAY } from '../entity/shared/constants';
 import { centerY, COLUMN_HEIGHT, EXPAND_COLLAPSE_COLUMNS_TOGGLE_HEIGHT, iconX, width } from './constants';
 import { truncate } from '../entity/shared/utils';
 import { highlightColumnLineage } from './utils/highlightColumnLineage';
+import useFieldDescription from './utils/useFieldDescription';
 
 const MAX_NUM_FIELD_CHARACTERS = 25;
 const HOVER_TEXT_SHIFT = 10;
@@ -43,7 +44,8 @@ export default function ColumnNode({ field, index, node, titleHeight, onHover }:
         ((fineGrainedMap.forward[nodeUrn] && fineGrainedMap.forward[nodeUrn][field.fieldPath]) ||
             (fineGrainedMap.reverse[nodeUrn] && fineGrainedMap.reverse[nodeUrn][field.fieldPath]));
     const fieldPath = downgradeV2FieldPath(field.fieldPath);
-    const isTruncated = fieldPath && fieldPath.length > MAX_NUM_FIELD_CHARACTERS;
+    const fieldDescription = useFieldDescription(field, node.data.editableSchemaMetadata);
+    const fieldPathWithDescription = `${fieldPath} - ${fieldDescription}`;
     const titleAndToggleHeight = titleHeight + EXPAND_COLLAPSE_COLUMNS_TOGGLE_HEIGHT;
 
     return (
@@ -93,7 +95,7 @@ export default function ColumnNode({ field, index, node, titleHeight, onHover }:
                     <rect
                         x={iconX - 21 + HOVER_TEXT_SHIFT}
                         y={centerY + 30 + titleAndToggleHeight + index * COLUMN_HEIGHT}
-                        width={width + (fieldPath?.substring(MAX_NUM_FIELD_CHARACTERS).length || 0) * 7}
+                        width={width + (fieldPathWithDescription.substring(MAX_NUM_FIELD_CHARACTERS).length || 0) * 7}
                         height="29"
                         fill="white"
                         stroke={ANTD_GRAY[8]}
@@ -110,7 +112,7 @@ export default function ColumnNode({ field, index, node, titleHeight, onHover }:
                         fontFamily="'Roboto Mono',monospace"
                         fill={hasEdge ? 'black' : ANTD_GRAY[7]}
                     >
-                        {fieldPath}
+                        {fieldPathWithDescription}
                     </UnselectableText>
                 </>
             )}
@@ -121,9 +123,7 @@ export default function ColumnNode({ field, index, node, titleHeight, onHover }:
                 fontSize={12}
                 fontFamily="'Roboto Mono',monospace"
                 fill={hasEdge ? 'black' : ANTD_GRAY[7]}
-                onMouseEnter={() => {
-                    if (isTruncated) setShowHoverText(true);
-                }}
+                onMouseEnter={() => setShowHoverText(true)}
                 onMouseLeave={() => setShowHoverText(false)}
             >
                 {truncate(MAX_NUM_FIELD_CHARACTERS, fieldPath)}

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -20,6 +20,7 @@ import {
     LineageRelationship,
     SiblingProperties,
     Health,
+    EditableSchemaMetadata,
 } from '../../types.generated';
 
 export type EntitySelectParams = {
@@ -55,6 +56,7 @@ export type FetchedEntity = {
     fineGrainedLineages?: FineGrainedLineage[];
     siblings?: Maybe<SiblingProperties>;
     schemaMetadata?: SchemaMetadata;
+    editableSchemaMetadata?: EditableSchemaMetadata;
     inputFields?: InputFields;
     canEditLineage?: boolean;
     health?: Health[];
@@ -77,6 +79,7 @@ export type NodeData = {
     status?: Maybe<Status>;
     siblingPlatforms?: Maybe<DataPlatform[]>;
     schemaMetadata?: SchemaMetadata;
+    editableSchemaMetadata?: EditableSchemaMetadata;
     inputFields?: InputFields;
     canEditLineage?: boolean;
     upstreamRelationships?: Array<LineageRelationship>;

--- a/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
@@ -63,6 +63,7 @@ export default function constructFetchedNode(
             status: fetchedNode.status,
             siblingPlatforms: fetchedNode.siblingPlatforms,
             schemaMetadata: fetchedNode.schemaMetadata,
+            editableSchemaMetadata: fetchedNode.editableSchemaMetadata,
             inputFields: fetchedNode.inputFields,
             canEditLineage: fetchedNode.canEditLineage,
             upstreamRelationships: fetchedNode?.upstreamRelationships || [],

--- a/datahub-web-react/src/app/lineage/utils/constructTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructTree.ts
@@ -96,6 +96,7 @@ export default function constructTree(
         unexploredChildren: 0,
         siblingPlatforms: fetchedEntity?.siblingPlatforms,
         schemaMetadata: fetchedEntity?.schemaMetadata,
+        editableSchemaMetadata: fetchedEntity?.editableSchemaMetadata,
         inputFields: fetchedEntity?.inputFields,
         canEditLineage: fetchedEntity?.canEditLineage,
         upstreamRelationships: fetchedEntity?.upstreamRelationships || [],

--- a/datahub-web-react/src/app/lineage/utils/useFieldDescription.ts
+++ b/datahub-web-react/src/app/lineage/utils/useFieldDescription.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+import { EditableSchemaMetadata, Maybe, SchemaField } from '../../../types.generated';
+import { getFieldRelevantDescription } from '../../entity/dataset/profile/schema/utils/utils';
+import { removeMarkdown } from '../../entity/shared/components/styled/StripMarkdownText';
+
+export default function useFieldDescription(
+    field: SchemaField,
+    editableSchemaMetadata: Maybe<EditableSchemaMetadata> | undefined,
+): string {
+    return useMemo(() => {
+        const fieldRelevantDescription = getFieldRelevantDescription(field, editableSchemaMetadata);
+
+        return fieldRelevantDescription ? removeMarkdown(fieldRelevantDescription) : 'unknown';
+    }, [editableSchemaMetadata, field]);
+}

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -324,6 +324,12 @@ fragment fullLineageResults on EntityLineageResult {
                 schemaMetadata(version: 0) @include(if: $showColumns) {
                     ...schemaMetadataFields
                 }
+                editableSchemaMetadata @include(if: $showColumns) {
+                    editableSchemaFieldInfo {
+                        fieldPath
+                        description
+                    }
+                }
             }
             ... on Chart {
                 inputFields @include(if: $showColumns) {
@@ -372,6 +378,12 @@ query getEntityLineage(
         ... on Dataset {
             schemaMetadata(version: 0) @include(if: $showColumns) {
                 ...schemaMetadataFields
+            }
+            editableSchemaMetadata @include(if: $showColumns) {
+                editableSchemaFieldInfo {
+                    fieldPath
+                    description
+                }
             }
             siblings {
                 isPrimary


### PR DESCRIPTION
Hi! Sometimes it's not obvious what is a field about. So we think it would be helpful to see a description right in the lineage visualization view inside a tooltip. If there is no any description, then "unknown" is shown.

<img width="456" alt="image" src="https://github.com/datahub-project/datahub/assets/150264485/ad496336-dc09-4793-bfc8-4945d8e9c514">

<img width="443" alt="image" src="https://github.com/datahub-project/datahub/assets/150264485/ad4c1e3b-1b50-4e89-916e-4693d4498429">


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
