### PR TITLE
feat(recomendations): Make top platforms account only for searchable entities

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.search.elasticsearch;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.browse.BrowseResultV2;
@@ -142,11 +143,11 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
 
   @Nonnull
   @Override
-  public Map<String, Long> aggregateByValue(@Nullable String entityName, @Nonnull String field,
+  public Map<String, Long> aggregateByValue(@Nullable List<String> entityNames, @Nonnull String field,
       @Nullable Filter requestParams, int limit) {
-    log.debug("Aggregating by value: {}, field: {}, requestParams: {}, limit: {}", entityName, field, requestParams,
-        limit);
-    return esSearchDAO.aggregateByValue(entityName, field, requestParams, limit);
+    log.debug("Aggregating by value: {}, field: {}, requestParams: {}, limit: {}", entityNames.toString(), field,
+        requestParams, limit);
+    return esSearchDAO.aggregateByValue(entityNames, field, requestParams, limit);
   }
 
   @Nonnull

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.search.elasticsearch;
 
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.browse.BrowseResultV2;

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/TestEntityTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/TestEntityTestBase.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.search;
 import com.datahub.test.Snapshot;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.TestEntityUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
@@ -99,7 +100,7 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     BrowseResult browseResult = _elasticSearchService.browse(ENTITY_NAME, "", null, 0, 10);
     assertEquals(browseResult.getMetadata().getTotalNumEntities().longValue(), 0);
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 0);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textField", null, 10).size(), 0);
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textField", null, 10).size(), 0);
 
     Urn urn = new TestEntityUrn("test", "urn1", "VALUE_1");
     ObjectNode document = JsonNodeFactory.instance.objectNode();
@@ -124,7 +125,7 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     assertEquals(browseResult.getMetadata().getTotalNumEntities().longValue(), 1);
     assertEquals(browseResult.getGroups().get(0).getName(), "b");
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 1);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textFieldOverride", null, 10),
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textFieldOverride", null, 10),
         ImmutableMap.of("textFieldOverride", 1L));
 
     Urn urn2 = new TestEntityUrn("test2", "urn2", "VALUE_2");
@@ -147,7 +148,7 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     assertEquals(browseResult.getMetadata().getTotalNumEntities().longValue(), 1);
     assertEquals(browseResult.getGroups().get(0).getName(), "b");
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 2);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textFieldOverride", null, 10),
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textFieldOverride", null, 10),
         ImmutableMap.of("textFieldOverride", 1L, "textFieldOverride2", 1L));
 
     _elasticSearchService.deleteDocument(ENTITY_NAME, urn.toString());
@@ -158,7 +159,7 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     browseResult = _elasticSearchService.browse(ENTITY_NAME, "", null, 0, 10);
     assertEquals(browseResult.getMetadata().getTotalNumEntities().longValue(), 0);
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 0);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textField", null, 10).size(), 0);
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textField", null, 10).size(), 0);
   }
 
   @Test
@@ -181,7 +182,7 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     assertEquals(searchResult.getEntities().get(0).getEntity(), urn);
 
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 1);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textFieldOverride", null, 10),
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textFieldOverride", null, 10),
             ImmutableMap.of("textFieldOverride", 1L));
 
     Urn urn2 = new TestEntityUrn("test2", "urn2", "VALUE_2");
@@ -198,7 +199,7 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     assertEquals(searchResult.getEntities().get(0).getEntity(), urn2);
 
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 2);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textFieldOverride", null, 10),
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textFieldOverride", null, 10),
             ImmutableMap.of("textFieldOverride", 1L, "textFieldOverride2", 1L));
 
     _elasticSearchService.deleteDocument(ENTITY_NAME, urn.toString());
@@ -208,6 +209,6 @@ abstract public class TestEntityTestBase extends AbstractTestNGSpringContextTest
     assertEquals(searchResult.getNumEntities().intValue(), 0);
 
     assertEquals(_elasticSearchService.docCount(ENTITY_NAME), 0);
-    assertEquals(_elasticSearchService.aggregateByValue(ENTITY_NAME, "textField", null, 10).size(), 0);
+    assertEquals(_elasticSearchService.aggregateByValue(ImmutableList.of(ENTITY_NAME), "textField", null, 10).size(), 0);
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.CriterionArray;
-import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.recommendation.ContentParams;
 import com.linkedin.metadata.recommendation.RecommendationContent;
 import com.linkedin.metadata.recommendation.RecommendationParams;
