### PR TITLE
fix(ingest): Fix the secret resolution process to correctly escape backslashes 

### DIFF
--- a/metadata-ingestion/src/datahub/secret/secret_common.py
+++ b/metadata-ingestion/src/datahub/secret/secret_common.py
@@ -1,0 +1,84 @@
+import json
+import logging
+import re
+from typing import List
+
+from datahub.secret.secret_store import SecretStore
+
+logger = logging.getLogger(__name__)
+
+"""
+The following was borrowed from the acryl-executor repository.
+"""
+
+
+def resolve_secrets(secret_names: List[str], secret_stores: List[SecretStore]) -> dict:
+    # Attempt to resolve secret using by checking each configured secret store.
+    final_secret_values = dict({})
+
+    for secret_store in secret_stores:
+        try:
+            # Retrieve secret values from the store.
+            secret_values_dict = secret_store.get_secret_values(secret_names)
+            # Overlay secret values from each store, if not None.
+            for secret_name, secret_value in secret_values_dict.items():
+                if secret_value is not None:
+                    final_secret_values[secret_name] = secret_value
+        except Exception:
+            logger.exception(
+                f"Failed to fetch secret values from secret store with id {secret_store.get_id()}"
+            )
+    return final_secret_values
+
+
+def safe_escape_secret(secret_value: str) -> str:
+    # Escape the secret value to ensure that slashes are correctly escaped.
+    # Assume that all other special characters - e.g. newlines, tabs, and more, are already coming in properly
+    # as a string.
+    # Step 1: Escape all backslashes first. This will temporarily double-escape already escaped characters like \n
+    escaped_secret_value = secret_value.replace("\\", "\\\\")
+
+    # Step 2: Restore already escaped characters to their single-escaped form
+    # This list can be extended with other escaped characters if needed
+    for char in ["n", "r", "t", "b", "f", '"', "'"]:
+        escaped_secret_value = escaped_secret_value.replace("\\\\" + char, "\\" + char)
+
+    return escaped_secret_value
+
+
+def resolve_recipe(recipe: str, secret_stores: List[SecretStore]) -> dict:
+    # Now attempt to find and replace all secrets inside the recipe.
+    secret_pattern = re.compile(".*?\\${(\\w+)}.*?")
+
+    resolved_recipe = recipe
+    secret_matches = secret_pattern.findall(resolved_recipe)
+
+    # 1. Extract all secrets needing resolved.
+    secrets_to_resolve = []
+    if secret_matches:
+        for match in secret_matches:
+            secrets_to_resolve.append(match)
+
+    # 2. Resolve secret values
+    secret_values_dict = resolve_secrets(secrets_to_resolve, secret_stores)
+
+    # 3. Substitute secrets into recipe file
+    if secret_matches:
+        for match in secret_matches:
+            # a. Check if secret was successfully resolved.
+            secret_value = secret_values_dict.get(match)
+            if secret_value is None:
+                # Failed to resolve secret.
+                raise Exception(
+                    f"Failed to resolve secret with name {match}. Aborting recipe execution."
+                )
+            # b. Ensure that we JSON escape the secret value to avoid any parsing errors during the loads below.
+            escaped_secret_value = safe_escape_secret(secret_value)
+
+            # b. Substitute secret value.
+            resolved_recipe = resolved_recipe.replace(
+                f"${{{match}}}", escaped_secret_value
+            )
+
+    json_recipe = json.loads(resolved_recipe, strict=False)
+    return json_recipe


### PR DESCRIPTION
This PR fixes the ingestion issue that occurs when a datahub secret has a valid single backslash contained inside. This is the current error in ingestion:

```
           '  File "/usr/local/lib/python3.10/json/__init__.py", line 359, in loads\n'
           '    return cls(**kw).decode(s)\n'
           '  File "/usr/local/lib/python3.10/json/decoder.py", line 337, in decode\n'
           '    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n'
           '  File "/usr/local/lib/python3.10/json/decoder.py", line 353, in raw_decode\n'
           '    obj, end = self.scan_once(s, idx)\n'
           'json.decoder.JSONDecodeError: Invalid \\escape: line 1 column 205 (char 204)\n'],
 'errors': []}
```

In this PR, we update the secret resolution piece that occurs before ingestion runs. In the change, we assume that secrets with certain special characters like \n, \", \', \t, and more are ALREADY encoded / escaped, but we assume that single slashes may NOT be properly escaped. This can occur if a secret e.g. a special key has a valid single backslash in it, for example: 

```
my\secret
```

Currently, what is happening is that the json decoding step we take AFTER secret resolution is failing because it believes that we are trying to provide an invalid escape character `\s`, when in reality we want to parse into an actual backslash. 

So in this PR, we escape the secret backslashes first, and then restore characters that are expected to have already been escaped correctly (newlines, tabs, and more - this is already performed by our secret form in the UI) to ensure that we don't mistakenly DOUBLE encode them. 

The impact should be that existing secrets containing newlines continue to work the same exact way (e/g BigQuery private key files) and secrets which actually contain valid backslashes inside start to work correctly. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
