### PR TITLE
refactor(ui): Remove primary color for sort selector + add t…

### DIFF
--- a/datahub-web-react/src/app/search/context/SearchContext.tsx
+++ b/datahub-web-react/src/app/search/context/SearchContext.tsx
@@ -3,13 +3,13 @@ import React, { useContext } from 'react';
 export type SearchContextType = {
     query: string | undefined;
     selectedSortOption: string | undefined;
-    setSelectedSortOption: (sortOption: string) => void;
+    setSelectedSortOption: (sortOption: string | null) => void;
 };
 
 export const DEFAULT_CONTEXT = {
     query: undefined,
     selectedSortOption: undefined,
-    setSelectedSortOption: (_: string) => null,
+    setSelectedSortOption: (_: string | null) => null,
 };
 
 export const SearchContext = React.createContext<SearchContextType>(DEFAULT_CONTEXT);

--- a/datahub-web-react/src/app/search/context/SearchContext.tsx
+++ b/datahub-web-react/src/app/search/context/SearchContext.tsx
@@ -3,13 +3,13 @@ import React, { useContext } from 'react';
 export type SearchContextType = {
     query: string | undefined;
     selectedSortOption: string | undefined;
-    setSelectedSortOption: (sortOption: string | null) => void;
+    setSelectedSortOption: (sortOption: string) => void;
 };
 
 export const DEFAULT_CONTEXT = {
     query: undefined,
     selectedSortOption: undefined,
-    setSelectedSortOption: (_: string | null) => null,
+    setSelectedSortOption: (_: string) => null,
 };
 
 export const SearchContext = React.createContext<SearchContextType>(DEFAULT_CONTEXT);

