### PR TITLE
fix(ui) Set explicit height on logo images to fix render bug

### DIFF
--- a/datahub-web-react/src/app/shared/LogoCountCard.tsx
+++ b/datahub-web-react/src/app/shared/LogoCountCard.tsx
@@ -7,6 +7,7 @@ import { HomePageButton } from './components';
 
 const PlatformLogo = styled(Image)`
     max-height: 32px;
+    height: 32px;
     width: auto;
     object-fit: contain;
     background-color: transparent;


### PR DESCRIPTION
If someone uses a custom platform and provides a logo URL to an image without a height explicitly set (can happen with SVGs) then on the home page we will not show the image since we only set a `max-height`. this fixes that by setting an explicit `height` on the image.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
