### PR TITLE
fix(ingest/mongodb): support disabling schemaSamplingSize

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -102,7 +102,7 @@ class MongoDBConfig(
     )
     schemaSamplingSize: Optional[PositiveInt] = Field(
         default=1000,
-        description="Number of documents to use when inferring schema size. If set to `0`, all documents will be scanned.",
+        description="Number of documents to use when inferring schema size. If set to `null`, all documents will be scanned.",
     )
     useRandomSampling: bool = Field(
         default=True,
@@ -225,13 +225,15 @@ def construct_schema_pymongo(
         ]
     if use_random_sampling:
         # get sample documents in collection
-        aggregations.append({"$sample": {"size": sample_size}})
+        if sample_size:
+            aggregations.append({"$sample": {"size": sample_size}})
         documents = collection.aggregate(
             aggregations,
             allowDiskUse=True,
         )
     else:
-        aggregations.append({"$limit": sample_size})
+        if sample_size:
+            aggregations.append({"$limit": sample_size})
         documents = collection.aggregate(aggregations, allowDiskUse=True)
 
     return construct_schema(list(documents), delimiter)

--- a/metadata-ingestion/tests/integration/mongodb/test_mongodb.py
+++ b/metadata-ingestion/tests/integration/mongodb/test_mongodb.py
@@ -26,6 +26,7 @@ def test_mongodb_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time
                         "password": "examplepass",
                         "maxDocumentSize": 25000,
                         "platform_instance": "instance",
+                        "schemaSamplingSize": None,
                     },
                 },
                 "sink": {


### PR DESCRIPTION
fix: allow mongodb source connector to have a 0 input for field schemaSamplingSize

Fixes https://github.com/datahub-project/datahub/issues/9287

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
