### PR TITLE
fix(ingest/profiling): Add back db_name to sql_generic_profiler methods

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/profile.py
@@ -60,6 +60,7 @@ class RedshiftProfiler(GenericProfiler):
             yield from self.generate_profile_workunits(
                 profile_requests,
                 max_workers=self.config.profiling.max_workers,
+                db_name=db,
                 platform=self.platform,
                 profiler_args=self.get_profile_args(),
             )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_profiler.py
@@ -63,6 +63,7 @@ class SnowflakeProfiler(GenericProfiler, SnowflakeCommonMixin):
         yield from self.generate_profile_workunits(
             profile_requests,
             max_workers=self.config.profiling.max_workers,
+            db_name=database.name,
             platform=self.platform,
             profiler_args=self.get_profile_args(),
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_generic_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_generic_profiler.py
@@ -71,6 +71,7 @@ class GenericProfiler:
         requests: List[TableProfilerRequest],
         *,
         max_workers: int,
+        db_name: Optional[str] = None,
         platform: Optional[str] = None,
         profiler_args: Optional[Dict] = None,
     ) -> Iterable[MetadataWorkUnit]:
@@ -98,7 +99,7 @@ class GenericProfiler:
             return
 
         # Otherwise, if column level profiling is enabled, use  GE profiler.
-        ge_profiler = self.get_profiler_instance()
+        ge_profiler = self.get_profiler_instance(db_name)
 
         for ge_profiler_request, profile in ge_profiler.generate_profiles(
             ge_profile_requests, max_workers, platform, profiler_args
@@ -205,7 +206,9 @@ class GenericProfiler:
             inspector = inspect(conn)
             yield inspector
 
-    def get_profiler_instance(self) -> "DatahubGEProfiler":
+    def get_profiler_instance(
+        self, db_name: Optional[str] = None
+    ) -> "DatahubGEProfiler":
         logger.debug(f"Getting profiler instance from {self.platform}")
         url = self.config.get_sql_alchemy_url()
 


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
