### PR TITLE
fix(ingest): Fix mongodb ingestion when platform_instance is missing from recipe

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -469,13 +469,9 @@ class MongoDBSource(StatefulIngestionSourceBase):
                     for mcp in MetadataChangeProposalWrapper.construct_many(
                         entityUrn=dataset_urn,
                         aspects=[
-                            aspect
-                            for aspect in [
-                                schema_metadata,
-                                dataset_properties,
-                                data_platform_instance,
-                            ]
-                            if aspect is not None
+                            schema_metadata,
+                            dataset_properties,
+                            data_platform_instance,
                         ],
                     )
                 ]

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -377,6 +377,8 @@ class MongoDBSource(StatefulIngestionSourceBase):
                     platform_instance=self.config.platform_instance,
                 )
 
+                # Initialize data_platform_instance with a default value
+                data_platform_instance = None
                 if self.config.platform_instance:
                     data_platform_instance = DataPlatformInstanceClass(
                         platform=make_data_platform_urn(platform),
@@ -467,9 +469,13 @@ class MongoDBSource(StatefulIngestionSourceBase):
                     for mcp in MetadataChangeProposalWrapper.construct_many(
                         entityUrn=dataset_urn,
                         aspects=[
-                            schema_metadata,
-                            dataset_properties,
-                            data_platform_instance,
+                            aspect
+                            for aspect in [
+                                schema_metadata,
+                                dataset_properties,
+                                data_platform_instance,
+                            ]
+                            if aspect is not None
                         ],
                     )
                 ]


### PR DESCRIPTION
The current mongodb ingestion will fail if the platform instance is missing from the recipe with `UnboundLocalError`:
`UnboundLocalError: local variable 'data_platform_instance' referenced before assignment`
This PR initiates this local variable to avoid this issue

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
