### PR TITLE
fix: show formatted total result count in Search

### DIFF
--- a/datahub-web-react/src/app/search/SearchResults.tsx
+++ b/datahub-web-react/src/app/search/SearchResults.tsx
@@ -28,6 +28,7 @@ import SearchSortSelect from './sorting/SearchSortSelect';
 import { combineSiblingsInSearchResults } from './utils/combineSiblingsInSearchResults';
 import SearchQuerySuggester from './suggestions/SearchQuerySugggester';
 import { ANTD_GRAY_V2 } from '../entity/shared/constants';
+import { formatNumberWithoutAbbreviation } from '../shared/formatNumber';
 
 const SearchResultsWrapper = styled.div<{ v2Styles: boolean }>`
     display: flex;
@@ -210,7 +211,13 @@ export const SearchResults = ({
                                     <b>
                                         {lastResultIndex > 0 ? (page - 1) * pageSize + 1 : 0} - {lastResultIndex}
                                     </b>{' '}
-                                    of <b>{totalResults}</b> results
+                                    of{' '}
+                                    <b>
+                                        {totalResults >= 10000
+                                            ? `${formatNumberWithoutAbbreviation(10000)}+`
+                                            : formatNumberWithoutAbbreviation(totalResults)}
+                                    </b>{' '}
+                                    results
                                 </Typography.Text>
                             </LeftControlsContainer>
                             <SearchMenuContainer>


### PR DESCRIPTION
## Checklist
here is the screenshot
![Screenshot from 2023-11-30 17-53-43](https://github.com/datahub-project/datahub/assets/77378510/8b0f0d75-ed2b-44b4-849b-488a0714e5f4)


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
