### PR TITLE
feat(ingestion): Add typeUrn handling to ownership transformers

### DIFF
--- a/metadata-ingestion/docs/transformer/dataset_transformer.md
+++ b/metadata-ingestion/docs/transformer/dataset_transformer.md
@@ -55,12 +55,13 @@ transformers:
 ```
 ## Simple Add Dataset ownership 
 ### Config Details
-| Field                       | Required | Type         | Default       | Description                                                      |
-|-----------------------------|----------|--------------|---------------|------------------------------------------------------------------|
-| `owner_urns`                | ✅        | list[string] |               | List of owner urns.                                              |
-| `ownership_type`            |          | string       | `DATAOWNER`   | ownership type of the owners.                                    |
-| `replace_existing`          |          | boolean      | `false`       | Whether to remove owners from entity sent by ingestion source.   |
-| `semantics`                 |          | enum         | `OVERWRITE`   | Whether to OVERWRITE or PATCH the entity present on DataHub GMS. |
+| Field                  | Required  | Type          | Default     | Description                                                                                |
+|------------------------|-----------|---------------|-------------|--------------------------------------------------------------------------------------------|
+| `owner_urns`           | ✅         | list[string]  |             | List of owner urns.                                                                        |
+| `ownership_type`       |           | string        |             | ownership type of the owners (either this one or `ownership_type_urn` need to be defined) |
+| `ownership_type_urn`   |           | string        |             | ownership type urn of the owners (either this or `ownership_type` need to be defined)      |
+| `replace_existing`     |           | boolean       | `false`     | Whether to remove owners from entity sent by ingestion source.                             |
+| `semantics`            |           | enum          | `OVERWRITE` | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.                           |
 
 For transformer behaviour on `replace_existing` and `semantics`, please refer section [Relationship Between replace_existing And semantics](#relationship-between-replace_existing-and-semantics).
 
@@ -95,7 +96,8 @@ transformers:
             - "urn:li:corpuser:username1"
             - "urn:li:corpuser:username2"
             - "urn:li:corpGroup:groupname"
-          ownership_type: "PRODUCER"
+          ownership_type: "CUSTOM"
+          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
     ```
 - Add owners, however overwrite the owners available for the dataset on DataHub GMS
     ```yaml
@@ -107,7 +109,7 @@ transformers:
             - "urn:li:corpuser:username1"
             - "urn:li:corpuser:username2"
             - "urn:li:corpGroup:groupname"
-          ownership_type: "PRODUCER"
+          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
     ```
 - Add owners, however keep the owners available for the dataset on DataHub GMS
     ```yaml
@@ -124,12 +126,13 @@ transformers:
 
 ## Pattern Add Dataset ownership 
 ### Config Details
-| Field                       | Required | Type                  | Default          | Description                                                                             |
-|-----------------------------|--------- |-----------------------|------------------|-----------------------------------------------------------------------------------------|
-| `owner_pattern`             | ✅        | map[regx, list[urn]]  |                  | entity urn with regular expression and list of owners urn apply to matching entity urn. |
-| `ownership_type`            |          | string                | `DATAOWNER`      | ownership type of the owners.                                                           |
-| `replace_existing`          |          | boolean               | `false`          | Whether to remove owners from entity sent by ingestion source.                          |
-| `semantics`                 |          | enum                  | `OVERWRITE`      | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.                        |
+| Field                | Required | Type                 | Default     | Description                                                                               |
+|----------------------|----------|----------------------|-------------|-------------------------------------------------------------------------------------------|
+| `owner_pattern`      | ✅        | map[regx, list[urn]] |             | entity urn with regular expression and list of owners urn apply to matching entity urn.   |
+| `ownership_type`     |          | string               |             | ownership type of the owners (either this one or `ownership_type_urn` need to be defined) |
+| `ownership_type_urn` |          | string               |             | ownership type urn of the owners (either this or `ownership_type` need to be defined)     |
+| `replace_existing`   |          | boolean              | `false`     | Whether to remove owners from entity sent by ingestion source.                            |
+| `semantics`          |          | enum                 | `OVERWRITE` | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.                          |
 
 let’s suppose we’d like to append a series of users who we know to own a different dataset from a data source but aren't detected during normal ingestion. To do so, we can use the `pattern_add_dataset_ownership` module that’s included in the ingestion framework.  This will match the pattern to `urn` of the dataset and assign the respective owners.
 
@@ -158,7 +161,8 @@ The config, which we’d append to our ingestion recipe YAML, would look like th
             rules:
               ".*example1.*": ["urn:li:corpuser:username1"]
               ".*example2.*": ["urn:li:corpuser:username2"]
-          ownership_type: "PRODUCER"
+          ownership_type: "CUSTOM"
+          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
     ```
 - Add owner, however overwrite the owners available for the dataset on DataHub GMS
     ```yaml
@@ -170,7 +174,7 @@ The config, which we’d append to our ingestion recipe YAML, would look like th
             rules:
               ".*example1.*": ["urn:li:corpuser:username1"]
               ".*example2.*": ["urn:li:corpuser:username2"]
-          ownership_type: "PRODUCER"
+          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
     ```
 - Add owner, however keep the owners available for the dataset on DataHub GMS
     ```yaml

--- a/metadata-ingestion/docs/transformer/dataset_transformer.md
+++ b/metadata-ingestion/docs/transformer/dataset_transformer.md
@@ -55,13 +55,12 @@ transformers:
 ```
 ## Simple Add Dataset ownership 
 ### Config Details
