### PR TITLE
fix(ingest/powerbi): fix powerbi chart input handling

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/powerbi/powerbi.py
@@ -504,7 +504,7 @@ class Mapper:
 
         logger.info(f"{Constant.CHART_URN}={chart_urn}")
 
-        ds_input: List[str] = self.to_urn_set(ds_mcps)
+        ds_input: List[str] = self.to_urn_set([x for x in ds_mcps if x.entityType == Constant.DATASET])
 
         def tile_custom_properties(tile: powerbi_data_classes.Tile) -> dict:
             custom_properties: dict = {
@@ -927,7 +927,7 @@ class Mapper:
 
             logger.debug(f"{Constant.CHART_URN}={chart_urn}")
 
-            ds_input: List[str] = self.to_urn_set(ds_mcps)
+            ds_input: List[str] = self.to_urn_set([x for x in ds_mcps if x.entityType == Constant.DATASET])
 
             # Create chartInfo mcp
             # Set chartUrl only if tile is created from Report

--- a/metadata-ingestion/tests/integration/powerbi/golden_test_container.json
+++ b/metadata-ingestion/tests/integration/powerbi/golden_test_container.json
@@ -1401,9 +1401,6 @@
             },
             "inputs": [
                 {
-                    "string": "urn:li:container:6ac0662f0f2fc3a9196ac505da2182b2"
-                },
-                {
                     "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)"
                 },
                 {
@@ -1546,9 +1543,6 @@
                 }
             },
             "inputs": [
-                {
-                    "string": "urn:li:container:977b804137a1d2bf897ff1bbf440a1cc"
-                },
                 {
                     "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,hr_pbi_test.dbo_book_issue,DEV)"
                 },
@@ -2388,9 +2382,6 @@
             },
             "inputs": [
                 {
-                    "string": "urn:li:container:6ac0662f0f2fc3a9196ac505da2182b2"
-                },
-                {
                     "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)"
                 },
                 {
@@ -2514,9 +2505,6 @@
                 }
             },
             "inputs": [
-                {
-                    "string": "urn:li:container:6ac0662f0f2fc3a9196ac505da2182b2"
-                },
                 {
                     "string": "urn:li:dataset:(urn:li:dataPlatform:powerbi,library-dataset.public_issue_history,DEV)"
                 },


### PR DESCRIPTION
My previous PR included a change which added dataset container MCPs to same list of MCPs which was used downstream in the processing for input entities for a Chart entity. As a result, the chart MCPs are now malformed and cannot be ingested. Here's a fix to remove the container references from Chart input side and now it seems to work correctly again.

I'm very sorry for this regression!

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
