### PR TITLE
fix: Tab doesn't represent the page you are on for non-data asset pages

### DIFF
--- a/datahub-web-react/src/app/AppProviders.tsx
+++ b/datahub-web-react/src/app/AppProviders.tsx
@@ -4,6 +4,7 @@ import { EducationStepsProvider } from '../providers/EducationStepsProvider';
 import UserContextProvider from './context/UserContextProvider';
 import QuickFiltersProvider from '../providers/QuickFiltersProvider';
 import SearchContextProvider from './search/context/SearchContextProvider';
+import { BrowserTitleProvider } from './shared/BrowserTabTitleContext';
 
 interface Props {
     children: React.ReactNode;
@@ -13,11 +14,13 @@ export default function AppProviders({ children }: Props) {
     return (
         <AppConfigProvider>
             <UserContextProvider>
-                <EducationStepsProvider>
-                    <QuickFiltersProvider>
-                        <SearchContextProvider>{children}</SearchContextProvider>
-                    </QuickFiltersProvider>
-                </EducationStepsProvider>
+                <BrowserTitleProvider>
+                    <EducationStepsProvider>
+                        <QuickFiltersProvider>
+                            <SearchContextProvider>{children}</SearchContextProvider>
+                        </QuickFiltersProvider>
+                    </EducationStepsProvider>
+                </BrowserTitleProvider>
             </UserContextProvider>
         </AppConfigProvider>
     );

--- a/datahub-web-react/src/app/shared/BrowserTabTitleContext.tsx
+++ b/datahub-web-react/src/app/shared/BrowserTabTitleContext.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, ReactNode, useContext } from 'react';
+
+interface BrowserTitleContextProps {
+  title: string;
+  updateTitle: (newTitle: string) => void;
+}
+
+const BrowserTitleContext = createContext<BrowserTitleContextProps | undefined>(undefined);
+
+export const BrowserTitleProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [title, setTitle] = React.useState<string>('');
+
+  const updateTitle = (newTitle: string) => {
+    setTitle(newTitle);
+  };
+
+  return (
+    <BrowserTitleContext.Provider value={{ title, updateTitle }}>
+      {children}
+    </BrowserTitleContext.Provider>
+  );
+};
+
+export const useBrowserTitle = () => {
+  const context = useContext(BrowserTitleContext);
+  if (!context) {
+    throw new Error('useBrowserTitle must be used within a BrowserTitleProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)- https://linear.app/acryl-data/issue/PRD-667/tab-doesnt-represent-the-page-you-are-on-for-non-data-asset-pages
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
