### PR TITLE
fix: fix the settings height when there are not many items

### DIFF
--- a/datahub-web-react/src/app/settings/SettingsPage.tsx
+++ b/datahub-web-react/src/app/settings/SettingsPage.tsx
@@ -25,11 +25,11 @@ import ManagePosts from './posts/ManagePosts';
 const PageContainer = styled.div`
     display: flex;
     overflow: auto;
+    flex: 1;
 `;
 
 const SettingsBarContainer = styled.div`
     padding-top: 20px;
-    max-height: 100vh;
     border-right: 1px solid ${ANTD_GRAY[5]};
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)-https://linear.app/acryl-data/issue/PRD-811/datahub-oss-fix-the-settings-height-when-there-are-not-many-items
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