@@ -83,7 +82,7 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
   public List<RecommendationContent> getRecommendations(@Nonnull Urn userUrn,
       @Nullable RecommendationRequestContext requestContext) {
     Map<String, Long> aggregationResult =
-        _entitySearchService.aggregateByValue(null, getSearchFieldName(), buildAggregationFilter(), getMaxContent());
+        _entitySearchService.aggregateByValue(getEntityNames(), getSearchFieldName(), null, getMaxContent());
 
     if (aggregationResult.isEmpty()) {
       return Collections.emptyList();
@@ -117,8 +116,8 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
         .collect(Collectors.toList());
   }
 
-  protected Filter buildAggregationFilter() {
-    // By default, no filter is applied
+  protected List<String> getEntityNames() {
+    // By default, no list is applied which means searching across entities.
     return null;
   }
 

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationSource.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.recommendation.ContentParams;
 import com.linkedin.metadata.recommendation.RecommendationContent;
 import com.linkedin.metadata.recommendation.RecommendationParams;
@@ -82,7 +83,7 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
   public List<RecommendationContent> getRecommendations(@Nonnull Urn userUrn,
       @Nullable RecommendationRequestContext requestContext) {
     Map<String, Long> aggregationResult =
-        _entitySearchService.aggregateByValue(null, getSearchFieldName(), null, getMaxContent());
+        _entitySearchService.aggregateByValue(null, getSearchFieldName(), buildAggregationFilter(), getMaxContent());
 
     if (aggregationResult.isEmpty()) {
       return Collections.emptyList();
@@ -114,6 +115,11 @@ public abstract class EntitySearchAggregationSource implements RecommendationSou
     return getTopKValues(urnCounts).stream()
         .map(entry -> buildRecommendationContent(entry.getKey(), entry.getValue()))
         .collect(Collectors.toList());
+  }
+
+  protected Filter buildAggregationFilter() {
+    // By default, no filter is applied
+    return null;
   }
 
   // Get top K entries with the most count

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
@@ -1,24 +1,16 @@
 package com.linkedin.metadata.recommendation.candidatesource;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.dataplatform.DataPlatformInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.query.filter.Condition;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
-import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
-import com.linkedin.metadata.query.filter.Criterion;
-import com.linkedin.metadata.query.filter.CriterionArray;
-import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
 import com.linkedin.metadata.recommendation.ScenarioType;
 import com.linkedin.metadata.search.EntitySearchService;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,7 +22,7 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
    * Set of entities that we want to consider for defining the top platform sources.
    * This must match SearchUtils.SEARCHABLE_ENTITY_TYPES
    */
-  private static final Set<String> SEARCHABLE_ENTITY_TYPES = ImmutableSet.of(
+  private static final List<String> SEARCHABLE_ENTITY_TYPES = ImmutableList.of(
       Constants.DATASET_ENTITY_NAME,
       Constants.DASHBOARD_ENTITY_NAME,
       Constants.CHART_ENTITY_NAME,
@@ -41,34 +33,16 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
       Constants.ML_PRIMARY_KEY_ENTITY_NAME,
       Constants.DATA_FLOW_ENTITY_NAME,
       Constants.DATA_JOB_ENTITY_NAME,
-      Constants.GLOSSARY_TERM_ENTITY_NAME,
-      Constants.GLOSSARY_NODE_ENTITY_NAME,
       Constants.TAG_ENTITY_NAME,
-      Constants.ROLE_ENTITY_NAME,
-      Constants.CORP_USER_ENTITY_NAME,
-      Constants.CORP_GROUP_ENTITY_NAME,
       Constants.CONTAINER_ENTITY_NAME,
-      Constants.DOMAIN_ENTITY_NAME,
-      Constants.DATA_PRODUCT_ENTITY_NAME,
       Constants.NOTEBOOK_ENTITY_NAME
   );
-  private final Filter aggregationFilter;
   private final EntityService _entityService;
   private static final String PLATFORM = "platform";
 
   public TopPlatformsSource(EntityService entityService, EntitySearchService entitySearchService) {
     super(entitySearchService);
     _entityService = entityService;
-
-    // Filter for platforms that only have the entities that have search cards
-    Filter filter = new Filter();
-    CriterionArray array = new CriterionArray(
-        SEARCHABLE_ENTITY_TYPES.stream()
-            .map(entityName -> new Criterion().setField("urn").setValue(entityName).setCondition(Condition.CONTAIN))
-            .collect(Collectors.toList())
-    );
-    filter.setOr(new ConjunctiveCriterionArray(ImmutableList.of(new ConjunctiveCriterion().setAnd(array))));
-    aggregationFilter = filter;
   }
 
   @Override
@@ -90,9 +64,9 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
   public boolean isEligible(@Nonnull Urn userUrn, @Nonnull RecommendationRequestContext requestContext) {
     return requestContext.getScenario() == ScenarioType.HOME;
   }
-  @Override
-  protected Filter buildAggregationFilter() {
-    return aggregationFilter;
+
+  protected List<String> getEntityNames() {
+    return SEARCHABLE_ENTITY_TYPES;
   }
 
   @Override

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
@@ -1,15 +1,24 @@
 package com.linkedin.metadata.recommendation.candidatesource;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.dataplatform.DataPlatformInfo;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
 import com.linkedin.metadata.recommendation.ScenarioType;
 import com.linkedin.metadata.search.EntitySearchService;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,18 +27,48 @@ import lombok.extern.slf4j.Slf4j;
 public class TopPlatformsSource extends EntitySearchAggregationSource {
 
   /**
-   * TODO: Remove this once we permit specifying set of entities in aggregation API (filter out assertions)
+   * Set of entities that we want to consider for defining the top platform sources.
+   * This must match SearchUtils.SEARCHABLE_ENTITY_TYPES
    */
-  private static final Set<String> FILTERED_DATA_PLATFORM_URNS = ImmutableSet.of(
-      "urn:li:dataPlatform:great-expectations"
+  private static final Set<String> SEARCHABLE_ENTITY_TYPES = ImmutableSet.of(
+      Constants.DATASET_ENTITY_NAME,
+      Constants.DASHBOARD_ENTITY_NAME,
+      Constants.CHART_ENTITY_NAME,
+      Constants.ML_MODEL_ENTITY_NAME,
+      Constants.ML_MODEL_GROUP_ENTITY_NAME,
+      Constants.ML_FEATURE_TABLE_ENTITY_NAME,
+      Constants.ML_FEATURE_ENTITY_NAME,
+      Constants.ML_PRIMARY_KEY_ENTITY_NAME,
+      Constants.DATA_FLOW_ENTITY_NAME,
+      Constants.DATA_JOB_ENTITY_NAME,
+      Constants.GLOSSARY_TERM_ENTITY_NAME,
+      Constants.GLOSSARY_NODE_ENTITY_NAME,
+      Constants.TAG_ENTITY_NAME,
+      Constants.ROLE_ENTITY_NAME,
+      Constants.CORP_USER_ENTITY_NAME,
+      Constants.CORP_GROUP_ENTITY_NAME,
+      Constants.CONTAINER_ENTITY_NAME,
+      Constants.DOMAIN_ENTITY_NAME,
+      Constants.DATA_PRODUCT_ENTITY_NAME,
+      Constants.NOTEBOOK_ENTITY_NAME
   );
-
+  private final Filter aggregationFilter;
   private final EntityService _entityService;
   private static final String PLATFORM = "platform";
 
   public TopPlatformsSource(EntityService entityService, EntitySearchService entitySearchService) {
     super(entitySearchService);
     _entityService = entityService;
+
+    // Filter for platforms that only have the entities that have search cards
+    Filter filter = new Filter();
+    CriterionArray array = new CriterionArray(
+        SEARCHABLE_ENTITY_TYPES.stream()
+            .map(entityName -> new Criterion().setField("urn").setValue(entityName).setCondition(Condition.CONTAIN))
+            .collect(Collectors.toList())
+    );
+    filter.setOr(new ConjunctiveCriterionArray(ImmutableList.of(new ConjunctiveCriterion().setAnd(array))));
+    aggregationFilter = filter;
   }
 
   @Override
@@ -51,6 +90,10 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
   public boolean isEligible(@Nonnull Urn userUrn, @Nonnull RecommendationRequestContext requestContext) {
     return requestContext.getScenario() == ScenarioType.HOME;
   }
+  @Override
+  protected Filter buildAggregationFilter() {
+    return aggregationFilter;
+  }
 
   @Override
   protected String getSearchFieldName() {
@@ -69,9 +112,6 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
 
   @Override
   protected boolean isValidCandidateUrn(Urn urn) {
-    if (FILTERED_DATA_PLATFORM_URNS.contains(urn.toString())) {
-      return false;
-    }
     RecordTemplate dataPlatformInfo = _entityService.getLatestAspect(urn, "dataPlatformInfo");
     if (dataPlatformInfo == null) {
       return false;

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
@@ -131,15 +131,15 @@ public interface EntitySearchService {
   /**
    * Returns number of documents per field value given the field and filters
    *
-   * @param entityName name of the entity, if empty aggregate over all entities
+   * @param entityNames list of name of entities to aggregate across, if empty aggregate over all entities
    * @param field the field name for aggregate
    * @param requestParams filters to apply before aggregating
    * @param limit the number of aggregations to return
    * @return
    */
   @Nonnull
-  Map<String, Long> aggregateByValue(@Nullable String entityName, @Nonnull String field, @Nullable Filter requestParams,
-      int limit);
+  Map<String, Long> aggregateByValue(@Nullable List<String> entityNames, @Nonnull String field,
+      @Nullable Filter requestParams, int limit);
 
   /**
    * Gets a list of groups/entities that match given browse request.


### PR DESCRIPTION
This fixes a UI bug where if slack is configured or a custom platform for non-searchable entities is added, then those platforms are not counted towards platforms to be shown above the fold in the homepage.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