-| Field                  | Required  | Type          | Default     | Description                                                                                |
-|------------------------|-----------|---------------|-------------|--------------------------------------------------------------------------------------------|
-| `owner_urns`           | ✅         | list[string]  |             | List of owner urns.                                                                        |
-| `ownership_type`       |           | string        |             | ownership type of the owners (either this one or `ownership_type_urn` need to be defined) |
-| `ownership_type_urn`   |           | string        |             | ownership type urn of the owners (either this or `ownership_type` need to be defined)      |
-| `replace_existing`     |           | boolean       | `false`     | Whether to remove owners from entity sent by ingestion source.                             |
-| `semantics`            |           | enum          | `OVERWRITE` | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.                           |
+| Field              | Required | Type         | Default     | Description                                                         |
+|--------------------|----------|--------------|-------------|---------------------------------------------------------------------|
+| `owner_urns`       | ✅        | list[string] |             | List of owner urns.                                                 |
+| `ownership_type`   |          | string       | "DATAOWNER" | ownership type of the owners (either as enum or ownership type urn) |
+| `replace_existing` |          | boolean      | `false`     | Whether to remove owners from entity sent by ingestion source.      |
+| `semantics`        |          | enum         | `OVERWRITE` | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.    |
 
 For transformer behaviour on `replace_existing` and `semantics`, please refer section [Relationship Between replace_existing And semantics](#relationship-between-replace_existing-and-semantics).
 
@@ -96,8 +95,7 @@ transformers:
             - "urn:li:corpuser:username1"
             - "urn:li:corpuser:username2"
             - "urn:li:corpGroup:groupname"
-          ownership_type: "CUSTOM"
-          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
+          ownership_type: "urn:li:ownershipType:__system__producer"
     ```
 - Add owners, however overwrite the owners available for the dataset on DataHub GMS
     ```yaml
@@ -109,7 +107,7 @@ transformers:
             - "urn:li:corpuser:username1"
             - "urn:li:corpuser:username2"
             - "urn:li:corpGroup:groupname"
-          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
+          ownership_type: "urn:li:ownershipType:__system__producer" 
     ```
 - Add owners, however keep the owners available for the dataset on DataHub GMS
     ```yaml
@@ -126,13 +124,12 @@ transformers:
 
 ## Pattern Add Dataset ownership 
 ### Config Details
-| Field                | Required | Type                 | Default     | Description                                                                               |
-|----------------------|----------|----------------------|-------------|-------------------------------------------------------------------------------------------|
-| `owner_pattern`      | ✅        | map[regx, list[urn]] |             | entity urn with regular expression and list of owners urn apply to matching entity urn.   |
-| `ownership_type`     |          | string               |             | ownership type of the owners (either this one or `ownership_type_urn` need to be defined) |
-| `ownership_type_urn` |          | string               |             | ownership type urn of the owners (either this or `ownership_type` need to be defined)     |
-| `replace_existing`   |          | boolean              | `false`     | Whether to remove owners from entity sent by ingestion source.                            |
-| `semantics`          |          | enum                 | `OVERWRITE` | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.                          |
+| Field              | Required | Type                 | Default     | Description                                                                             |
+|--------------------|----------|----------------------|-------------|-----------------------------------------------------------------------------------------|
+| `owner_pattern`    | ✅        | map[regx, list[urn]] |             | entity urn with regular expression and list of owners urn apply to matching entity urn. |
+| `ownership_type`   |          | string               | "DATAOWNER" | ownership type of the owners (either as enum or ownership type urn)                     |
+| `replace_existing` |          | boolean              | `false`     | Whether to remove owners from entity sent by ingestion source.                          |
+| `semantics`        |          | enum                 | `OVERWRITE` | Whether to OVERWRITE or PATCH the entity present on DataHub GMS.                        |
 
 let’s suppose we’d like to append a series of users who we know to own a different dataset from a data source but aren't detected during normal ingestion. To do so, we can use the `pattern_add_dataset_ownership` module that’s included in the ingestion framework.  This will match the pattern to `urn` of the dataset and assign the respective owners.
 
@@ -161,8 +158,7 @@ The config, which we’d append to our ingestion recipe YAML, would look like th
             rules:
               ".*example1.*": ["urn:li:corpuser:username1"]
               ".*example2.*": ["urn:li:corpuser:username2"]
-          ownership_type: "CUSTOM"
-          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
+          ownership_type: "urn:li:ownershipType:__system__producer"
     ```
 - Add owner, however overwrite the owners available for the dataset on DataHub GMS
     ```yaml
@@ -174,7 +170,7 @@ The config, which we’d append to our ingestion recipe YAML, would look like th
             rules:
               ".*example1.*": ["urn:li:corpuser:username1"]
               ".*example2.*": ["urn:li:corpuser:username2"]
-          ownership_type_urn: "urn:li:ownershipType:__system__producer" 
+          ownership_type: "urn:li:ownershipType:__system__producer" 
     ```
 - Add owner, however keep the owners available for the dataset on DataHub GMS
     ```yaml

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -16,7 +16,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    get_type_hints,
+    get_type_hints, Tuple,
 )
 
 import typing_inspect
