### PR TITLE
refactor(datahub-web-react): allows proxying to external datahub-frontend servers

### DIFF
--- a/datahub-web-react/.env
+++ b/datahub-web-react/.env
@@ -2,3 +2,4 @@ PUBLIC_URL=/assets
 REACT_APP_THEME_CONFIG=theme_light.config.json
 SKIP_PREFLIGHT_CHECK=true
 BUILD_PATH=build/yarn
+REACT_APP_PROXY_TARGET=http://localhost:9002

--- a/datahub-web-react/README.md
+++ b/datahub-web-react/README.md
@@ -51,6 +51,14 @@ need to be deployed, still at `http://localhost:9002`, to service GraphQL API re
 
 Optionally you could also start the app with the mock server without running the docker containers by executing `yarn start:mock`. See [here](src/graphql-mock/fixtures/searchResult/userSearchResult.ts#L6) for available login users.
 
+### Testing your customizations
+
+There is two options to test your customizations:
+* **Option 1**: Initialize the docker containers with the `quickstart.sh` script (or if any custom docker-compose file) and then run `yarn start` in this directory. This will start a forwarding server at `localhost:3000` that will use the `datahub-frontend` server at `http://localhost:9002` to fetch real data.
+* **Option 2**: Change the environment variable `REACT_APP_PROXY_TARGET` in the `.env` file to point to your `datahub-frontend` server (ex: https://my_datahub_host.com) and then run `yarn start` in this directory. This will start a forwarding server at `localhost:3000` that will use the `datahub-frontend` server at some domain to fetch real data.
+
+The option 2 is useful if you want to test your React customizations without having to run the hole DataHub stack locally. However, if you changed other components of the DataHub stack, you will need to run the hole stack locally (building the docker images) and use the option 1.
+
 ### Functional testing
 
 In order to start a server and run frontend unit tests using react-testing-framework, run:

--- a/datahub-web-react/src/setupProxy.js
+++ b/datahub-web-react/src/setupProxy.js
@@ -2,6 +2,8 @@ const logInFilter = function (pathname, req) {
   return pathname.match('^/logIn') && req.method === 'POST';
 };
 
+const proxyTarget = process.env.REACT_APP_PROXY_TARGET || 'http://localhost:9002';
+
 if (process.env.REACT_APP_MOCK === 'true' || process.env.REACT_APP_MOCK === 'cy') {
     // no proxy needed, MirageJS will intercept all http requests
     module.exports = function () {};
@@ -13,21 +15,21 @@ if (process.env.REACT_APP_MOCK === 'true' || process.env.REACT_APP_MOCK === 'cy'
         app.use(
             '/logIn',
             createProxyMiddleware(logInFilter, {
-                target: 'http://localhost:9002',
+                target: proxyTarget,
                 changeOrigin: true,
             }),
         );
         app.use(
             '/authenticate',
             createProxyMiddleware({
-                target: 'http://localhost:9002',
+                target: proxyTarget,
                 changeOrigin: true,
             }),
         );
         app.use(
             '/api/v2/graphql',
             createProxyMiddleware({
-                target: 'http://localhost:9002',
+                target: proxyTarget,
                 changeOrigin: true,
             }),
         );


### PR DESCRIPTION
## Context

Most of the customizations made by my team are only in the datahub-web-react component (for example: some styling or button addition). However, in order for developers to test their changes in a local environment, they need to use `quickstart.sh` and setup a whole set of services that have a certain complexity. Given that we have a dedicated DataHub environment for Homologation/Development, this change allows developers to use this cloud-hosted server and use "real" data during their customization tests, without the need to setup an entire local environment.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
