### PR TITLE
fix: increase the search bar highlight border to double the width

### DIFF
--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -45,7 +45,7 @@ const StyledSearchBar = styled(Input)`
         border: 2px solid transparent;
 
         &:focus-within {
-            border: 1.5px solid ${REDESIGN_COLORS.BLUE};
+            border: 2.5px solid ${REDESIGN_COLORS.BLUE};
         }
     }
     > .ant-input::placeholder {

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -45,7 +45,7 @@ const StyledSearchBar = styled(Input)`
         border: 2px solid transparent;
 
         &:focus-within {
-            border: 2.5px solid ${REDESIGN_COLORS.BLUE};
+            border: 2px solid ${REDESIGN_COLORS.BLUE};
         }
     }
     > .ant-input::placeholder {


### PR DESCRIPTION
## Checklist

here is the screenshot - 
![Screenshot from 2023-11-16 12-40-22](https://github.com/datahub-project/datahub/assets/77378510/4b641647-6999-4b1b-b58f-401f9ae66e35)


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
