### PR TITLE
fix: Adjusting the view of the Column Stats

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/ColumnStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/ColumnStats.tsx
@@ -14,6 +14,8 @@ type Props = {
 const StatSection = styled.div`
     padding: 20px 20px;
     overflow: auto;
+    display: flex;
+    flex-direction: column;
 `;
 
 const NameText = styled(Typography.Text)`
@@ -162,7 +164,12 @@ export default function ColumnStats({ columnStats }: Props) {
     return (
         <StatSection>
             <Typography.Title level={5}>Column Stats</Typography.Title>
-            <StyledTable pagination={false} columns={columnStatsColumns} dataSource={columnStatsTableData} />
+            <StyledTable
+                pagination={false}
+                columns={columnStatsColumns}
+                dataSource={columnStatsTableData} 
+                sticky
+            />
         </StatSection>
     );
 }


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)- https://linear.app/acryl-data/issue/PRD-850/adjusting-the-view-of-the-column-stats
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
