### PR TITLE
fix(sidebar): remove a space reserved for scroll bars when sidebar is collapsed

### DIFF
--- a/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
+++ b/datahub-web-react/src/app/search/sidebar/BrowseSidebar.tsx
@@ -26,12 +26,12 @@ const SidebarHeader = styled.div`
     white-space: nowrap;
 `;
 
-const SidebarBody = styled.div`
+const SidebarBody = styled.div<{ visible: boolean }>`
     height: calc(100% - 47px);
     padding-left: 16px;
     padding-right: 12px;
     padding-bottom: 200px;
-    overflow: auto;
+    overflow: ${(props) => (props.visible ? 'auto' : 'hidden')};
     white-space: nowrap;
 `;
 
@@ -50,7 +50,7 @@ const BrowseSidebar = ({ visible, width }: Props) => {
             <SidebarHeader>
                 <Typography.Text strong>Navigate</Typography.Text>
             </SidebarHeader>
-            <SidebarBody>
+            <SidebarBody visible={visible}>
                 {entityAggregations && !entityAggregations.length && <div>No results found</div>}
                 {entityAggregations?.map((entityAggregation) => (
                     <BrowseProvider key={entityAggregation.value} entityAggregation={entityAggregation}>


### PR DESCRIPTION
We found a visual bug in safari when sidebar is collapsed

<img width="792" alt="image" src="https://github.com/datahub-project/datahub/assets/150264485/fa452fe7-cb7a-448e-a626-985a31a4b2b9">

<img width="757" alt="image" src="https://github.com/datahub-project/datahub/assets/150264485/b6b1e097-0d32-430d-9f9c-3bfb831dd37c">

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
