### PR TITLE
fix(quickstart): force strings for mysql version

### DIFF
--- a/docker/quickstart/quickstart_version_mapping.yaml
+++ b/docker/quickstart/quickstart_version_mapping.yaml
@@ -23,7 +23,7 @@ quickstart_version_map:
   default:
     composefile_git_ref: master
     docker_tag: head
-    mysql_tag: 5.7
+    mysql_tag: "5.7"
   # default:  # Use this to pin default to a specific version.
   #   composefile_git_ref: fd1bd51541a132017a648f4a2f037eec8f70ba26 # v0.10.0 + quickstart compose file fixes
   #   docker_tag: v0.10.0
@@ -31,19 +31,19 @@ quickstart_version_map:
   head:
     composefile_git_ref: master
     docker_tag: head
-    mysql_tag: 5.7
+    mysql_tag: "5.7"
 
   # v0.13.0 we upgraded MySQL image for EOL
   v0.13.0:
     composefile_git_ref: master
     docker_tag: head
-    mysql_tag: 8.2
+    mysql_tag: "8.2"
 
   # v0.9.6 images contain security vulnerabilities
   v0.9.6:
     composefile_git_ref: v0.9.6.1
     docker_tag: v0.9.6.1
-    mysql_tag: 5.7
+    mysql_tag: "5.7"
 
   # If stable is not defined the latest released version will be used.
   # stable:

--- a/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
+++ b/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
@@ -94,7 +94,7 @@ class QuickstartVersionMappingConfig(BaseModel):
             try:
                 release = cls._fetch_latest_version()
                 config.quickstart_version_map["stable"] = QuickstartExecutionPlan(
-                    composefile_git_ref=release, docker_tag=release, mysql_tag='5.7'
+                    composefile_git_ref=release, docker_tag=release, mysql_tag="5.7"
                 )
             except Exception:
                 click.echo(

--- a/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
+++ b/metadata-ingestion/src/datahub/cli/quickstart_versioning.py
@@ -94,7 +94,7 @@ class QuickstartVersionMappingConfig(BaseModel):
             try:
                 release = cls._fetch_latest_version()
                 config.quickstart_version_map["stable"] = QuickstartExecutionPlan(
-                    composefile_git_ref=release, docker_tag=release, mysql_tag=release
+                    composefile_git_ref=release, docker_tag=release, mysql_tag='5.7'
                 )
             except Exception:
                 click.echo(
@@ -123,7 +123,7 @@ class QuickstartVersionMappingConfig(BaseModel):
             QuickstartExecutionPlan(
                 composefile_git_ref=composefile_git_ref,
                 docker_tag=docker_tag,
-                mysql_tag=mysql_tag,
+                mysql_tag=str(mysql_tag),
             ),
         )
         # new CLI version is downloading the composefile corresponding to the requested version


### PR DESCRIPTION
Fixes quickstart errors related to the mysql version being interpreted as a float instead of a string.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
