### PR TITLE
feat(lineage): allows recursive lineage nodes collapsing

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -5,9 +5,10 @@ import { InfoCircleOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { useEntityRegistry } from '../useEntityRegistry';
 import CompactContext from '../shared/CompactContext';
-import { EntityAndType, EntitySelectParams, FetchedEntities } from './types';
+import { EntityAndType, EntitySelectParams, FetchedEntities, VizNode } from './types';
 import LineageViz from './LineageViz';
 import extendAsyncEntities from './utils/extendAsyncEntities';
+import collapseLineageNode from './utils/collapseLineageNode';
 import { EntityType } from '../../types.generated';
 import { ANTD_GRAY } from '../entity/shared/constants';
 import { GetEntityLineageQuery, useGetEntityLineageQuery } from '../../graphql/lineage.generated';
@@ -147,6 +148,21 @@ export default function LineageExplorer({ urn, type }: Props) {
         });
     }
 
+    function collapseNode(vizNode: VizNode) {
+        setAsyncEntities((entities) => {
+            const {
+                data: { urn: nodeUrn },
+                direction,
+            } = vizNode;
+
+            if (!nodeUrn) {
+                return entities;
+            }
+
+            return collapseLineageNode(nodeUrn, direction, entities);
+        });
+    }
+
     const handleClose = () => {
         setIsDrawVisible(false);
         setSelectedEntity(undefined);
@@ -191,6 +207,9 @@ export default function LineageExplorer({ urn, type }: Props) {
                                 type: EventType.VisualLineageExpandGraphEvent,
                                 targetEntityType: asyncData?.type,
                             });
