### PR TITLE
fix: support Apollo caching for settings / Policies

### DIFF
--- a/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
+++ b/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
@@ -1,33 +1,21 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Button, Empty, message, Modal, Pagination, Tag } from 'antd';
+import { Button, Empty, message, Pagination, Tag } from 'antd';
 import styled from 'styled-components/macro';
 import * as QueryString from 'query-string';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { useLocation } from 'react-router';
-import { useApolloClient } from '@apollo/client';
 import PolicyBuilderModal from './PolicyBuilderModal';
 import {
     Policy,
-    PolicyUpdateInput,
     PolicyState,
-    PolicyType,
-    Maybe,
-    ResourceFilterInput,
-    PolicyMatchFilter,
-    PolicyMatchFilterInput,
-    PolicyMatchCriterionInput,
-    EntityType,
 } from '../../../types.generated';
 import { useAppConfig } from '../../useAppConfig';
 import PolicyDetailsModal from './PolicyDetailsModal';
 import {
-    useCreatePolicyMutation,
-    useDeletePolicyMutation,
     useListPoliciesQuery,
-    useUpdatePolicyMutation,
 } from '../../../graphql/policy.generated';
 import { Message } from '../../shared/Message';
-import { EMPTY_POLICY, removeFromListPoliciesCache, updateListPoliciesCache } from './policyUtils';
+import { DEFAULT_PAGE_SIZE, EMPTY_POLICY } from './policyUtils';
 import TabToolbar from '../../entity/shared/components/styled/TabToolbar';
 import { StyledTable } from '../../entity/shared/components/styled/StyledTable';
 import AvatarsGroup from '../AvatarsGroup';
@@ -38,6 +26,7 @@ import { scrollToTop } from '../../shared/searchUtils';
 import analytics, { EventType } from '../../analytics';
 import { POLICIES_CREATE_POLICY_ID, POLICIES_INTRO_ID } from '../../onboarding/config/PoliciesOnboardingConfig';
 import { OnboardingTour } from '../../onboarding/OnboardingTour';
