### PR TITLE
fix(migrate): connect with token without dry-run

### DIFF
--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -23,7 +23,11 @@ from datahub.emitter.mcp_builder import (
     SchemaKey,
 )
 from datahub.emitter.rest_emitter import DatahubRestEmitter
-from datahub.ingestion.graph.client import DataHubGraph, DataHubGraphConfig
+from datahub.ingestion.graph.client import (
+    DataHubGraph,
+    DataHubGraphConfig,
+    get_default_graph,
+)
 from datahub.metadata.schema_classes import (
     ContainerKeyClass,
     ContainerPropertiesClass,
@@ -141,13 +145,10 @@ def dataplatform2instance_func(
     migration_report = MigrationReport(run_id, dry_run, keep)
     system_metadata = SystemMetadataClass(runId=run_id)
 
-    # initialize for dry-run
-    graph = DataHubGraph(config=DataHubGraphConfig(server="127.0.0.1"))
-
-    if not dry_run:
-        graph = DataHubGraph(
-            config=DataHubGraphConfig(server=cli_utils.get_session_and_host()[1])
-        )
+    if dry_run:
+        graph = DataHubGraph(config=DataHubGraphConfig(server="127.0.0.1"))
+    else:
+        graph = get_default_graph()
 
     urns_to_migrate = []
 

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -23,11 +23,7 @@ from datahub.emitter.mcp_builder import (
     SchemaKey,
 )
 from datahub.emitter.rest_emitter import DatahubRestEmitter
-from datahub.ingestion.graph.client import (
-    DataHubGraph,
-    DataHubGraphConfig,
-    get_default_graph,
-)
+from datahub.ingestion.graph.client import DataHubGraph, get_default_graph
 from datahub.metadata.schema_classes import (
     ContainerKeyClass,
     ContainerPropertiesClass,

--- a/metadata-ingestion/src/datahub/cli/migrate.py
+++ b/metadata-ingestion/src/datahub/cli/migrate.py
@@ -145,10 +145,7 @@ def dataplatform2instance_func(
     migration_report = MigrationReport(run_id, dry_run, keep)
     system_metadata = SystemMetadataClass(runId=run_id)
 
-    if dry_run:
-        graph = DataHubGraph(config=DataHubGraphConfig(server="127.0.0.1"))
-    else:
-        graph = get_default_graph()
+    graph = get_default_graph()
 
     urns_to_migrate = []
 


### PR DESCRIPTION
Currently this just failed to connect to a server due to earlier connection to `127.0.0.1`. This gets it past that.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
