### PR TITLE
fix: correct the color of edit links

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
@@ -159,7 +159,7 @@ export const LinkList = ({ refetch }: LinkListProps) => {
                         <LinkListItem
                             extra={
                                 <>
-                                    <Button onClick={() => handleEditLink(link)} type="text" shape="circle" danger>
+                                    <Button onClick={() => handleEditLink(link)} type="text" shape="circle">
                                         <EditOutlined />
                                     </Button>
                                     <Button onClick={() => handleDeleteLink(link)} type="text" shape="circle" danger>


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

<img width="1120" alt="Screenshot 2023-12-25 at 7 58 28 PM" src="https://github.com/datahub-project/datahub/assets/81357546/b8832071-d19c-433f-94b7-44837c19b47f">

