### PR TITLE
feat(config): Configurable bootstrap of ownership types

### DIFF
--- a/metadata-service/configuration/src/main/resources/application.yml
+++ b/metadata-service/configuration/src/main/resources/application.yml
@@ -292,6 +292,8 @@ bootstrap:
     file: ${BOOTSTRAP_POLICIES_FILE:classpath:boot/policies.json}
     # eg for local file
     # file: "file:///datahub/datahub-gms/resources/custom-policies.json"
+  ownershipTypes:
+    file: ${BOOTSTRAP_OWNERSHIP_TYPES_FILE:classpath:boot/ownership_types.json}
   servlets:
     waitTimeout: ${BOOTSTRAP_SERVLETS_WAITTIMEOUT:60} # Total waiting time in seconds for servlets to initialize
 

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
@@ -94,6 +94,9 @@ public class BootstrapManagerFactory {
   @Value("${bootstrap.policies.file}")
   private Resource _policiesResource;
 
+  @Value("${bootstrap.ownershipTypes.file}")
+  private Resource _ownershipTypesResource;
+
   @Bean(name = "bootstrapManager")
   @Scope("singleton")
   @Nonnull
@@ -116,7 +119,7 @@ public class BootstrapManagerFactory {
     final IngestDefaultGlobalSettingsStep ingestSettingsStep = new IngestDefaultGlobalSettingsStep(_entityService);
     final WaitForSystemUpdateStep waitForSystemUpdateStep = new WaitForSystemUpdateStep(_dataHubUpgradeKafkaListener,
         _configurationProvider);
-    final IngestOwnershipTypesStep ingestOwnershipTypesStep = new IngestOwnershipTypesStep(_entityService);
+    final IngestOwnershipTypesStep ingestOwnershipTypesStep = new IngestOwnershipTypesStep(_entityService, _ownershipTypesResource);
 
     final List<BootstrapStep> finalSteps = new ArrayList<>(ImmutableList.of(
         waitForSystemUpdateStep,


### PR DESCRIPTION
Changes logic of ownership types bootstrap process:

* Now it runs with every start of the GMS (instead of only during upgrade)
* It is possible to provide file path to custom ownership types instead of hard-coded ones

In case the new environmental variable (`BOOTSTRAP_OWNERSHIP_TYPES_FILE`) is not set, the old one is used. In such case the only change of behavior of the app will be the fact that the process will be run with every restart of the GMS instead of only running during the upgrade (similarly to how policies are set).

Change similar to the https://github.com/datahub-project/datahub/pull/8812