### PR TITLE
feat(glossary): add toggle sidebar button and functionality to Busine…

### DIFF
--- a/datahub-web-react/src/app/entity/shared/GlossaryEntityContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/GlossaryEntityContext.tsx
@@ -10,6 +10,8 @@ export interface GlossaryEntityContextType {
     // This will happen when you edit a name, move a term/group, create a new term/group, and delete a term/group
     urnsToUpdate: string[];
     setUrnsToUpdate: (updatdUrns: string[]) => void;
+    isSidebarOpen: boolean;
+    setIsSidebarOpen: (isOpen: boolean) => void;
 }
 
 export const GlossaryEntityContext = React.createContext<GlossaryEntityContextType>({
@@ -18,10 +20,27 @@ export const GlossaryEntityContext = React.createContext<GlossaryEntityContextTy
     setEntityData: () => {},
     urnsToUpdate: [],
     setUrnsToUpdate: () => {},
+    isSidebarOpen: true,
+    setIsSidebarOpen: () => {},
 });
 
 export const useGlossaryEntityData = () => {
-    const { isInGlossaryContext, entityData, setEntityData, urnsToUpdate, setUrnsToUpdate } =
-        useContext(GlossaryEntityContext);
-    return { isInGlossaryContext, entityData, setEntityData, urnsToUpdate, setUrnsToUpdate };
+    const {
+        isInGlossaryContext,
+        entityData,
+        setEntityData,
+        urnsToUpdate,
+        setUrnsToUpdate,
+        isSidebarOpen,
+        setIsSidebarOpen,
+    } = useContext(GlossaryEntityContext);
+    return {
+        isInGlossaryContext,
+        entityData,
+        setEntityData,
+        urnsToUpdate,
+        setUrnsToUpdate,
+        isSidebarOpen,
+        setIsSidebarOpen,
+    };
 };