@@ -351,15 +351,15 @@ def get_class_fields(_class: Type[object]) -> Iterable[str]:
     ]
 
 
-def validate_ownership_type(
-    ownership_type: Optional[str], ownership_type_urn: Optional[str]
-) -> str:
+def validate_ownership_type(ownership_type: Optional[str]) -> Tuple[str, Optional[str]]:
+    if ownership_type is None:
+        return OwnershipTypeClass.DATAOWNER, None
     try:
         ownership_type_str = cast(str, ownership_type)
-        if not ownership_type_str and ownership_type_urn:
-            ownership_type_str = OwnershipTypeClass.CUSTOM
+        if ownership_type_str.startswith("urn:li:"):
+            return OwnershipTypeClass.CUSTOM, ownership_type_str
         if ownership_type_str in get_class_fields(OwnershipTypeClass):
-            return ownership_type_str
+            return ownership_type_str, None
         raise ValueError
     except ValueError:
         raise ValueError(f"Unexpected ownership type: {ownership_type}")

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -12,11 +12,12 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     Union,
     cast,
-    get_type_hints, Tuple,
+    get_type_hints,
 )
 
 import typing_inspect

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -16,7 +16,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
     get_type_hints,
 )
 

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -352,18 +352,12 @@ def get_class_fields(_class: Type[object]) -> Iterable[str]:
     ]
 
 
