### PR TITLE
Update gradle-node-plugin to enable building on m1 macs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
   buildscript.repositories.addAll(project.repositories)
   dependencies {
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
-    classpath 'com.github.node-gradle:gradle-node-plugin:2.2.4'
+    classpath 'com.github.node-gradle:gradle-node-plugin:3.2.1'
     classpath 'io.acryl.gradle.plugin:gradle-avro-plugin:0.2.0'
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:' + springBootVersion
     classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"


### PR DESCRIPTION
Issue faced:

The gradle-node-plugin used by datahub (currently version 2.2.4) assembles an invalid nodejs download url for M1 machines. 

See related issue: https://github.com/node-gradle/gradle-node-plugin/issues/154
This was fixed in version 3.2.1: https://github.com/node-gradle/gradle-node-plugin/releases/tag/3.2.1

I've successfully built the frontend using gradle with the updated version of the gradle-node-plugin, so I assume we're safe to update.

Let me know if you see any issues with this :) Thanks!