--- a/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
+++ b/datahub-web-react/src/app/glossary/BusinessGlossaryPage.tsx
@@ -20,6 +20,8 @@ import {
 import { OnboardingTour } from '../onboarding/OnboardingTour';
 import { useGlossaryEntityData } from '../entity/shared/GlossaryEntityContext';
 import { useUserContext } from '../context/useUserContext';
+import useToggleSidebar from './useToggleSidebar';
+import ToggleSidebarButton from '../search/ToggleSidebarButton';
 
 export const HeaderWrapper = styled(TabToolbar)`
     padding: 15px 45px 10px 24px;
@@ -36,6 +38,12 @@ const MainContentWrapper = styled.div`
     display: flex;
     flex: 1;
     flex-direction: column;
+`;
+
+const TitleContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 12px;
 `;
 
 export const MAX_BROWSER_WIDTH = 500;
@@ -56,6 +64,7 @@ function BusinessGlossaryPage() {
     } = useGetRootGlossaryNodesQuery();
     const entityRegistry = useEntityRegistry();
     const { setEntityData } = useGlossaryEntityData();
+    const { isOpen: isSidebarOpen, toggleSidebar } = useToggleSidebar();
 
     useEffect(() => {
         setEntityData(null);
@@ -94,7 +103,12 @@ function BusinessGlossaryPage() {
                 )}
                 <MainContentWrapper data-testid="glossary-entities-list">
                     <HeaderWrapper>
-                        <Typography.Title level={3}>Business Glossary</Typography.Title>
+                        <TitleContainer>
+                            <ToggleSidebarButton isOpen={isSidebarOpen} onClick={toggleSidebar} />
+                            <Typography.Title style={{ margin: '0' }} level={3}>
+                                Business Glossary
+                            </Typography.Title>
+                        </TitleContainer>
                         <div>
                             <Button
                                 data-testid="add-term-button"

--- a/datahub-web-react/src/app/glossary/GlossaryRoutes.tsx
+++ b/datahub-web-react/src/app/glossary/GlossaryRoutes.tsx
@@ -20,12 +20,21 @@ export default function GlossaryRoutes() {
     const entityRegistry = useEntityRegistry();
     const [entityData, setEntityData] = useState<GenericEntityProperties | null>(null);
     const [urnsToUpdate, setUrnsToUpdate] = useState<string[]>([]);
+    const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(true);
 
     const isAtRootGlossary = window.location.pathname === PageRoutes.GLOSSARY;
 
     return (
         <GlossaryEntityContext.Provider
-            value={{ isInGlossaryContext: true, entityData, setEntityData, urnsToUpdate, setUrnsToUpdate }}
+            value={{
+                isInGlossaryContext: true,
+                entityData,
+                setEntityData,
+                urnsToUpdate,
+                setUrnsToUpdate,
+                isSidebarOpen,
+                setIsSidebarOpen,
+            }}
         >
             {!isAtRootGlossary && <GlossaryEntitiesPath />}
             <ContentWrapper>

--- a/datahub-web-react/src/app/glossary/GlossarySidebar.tsx
+++ b/datahub-web-react/src/app/glossary/GlossarySidebar.tsx
@@ -1,14 +1,25 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import GlossarySearch from './GlossarySearch';
 import GlossaryBrowser from './GlossaryBrowser/GlossaryBrowser';
 import { ProfileSidebarResizer } from '../entity/shared/containers/profile/sidebar/ProfileSidebarResizer';
 import { SidebarWrapper } from '../shared/sidebar/components';
+import { useGlossaryEntityData } from '../entity/shared/GlossaryEntityContext';
 
 export const MAX_BROWSER_WIDTH = 500;
 export const MIN_BROWSWER_WIDTH = 200;
 
 export default function GlossarySidebar() {
-    const [browserWidth, setBrowserWith] = useState(window.innerWidth * 0.2);
+    const [browserWidth, setBrowserWidth] = useState(window.innerWidth * 0.2);
+    const [previousBrowserWidth, setPreviousBrowserWidth] = useState(window.innerWidth * 0.2);
+    const { isSidebarOpen } = useGlossaryEntityData();
+
+    useEffect(() => {
+        if (isSidebarOpen) {
+            setBrowserWidth(previousBrowserWidth);
+        } else {
+            setBrowserWidth(0);
+        }
+    }, [isSidebarOpen, previousBrowserWidth]);
 
     return (
         <>
@@ -17,9 +28,11 @@ export default function GlossarySidebar() {
                 <GlossaryBrowser openToEntity />
             </SidebarWrapper>
             <ProfileSidebarResizer
-                setSidePanelWidth={(width) =>
-                    setBrowserWith(Math.min(Math.max(width, MIN_BROWSWER_WIDTH), MAX_BROWSER_WIDTH))
-                }
+                setSidePanelWidth={(width) => {
+                    const newWidth = Math.min(Math.max(width, MIN_BROWSWER_WIDTH), MAX_BROWSER_WIDTH);
+                    setBrowserWidth(newWidth);
+                    setPreviousBrowserWidth(newWidth);
+                }}
                 initialSize={browserWidth}
                 isSidebarOnLeft
             />

--- a/datahub-web-react/src/app/glossary/useToggleSidebar.tsx
+++ b/datahub-web-react/src/app/glossary/useToggleSidebar.tsx
@@ -1,0 +1,17 @@
+import { useGlossaryEntityData } from '../entity/shared/GlossaryEntityContext';
+import useToggle from '../shared/useToggle';
+
+const useToggleSidebar = () => {
+    const { isSidebarOpen, setIsSidebarOpen } = useGlossaryEntityData();
+
+    const { isOpen, toggle: toggleSidebar } = useToggle({
+        initialValue: isSidebarOpen ?? true,
+        onToggle: (isNowOpen: boolean) => {
+            setIsSidebarOpen(isNowOpen);
+        },
+    });
+
+    return { isOpen, toggleSidebar } as const;
+};
+
+export default useToggleSidebar;

--- a/datahub-web-react/src/app/shared/sidebar/components.tsx
+++ b/datahub-web-react/src/app/shared/sidebar/components.tsx
@@ -7,6 +7,7 @@ export const SidebarWrapper = styled.div<{ width: number }>`
     max-height: 100%;
     width: ${(props) => props.width}px;
     min-width: ${(props) => props.width}px;
+    display: ${(props) => (props.width ? 'block' : 'none')};
 `;
 
 export function RotatingTriangle({ isOpen, onClick }: { isOpen: boolean; onClick?: () => void }) {


### PR DESCRIPTION
…ss Glossary page

This PR adds collapse/expand sidebar button to 'Business Glossary' page similar to the one on 'Search' Page. Collapse/expand sidebar functionality makes working with Glossary easier as there is more space available for main glossary block and search is not always needed. Also, it is not possible to hide sidebar fully with existing resize sidebar functionality.

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

![toggle-glossary-1](https://github.com/datahub-project/datahub/assets/38855943/da265016-61ef-412f-8a00-434dd85b0852)
![toggle-glossary-2](https://github.com/datahub-project/datahub/assets/38855943/3e3b280d-3b3e-4e3e-b7ba-e6216ecacc2b)