-def validate_ownership_type(ownership_type: Optional[str]) -> Tuple[str, Optional[str]]:
-    if ownership_type is None:
-        return OwnershipTypeClass.DATAOWNER, None
-    try:
-        ownership_type_str = cast(str, ownership_type)
-        if ownership_type_str.startswith("urn:li:"):
-            return OwnershipTypeClass.CUSTOM, ownership_type_str
-        if ownership_type_str in get_class_fields(OwnershipTypeClass):
-            return ownership_type_str, None
-        raise ValueError
-    except ValueError:
-        raise ValueError(f"Unexpected ownership type: {ownership_type}")
+def validate_ownership_type(ownership_type: str) -> Tuple[str, Optional[str]]:
+    if ownership_type.startswith("urn:li:"):
+        return OwnershipTypeClass.CUSTOM, ownership_type
+    if ownership_type in get_class_fields(OwnershipTypeClass):
+        return ownership_type, None
+    raise ValueError(f"Unexpected ownership type: {ownership_type}")
 
 
 def make_lineage_mce(

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -102,7 +102,8 @@ class AddDatasetOwnership(DatasetOwnershipTransformer):
 
 
 class DatasetOwnershipBaseConfig(TransformerSemanticsConfigModel):
-    ownership_type: Optional[str] = OwnershipTypeClass.DATAOWNER
+    ownership_type: Optional[str]
+    ownership_type_urn: Optional[str]
 
 
 class SimpleDatasetOwnershipConfig(DatasetOwnershipBaseConfig):
@@ -114,11 +115,14 @@ class SimpleAddDatasetOwnership(AddDatasetOwnership):
     """Transformer that adds a specified set of owners to each dataset."""
 
     def __init__(self, config: SimpleDatasetOwnershipConfig, ctx: PipelineContext):
-        ownership_type = builder.validate_ownership_type(config.ownership_type)
+        ownership_type = builder.validate_ownership_type(
+            config.ownership_type, config.ownership_type_urn
+        )
         owners = [
             OwnerClass(
                 owner=owner,
                 type=ownership_type,
+                typeUrn=config.ownership_type_urn,
             )
             for owner in config.owner_urns
         ]
@@ -147,29 +151,17 @@ class PatternDatasetOwnershipConfig(DatasetOwnershipBaseConfig):
 class PatternAddDatasetOwnership(AddDatasetOwnership):
     """Transformer that adds a specified set of owners to each dataset."""
 
-    def getOwners(
-        self,
-        key: str,
-        owner_pattern: KeyValuePattern,
-        ownership_type: Optional[str] = None,
-    ) -> List[OwnerClass]:
-        owners = [
-            OwnerClass(
-                owner=owner,
-                type=builder.validate_ownership_type(ownership_type),
-            )
-            for owner in owner_pattern.value(key)
-        ]
-        return owners
-
     def __init__(self, config: PatternDatasetOwnershipConfig, ctx: PipelineContext):
-        ownership_type = builder.validate_ownership_type(config.ownership_type)
         owner_pattern = config.owner_pattern
+        ownership_type = builder.validate_ownership_type(
+            config.ownership_type, config.ownership_type_urn
+        )
         generic_config = AddDatasetOwnershipConfig(
             get_owners_to_add=lambda urn: [
                 OwnerClass(
                     owner=owner,
                     type=ownership_type,
+                    typeUrn=config.ownership_type_urn,
                 )
                 for owner in owner_pattern.value(urn)
             ],

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -99,7 +99,6 @@ class AddDatasetOwnership(DatasetOwnershipTransformer):
 
 class DatasetOwnershipBaseConfig(TransformerSemanticsConfigModel):
     ownership_type: Optional[str]
-    ownership_type_urn: Optional[str]
 
 
 class SimpleDatasetOwnershipConfig(DatasetOwnershipBaseConfig):
@@ -111,14 +110,14 @@ class SimpleAddDatasetOwnership(AddDatasetOwnership):
     """Transformer that adds a specified set of owners to each dataset."""
 
     def __init__(self, config: SimpleDatasetOwnershipConfig, ctx: PipelineContext):
-        ownership_type = builder.validate_ownership_type(
-            config.ownership_type, config.ownership_type_urn
+        ownership_type, ownership_type_urn = builder.validate_ownership_type(
+            config.ownership_type
         )
         owners = [
             OwnerClass(
                 owner=owner,
                 type=ownership_type,
-                typeUrn=config.ownership_type_urn,
+                typeUrn=ownership_type_urn,
             )
             for owner in config.owner_urns
         ]
@@ -149,15 +148,15 @@ class PatternAddDatasetOwnership(AddDatasetOwnership):
 
     def __init__(self, config: PatternDatasetOwnershipConfig, ctx: PipelineContext):
         owner_pattern = config.owner_pattern
-        ownership_type = builder.validate_ownership_type(
-            config.ownership_type, config.ownership_type_urn
+        ownership_type, ownership_type_urn = builder.validate_ownership_type(
+            config.ownership_type
         )
         generic_config = AddDatasetOwnershipConfig(
             get_owners_to_add=lambda urn: [
                 OwnerClass(
                     owner=owner,
                     type=ownership_type,
-                    typeUrn=config.ownership_type_urn,
+                    typeUrn=ownership_type_urn,
                 )
                 for owner in owner_pattern.value(urn)
             ],

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -16,6 +16,7 @@ from datahub.ingestion.transformer.dataset_transformer import (
 )
 from datahub.metadata.schema_classes import OwnerClass, OwnershipClass
 
+
 class AddDatasetOwnershipConfig(TransformerSemanticsConfigModel):
     get_owners_to_add: Callable[[str], List[OwnerClass]]
     default_actor: str = builder.make_user_urn("etl")

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -14,12 +14,7 @@ from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.transformer.dataset_transformer import (
     DatasetOwnershipTransformer,
 )
-from datahub.metadata.schema_classes import (
-    OwnerClass,
-    OwnershipClass,
-    OwnershipTypeClass,
-)
-
+from datahub.metadata.schema_classes import OwnerClass, OwnershipClass
 
 class AddDatasetOwnershipConfig(TransformerSemanticsConfigModel):
     get_owners_to_add: Callable[[str], List[OwnerClass]]

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -14,6 +14,7 @@ from datahub.ingestion.graph.client import DataHubGraph
 from datahub.ingestion.transformer.dataset_transformer import (
     DatasetOwnershipTransformer,
 )
+from datahub.metadata._schema_classes import OwnershipTypeClass
 from datahub.metadata.schema_classes import OwnerClass, OwnershipClass
 
 
@@ -98,7 +99,7 @@ class AddDatasetOwnership(DatasetOwnershipTransformer):
 
 
 class DatasetOwnershipBaseConfig(TransformerSemanticsConfigModel):
-    ownership_type: Optional[str]
+    ownership_type: str = OwnershipTypeClass.DATAOWNER
 
 
 class SimpleDatasetOwnershipConfig(DatasetOwnershipBaseConfig):

--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -216,7 +216,7 @@ class TestPipeline(object):
                         "type": "simple_add_dataset_ownership",
                         "config": {
                             "owner_urns": ["urn:li:corpuser:foo"],
-                            "ownership_type_urn": "urn:li:ownershipType:__system__technical_owner",
+                            "ownership_type": "urn:li:ownershipType:__system__technical_owner",
                         },
                     }
                 ],

--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -214,7 +214,10 @@ class TestPipeline(object):
                 "transformers": [
                     {
                         "type": "simple_add_dataset_ownership",
-                        "config": {"owner_urns": ["urn:li:corpuser:foo"]},
+                        "config": {
+                            "owner_urns": ["urn:li:corpuser:foo"],
+                            "ownership_type_urn": "urn:li:ownershipType:__system__technical_owner",
+                        },
                     }
                 ],
                 "sink": {"type": "tests.test_helpers.sink_helpers.RecordingSink"},

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -302,8 +302,7 @@ def test_simple_dataset_ownership_with_type_urn_transformation(mock_time):
             "owner_urns": [
                 builder.make_user_urn("person1"),
             ],
-            "ownership_type": OwnershipTypeClass.CUSTOM,
-            "ownership_type_urn": "urn:li:ownershipType:__system__technical_owner",
+            "ownership_type": "urn:li:ownershipType:__system__technical_owner",
         },
         PipelineContext(run_id="test"),
     )

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -210,7 +210,8 @@ def test_simple_dataset_ownership_transformation(mock_time):
             "owner_urns": [
                 builder.make_user_urn("person1"),
                 builder.make_user_urn("person2"),
-            ]
+            ],
+            "ownership_type": "DATAOWNER",
         },
         PipelineContext(run_id="test"),
     )
