### PR TITLE
fix(ui): Minor: fix unnecessary lineage tab scroll by removing -1 margin on lists

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Entity/components/EntityList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Entity/components/EntityList.tsx
@@ -8,7 +8,6 @@ import { EntityType } from '../../../../../../types.generated';
 const StyledList = styled(List)`
     padding-left: 40px;
     padding-right: 40px;
-    margin-top: -1px;
     .ant-list-items > .ant-list-item {
         padding-right: 0px;
         padding-left: 0px;

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -11,7 +11,6 @@ import { capitalizeFirstLetterOnly } from '../../../shared/textUtil';
 export const StyledList = styled(List)`
     overflow-y: auto;
     height: 100%;
-    margin-top: -1px;
     box-shadow: ${(props) => props.theme.styles['box-shadow']};
     flex: 1;
     .ant-list-items > .ant-list-item {


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
