### PR TITLE
fix(owner): last modified on adding owner

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
-import static com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
 import com.linkedin.common.AuditStamp;
@@ -16,7 +15,6 @@ import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
 import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.CreateDomainInput;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
-import com.linkedin.datahub.graphql.generated.OwnershipType;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.DomainUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.domain.DomainProperties;
@@ -100,14 +98,8 @@ public class CreateDomainResolver implements DataFetcher<CompletableFuture<Strin
 
             String domainUrn =
                 _entityClient.ingestProposal(proposal, context.getAuthentication(), false);
-            OwnershipType ownershipType = OwnershipType.TECHNICAL_OWNER;
-            if (!_entityService.exists(
-                UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())))) {
-              log.warn("Technical owner does not exist, defaulting to None ownership.");
-              ownershipType = OwnershipType.NONE;
-            }
             OwnerUtils.addCreatorAsOwner(
-                context, domainUrn, OwnerEntityType.CORP_USER, ownershipType, _entityService);
+                context, domainUrn, OwnerEntityType.CORP_USER, _entityService);
             return domainUrn;
           } catch (DataHubGraphQLException e) {
             throw e;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
-import static com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
 import com.linkedin.common.urn.GlossaryNodeUrn;
@@ -13,7 +12,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.CreateGlossaryEntityInput;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
-import com.linkedin.datahub.graphql.generated.OwnershipType;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.entity.client.EntityClient;
@@ -72,19 +70,8 @@ public class CreateGlossaryNodeResolver implements DataFetcher<CompletableFuture
               String glossaryNodeUrn =
                   _entityClient.ingestProposal(proposal, context.getAuthentication(), false);
 
-              OwnershipType ownershipType = OwnershipType.TECHNICAL_OWNER;
-              if (!_entityService.exists(
-                  UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())))) {
-                log.warn("Technical owner does not exist, defaulting to None ownership.");
-                ownershipType = OwnershipType.NONE;
-              }
-
               OwnerUtils.addCreatorAsOwner(
-                  context,
-                  glossaryNodeUrn,
-                  OwnerEntityType.CORP_USER,
-                  ownershipType,
-                  _entityService);
+                  context, glossaryNodeUrn, OwnerEntityType.CORP_USER, _entityService);
               return glossaryNodeUrn;
             } catch (Exception e) {
               log.error(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolver.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
-import static com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
 import com.linkedin.common.urn.GlossaryNodeUrn;
@@ -14,7 +13,6 @@ import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.CreateGlossaryEntityInput;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
-import com.linkedin.datahub.graphql.generated.OwnershipType;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.GlossaryUtils;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.entity.EntityResponse;
@@ -88,19 +86,9 @@ public class CreateGlossaryTermResolver implements DataFetcher<CompletableFuture
 
               String glossaryTermUrn =
                   _entityClient.ingestProposal(proposal, context.getAuthentication(), false);
-              OwnershipType ownershipType = OwnershipType.TECHNICAL_OWNER;
-              if (!_entityService.exists(
-                  UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())))) {
-                log.warn("Technical owner does not exist, defaulting to None ownership.");
-                ownershipType = OwnershipType.NONE;
-              }
 
               OwnerUtils.addCreatorAsOwner(
-                  context,
-                  glossaryTermUrn,
-                  OwnerEntityType.CORP_USER,
-                  ownershipType,
-                  _entityService);
+                  context, glossaryTermUrn, OwnerEntityType.CORP_USER, _entityService);
               return glossaryTermUrn;
             } catch (Exception e) {
               log.error(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnerResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnerResolver.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.AddOwnerInput;
 import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.datahub.graphql.generated.ResourceRefInput;
@@ -40,10 +39,7 @@ public class AddOwnerResolver implements DataFetcher<CompletableFuture<Boolean>>
     }
 
     OwnerInput ownerInput = ownerInputBuilder.build();
-    if (!OwnerUtils.isAuthorizedToUpdateOwners(environment.getContext(), targetUrn)) {
-      throw new AuthorizationException(
-          "Unauthorized to perform this action. Please contact your DataHub administrator.");
-    }
+    OwnerUtils.validateAuthorizedToUpdateOwners(environment.getContext(), targetUrn);
 
     return CompletableFuture.supplyAsync(
         () -> {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/AddOwnersResolver.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.AddOwnersInput;
 import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.datahub.graphql.generated.ResourceRefInput;
@@ -34,10 +33,7 @@ public class AddOwnersResolver implements DataFetcher<CompletableFuture<Boolean>
 
     return CompletableFuture.supplyAsync(
         () -> {
-          if (!OwnerUtils.isAuthorizedToUpdateOwners(environment.getContext(), targetUrn)) {
-            throw new AuthorizationException(
-                "Unauthorized to perform this action. Please contact your DataHub administrator.");
-          }
+          OwnerUtils.validateAuthorizedToUpdateOwners(environment.getContext(), targetUrn);
 
           OwnerUtils.validateAddOwnerInput(owners, targetUrn, _entityService);
           try {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchAddOwnersResolver.java
@@ -5,7 +5,6 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.BatchAddOwnersInput;
 import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.datahub.graphql.generated.ResourceRefInput;
@@ -74,10 +73,7 @@ public class BatchAddOwnersResolver implements DataFetcher<CompletableFuture<Boo
           "Malformed input provided: owners cannot be applied to subresources.");
     }
 
-    if (!OwnerUtils.isAuthorizedToUpdateOwners(context, resourceUrn)) {
-      throw new AuthorizationException(
-          "Unauthorized to perform this action. Please contact your DataHub administrator.");
-    }
+    OwnerUtils.validateAuthorizedToUpdateOwners(context, resourceUrn);
     LabelUtils.validateResource(
         resourceUrn, resource.getSubResource(), resource.getSubResourceType(), _entityService);
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveOwnersResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchRemoveOwnersResolver.java
@@ -5,7 +5,6 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.BatchRemoveOwnersInput;
 import com.linkedin.datahub.graphql.generated.ResourceRefInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LabelUtils;
@@ -14,7 +13,6 @@ import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -32,10 +30,10 @@ public class BatchRemoveOwnersResolver implements DataFetcher<CompletableFuture<
         bindArgument(environment.getArgument("input"), BatchRemoveOwnersInput.class);
     final List<String> owners = input.getOwnerUrns();
     final List<ResourceRefInput> resources = input.getResources();
-    final Optional<Urn> maybeOwnershipTypeUrn =
+    final Urn ownershipTypeUrn =
         input.getOwnershipTypeUrn() == null
-            ? Optional.empty()
-            : Optional.of(Urn.createFromString(input.getOwnershipTypeUrn()));
+            ? null
+            : Urn.createFromString(input.getOwnershipTypeUrn());
     final QueryContext context = environment.getContext();
 
     return CompletableFuture.supplyAsync(
@@ -46,7 +44,7 @@ public class BatchRemoveOwnersResolver implements DataFetcher<CompletableFuture<
 
           try {
             // Then execute the bulk remove
-            batchRemoveOwners(owners, maybeOwnershipTypeUrn, resources, context);
+            batchRemoveOwners(owners, ownershipTypeUrn, resources, context);
             return true;
           } catch (Exception e) {
             log.error(
@@ -71,24 +69,21 @@ public class BatchRemoveOwnersResolver implements DataFetcher<CompletableFuture<
           "Malformed input provided: owners cannot be removed from subresources.");
     }
 
-    if (!OwnerUtils.isAuthorizedToUpdateOwners(context, resourceUrn)) {
-      throw new AuthorizationException(
-          "Unauthorized to perform this action. Please contact your DataHub administrator.");
-    }
+    OwnerUtils.validateAuthorizedToUpdateOwners(context, resourceUrn);
     LabelUtils.validateResource(
         resourceUrn, resource.getSubResource(), resource.getSubResourceType(), _entityService);
   }
 
   private void batchRemoveOwners(
       List<String> ownerUrns,
-      Optional<Urn> maybeOwnershipTypeUrn,
+      Urn ownershipTypeUrn,
       List<ResourceRefInput> resources,
       QueryContext context) {
     log.debug("Batch removing owners. owners: {}, resources: {}", ownerUrns, resources);
     try {
       OwnerUtils.removeOwnersFromResources(
           ownerUrns.stream().map(UrnUtils::getUrn).collect(Collectors.toList()),
-          maybeOwnershipTypeUrn,
+          ownershipTypeUrn,
           resources,
           UrnUtils.getUrn(context.getActorUrn()),
           _entityService);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/RemoveOwnerResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/RemoveOwnerResolver.java
@@ -6,14 +6,12 @@ import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.RemoveOwnerInput;
 import com.linkedin.datahub.graphql.generated.ResourceRefInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,15 +29,12 @@ public class RemoveOwnerResolver implements DataFetcher<CompletableFuture<Boolea
 
     Urn ownerUrn = Urn.createFromString(input.getOwnerUrn());
     Urn targetUrn = Urn.createFromString(input.getResourceUrn());
-    Optional<Urn> maybeOwnershipTypeUrn =
+    Urn ownershipTypeUrn =
         input.getOwnershipTypeUrn() == null
-            ? Optional.empty()
-            : Optional.of(Urn.createFromString(input.getOwnershipTypeUrn()));
+            ? null
+            : Urn.createFromString(input.getOwnershipTypeUrn());
 
-    if (!OwnerUtils.isAuthorizedToUpdateOwners(environment.getContext(), targetUrn)) {
-      throw new AuthorizationException(
-          "Unauthorized to perform this action. Please contact your DataHub administrator.");
-    }
+    OwnerUtils.validateAuthorizedToUpdateOwners(environment.getContext(), targetUrn);
 
     return CompletableFuture.supplyAsync(
         () -> {
@@ -50,7 +45,7 @@ public class RemoveOwnerResolver implements DataFetcher<CompletableFuture<Boolea
                     ((QueryContext) environment.getContext()).getActorUrn());
             OwnerUtils.removeOwnersFromResources(
                 ImmutableList.of(ownerUrn),
-                maybeOwnershipTypeUrn,
+                ownershipTypeUrn,
                 ImmutableList.of(new ResourceRefInput(input.getResourceUrn(), null, null)),
                 actor,
                 _entityService);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -148,21 +148,23 @@ public class OwnerUtils {
     ownerArray.removeIf(
         owner -> {
           // Remove old ownership if it exists (check ownerUrn + type (entity & deprecated type))
-
-          // Owner is not what we are looking for
-          if (!owner.getOwner().equals(ownerUrn)) {
-            return false;
-          }
-
-          // Check custom entity type urn if exists
-          if (owner.getTypeUrn() != null) {
-            return owner.getTypeUrn().equals(ownershipTypeUrn);
-          }
-
-          // Fall back to mapping deprecated type to the new ownership entity, if it matches remove
-          return mapOwnershipTypeToEntity(OwnershipType.valueOf(owner.getType().toString()).name())
-              .equals(ownershipTypeUrn.toString());
+          return isEqual(owner, ownerUrn, ownershipTypeUrn);
         });
+  }
+
+  public static boolean isEqual(Owner owner, Urn ownerUrn, Urn ownershipTypeUrn) {
+    if (!owner.getOwner().equals(ownerUrn)) {
+      return false;
+    }
+    if (owner.getTypeUrn() != null) {
+      return owner.getTypeUrn().equals(ownershipTypeUrn);
+    }
+    if (ownershipTypeUrn == null) {
+      return false;
+    }
+    // Fall back to mapping deprecated type to the new ownership entity
+    return mapOwnershipTypeToEntity(OwnershipType.valueOf(owner.getType().toString()).name())
+        .equals(ownershipTypeUrn.toString());
   }
 
   private static void removeOwnersIfExists(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -15,6 +15,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
 import com.linkedin.datahub.graphql.generated.OwnerInput;
 import com.linkedin.datahub.graphql.generated.OwnershipType;
@@ -26,7 +27,6 @@ import com.linkedin.metadata.entity.EntityUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,22 +42,22 @@ public class OwnerUtils {
   private OwnerUtils() {}
 
   public static void addOwnersToResources(
-      List<OwnerInput> owners,
-      List<ResourceRefInput> resources,
-      Urn actor,
+      List<OwnerInput> ownerInputs,
+      List<ResourceRefInput> resourceRefs,
+      Urn actorUrn,
       EntityService entityService) {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
-    for (ResourceRefInput resource : resources) {
+    for (ResourceRefInput resource : resourceRefs) {
       changes.add(
           buildAddOwnersProposal(
-              owners, UrnUtils.getUrn(resource.getResourceUrn()), entityService));
+              ownerInputs, UrnUtils.getUrn(resource.getResourceUrn()), actorUrn, entityService));
     }
-    EntityUtils.ingestChangeProposals(changes, entityService, actor, false);
+    EntityUtils.ingestChangeProposals(changes, entityService, actorUrn, false);
   }
 
   public static void removeOwnersFromResources(
       List<Urn> ownerUrns,
-      Optional<Urn> maybeOwnershipTypeUrn,
+      Urn ownershipTypeUrn,
       List<ResourceRefInput> resources,
       Urn actor,
       EntityService entityService) {
@@ -66,7 +66,7 @@ public class OwnerUtils {
       changes.add(
           buildRemoveOwnersProposal(
               ownerUrns,
-              maybeOwnershipTypeUrn,
+              ownershipTypeUrn,
               UrnUtils.getUrn(resource.getResourceUrn()),
               actor,
               entityService));
@@ -75,7 +75,7 @@ public class OwnerUtils {
   }
 
   static MetadataChangeProposal buildAddOwnersProposal(
-      List<OwnerInput> owners, Urn resourceUrn, EntityService entityService) {
+      List<OwnerInput> owners, Urn resourceUrn, Urn actor, EntityService entityService) {
     Ownership ownershipAspect =
         (Ownership)
             EntityUtils.getAspectFromEntity(
@@ -83,8 +83,10 @@ public class OwnerUtils {
                 Constants.OWNERSHIP_ASPECT_NAME,
                 entityService,
                 new Ownership());
+    assert ownershipAspect != null;
+    ownershipAspect.setLastModified(EntityUtils.getAuditStamp(actor));
     for (OwnerInput input : owners) {
-      addOwner(
+      addOwnerToAspect(
           ownershipAspect,
           UrnUtils.getUrn(input.getOwnerUrn()),
           input.getType(),
@@ -96,7 +98,7 @@ public class OwnerUtils {
 
   public static MetadataChangeProposal buildRemoveOwnersProposal(
       List<Urn> ownerUrns,
-      Optional<Urn> maybeOwnershipTypeUrn,
+      Urn ownershipTypeUrn,
       Urn resourceUrn,
       Urn actor,
       EntityService entityService) {
@@ -107,37 +109,21 @@ public class OwnerUtils {
                 Constants.OWNERSHIP_ASPECT_NAME,
                 entityService,
                 new Ownership());
+    assert ownershipAspect != null;
     ownershipAspect.setLastModified(EntityUtils.getAuditStamp(actor));
-    removeOwnersIfExists(ownershipAspect, ownerUrns, maybeOwnershipTypeUrn);
+    removeOwnersIfExists(ownershipAspect, ownerUrns, ownershipTypeUrn);
     return buildMetadataChangeProposalWithUrn(
         resourceUrn, Constants.OWNERSHIP_ASPECT_NAME, ownershipAspect);
   }
 
-  private static void addOwner(
-      Ownership ownershipAspect, Urn ownerUrn, OwnershipType type, Urn ownershipUrn) {
+  private static void addOwnerToAspect(
+      Ownership ownershipAspect, Urn ownerUrn, OwnershipType type, Urn ownershipTypeUrn) {
     if (!ownershipAspect.hasOwners()) {
       ownershipAspect.setOwners(new OwnerArray());
     }
 
-    final OwnerArray ownerArray = new OwnerArray(ownershipAspect.getOwners());
-    ownerArray.removeIf(
-        owner -> {
-          // Remove old ownership if it exists (check ownerUrn + type (entity & deprecated type))
-
-          // Owner is not what we are looking for
-          if (!owner.getOwner().equals(ownerUrn)) {
-            return false;
-          }
-
-          // Check custom entity type urn if exists
-          if (owner.getTypeUrn() != null) {
-            return owner.getTypeUrn().equals(ownershipUrn);
-          }
-
-          // Fall back to mapping deprecated type to the new ownership entity, if it matches remove
-          return mapOwnershipTypeToEntity(OwnershipType.valueOf(owner.getType().toString()).name())
-              .equals(ownershipUrn.toString());
-        });
+    OwnerArray ownerArray = new OwnerArray(ownershipAspect.getOwners());
+    removeExistingOwnerIfExists(ownerArray, ownerUrn, ownershipTypeUrn);
 
     Owner newOwner = new Owner();
 
@@ -150,49 +136,49 @@ public class OwnerUtils {
             : com.linkedin.common.OwnershipType.CUSTOM;
 
     newOwner.setType(gmsType);
-    newOwner.setTypeUrn(ownershipUrn);
+    newOwner.setTypeUrn(ownershipTypeUrn);
     newOwner.setSource(new OwnershipSource().setType(OwnershipSourceType.MANUAL));
     newOwner.setOwner(ownerUrn);
     ownerArray.add(newOwner);
     ownershipAspect.setOwners(ownerArray);
   }
 
+  private static void removeExistingOwnerIfExists(
+      OwnerArray ownerArray, Urn ownerUrn, Urn ownershipTypeUrn) {
+    ownerArray.removeIf(
+        owner -> {
+          // Remove old ownership if it exists (check ownerUrn + type (entity & deprecated type))
+
+          // Owner is not what we are looking for
+          if (!owner.getOwner().equals(ownerUrn)) {
+            return false;
+          }
+
+          // Check custom entity type urn if exists
+          if (owner.getTypeUrn() != null) {
+            return owner.getTypeUrn().equals(ownershipTypeUrn);
+          }
+
+          // Fall back to mapping deprecated type to the new ownership entity, if it matches remove
+          return mapOwnershipTypeToEntity(OwnershipType.valueOf(owner.getType().toString()).name())
+              .equals(ownershipTypeUrn.toString());
+        });
+  }
+
   private static void removeOwnersIfExists(
-      Ownership ownership, List<Urn> ownerUrns, Optional<Urn> maybeOwnershipTypeUrn) {
-    if (!ownership.hasOwners()) {
-      ownership.setOwners(new OwnerArray());
+      Ownership ownershipAspect, List<Urn> ownerUrns, Urn ownershipTypeUrn) {
+    if (!ownershipAspect.hasOwners()) {
+      ownershipAspect.setOwners(new OwnerArray());
     }
 
-    OwnerArray ownerArray = ownership.getOwners();
+    OwnerArray ownerArray = ownershipAspect.getOwners();
     for (Urn ownerUrn : ownerUrns) {
-      if (maybeOwnershipTypeUrn.isPresent()) {
-        ownerArray.removeIf(
-            owner -> {
-              // Remove ownership if it exists (check ownerUrn + type (entity & deprecated type))
-
-              // Owner is not what we are looking for
-              if (!owner.getOwner().equals(ownerUrn)) {
-                return false;
-              }
-
-              // Check custom entity type urn if exists
-              if (owner.getTypeUrn() != null) {
-                return owner.getTypeUrn().equals(maybeOwnershipTypeUrn.get());
-              }
-
-              // Fall back to mapping deprecated type to the new ownership entity, if it matches
-              // remove
-              return mapOwnershipTypeToEntity(
-                      OwnershipType.valueOf(owner.getType().toString()).name())
-                  .equals(maybeOwnershipTypeUrn.get().toString());
-            });
-      } else {
-        ownerArray.removeIf(owner -> owner.getOwner().equals(ownerUrn));
-      }
+      removeExistingOwnerIfExists(ownerArray, ownerUrn, ownershipTypeUrn);
     }
   }
 
-  public static boolean isAuthorizedToUpdateOwners(@Nonnull QueryContext context, Urn resourceUrn) {
+  public static void validateAuthorizedToUpdateOwners(
+      @Nonnull QueryContext context, Urn resourceUrn) {
     final DisjunctivePrivilegeGroup orPrivilegeGroups =
         new DisjunctivePrivilegeGroup(
             ImmutableList.of(
@@ -200,26 +186,27 @@ public class OwnerUtils {
                 new ConjunctivePrivilegeGroup(
                     ImmutableList.of(PoliciesConfig.EDIT_ENTITY_OWNERS_PRIVILEGE.getType()))));
 
-    return AuthorizationUtils.isAuthorized(
-        context.getAuthorizer(),
-        context.getActorUrn(),
-        resourceUrn.getEntityType(),
-        resourceUrn.toString(),
-        orPrivilegeGroups);
+    boolean authorized =
+        AuthorizationUtils.isAuthorized(
+            context.getAuthorizer(),
+            context.getActorUrn(),
+            resourceUrn.getEntityType(),
+            resourceUrn.toString(),
+            orPrivilegeGroups);
+    if (!authorized) {
+      throw new AuthorizationException(
+          "Unauthorized to update owners. Please contact your DataHub administrator.");
+    }
   }
 
-  public static Boolean validateAddOwnerInput(
+  public static void validateAddOwnerInput(
       List<OwnerInput> owners, Urn resourceUrn, EntityService entityService) {
     for (OwnerInput owner : owners) {
-      boolean result = validateAddOwnerInput(owner, resourceUrn, entityService);
-      if (!result) {
-        return false;
-      }
+      validateAddOwnerInput(owner, resourceUrn, entityService);
     }
-    return true;
   }
 
-  public static Boolean validateAddOwnerInput(
+  public static void validateAddOwnerInput(
       OwnerInput owner, Urn resourceUrn, EntityService entityService) {
 
     if (!entityService.exists(resourceUrn)) {
@@ -229,8 +216,6 @@ public class OwnerUtils {
     }
 
     validateOwner(owner, entityService);
-
-    return true;
   }
 
   public static void validateOwner(OwnerInput owner, EntityService entityService) {
@@ -277,23 +262,26 @@ public class OwnerUtils {
     }
   }
 
-  public static Boolean validateRemoveInput(Urn resourceUrn, EntityService entityService) {
+  public static void validateRemoveInput(Urn resourceUrn, EntityService entityService) {
     if (!entityService.exists(resourceUrn)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource %s. Resource does not exist.", resourceUrn));
     }
-    return true;
   }
 
   public static void addCreatorAsOwner(
       QueryContext context,
       String urn,
       OwnerEntityType ownerEntityType,
-      OwnershipType ownershipType,
       EntityService entityService) {
     try {
       Urn actorUrn = CorpuserUrn.createFromString(context.getActorUrn());
+      OwnershipType ownershipType = OwnershipType.TECHNICAL_OWNER;
+      if (!entityService.exists(UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())))) {
+        log.warn("Technical owner does not exist, defaulting to None ownership.");
+        ownershipType = OwnershipType.NONE;
+      }
       String ownershipTypeUrn = mapOwnershipTypeToEntity(ownershipType.name());
 
       if (!entityService.exists(UrnUtils.getUrn(ownershipTypeUrn))) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/tag/CreateTagResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/tag/CreateTagResolver.java
@@ -2,17 +2,14 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
-import static com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils.*;
 import static com.linkedin.metadata.Constants.*;
 
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.CreateTagInput;
 import com.linkedin.datahub.graphql.generated.OwnerEntityType;
-import com.linkedin.datahub.graphql.generated.OwnershipType;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
@@ -72,15 +69,9 @@ public class CreateTagResolver implements DataFetcher<CompletableFuture<String>>
                     key, TAG_ENTITY_NAME, TAG_PROPERTIES_ASPECT_NAME, mapTagProperties(input));
             String tagUrn =
                 _entityClient.ingestProposal(proposal, context.getAuthentication(), false);
-            OwnershipType ownershipType = OwnershipType.TECHNICAL_OWNER;
-            if (!_entityService.exists(
-                UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())))) {
-              log.warn("Technical owner does not exist, defaulting to None ownership.");
-              ownershipType = OwnershipType.NONE;
-            }
 
             OwnerUtils.addCreatorAsOwner(
-                context, tagUrn, OwnerEntityType.CORP_USER, ownershipType, _entityService);
+                context, tagUrn, OwnerEntityType.CORP_USER, _entityService);
             return tagUrn;
           } catch (Exception e) {
             log.error(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
@@ -13,7 +13,7 @@ public class OwnerUtilsTest {
 
   public static String TECHNICAL_OWNER_OWNERSHIP_TYPE_URN =
       "urn:li:ownershipType:__system__technical_owner";
-
+  public static String BUSINESS_OWNER_OWNERSHIP_TYPE_URN = "urn:li:ownershipType:__system__business_owner";
   @Test
   public void testMapOwnershipType() {
     assertEquals(
@@ -32,38 +32,64 @@ public class OwnerUtilsTest {
   }
 
   @Test
-  public void testIsOwnerEqualWithLegacyTypeIsNotConsidered() throws URISyntaxException {
+  public void testIsOwnerEqualWithLegacyTypeOnly() throws URISyntaxException {
 
     Urn technicalOwnershipTypeUrn = new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN);
     Urn ownerUrn1 = new Urn("urn:li:corpuser:foo");
-    Owner owner1 = new Owner();
-    owner1.setOwner(ownerUrn1);
-    owner1.setType(OwnershipType.TECHNICAL_OWNER);
+    Owner ownerWithTechnicalOwnership = new Owner();
+    ownerWithTechnicalOwnership.setOwner(ownerUrn1);
+    ownerWithTechnicalOwnership.setType(OwnershipType.TECHNICAL_OWNER);
 
-    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, technicalOwnershipTypeUrn));
+    assertTrue(OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
 
-    Owner owner2 = new Owner();
-    owner2.setOwner(ownerUrn1);
-    owner2.setType(OwnershipType.BUSINESS_OWNER);
-    assertTrue(
-        OwnerUtils.isOwnerEqual(owner1, ownerUrn1, new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN)));
+    Owner ownerWithBusinessOwnership = new Owner();
+    ownerWithBusinessOwnership.setOwner(ownerUrn1);
+    ownerWithBusinessOwnership.setType(OwnershipType.BUSINESS_OWNER);
+    assertFalse(
+        OwnerUtils.isOwnerEqual(ownerWithBusinessOwnership, ownerUrn1, new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN)));
   }
 
   @Test
-  public void testIsOwnerEqualOwnershipTypeUrnIsConsidered() throws URISyntaxException {
+  public void testIsOwnerEqualOnlyOwnershipTypeUrn() throws URISyntaxException {
 
     Urn technicalOwnershipTypeUrn = new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN);
+    Urn businessOwnershipTypeUrn = new Urn(BUSINESS_OWNER_OWNERSHIP_TYPE_URN);
     Urn ownerUrn1 = new Urn("urn:li:corpuser:foo");
-    Owner owner1 = new Owner();
-    owner1.setOwner(ownerUrn1);
-    owner1.setTypeUrn(technicalOwnershipTypeUrn);
 
-    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, technicalOwnershipTypeUrn));
+    Owner ownerWithTechnicalOwnership = new Owner();
+    ownerWithTechnicalOwnership.setOwner(ownerUrn1);
+    ownerWithTechnicalOwnership.setTypeUrn(technicalOwnershipTypeUrn);
 
-    Urn businessOwnershipTypeUrn = new Urn("urn:li:ownershipType:__system__business_owner");
-    Owner owner2 = new Owner();
-    owner2.setOwner(ownerUrn1);
-    owner2.setTypeUrn(businessOwnershipTypeUrn);
-    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, technicalOwnershipTypeUrn));
+    Owner ownerWithBusinessOwnership = new Owner();
+    ownerWithBusinessOwnership.setOwner(ownerUrn1);
+    ownerWithBusinessOwnership.setTypeUrn(businessOwnershipTypeUrn);
+
+    Owner ownerWithoutOwnershipType = new Owner();
+    ownerWithoutOwnershipType.setOwner(ownerUrn1);
+
+    assertTrue(OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(OwnerUtils.isOwnerEqual(ownerWithBusinessOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, null));
+    assertTrue(OwnerUtils.isOwnerEqual(ownerWithoutOwnershipType, ownerUrn1, null));
+  }
+
+  public void testIsOwnerEqualWithBothLegacyAndNewType() throws URISyntaxException {
+    Urn technicalOwnershipTypeUrn = new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN);
+    Urn businessOwnershipTypeUrn = new Urn(BUSINESS_OWNER_OWNERSHIP_TYPE_URN);
+    Urn ownerUrn1 = new Urn("urn:li:corpuser:foo");
+
+    Owner ownerWithLegacyTechnicalOwnership = new Owner();
+    ownerWithLegacyTechnicalOwnership.setOwner(ownerUrn1);
+    ownerWithLegacyTechnicalOwnership.setType(OwnershipType.TECHNICAL_OWNER);
+
+    assertTrue(OwnerUtils.isOwnerEqual(ownerWithLegacyTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(OwnerUtils.isOwnerEqual(ownerWithLegacyTechnicalOwnership, ownerUrn1, businessOwnershipTypeUrn));
+
+    Owner ownerWithNewTechnicalOwnership = new Owner();
+    ownerWithLegacyTechnicalOwnership.setOwner(ownerUrn1);
+    ownerWithLegacyTechnicalOwnership.setTypeUrn(technicalOwnershipTypeUrn);
+
+    assertTrue(OwnerUtils.isOwnerEqual(ownerWithNewTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(OwnerUtils.isOwnerEqual(ownerWithNewTechnicalOwnership, ownerUrn1, businessOwnershipTypeUrn));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
@@ -70,6 +70,7 @@ public class OwnerUtilsTest {
 
     Owner ownerWithoutOwnershipType = new Owner();
     ownerWithoutOwnershipType.setOwner(ownerUrn1);
+    ownerWithoutOwnershipType.setType(OwnershipType.NONE);
 
     assertTrue(
         OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
@@ -13,7 +13,9 @@ public class OwnerUtilsTest {
 
   public static String TECHNICAL_OWNER_OWNERSHIP_TYPE_URN =
       "urn:li:ownershipType:__system__technical_owner";
-  public static String BUSINESS_OWNER_OWNERSHIP_TYPE_URN = "urn:li:ownershipType:__system__business_owner";
+  public static String BUSINESS_OWNER_OWNERSHIP_TYPE_URN =
+      "urn:li:ownershipType:__system__business_owner";
+
   @Test
   public void testMapOwnershipType() {
     assertEquals(
@@ -40,13 +42,15 @@ public class OwnerUtilsTest {
     ownerWithTechnicalOwnership.setOwner(ownerUrn1);
     ownerWithTechnicalOwnership.setType(OwnershipType.TECHNICAL_OWNER);
 
-    assertTrue(OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertTrue(
+        OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
 
     Owner ownerWithBusinessOwnership = new Owner();
     ownerWithBusinessOwnership.setOwner(ownerUrn1);
     ownerWithBusinessOwnership.setType(OwnershipType.BUSINESS_OWNER);
     assertFalse(
-        OwnerUtils.isOwnerEqual(ownerWithBusinessOwnership, ownerUrn1, new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN)));
+        OwnerUtils.isOwnerEqual(
+            ownerWithBusinessOwnership, ownerUrn1, new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN)));
   }
 
   @Test
@@ -67,8 +71,10 @@ public class OwnerUtilsTest {
     Owner ownerWithoutOwnershipType = new Owner();
     ownerWithoutOwnershipType.setOwner(ownerUrn1);
 
-    assertTrue(OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
-    assertFalse(OwnerUtils.isOwnerEqual(ownerWithBusinessOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertTrue(
+        OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(
+        OwnerUtils.isOwnerEqual(ownerWithBusinessOwnership, ownerUrn1, technicalOwnershipTypeUrn));
     assertFalse(OwnerUtils.isOwnerEqual(ownerWithTechnicalOwnership, ownerUrn1, null));
     assertTrue(OwnerUtils.isOwnerEqual(ownerWithoutOwnershipType, ownerUrn1, null));
   }
@@ -82,14 +88,22 @@ public class OwnerUtilsTest {
     ownerWithLegacyTechnicalOwnership.setOwner(ownerUrn1);
     ownerWithLegacyTechnicalOwnership.setType(OwnershipType.TECHNICAL_OWNER);
 
-    assertTrue(OwnerUtils.isOwnerEqual(ownerWithLegacyTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
-    assertFalse(OwnerUtils.isOwnerEqual(ownerWithLegacyTechnicalOwnership, ownerUrn1, businessOwnershipTypeUrn));
+    assertTrue(
+        OwnerUtils.isOwnerEqual(
+            ownerWithLegacyTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(
+        OwnerUtils.isOwnerEqual(
+            ownerWithLegacyTechnicalOwnership, ownerUrn1, businessOwnershipTypeUrn));
 
     Owner ownerWithNewTechnicalOwnership = new Owner();
     ownerWithLegacyTechnicalOwnership.setOwner(ownerUrn1);
     ownerWithLegacyTechnicalOwnership.setTypeUrn(technicalOwnershipTypeUrn);
 
-    assertTrue(OwnerUtils.isOwnerEqual(ownerWithNewTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
-    assertFalse(OwnerUtils.isOwnerEqual(ownerWithNewTechnicalOwnership, ownerUrn1, businessOwnershipTypeUrn));
+    assertTrue(
+        OwnerUtils.isOwnerEqual(
+            ownerWithNewTechnicalOwnership, ownerUrn1, technicalOwnershipTypeUrn));
+    assertFalse(
+        OwnerUtils.isOwnerEqual(
+            ownerWithNewTechnicalOwnership, ownerUrn1, businessOwnershipTypeUrn));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/utils/OwnerUtilsTest.java
@@ -1,0 +1,69 @@
+package com.linkedin.datahub.graphql.utils;
+
+import static org.testng.AssertJUnit.*;
+
+import com.linkedin.common.Owner;
+import com.linkedin.common.OwnershipType;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.resolvers.mutate.util.OwnerUtils;
+import java.net.URISyntaxException;
+import org.testng.annotations.Test;
+
+public class OwnerUtilsTest {
+
+  public static String TECHNICAL_OWNER_OWNERSHIP_TYPE_URN =
+      "urn:li:ownershipType:__system__technical_owner";
+
+  @Test
+  public void testMapOwnershipType() {
+    assertEquals(
+        OwnerUtils.mapOwnershipTypeToEntity("TECHNICAL_OWNER"), TECHNICAL_OWNER_OWNERSHIP_TYPE_URN);
+  }
+
+  @Test
+  public void testIsOwnerEqualUrnOnly() throws URISyntaxException {
+    Urn ownerUrn1 = new Urn("urn:li:corpuser:foo");
+    Owner owner1 = new Owner();
+    owner1.setOwner(ownerUrn1);
+    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, null));
+
+    Urn ownerUrn2 = new Urn("urn:li:corpuser:bar");
+    assertFalse(OwnerUtils.isOwnerEqual(owner1, ownerUrn2, null));
+  }
+
+  @Test
+  public void testIsOwnerEqualWithLegacyTypeIsNotConsidered() throws URISyntaxException {
+
+    Urn technicalOwnershipTypeUrn = new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN);
+    Urn ownerUrn1 = new Urn("urn:li:corpuser:foo");
+    Owner owner1 = new Owner();
+    owner1.setOwner(ownerUrn1);
+    owner1.setType(OwnershipType.TECHNICAL_OWNER);
+
+    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, technicalOwnershipTypeUrn));
+
+    Owner owner2 = new Owner();
+    owner2.setOwner(ownerUrn1);
+    owner2.setType(OwnershipType.BUSINESS_OWNER);
+    assertTrue(
+        OwnerUtils.isOwnerEqual(owner1, ownerUrn1, new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN)));
+  }
+
+  @Test
+  public void testIsOwnerEqualOwnershipTypeUrnIsConsidered() throws URISyntaxException {
+
+    Urn technicalOwnershipTypeUrn = new Urn(TECHNICAL_OWNER_OWNERSHIP_TYPE_URN);
+    Urn ownerUrn1 = new Urn("urn:li:corpuser:foo");
+    Owner owner1 = new Owner();
+    owner1.setOwner(ownerUrn1);
+    owner1.setTypeUrn(technicalOwnershipTypeUrn);
+
+    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, technicalOwnershipTypeUrn));
+
+    Urn businessOwnershipTypeUrn = new Urn("urn:li:ownershipType:__system__business_owner");
+    Owner owner2 = new Owner();
+    owner2.setOwner(ownerUrn1);
+    owner2.setTypeUrn(businessOwnershipTypeUrn);
+    assertTrue(OwnerUtils.isOwnerEqual(owner1, ownerUrn1, technicalOwnershipTypeUrn));
+  }
+}


### PR DESCRIPTION
- Fix last modified not being updated on adding owner via the UI
- Some cleanup in OwnerUtils to avoid copy-paste
- Rename some confusing variable names
- `Optional` should not be an argument to methods
- Extract code out to make code readable in OwnerUtils

Things to pay special attention to
- With the ownership type how do we define equality of an Owner? If owner urn is same but ownership type is different then is owner obj considered equal? There were 2 different definitions of equality in add owner and remove owner in OwnerUtils here.  I have updated it to be what I consider to be correct equality definition. But please pay attention to that.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