@@ -234,7 +235,7 @@ def test_simple_dataset_ownership_transformation(mock_time):
     assert last_event.entityUrn == outputs[0].record.proposedSnapshot.urn
     assert all(
         [
-            owner.type == models.OwnershipTypeClass.DATAOWNER
+            owner.type == models.OwnershipTypeClass.DATAOWNER and owner.typeUrn is None
             for owner in last_event.aspect.owners
         ]
     )
@@ -247,7 +248,7 @@ def test_simple_dataset_ownership_transformation(mock_time):
     assert len(second_ownership_aspect.owners) == 3
     assert all(
         [
-            owner.type == models.OwnershipTypeClass.DATAOWNER
+            owner.type == models.OwnershipTypeClass.DATAOWNER and owner.typeUrn is None
             for owner in second_ownership_aspect.owners
         ]
     )
@@ -291,6 +292,45 @@ def test_simple_dataset_ownership_with_type_transformation(mock_time):
     assert isinstance(ownership_aspect, OwnershipClass)
     assert len(ownership_aspect.owners) == 1
     assert ownership_aspect.owners[0].type == models.OwnershipTypeClass.PRODUCER
+
+
+def test_simple_dataset_ownership_with_type_urn_transformation(mock_time):
+    input = make_generic_dataset()
+
+    transformer = SimpleAddDatasetOwnership.create(
+        {
+            "owner_urns": [
+                builder.make_user_urn("person1"),
+            ],
+            "ownership_type": OwnershipTypeClass.CUSTOM,
+            "ownership_type_urn": "urn:li:ownershipType:__system__technical_owner",
+        },
+        PipelineContext(run_id="test"),
+    )
+
+    output = list(
+        transformer.transform(
+            [
+                RecordEnvelope(input, metadata={}),
+                RecordEnvelope(EndOfStream(), metadata={}),
+            ]
+        )
+    )
+
+    assert len(output) == 3
+
+    # original MCE is unchanged
+    assert input == output[0].record
+
+    ownership_aspect = output[1].record.aspect
+
+    assert isinstance(ownership_aspect, OwnershipClass)
+    assert len(ownership_aspect.owners) == 1
+    assert ownership_aspect.owners[0].type == OwnershipTypeClass.CUSTOM
+    assert (
+        ownership_aspect.owners[0].typeUrn
+        == "urn:li:ownershipType:__system__technical_owner"
+    )
 
 
 def _test_extract_tags(in_urn: str, regex_str: str, out_tag: str) -> None:
@@ -883,6 +923,7 @@ def test_pattern_dataset_ownership_transformation(mock_time):
                     ".*example2.*": [builder.make_user_urn("person2")],
                 }
             },
+            "ownership_type": "DATAOWNER",
         },
         PipelineContext(run_id="test"),
     )
@@ -2233,6 +2274,7 @@ def test_simple_dataset_ownership_transformer_semantics_patch(mock_datahub_graph
             "replace_existing": False,
             "semantics": TransformerSemantics.PATCH,
             "owner_urns": [owner2],
+            "ownership_type": "DATAOWNER",
         },
         pipeline_context=pipeline_context,
     )

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -210,8 +210,7 @@ def test_simple_dataset_ownership_transformation(mock_time):
             "owner_urns": [
                 builder.make_user_urn("person1"),
                 builder.make_user_urn("person2"),
-            ],
-            "ownership_type": "DATAOWNER",
+            ]
         },
         PipelineContext(run_id="test"),
     )


### PR DESCRIPTION
Changed behavior of both ownership transformers by adding possibility to define `ownership_type_urn`, as well as removing default value of ownership_type (it will be populated as CUSTOM if user defines ownership_type_urn). This way the transformers maintain backward compatibility as long as the users don't base on default value for `ownership_type` (if `ownership_type` is set but not `ownership_type_urn` transformers work as before, setting the ownership without `typeUrn`.

Fixes https://github.com/datahub-project/datahub/issues/8441
