### PR TITLE
Add button to copy urn of an Ownership Type

### DIFF
--- a/datahub-web-react/src/app/entity/ownership/table/ActionsColumn.tsx
+++ b/datahub-web-react/src/app/entity/ownership/table/ActionsColumn.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dropdown, MenuProps, Popconfirm, Typography, message, notification } from 'antd';
-import { DeleteOutlined, EditOutlined, MoreOutlined } from '@ant-design/icons';
+import { CopyOutlined, DeleteOutlined, EditOutlined, MoreOutlined } from '@ant-design/icons';
 import styled from 'styled-components/macro';
 import { OwnershipTypeEntity } from '../../../../types.generated';
 import { useDeleteOwnershipTypeMutation } from '../../../../graphql/ownership.generated';
@@ -47,6 +47,10 @@ export const ActionsColumn = ({ ownershipType, setIsOpen, setOwnershipType, refe
         setIsOpen(true);
         setOwnershipType(ownershipType);
     };
+
+    const onCopy=() => {
+        navigator.clipboard.writeText(ownershipType.urn);
+    }
 
     const [deleteOwnershipTypeMutation] = useDeleteOwnershipTypeMutation();
 
@@ -106,12 +110,24 @@ export const ActionsColumn = ({ ownershipType, setIsOpen, setOwnershipType, refe
                 </Popconfirm>
             ),
         },
+        {
+            key: 'copy',
+            icon: (
+                <MenuButtonContainer>
+                    <CopyOutlined />
+                    <MenuButtonText>Copy Urn</MenuButtonText>
+                </MenuButtonContainer>
+            ),
+        },
     ];
 
     const onClick: MenuProps['onClick'] = (e) => {
         const key = e.key as string;
         if (key === 'edit') {
             editOnClick();
+        }
+        else if( key === 'copy') {
+            onCopy();
         }
     };
 


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)-https://linear.app/acryl-data/issue/PRD-346/add-button-to-copy-urn-of-an-ownership-type
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
