### PR TITLE
fix(frontend): Add fallback for image load error on Avatar

### DIFF
--- a/datahub-web-react/src/app/shared/avatar/CustomAvatar.tsx
+++ b/datahub-web-react/src/app/shared/avatar/CustomAvatar.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Tooltip } from 'antd';
 import { TooltipPlacement } from 'antd/lib/tooltip';
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -50,6 +50,8 @@ export default function CustomAvatar({
     isRole = false,
     hideTooltip = false,
 }: Props) {
+    const [imageError, setImageError] = useState(false);
+
     const avatarWithInitial = name ? (
         <AvatarStyled style={style} size={size} $backgroundColor={getAvatarColor(name)}>
             {name.charAt(0).toUpperCase()}
@@ -62,8 +64,15 @@ export default function CustomAvatar({
     ) : (
         avatarWithInitial
     );
+
+    const onErrorHandling = () => {
+      setImageError(true);
+      // To prevent fallback error handling from Ant Design
+      return false;
+    };
+
     const avatar =
-        photoUrl && photoUrl !== '' ? <AvatarStyled src={photoUrl} style={style} size={size} /> : avatarWithDefault;
+        photoUrl && photoUrl !== '' && !imageError ? <AvatarStyled src={photoUrl} style={style} size={size} onError={() => onErrorHandling()} /> : avatarWithDefault;
     if (!name) {
         return url ? <Link to={url}>{avatar}</Link> : avatar;
     }


### PR DESCRIPTION
## Description
This is a fix for when using the CorpUser Image URL and there is an error when fetching the image. Before the error was not handled and showed an empty space where the image should be but now with the onError function from Ant we have a fallback Avatar Style which is the default one.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