+                        }}
+                        onLineageCollapse={(vizNode: VizNode) => {
+                            collapseNode(vizNode);
                         }}
                         refetchCenterNode={() => {
                             refetch().then(() => {

--- a/datahub-web-react/src/app/lineage/LineageTree.tsx
+++ b/datahub-web-react/src/app/lineage/LineageTree.tsx
@@ -1,7 +1,15 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { TransformMatrix } from '@visx/zoom/lib/types';
 
-import { NodeData, EntitySelectParams, TreeProps, EntityAndType, FetchedEntity, UpdatedLineages } from './types';
+import {
+    NodeData,
+    EntitySelectParams,
+    TreeProps,
+    EntityAndType,
+    FetchedEntity,
+    UpdatedLineages,
+    VizNode,
+} from './types';
 import LineageTreeNodeAndEdgeRenderer from './LineageTreeNodeAndEdgeRenderer';
 import layoutTree from './utils/layoutTree';
 import { LineageExplorerContext } from './utils/LineageExplorerContext';
@@ -17,6 +25,7 @@ type LineageTreeProps = {
     onEntityClick: (EntitySelectParams) => void;
     onEntityCenter: (EntitySelectParams) => void;
     onLineageExpand: (data: EntityAndType) => void;
+    onLineageCollapse: (data: VizNode) => void;
     selectedEntity?: EntitySelectParams;
     hoveredEntity?: EntitySelectParams;
     setHoveredEntity: (EntitySelectParams) => void;
@@ -37,6 +46,7 @@ export default function LineageTree({
     onEntityClick,
     onEntityCenter,
     onLineageExpand,
+    onLineageCollapse,
     selectedEntity,
     hoveredEntity,
     setHoveredEntity,
@@ -148,6 +158,7 @@ export default function LineageTree({
             onEntityClick={onEntityClick}
             onEntityCenter={onEntityCenter}
             onLineageExpand={onLineageExpand}
+            onLineageCollapse={onLineageCollapse}
             selectedEntity={selectedEntity}
             hoveredEntity={hoveredEntity}
             setHoveredEntity={setHoveredEntity}

--- a/datahub-web-react/src/app/lineage/LineageTreeNodeAndEdgeRenderer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageTreeNodeAndEdgeRenderer.tsx
@@ -15,6 +15,7 @@ type Props = {
     onEntityClick: (EntitySelectParams) => void;
     onEntityCenter: (EntitySelectParams) => void;
     onLineageExpand: (data: EntityAndType) => void;
+    onLineageCollapse: (data: VizNode) => void;
     selectedEntity?: EntitySelectParams;
     hoveredEntity?: EntitySelectParams;
     setHoveredEntity: (EntitySelectParams) => void;
@@ -44,6 +45,7 @@ export default function LineageTreeNodeAndEdgeRenderer({
     onEntityClick,
     onEntityCenter,
     onLineageExpand,
+    onLineageCollapse,
     selectedEntity,
     hoveredEntity,
     setHoveredEntity,
@@ -94,6 +96,7 @@ export default function LineageTreeNodeAndEdgeRenderer({
                         onEntityClick={onEntityClick}
                         onEntityCenter={onEntityCenter}
                         onExpandClick={onLineageExpand}
+                        onLineageCollapse={onLineageCollapse}
                         isCenterNode={data.urn === node.data.urn}
                         nodesToRenderByUrn={nodesByUrn}
                         onDrag={onDrag}

--- a/datahub-web-react/src/app/lineage/LineageViz.tsx
+++ b/datahub-web-react/src/app/lineage/LineageViz.tsx
@@ -18,6 +18,7 @@ export default function LineageViz({
     onEntityClick,
     onEntityCenter,
     onLineageExpand,
+    onLineageCollapse,
     selectedEntity,
     fineGrainedMap,
     refetchCenterNode,
@@ -54,6 +55,7 @@ export default function LineageViz({
                     onEntityClick={onEntityClick}
                     onEntityCenter={onEntityCenter}
                     onLineageExpand={onLineageExpand}
+                    onLineageCollapse={onLineageCollapse}
                     selectedEntity={selectedEntity}
                     zoom={zoom}
                     fetchedEntities={fetchedEntities}

--- a/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
+++ b/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/macro';
 import { Button } from 'antd';
 import { ProvidedZoom, TransformMatrix } from '@visx/zoom/lib/types';
 
-import { ColumnEdge, EntityAndType, EntitySelectParams, FetchedEntity } from './types';
+import { ColumnEdge, EntityAndType, EntitySelectParams, FetchedEntity, VizNode } from './types';
 import { LineageExplorerContext } from './utils/LineageExplorerContext';
 import { SchemaField, SchemaFieldRef } from '../../types.generated';
 import { useIsShowColumnsMode } from './utils/useIsShowColumnsMode';
@@ -40,6 +40,7 @@ type Props = {
     onEntityClick: (EntitySelectParams) => void;
     onEntityCenter: (EntitySelectParams) => void;
     onLineageExpand: (data: EntityAndType) => void;
+    onLineageCollapse: (data: VizNode) => void;
     selectedEntity?: EntitySelectParams;
     zoom: ProvidedZoom<any> & {
         transformMatrix: TransformMatrix;
@@ -59,6 +60,7 @@ export default function LineageVizInsideZoom({
     onEntityClick,
     onEntityCenter,
     onLineageExpand,
+    onLineageCollapse,
     selectedEntity,
     width,
     height,
@@ -121,6 +123,7 @@ export default function LineageVizInsideZoom({
                         onEntityClick={onEntityClick}
                         onEntityCenter={onEntityCenter}
                         onLineageExpand={onLineageExpand}
+                        onLineageCollapse={onLineageCollapse}
                         selectedEntity={selectedEntity}
                         zoom={zoom}
                         fetchedEntities={fetchedEntities}

--- a/datahub-web-react/src/app/lineage/LineageVizRootSvg.tsx
+++ b/datahub-web-react/src/app/lineage/LineageVizRootSvg.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/macro';
 
 import { useEntityRegistry } from '../useEntityRegistry';
 import LineageTree from './LineageTree';
-import { EntityAndType, FetchedEntity, EntitySelectParams, Direction, UpdatedLineages } from './types';
+import { EntityAndType, FetchedEntity, EntitySelectParams, Direction, UpdatedLineages, VizNode } from './types';
 import constructTree from './utils/constructTree';
 
 type Props = {
@@ -14,6 +14,7 @@ type Props = {
     onEntityClick: (EntitySelectParams) => void;
     onEntityCenter: (EntitySelectParams) => void;
     onLineageExpand: (data: EntityAndType) => void;
+    onLineageCollapse: (data: VizNode) => void;
     selectedEntity?: EntitySelectParams;
     zoom: ProvidedZoom<any> & {
         transformMatrix: TransformMatrix;
@@ -48,6 +49,7 @@ export default function LineageVizRootSvg({
     onEntityClick,
     onEntityCenter,
     onLineageExpand,
+    onLineageCollapse,
     selectedEntity,
     width,
     height,
@@ -180,6 +182,7 @@ export default function LineageVizRootSvg({
                     onEntityClick={onEntityClick}
                     onEntityCenter={onEntityCenter}
                     onLineageExpand={onLineageExpand}
+                    onLineageCollapse={onLineageCollapse}
                     margin={margin}
                     selectedEntity={selectedEntity}
                     hoveredEntity={hoveredEntity}

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -69,6 +69,7 @@ export type NodeData = {
     subtype?: string;
     children?: Array<NodeData>;
     unexploredChildren?: number;
+    isExplored?: boolean;
     icon?: string;
     // Hidden children are unexplored but in the opposite direction of the flow of the graph.
     // Currently our visualization does not support expanding in two directions
@@ -130,6 +131,7 @@ export type TreeProps = {
     onEntityClick: (EntitySelectParams) => void;
     onEntityCenter: (EntitySelectParams) => void;
     onLineageExpand: (data: EntityAndType) => void;
+    onLineageCollapse: (data: VizNode) => void;
     selectedEntity?: EntitySelectParams;
     hoveredEntity?: EntitySelectParams;
     fineGrainedMap?: any;

--- a/datahub-web-react/src/app/lineage/utils/collapseLineageNode.ts
+++ b/datahub-web-react/src/app/lineage/utils/collapseLineageNode.ts
@@ -1,0 +1,54 @@
+import { Direction, FetchedEntities } from '../types';
+
+const findEntitiesToCollapse = (entityUrn: string, direction: Direction, fetchedEntities: FetchedEntities) => {
+    const { [entityUrn]: collapsingEntity, ...entitiesButNodeMap } = fetchedEntities;
+    const fullyFetchedEntities = Object.values(entitiesButNodeMap).filter((entity) => entity.fullyFetched);
+    const directionChildren = direction === Direction.Upstream ? 'upstreamChildren' : 'downstreamChildren';
+
+    // children who belong exclusively to collapsing entity within all fetched (expanded) entities
+    const exclusiveChildren =
+        collapsingEntity?.[directionChildren]?.filter((directionChild) => {
+            return !fullyFetchedEntities.some((fetchedEntity) =>
+                fetchedEntity[directionChildren]?.some(
+                    (fetchedDirectionChild) => fetchedDirectionChild.entity.urn === directionChild.entity.urn,
+                ),
+            );
+        }) ?? [];
+
+    const entitiesToCollapse = [...exclusiveChildren];
+
+    // looking for full fetched children, we need to collapse them too
+    exclusiveChildren.forEach((exclusiveChild) => {
+        const fullFetchedExclusiveChild = fullyFetchedEntities.find(
+            (fullFetchedEntity) => fullFetchedEntity.urn === exclusiveChild.entity.urn,
+        );
+
+        if (!fullFetchedExclusiveChild) {
+            return;
+        }
+
+        entitiesToCollapse.push(
+            ...findEntitiesToCollapse(fullFetchedExclusiveChild.urn, direction, entitiesButNodeMap),
+        );
+    });
+
+    return entitiesToCollapse;
+};
+
+const collapseLineageNode = (nodeUrn: string, direction: Direction, asyncEntities: FetchedEntities) => {
+    const entitiesToCollapse = findEntitiesToCollapse(nodeUrn, direction, asyncEntities);
+    const newEntities = { ...asyncEntities };
+
+    entitiesToCollapse.forEach((child) => {
+        delete newEntities[child.entity.urn];
+    });
+
+    newEntities[nodeUrn] = {
+        ...newEntities[nodeUrn],
+        fullyFetched: false,
+    };
+
+    return newEntities;
+};
+
+export default collapseLineageNode;

--- a/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
@@ -54,6 +54,7 @@ export default function constructFetchedNode(
             icon: fetchedNode.icon,
             unexploredChildren:
                 fetchedNode?.[childrenKey]?.filter((childUrn) => !(childUrn.entity.urn in fetchedEntities)).length || 0,
+            isExplored: !!fetchedNode.fullyFetched && (fetchedNode?.[childrenKey]?.length ?? 0) > 0,
             countercurrentChildrenUrns:
                 fetchedNode?.[direction === Direction.Downstream ? 'upstreamChildren' : 'downstreamChildren']?.map(
                     (child) => child.entity.urn,


### PR DESCRIPTION
Hi! We developed a feature which allows collapsing expanded lineage nodes. Collapsing works by the following logic:

1. It finds all the full fetched (means expanded) nodes, which are upstreams/downstream of the collapsing one
2. Then it loops over these nodes to recursively find more outgoing full fetched node

Here are some examples of how it works:

https://github.com/datahub-project/datahub/assets/150264485/bfdcee20-20b7-4b19-851f-7687e27db083

https://github.com/datahub-project/datahub/assets/150264485/913f10a0-4dcf-4012-b79a-d316f27aa2eb

The implementation has one issue, when expanded upstream/downstream also expands respectively its downstreams/upstreams. It seems like quite unexpected behaviour and it's not as easy to rollback changes made, but still possible if follow normal downstream/upstream user flow. 

https://github.com/datahub-project/datahub/assets/150264485/5d16a264-7a50-445c-9fbf-95a71f78eb56

This feature should not introduce any breaking changes, cause I tried to keep existing expanding logic untouched. We understand that this feature requires complex testing and code explanation, so I'm open to help with any questions.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
