### PR TITLE
feat: add townhall RSVP link on the main page 

### DIFF
--- a/docs-website/src/pages/_components/Hero/index.js
+++ b/docs-website/src/pages/_components/Hero/index.js
@@ -8,6 +8,7 @@ import { QuestionCircleOutlined } from "@ant-design/icons";
 import styles from "./hero.module.scss";
 import CodeBlock from "@theme/CodeBlock";
 import CardCTAs from "../CardCTAs";
+import TownhallButton from "../TownhallButton";
 
 const HeroAnnouncement = ({ message, linkUrl, linkText }) => (
   <div className={clsx("hero__alert alert alert--primary", styles.hero__alert)}>
@@ -46,6 +47,7 @@ const Hero = ({}) => {
             <Link className="button button--secondary button--md" to="https://slack.datahubproject.io">
               Join our Slack
             </Link>
+            <TownhallButton />
           </div>
         </div>
         <CardCTAs />

--- a/docs-website/src/pages/_components/TownhallButton/index.jsx
+++ b/docs-website/src/pages/_components/TownhallButton/index.jsx
@@ -1,39 +1,31 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styles from "./townhallbutton.module.scss";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 
 const TownhallButton = () => {
-  const [showButton, setShowButton] = useState(false);
-  const [currentMonth, setCurrentMonth] = useState('');
+  const today = new Date();
+  const currentDay = today.getDate();
+  const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  const lastThursday = lastDayOfMonth.getDate() - ((lastDayOfMonth.getDay() + 7 - 4) % 7);
 
-  useEffect(() => {
-    const today = new Date();
-    const currentDay = today.getDate();
-    const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-    const lastThursday = lastDayOfMonth.getDate() - ((lastDayOfMonth.getDay() + 7 - 4) % 7);
+  const daysUntilLastThursday = lastThursday - currentDay;
 
-    const daysUntilLastThursday = lastThursday - currentDay;
+  let showButton = false;
+  let currentMonth = '';
 
-    let shouldShowButton = false;
-    let monthText = '';
-
-    if (daysUntilLastThursday > 0 && daysUntilLastThursday <= 14) {
-      shouldShowButton = true;
-      monthText = new Intl.DateTimeFormat('en-US', { month: 'long' }).format(today);
-    }
-
-    setShowButton(shouldShowButton);
-    setCurrentMonth(monthText);
-  }); 
+  if (daysUntilLastThursday > 0 && daysUntilLastThursday <= 14) {
+    showButton = true;
+    currentMonth = new Intl.DateTimeFormat('en-US', { month: 'long' }).format(today);
+  }
 
   return (
-      showButton && (
-        <Link to="http://rsvp.datahubproject.io" className={clsx("button button--primary button--md", styles.feature)} >
-            Join {currentMonth} Townhall!&nbsp;✨
-        </Link>
-      )
-  ); 
+    showButton && (
+      <Link to="http://rsvp.datahubproject.io" className={clsx('button button--primary button--md', styles.feature)}>
+        Join {currentMonth} Townhall!&nbsp;✨
+      </Link>
+    )
+  );
 };
 
 export default TownhallButton;

--- a/docs-website/src/pages/_components/TownhallButton/index.jsx
+++ b/docs-website/src/pages/_components/TownhallButton/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import styles from "./townhallbutton.module.scss";
-import useBaseUrl from "@docusaurus/useBaseUrl";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 
@@ -26,7 +25,7 @@ const TownhallButton = () => {
 
     setShowButton(shouldShowButton);
     setCurrentMonth(monthText);
-  }, []); 
+  }); 
 
   return (
       showButton && (

--- a/docs-website/src/pages/_components/TownhallButton/index.jsx
+++ b/docs-website/src/pages/_components/TownhallButton/index.jsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+import styles from "./townhallbutton.module.scss";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+
+const TownhallButton = () => {
+  const [showButton, setShowButton] = useState(false);
+  const [currentMonth, setCurrentMonth] = useState('');
+
+  useEffect(() => {
+    const today = new Date();
+    const currentDay = today.getDate();
+    const lastDayOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    const lastThursday = lastDayOfMonth.getDate() - ((lastDayOfMonth.getDay() + 7 - 4) % 7);
+
+    const daysUntilLastThursday = lastThursday - currentDay;
+
+    let shouldShowButton = false;
+    let monthText = '';
+
+    if (daysUntilLastThursday > 0 && daysUntilLastThursday <= 14) {
+      shouldShowButton = true;
+      monthText = new Intl.DateTimeFormat('en-US', { month: 'long' }).format(today);
+    }
+
+    setShowButton(shouldShowButton);
+    setCurrentMonth(monthText);
+  }, []); 
+
+  return (
+      showButton && (
+        <Link to="http://rsvp.datahubproject.io" className={clsx("button button--primary button--md", styles.feature)} >
+            Join {currentMonth} Townhall!&nbsp;✨
+        </Link>
+      )
+  ); 
+};
+
+export default TownhallButton;

--- a/docs-website/src/pages/_components/TownhallButton/townhallbutton.module.scss
+++ b/docs-website/src/pages/_components/TownhallButton/townhallbutton.module.scss
@@ -1,14 +1,14 @@
 .feature {
-    color: white;
-    border: 1px solid transparent;
+  color: white;
+  border: 1px solid transparent;
+  background-image: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
+  background-origin: border-box;
+  opacity: 90%;
+
+  &:hover {
+    opacity: 100%;
+    background: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
     background-image: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
     background-origin: border-box;
-
-    &:hover {
-        opacity: 90%;
-        background: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
-        background-image: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
-        background-origin: border-box;
-    }
-
+  }
 }

--- a/docs-website/src/pages/_components/TownhallButton/townhallbutton.module.scss
+++ b/docs-website/src/pages/_components/TownhallButton/townhallbutton.module.scss
@@ -1,0 +1,14 @@
+.feature {
+    color: white;
+    border: 1px solid transparent;
+    background-image: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
+    background-origin: border-box;
+
+    &:hover {
+        opacity: 90%;
+        background: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
+        background-image: linear-gradient(to right, #1890ff 0%, #9c27b0 100%);
+        background-origin: border-box;
+    }
+
+}


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Displays the townhall RSVP button for 2 weeks before each event. 


2 weeks before ~ the day of the townhall
![image](https://github.com/datahub-project/datahub/assets/26561086/da1be896-9292-43c2-8f44-7cb40f9c369d)

the rest of the month 
![Screen Shot 2023-11-21 at 6 56 37 PM](https://github.com/datahub-project/datahub/assets/26561086/29f11674-96a7-4479-97a0-b9891cf8c58c)

Any feedback on the design is welcome!
  