### PR TITLE
Add Python version in Developer README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ venv.bak/
 dmypy.json
 MANIFEST
 *.pyc
+.python-version
 
 # Generated files
 **/bin

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -6,6 +6,7 @@ title: "Local Development"
 
 ## Pre-requirements
  - [Java 11 SDK](https://openjdk.org/projects/jdk/11/)
+ - [Python 3.10] (https://www.python.org/downloads/release/python-3100/)
  - [Docker](https://www.docker.com/)
  - [Docker Compose](https://docs.docker.com/compose/)
  - Docker engine with at least 8GB of memory to run tests.


### PR DESCRIPTION
This change adds Python 3.10 to the Local Development README page. Currently, if Python 3.11+ is used then the build process fails.
```
> Task :metadata-ingestion:checkPythonVersion FAILED
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError: Python version (3, 11) not allowed
```
Py3.7 and 3.10 are technically both valid (see: https://github.com/datahub-project/datahub/blob/master/.github/workflows/metadata-ingestion.yml#L34), however, 3.7 is already EOL.

I also added the [pyenv](https://github.com/pyenv/pyenv) local version config file to .gitignore since this popular tool allows developers to use pyenv to control their python version.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
