### PR TITLE
fix(ci): make test flexible to allow sha-based cli versions

### DIFF
--- a/smoke-test/tests/read_only/test_services_up.py
+++ b/smoke-test/tests/read_only/test_services_up.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 import requests
+import re
 
 from tests.utils import get_gms_url, wait_for_healthcheck_util
 
@@ -13,6 +14,8 @@ DATAHUB_VERSION = os.getenv("TEST_DATAHUB_VERSION")
 def test_services_up():
     wait_for_healthcheck_util()
 
+def looks_like_a_short_sha(sha: str) -> bool:
+    return len(sha) == 7 and re.match(r"[0-9a-f]{7}", sha) is not None
 
 @pytest.mark.read_only
 def test_gms_config_accessible():
@@ -30,4 +33,4 @@ def test_gms_config_accessible():
     default_cli_version: str = gms_config["managedIngestion"]["defaultCliVersion"]
     print(f"Default CLI version: {default_cli_version}")
     assert not default_cli_version.startswith("@")
-    assert "." in default_cli_version
+    assert "." in default_cli_version or looks_like_a_short_sha(default_cli_version), "Default CLI version does not look like a version string"


### PR DESCRIPTION
Forks of the main repo will use git-sha as the py cli version resulting in the version test failing.
This PR makes the test allow those version strings.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