+import { usePolicy } from './usePolicy';
 
 const SourceContainer = styled.div`
     overflow: auto;
@@ -85,64 +74,11 @@ const PageContainer = styled.span`
     overflow: auto;
 `;
 
-const DEFAULT_PAGE_SIZE = 10;
-
-type PrivilegeOptionType = {
-    type?: string;
-    name?: Maybe<string>;
-};
-
-const toFilterInput = (filter: PolicyMatchFilter): PolicyMatchFilterInput => {
-    return {
-        criteria: filter.criteria?.map((criterion): PolicyMatchCriterionInput => {
-            return {
-                field: criterion.field,
-                values: criterion.values.map((criterionValue) => criterionValue.value),
-                condition: criterion.condition,
-            };
-        }),
-    };
-};
-
-const toPolicyInput = (policy: Omit<Policy, 'urn'>): PolicyUpdateInput => {
-    let policyInput: PolicyUpdateInput = {
-        type: policy.type,
-        name: policy.name,
-        state: policy.state,
-        description: policy.description,
-        privileges: policy.privileges,
-        actors: {
-            users: policy.actors.users,
-            groups: policy.actors.groups,
-            allUsers: policy.actors.allUsers,
-            allGroups: policy.actors.allGroups,
-            resourceOwners: policy.actors.resourceOwners,
-            resourceOwnersTypes: policy.actors.resourceOwnersTypes,
-        },
-    };
-    if (policy.resources !== null && policy.resources !== undefined) {
-        let resourceFilter: ResourceFilterInput = {
-            type: policy.resources.type,
-            resources: policy.resources.resources,
-            allResources: policy.resources.allResources,
-        };
-        if (policy.resources.filter) {
-            resourceFilter = { ...resourceFilter, filter: toFilterInput(policy.resources.filter) };
-        }
-        // Add the resource filters.
-        policyInput = {
-            ...policyInput,
-            resources: resourceFilter,
-        };
-    }
-    return policyInput;
-};
 
 // TODO: Cleanup the styling.
 export const ManagePolicies = () => {
     const entityRegistry = useEntityRegistry();
     const location = useLocation();
-    const client = useApolloClient();
     const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
     const paramsQuery = (params?.query as string) || undefined;
     const [query, setQuery] = useState<undefined | string>(undefined);
@@ -165,9 +101,7 @@ export const ManagePolicies = () => {
     const [focusPolicyUrn, setFocusPolicyUrn] = useState<undefined | string>(undefined);
     const [focusPolicy, setFocusPolicy] = useState<Omit<Policy, 'urn'>>(EMPTY_POLICY);
 
-    // Construct privileges
-    const platformPrivileges = policiesConfig?.platformPrivileges || [];
-    const resourcePrivileges = policiesConfig?.resourcePrivileges || [];
+
 
     const {
         loading: policiesLoading,
@@ -184,15 +118,6 @@ export const ManagePolicies = () => {
         },
         fetchPolicy: (query?.length || 0) > 0 ? 'no-cache' : 'cache-first',
     });
-
-    // Any time a policy is removed, edited, or created, refetch the list.
-    const [createPolicy, { error: createPolicyError }] = useCreatePolicyMutation();
-
-    const [updatePolicy, { error: updatePolicyError }] = useUpdatePolicyMutation();
-
-    const [deletePolicy, { error: deletePolicyError }] = useDeletePolicyMutation();
-
-    const updateError = createPolicyError || updatePolicyError || deletePolicyError;
 
     const totalPolicies = policiesData?.listPolicies?.total || 0;
     const policies = useMemo(() => policiesData?.listPolicies?.policies || [], [policiesData]);
@@ -214,28 +139,6 @@ export const ManagePolicies = () => {
         setShowPolicyBuilderModal(false);
     };
 
-    const getPrivilegeNames = (policy: Omit<Policy, 'urn'>) => {
-        let privileges: PrivilegeOptionType[] = [];
-        if (policy?.type === PolicyType.Platform) {
-            privileges = platformPrivileges
-                .filter((platformPrivilege) => policy.privileges.includes(platformPrivilege.type))
-                .map((platformPrivilege) => {
-                    return { type: platformPrivilege.type, name: platformPrivilege.displayName };
-                });
-        } else {
-            const allResourcePriviliges = resourcePrivileges.find(
-                (resourcePrivilege) => resourcePrivilege.resourceType === 'all',
-            );
-            privileges =
-                allResourcePriviliges?.privileges
-                    .filter((resourcePrivilege) => policy.privileges.includes(resourcePrivilege.type))
-                    .map((b) => {
-                        return { type: b.type, name: b.displayName };
-                    }) || [];
-        }
-        return privileges;
-    };
-
     const onViewPolicy = (policy: Policy) => {
         setShowViewPolicyModal(true);
         setFocusPolicyUrn(policy?.urn);
@@ -249,114 +152,30 @@ export const ManagePolicies = () => {
     };
 
     const onEditPolicy = (policy: Policy) => {
-        setShowPolicyBuilderModal(true);
-        setFocusPolicyUrn(policy?.urn);
-        setFocusPolicy({ ...policy });
+    setShowPolicyBuilderModal(true);
+    setFocusPolicyUrn(policy?.urn);
+    setFocusPolicy({ ...policy });
     };
 
-    // On Delete Policy handler
-    const onRemovePolicy = (policy: Policy) => {
-        Modal.confirm({
-            title: `Delete ${policy?.name}`,
-            content: `Are you sure you want to remove policy?`,
-            onOk() {
-                deletePolicy({ variables: { urn: policy?.urn as string } })
-                .then(()=>{
-                    // There must be a focus policy urn.
-                    analytics.event({
-                        type: EventType.DeleteEntityEvent,
-                        entityUrn: policy?.urn,
-                        entityType: EntityType.DatahubPolicy,
-                    });
-                    message.success('Successfully removed policy.');
-                    removeFromListPoliciesCache(client,policy?.urn, DEFAULT_PAGE_SIZE);
-                    setTimeout(() => {
-                        policiesRefetch();
-                    }, 3000);
-                    onCancelViewPolicy();
-                })
-            },
-            onCancel() {},
-            okText: 'Yes',
-            maskClosable: true,
-            closable: true,
-        });
-    };
+    const {
+        createPolicyError,
+        updatePolicyError,
+        deletePolicyError,
+        onSavePolicy,
+        onToggleActiveDuplicate,
+        onRemovePolicy,
+        getPrivilegeNames
+    } = usePolicy(
+        policiesConfig,
+        focusPolicyUrn,
+        policiesRefetch,
+        setShowViewPolicyModal,
+        onCancelViewPolicy,
+        onClosePolicyBuilder
+    );
 
-    // On Activate and deactivate Policy handler
-    const onToggleActiveDuplicate = (policy: Policy) => {
-        const newState = policy?.state === PolicyState.Active ? PolicyState.Inactive : PolicyState.Active;
-        const newPolicy = {
-            ...policy,
-            state: newState,
-        };
-        updatePolicy({
-            variables: {
-                urn: policy?.urn as string, // There must be a focus policy urn.
-                input: toPolicyInput(newPolicy),
-            },
-        }).then(()=>{
-            const updatePolicies= {
-                ...newPolicy,
-                __typename: 'ListPoliciesResult',
-            }
-            updateListPoliciesCache(client,updatePolicies,DEFAULT_PAGE_SIZE);
-            message.success(`Successfully ${newState === PolicyState.Active ? 'activated' : 'deactivated'} policy.`);
-            setTimeout(() => {
-                policiesRefetch();
-            }, 3000);
-        })
-        
-        setShowViewPolicyModal(false);
-    };
-
-    // On Add/Update Policy handler
-    const onSavePolicy = (savePolicy: Omit<Policy, 'urn'>) => {
-        if (focusPolicyUrn) {
-            // If there's an URN associated with the focused policy, then we are editing an existing policy.
-            updatePolicy({ variables: { urn: focusPolicyUrn, input: toPolicyInput(savePolicy) } })
-            .then(()=>{
-                const newPolicy = {
-                    __typename: 'ListPoliciesResult',
-                    urn: focusPolicyUrn,
-                    ...savePolicy,
-                };
-                analytics.event({
-                    type: EventType.UpdatePolicyEvent,
-                    policyUrn: focusPolicyUrn,
-                });
-                message.success('Successfully saved policy.');
-                updateListPoliciesCache(client,newPolicy,DEFAULT_PAGE_SIZE);
-                setTimeout(() => {
-                    policiesRefetch();
-                }, 1000);
-                onClosePolicyBuilder();
-            })
-        } else {
-            // If there's no URN associated with the focused policy, then we are creating.
-            createPolicy({ variables: { input: toPolicyInput(savePolicy) } })
-            .then((result)=>{
-                const newPolicy = {
-                    __typename: 'ListPoliciesResult',
-                    urn: result?.data?.createPolicy,
-                    ...savePolicy,
-                    type: null,
-                    actors: null,
-                    resources: null,
-                };
-                analytics.event({
-                    type: EventType.CreatePolicyEvent,
-                });
-                message.success('Successfully saved policy.');
-                setTimeout(() => {
-                    policiesRefetch();
-                }, 1000);
-                updateListPoliciesCache(client,newPolicy,DEFAULT_PAGE_SIZE);
-                onClosePolicyBuilder();
-            })
-        }
-    };
-
+    const updateError = createPolicyError || updatePolicyError || deletePolicyError;
+    
     const tableColumns = [
         {
             title: 'Name',

--- a/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
+++ b/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
@@ -355,11 +355,6 @@ export const ManagePolicies = () => {
                 onClosePolicyBuilder();
             })
         }
-        message.success('Successfully saved policy.');
-        setTimeout(() => {
-            policiesRefetch();
-        }, 3000);
-        onClosePolicyBuilder();
     };
 
     const tableColumns = [

--- a/datahub-web-react/src/app/permissions/policy/_tests_/policyUtils.test.tsx
+++ b/datahub-web-react/src/app/permissions/policy/_tests_/policyUtils.test.tsx
@@ -1,0 +1,110 @@
+import {
+    addOrUpdatePoliciesInList,
+    updateListPoliciesCache,
+    removeFromListPoliciesCache,
+  } from '../policyUtils';
+  
+  // Mock the Apollo Client readQuery and writeQuery methods
+  const mockReadQuery = jest.fn();
+  const mockWriteQuery = jest.fn();
+  
+  jest.mock('@apollo/client', () => ({
+    ...jest.requireActual('@apollo/client'),
+    useApolloClient: () => ({
+      readQuery: mockReadQuery,
+      writeQuery: mockWriteQuery,
+    }),
+  }));
+  
+  describe('addOrUpdatePoliciesInList', () => {
+    it('should add a new policy to the list', () => {
+      const existingPolicies = [{ urn: 'existing-urn' }];
+      const newPolicies = { urn: 'new-urn' };
+  
+      const result = addOrUpdatePoliciesInList(existingPolicies, newPolicies);
+  
+      expect(result.length).toBe(existingPolicies.length + 1);
+      expect(result).toContain(newPolicies);
+    });
+  
+    it('should update an existing policy in the list', () => {
+      const existingPolicies = [{ urn: 'existing-urn' }];
+      const newPolicies = { urn: 'existing-urn', updatedField: 'new-value' };
+  
+      const result = addOrUpdatePoliciesInList(existingPolicies, newPolicies);
+  
+      expect(result.length).toBe(existingPolicies.length);
+      expect(result).toContainEqual(newPolicies);
+    });
+  });
+  
+  describe('updateListPoliciesCache', () => {
+    // Mock client.readQuery response
+    const mockReadQueryResponse = {
+      listPolicies: {
+        start: 0,
+        count: 1,
+        total: 1,
+        policies: [{ urn: 'existing-urn' }],
+      },
+    };
+  
+    beforeEach(() => {
+      mockReadQuery.mockReturnValueOnce(mockReadQueryResponse);
+    });
+  
+    it('should update the list policies cache with a new policy', () => {
+      const mockClient = {
+        readQuery: mockReadQuery,
+        writeQuery: mockWriteQuery,
+      };
+  
+      const policiesToAdd = [{ urn: 'new-urn' }];
+      const pageSize = 10;
+  
+      updateListPoliciesCache(mockClient, policiesToAdd, pageSize);
+  
+      // Ensure writeQuery is called with the expected data
+      expect(mockWriteQuery).toHaveBeenCalledWith({
+        query: expect.any(Object),
+        variables: { input: { start: 0, count: pageSize, query: undefined } },
+        data: expect.any(Object),
+      });
+    });
+  });
+  
+  describe('removeFromListPoliciesCache', () => {
+    // Mock client.readQuery response
+    const mockReadQueryResponse = {
+      listPolicies: {
+        start: 0,
+        count: 1,
+        total: 1,
+        policies: [{ urn: 'existing-urn' }],
+      },
+    };
+  
+    beforeEach(() => {
+      mockReadQuery.mockReturnValueOnce(mockReadQueryResponse);
+    });
+  
+    it('should remove a policy from the list policies cache', () => {
+      const mockClient = {
+        readQuery: mockReadQuery,
+        writeQuery: mockWriteQuery,
+      };
+  
+      const urnToRemove = 'existing-urn';
+      const pageSize = 10;
+  
+      removeFromListPoliciesCache(mockClient, urnToRemove, pageSize);
+  
+      // Ensure writeQuery is called with the expected data
+      expect(mockWriteQuery).toHaveBeenCalledWith({
+        query: expect.any(Object),
+        variables: { input: { start: 0, count: pageSize } },
+        data: expect.any(Object),
+      });
+    });
+  });
+  

--- a/datahub-web-react/src/app/permissions/policy/policyUtils.ts
+++ b/datahub-web-react/src/app/permissions/policy/policyUtils.ts
@@ -12,6 +12,8 @@ import {
 } from '../../../types.generated';
 import { ListPoliciesDocument, ListPoliciesQuery } from '../../../graphql/policy.generated';
 
+export const DEFAULT_PAGE_SIZE = 10;
+
 export const EMPTY_POLICY = {
     type: PolicyType.Metadata,
     name: '',

--- a/datahub-web-react/src/app/permissions/policy/policyUtils.ts
+++ b/datahub-web-react/src/app/permissions/policy/policyUtils.ts
@@ -128,15 +128,15 @@ export const setFieldValues = (
     return { ...filter, criteria: [...restCriteria, createCriterion(resourceFieldType, fieldValues)] };
 };
 
-const addOrUpdatePoliciesInList = (existingPolicies, newPolicies) => {
+export const addOrUpdatePoliciesInList = (existingPolicies, newPolicies) => {
     const policies = [...existingPolicies];
     let didUpdate = false;
-    const updatedPolicies = policies.map((test) => {
-        if (test.urn === newPolicies.urn) {
+    const updatedPolicies = policies.map((policy) => {
+        if (policy.urn === newPolicies.urn) {
             didUpdate = true;
             return newPolicies;
         }
-        return test;
+        return policy;
     });
     return didUpdate ? updatedPolicies : [newPolicies, ...existingPolicies];
 };
@@ -157,7 +157,7 @@ export const updateListPoliciesCache = (client, policies, pageSize) => {
         },
     });
 
-    // Add our new test into the existing list.
+    // Add our new policy into the existing list.
     const existingPolicies = [...(currData?.listPolicies?.policies || [])];
     const newPolicies = addOrUpdatePoliciesInList(existingPolicies, policies);
     const didAddTest = newPolicies.length > existingPolicies.length;
@@ -200,7 +200,7 @@ export const removeFromListPoliciesCache = (client, urn, pageSize) => {
         },
     });
 
-    // Remove the test from the existing tests set.
+    // Remove the policy from the existing tests set.
     const newPolicies = [...(currData?.listPolicies?.policies || []).filter((policy) => policy.urn !== urn)];
 
     // Write our data back to the cache.

--- a/datahub-web-react/src/app/permissions/policy/usePolicy.ts
+++ b/datahub-web-react/src/app/permissions/policy/usePolicy.ts
@@ -1,0 +1,227 @@
+import { Modal, message } from 'antd';
+import { useApolloClient } from '@apollo/client';
+import {
+    EntityType,
+    Policy,
+    PolicyMatchCriterionInput,
+    PolicyMatchFilter,
+    PolicyMatchFilterInput,
+    PolicyState,
+    PolicyType,
+    Maybe,
+    PolicyUpdateInput,
+    ResourceFilterInput,
+} from '../../../types.generated';
+import { useCreatePolicyMutation, useDeletePolicyMutation, useUpdatePolicyMutation } from '../../../graphql/policy.generated';
+import analytics, { EventType } from '../../analytics';
+import { DEFAULT_PAGE_SIZE, removeFromListPoliciesCache, updateListPoliciesCache } from './policyUtils';
+
+
+type PrivilegeOptionType = {
+    type?: string;
+    name?: Maybe<string>;
+};
+
+export function usePolicy(
+    policiesConfig, 
+    focusPolicyUrn, 
+    policiesRefetch, 
+    setShowViewPolicyModal, 
+    onCancelViewPolicy, 
+    onClosePolicyBuilder
+){
+
+    const client = useApolloClient();
+
+    // Construct privileges
+    const platformPrivileges = policiesConfig?.platformPrivileges || [];
+    const resourcePrivileges = policiesConfig?.resourcePrivileges || [];
+
+    // Any time a policy is removed, edited, or created, refetch the list.
+    const [createPolicy, { error: createPolicyError }] = useCreatePolicyMutation();
+
+    const [updatePolicy, { error: updatePolicyError }] = useUpdatePolicyMutation();
+
+    const [deletePolicy, { error: deletePolicyError }] = useDeletePolicyMutation();
+
+    const toFilterInput = (filter: PolicyMatchFilter): PolicyMatchFilterInput => {
+        return {
+            criteria: filter.criteria?.map((criterion): PolicyMatchCriterionInput => {
+                return {
+                    field: criterion.field,
+                    values: criterion.values.map((criterionValue) => criterionValue.value),
+                    condition: criterion.condition,
+                };
+            }),
+        };
+    };
+
+    const toPolicyInput = (policy: Omit<Policy, 'urn'>): PolicyUpdateInput => {
+        let policyInput: PolicyUpdateInput = {
+            type: policy.type,
+            name: policy.name,
+            state: policy.state,
+            description: policy.description,
+            privileges: policy.privileges,
+            actors: {
+                users: policy.actors.users,
+                groups: policy.actors.groups,
+                allUsers: policy.actors.allUsers,
+                allGroups: policy.actors.allGroups,
+                resourceOwners: policy.actors.resourceOwners,
+                resourceOwnersTypes: policy.actors.resourceOwnersTypes,
+            },
+        };
+        if (policy.resources !== null && policy.resources !== undefined) {
+            let resourceFilter: ResourceFilterInput = {
+                type: policy.resources.type,
+                resources: policy.resources.resources,
+                allResources: policy.resources.allResources,
+            };
+            if (policy.resources.filter) {
+                resourceFilter = { ...resourceFilter, filter: toFilterInput(policy.resources.filter) };
+            }
+            // Add the resource filters.
+            policyInput = {
+                ...policyInput,
+                resources: resourceFilter,
+            };
+        }
+        return policyInput;
+    };
+
+    const getPrivilegeNames = (policy: Omit<Policy, 'urn'>) => {
+        let privileges: PrivilegeOptionType[] = [];
+        if (policy?.type === PolicyType.Platform) {
+            privileges = platformPrivileges
+            .filter((platformPrivilege) => policy.privileges.includes(platformPrivilege.type))
+            .map((platformPrivilege) => {
+                return { type: platformPrivilege.type, name: platformPrivilege.displayName };
+                });
+        } else {
+            const allResourcePriviliges = resourcePrivileges.find(
+                (resourcePrivilege) => resourcePrivilege.resourceType === 'all',
+                );
+                privileges =
+                allResourcePriviliges?.privileges
+                .filter((resourcePrivilege) => policy.privileges.includes(resourcePrivilege.type))
+                .map((b) => {
+                    return { type: b.type, name: b.displayName };
+                }) || [];
+            }
+            return privileges;
+    };
+
+    // On Delete Policy handler
+    const onRemovePolicy = (policy: Policy) => {
+        Modal.confirm({
+            title: `Delete ${policy?.name}`,
+            content: `Are you sure you want to remove policy?`,
+            onOk() {
+                deletePolicy({ variables: { urn: policy?.urn as string } })
+                .then(()=>{
+                    // There must be a focus policy urn.
+                    analytics.event({
+                        type: EventType.DeleteEntityEvent,
+                        entityUrn: policy?.urn,
+                        entityType: EntityType.DatahubPolicy,
+                    });
+                    message.success('Successfully removed policy.');
+                    removeFromListPoliciesCache(client,policy?.urn, DEFAULT_PAGE_SIZE);
+                    setTimeout(() => {
+                        policiesRefetch();
+                    }, 3000);
+                    onCancelViewPolicy();
+                })
+            },
+            onCancel() {},
+            okText: 'Yes',
+            maskClosable: true,
+            closable: true,
+        });
+    };
+
+    // On Activate and deactivate Policy handler
+    const onToggleActiveDuplicate = (policy: Policy) => {
+        const newState = policy?.state === PolicyState.Active ? PolicyState.Inactive : PolicyState.Active;
+        const newPolicy = {
+            ...policy,
+            state: newState,
+        };
+        updatePolicy({
+            variables: {
+                urn: policy?.urn as string, // There must be a focus policy urn.
+                input: toPolicyInput(newPolicy),
+            },
+        }).then(()=>{
+            const updatePolicies= {
+                ...newPolicy,
+                __typename: 'ListPoliciesResult',
+            }
+            updateListPoliciesCache(client,updatePolicies,DEFAULT_PAGE_SIZE);
+            message.success(`Successfully ${newState === PolicyState.Active ? 'activated' : 'deactivated'} policy.`);
+            setTimeout(() => {
+                policiesRefetch();
+            }, 3000);
+        })
+        
+        setShowViewPolicyModal(false);
+    };
+
+    // On Add/Update Policy handler
+    const onSavePolicy = (savePolicy: Omit<Policy, 'urn'>) => {
+        if (focusPolicyUrn) {
+            // If there's an URN associated with the focused policy, then we are editing an existing policy.
+            updatePolicy({ variables: { urn: focusPolicyUrn, input: toPolicyInput(savePolicy) } })
+            .then(()=>{
+                const newPolicy = {
+                    __typename: 'ListPoliciesResult',
+                    urn: focusPolicyUrn,
+                    ...savePolicy,
+                };
+                analytics.event({
+                    type: EventType.UpdatePolicyEvent,
+                    policyUrn: focusPolicyUrn,
+                });
+                message.success('Successfully saved policy.');
+                updateListPoliciesCache(client,newPolicy,DEFAULT_PAGE_SIZE);
+                setTimeout(() => {
+                    policiesRefetch();
+                }, 1000);
+                onClosePolicyBuilder();
+            })
+        } else {
+            // If there's no URN associated with the focused policy, then we are creating.
+            createPolicy({ variables: { input: toPolicyInput(savePolicy) } })
+            .then((result)=>{
+                const newPolicy = {
+                    __typename: 'ListPoliciesResult',
+                    urn: result?.data?.createPolicy,
+                    ...savePolicy,
+                    type: null,
+                    actors: null,
+                    resources: null,
+                };
+                analytics.event({
+                    type: EventType.CreatePolicyEvent,
+                });
+                message.success('Successfully saved policy.');
+                setTimeout(() => {
+                    policiesRefetch();
+                }, 1000);
+                updateListPoliciesCache(client,newPolicy,DEFAULT_PAGE_SIZE);
+                onClosePolicyBuilder();
+            })
+        }
+    };
+
+    return{
+        createPolicyError,
+        updatePolicyError,
+        deletePolicyError,
+        onSavePolicy,
+        onToggleActiveDuplicate,
+        onRemovePolicy,
+        getPrivilegeNames,
+    }
+}


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)- https://linear.app/acryl-data/issue/PRD-835/[datahub-oss]-support-apollo-caching-for-settings-policies
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
