### PR TITLE
fix(ui): refactor add and remove Related Terms tab message to showcas…

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/AddRelatedTermsModal.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/AddRelatedTermsModal.tsx
@@ -34,6 +34,7 @@ function AddRelatedTermsModal(props: Props) {
     const [AddRelatedTerms] = useAddRelatedTermsMutation();
 
     function addTerms() {
+        message.loading({ content: 'Adding...' });
         AddRelatedTerms({
             variables: {
                 input: {
@@ -43,19 +44,19 @@ function AddRelatedTermsModal(props: Props) {
                 },
             },
         })
-            .catch((e) => {
-                message.destroy();
-                message.error({ content: `Failed to move: \n ${e.message || ''}`, duration: 3 });
-            })
-            .finally(() => {
-                message.loading({ content: 'Adding...', duration: 2 });
+            .then(() => {
                 setTimeout(() => {
+                    refetch();
+                    message.destroy();
                     message.success({
                         content: 'Added Related Terms!',
                         duration: 2,
                     });
-                    refetch();
                 }, 2000);
+            })
+            .catch((e) => {
+                message.destroy();
+                message.error({ content: `Failed to move: \n ${e.message || ''}`, duration: 3 });
             });
         onClose();
     }

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/useRemoveRelatedTerms.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/useRemoveRelatedTerms.tsx
@@ -12,6 +12,9 @@ function useRemoveRelatedTerms(termUrn: string, relationshipType: TermRelationsh
     const [removeRelatedTerms] = useRemoveRelatedTermsMutation();
 
     function handleRemoveRelatedTerms() {
+        message.loading({
+            content: 'Removing...',
+        });
         removeRelatedTerms({
             variables: {
                 input: {
@@ -21,22 +24,19 @@ function useRemoveRelatedTerms(termUrn: string, relationshipType: TermRelationsh
                 },
             },
         })
-            .catch((e) => {
-                message.destroy();
-                message.error({ content: `Failed to remove: \n ${e.message || ''}`, duration: 3 });
-            })
-            .finally(() => {
-                message.loading({
-                    content: 'Removing...',
-                    duration: 2,
-                });
+            .then(() => {
                 setTimeout(() => {
                     refetch();
+                    message.destroy();
                     message.success({
                         content: `Removed Glossary Term!`,
                         duration: 2,
                     });
                 }, 2000);
+            })
+            .catch((e) => {
+                message.destroy();
+                message.error({ content: `Failed to remove: \n ${e.message || ''}`, duration: 3 });
             });
     }
 


### PR DESCRIPTION
…e actual request result

 This PR fixes Business Glossary Related Terms bug when successful message was shown even on Add Terms / Remove Term request failed. 

## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

![1](https://github.com/datahub-project/datahub/assets/38855943/661dd857-ff9f-47bf-b02e-d398ac716509)
![2](https://github.com/datahub-project/datahub/assets/38855943/cb03b8d0-9255-4f88-a174-f51c2ff4a859)
![3](https://github.com/datahub-project/datahub/assets/38855943/1a8c3f3f-d49a-44bc-856e-736cc2775063)
![4](https://github.com/datahub-project/datahub/assets/38855943/9f5b9fc0-487f-46bf-864d-96c846eaef4b)

After fix:
![after](https://github.com/datahub-project/datahub/assets/38855943/9ecaf19d-c6fd-4484-9bf2-ad50e8a6bb8a)