### PR TITLE
fix(ingest): resolve issue with caplog and asyncio

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/lookml_source.py
@@ -550,7 +550,7 @@ class LookerModel:
 @dataclass
 class LookerViewFile:
     absolute_file_path: str
-    connection: Optional[str]
+    connection: Optional[LookerConnectionDefinition]
     includes: List[str]
     resolved_includes: List[ProjectInclude]
     views: List[Dict]

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_source_helpers.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_source_helpers.py
@@ -483,7 +483,7 @@ def test_auto_browse_path_v2_dry_run(telemetry_ping_mock):
 
 
 @freeze_time("2023-01-02 00:00:00")
-def test_auto_empty_dataset_usage_statistics(caplog: pytest.LogCaptureFixture):
+def test_auto_empty_dataset_usage_statistics(caplog: pytest.LogCaptureFixture) -> None:
     has_urn = make_dataset_urn("my_platform", "has_aspect")
     empty_urn = make_dataset_urn("my_platform", "no_aspect")
     config = BaseTimeWindowConfig()
@@ -534,7 +534,7 @@ def test_auto_empty_dataset_usage_statistics(caplog: pytest.LogCaptureFixture):
 @freeze_time("2023-01-02 00:00:00")
 def test_auto_empty_dataset_usage_statistics_invalid_timestamp(
     caplog: pytest.LogCaptureFixture,
-):
+) -> None:
     urn = make_dataset_urn("my_platform", "my_dataset")
     config = BaseTimeWindowConfig()
     wus = [

--- a/metadata-ingestion/tests/unit/api/source_helpers/test_source_helpers.py
+++ b/metadata-ingestion/tests/unit/api/source_helpers/test_source_helpers.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any, Dict, Iterable, List, Union
 from unittest.mock import patch
 
+import pytest
 from freezegun import freeze_time
 
 import datahub.metadata.schema_classes as models
@@ -482,7 +483,7 @@ def test_auto_browse_path_v2_dry_run(telemetry_ping_mock):
 
 
 @freeze_time("2023-01-02 00:00:00")
-def test_auto_empty_dataset_usage_statistics(caplog):
+def test_auto_empty_dataset_usage_statistics(caplog: pytest.LogCaptureFixture):
     has_urn = make_dataset_urn("my_platform", "has_aspect")
     empty_urn = make_dataset_urn("my_platform", "no_aspect")
     config = BaseTimeWindowConfig()
@@ -499,6 +500,7 @@ def test_auto_empty_dataset_usage_statistics(caplog):
             ),
         ).as_workunit()
     ]
+    caplog.clear()
     with caplog.at_level(logging.WARNING):
         new_wus = list(
             auto_empty_dataset_usage_statistics(
@@ -530,7 +532,9 @@ def test_auto_empty_dataset_usage_statistics(caplog):
 
 
 @freeze_time("2023-01-02 00:00:00")
-def test_auto_empty_dataset_usage_statistics_invalid_timestamp(caplog):
+def test_auto_empty_dataset_usage_statistics_invalid_timestamp(
+    caplog: pytest.LogCaptureFixture,
+):
     urn = make_dataset_urn("my_platform", "my_dataset")
     config = BaseTimeWindowConfig()
     wus = [
@@ -546,6 +550,7 @@ def test_auto_empty_dataset_usage_statistics_invalid_timestamp(caplog):
             ),
         ).as_workunit()
     ]
+    caplog.clear()
     with caplog.at_level(logging.WARNING):
         new_wus = list(
             auto_empty_dataset_usage_statistics(

--- a/metadata-ingestion/tests/unit/utilities/test_perf_timer.py
+++ b/metadata-ingestion/tests/unit/utilities/test_perf_timer.py
@@ -5,7 +5,7 @@ import pytest
 
 from datahub.utilities.perf_timer import PerfTimer
 
-approx = partial(pytest.approx, rel=1e-2)
+approx = partial(pytest.approx, rel=2e-2)
 
 
 def test_perf_timer_simple():


### PR DESCRIPTION
We're starting to see issues like this in CI, likely due to a dependency upgrade (probably freezegun https://pypi.org/project/freezegun/ - see discussion here https://github.com/spulec/freezegun/issues/521)

When using `caplog`, we see a stray asyncio log message before the rest of the logs. This should clear that out.

```
FAILED tests/unit/api/source_helpers/test_source_helpers.py::test_auto_empty_dataset_usage_statistics - assert not [<LogRecord: asyncio, 10, /opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/asyncio/selector_events.py, 58, "Using selector: %s">]
 +  where [<LogRecord: asyncio, 10, /opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/asyncio/selector_events.py, 58, "Using selector: %s">] = <_pytest.logging.LogCaptureFixture object at 0x7f067d18d9d0>.records
FAILED tests/unit/api/source_helpers/test_source_helpers.py::test_auto_empty_dataset_usage_statistics_invalid_timestamp - assert 2 == 1
 +  where 2 = len([<LogRecord: asyncio, 10, /opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/asyncio/selector_events.py, 58, "Using selector: %s">, <LogRecord: datahub.ingestion.api.source_helpers, 30, /home/runner/work/datahub/datahub/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py, 358, "1970-01-01 00:00:00+00:00">])
 +    where [<LogRecord: asyncio, 10, /opt/hostedtoolcache/Python/3.7.17/x64/lib/python3.7/asyncio/selector_events.py, 58, "Using selector: %s">, <LogRecord: datahub.ingestion.api.source_helpers, 30, /home/runner/work/datahub/datahub/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py, 358, "1970-01-01 00:00:00+00:00">] = <_pytest.logging.LogCaptureFixture object at 0x7f0689f161d0>.records
```

Example failure: https://github.com/datahub-project/datahub/actions/runs/7084142887/job/19277839780

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
