### PR TITLE
Searching for users on Users page shows incorrect roles: Issue resolved

### DIFF
--- a/datahub-web-react/src/app/identity/user/UserList.tsx
+++ b/datahub-web-react/src/app/identity/user/UserList.tsx
@@ -77,7 +77,7 @@ export const UserList = () => {
                 query: (query?.length && query) || undefined,
             },
         },
-        fetchPolicy: (query?.length || 0) > 0 ? 'no-cache' : 'cache-first',
+        fetchPolicy: 'no-cache',
     });
 
     const totalUsers = usersData?.listUsers?.total || 0;


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
https://linear.app/acryl-data/issue/PRD-568/searching-for-users-on-users-page-shows-incorrect-roles

- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Description: 
When the user removes the query from the search bar completely, like when the query length is 0 then we were using the cache-first so it was not updated data, so with no-cache will get the updated data and it will show the correct role on searching as well

[PRD-568_Searching_on_Users.webm](https://github.com/datahub-project/datahub/assets/81357546/7138df77-bc1a-495e-8152-5bab928fb7c2)