--- a/datahub-web-react/src/app/search/context/constants.ts
+++ b/datahub-web-react/src/app/search/context/constants.ts
@@ -7,7 +7,7 @@ export const LAST_OPERATION_TIME_FIELD = 'lastOperationTime';
 export const DEFAULT_SORT_OPTION = RELEVANCE;
 
 export const SORT_OPTIONS = {
-    [RELEVANCE]: { label: 'Relevance', field: RELEVANCE, sortOrder: SortOrder.Descending },
+    [RELEVANCE]: { label: 'Relevance (Default)', field: RELEVANCE, sortOrder: SortOrder.Descending },
     [`${ENTITY_NAME_FIELD}_${SortOrder.Ascending}`]: {
         label: 'Name A to Z',
         field: ENTITY_NAME_FIELD,
@@ -19,7 +19,7 @@ export const SORT_OPTIONS = {
         sortOrder: SortOrder.Descending,
     },
     [`${LAST_OPERATION_TIME_FIELD}_${SortOrder.Descending}`]: {
-        label: 'Last Modified (In Source)',
+        label: 'Last Modified In Source',
         field: LAST_OPERATION_TIME_FIELD,
         sortOrder: SortOrder.Descending,
     },

--- a/datahub-web-react/src/app/search/context/constants.ts
+++ b/datahub-web-react/src/app/search/context/constants.ts
@@ -9,17 +9,17 @@ export const DEFAULT_SORT_OPTION = RELEVANCE;
 export const SORT_OPTIONS = {
     [RELEVANCE]: { label: 'Relevance', field: RELEVANCE, sortOrder: SortOrder.Descending },
     [`${ENTITY_NAME_FIELD}_${SortOrder.Ascending}`]: {
-        label: 'A to Z',
+        label: 'Name A to Z',
         field: ENTITY_NAME_FIELD,
         sortOrder: SortOrder.Ascending,
     },
     [`${ENTITY_NAME_FIELD}_${SortOrder.Descending}`]: {
-        label: 'Z to A',
+        label: 'Name Z to A',
         field: ENTITY_NAME_FIELD,
         sortOrder: SortOrder.Descending,
     },
     [`${LAST_OPERATION_TIME_FIELD}_${SortOrder.Descending}`]: {
-        label: 'Last Modified in Platform',
+        label: 'Last Modified (In Source)',
         field: LAST_OPERATION_TIME_FIELD,
         sortOrder: SortOrder.Descending,
     },

--- a/datahub-web-react/src/app/search/sorting/SearchSortSelect.tsx
+++ b/datahub-web-react/src/app/search/sorting/SearchSortSelect.tsx
@@ -18,15 +18,16 @@ const SelectWrapper = styled.span`
         font-weight: 700;
     }
 
-    svg {
+    .ant-select-selection-placeholder {
         color: ${ANTD_GRAY[8]};
+        font-weight: 700;
     }
 `;
 
 const StyledIcon = styled(Icon)`
     color: ${ANTD_GRAY[8]};
     font-size: 16px;
-    margin-right: -6px;
+    margin-right: -8px;
 `;
 
 export default function SearchSortSelect() {
@@ -39,8 +40,8 @@ export default function SearchSortSelect() {
             <SelectWrapper>
                 <StyledIcon component={SortIcon} />
                 <Select
-                    value={selectedSortOption}
-                    defaultValue={DEFAULT_SORT_OPTION}
+                    placeholder="Sort"
+                    value={selectedSortOption === DEFAULT_SORT_OPTION ? null : selectedSortOption}
                     options={options}
                     bordered={false}
                     onChange={(sortOption) => setSelectedSortOption(sortOption)}

--- a/datahub-web-react/src/app/search/sorting/SearchSortSelect.tsx
+++ b/datahub-web-react/src/app/search/sorting/SearchSortSelect.tsx
@@ -1,8 +1,9 @@
 import Icon, { CaretDownFilled } from '@ant-design/icons';
-import { Select } from 'antd';
+import { Select, Tooltip } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
 import { ReactComponent as SortIcon } from '../../../images/sort.svg';
+import { ANTD_GRAY } from '../../entity/shared/constants';
 import { DEFAULT_SORT_OPTION, SORT_OPTIONS } from '../context/constants';
 import { useSearchContext } from '../context/SearchContext';
 
@@ -13,17 +14,17 @@ const SelectWrapper = styled.span`
 
     .ant-select-selection-item {
         // !important is necessary because updating Select styles for antd is impossible
-        color: ${(props) => props.theme.styles['primary-color']} !important;
+        color: ${ANTD_GRAY[8]} !important;
         font-weight: 700;
     }
 
     svg {
-        color: ${(props) => props.theme.styles['primary-color']};
+        color: ${ANTD_GRAY[8]};
     }
 `;
 
 const StyledIcon = styled(Icon)`
-    color: ${(props) => props.theme.styles['primary-color']};
+    color: ${ANTD_GRAY[8]};
     font-size: 16px;
     margin-right: -6px;
 `;
@@ -34,18 +35,20 @@ export default function SearchSortSelect() {
     const options = Object.entries(SORT_OPTIONS).map(([value, option]) => ({ value, label: option.label }));
 
     return (
-        <SelectWrapper>
-            <StyledIcon component={SortIcon} />
-            <Select
-                value={selectedSortOption}
-                defaultValue={DEFAULT_SORT_OPTION}
-                options={options}
-                bordered={false}
-                onChange={(sortOption) => setSelectedSortOption(sortOption)}
-                dropdownStyle={{ minWidth: 'max-content' }}
-                placement="bottomRight"
-                suffixIcon={<CaretDownFilled />}
-            />
-        </SelectWrapper>
+        <Tooltip title="Sort search results" showArrow={false} placement="left">
+            <SelectWrapper>
+                <StyledIcon component={SortIcon} />
+                <Select
+                    value={selectedSortOption}
+                    defaultValue={DEFAULT_SORT_OPTION}
+                    options={options}
+                    bordered={false}
+                    onChange={(sortOption) => setSelectedSortOption(sortOption)}
+                    dropdownStyle={{ minWidth: 'max-content' }}
+                    placement="bottomRight"
+                    suffixIcon={<CaretDownFilled />}
+                />
+            </SelectWrapper>
+        </Tooltip>
     );
 }


### PR DESCRIPTION
Design improvements:

1. Remove primary color CTA for sorting selector
2. Display the name "sort" for default relevance sorting
3. Adding tooltips
4. Adding more clarity to the names in dropdown


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
