### PR TITLE
fix(compose-profiles): hostname kafka-broker -> broker

### DIFF
--- a/docker/profiles/docker-compose.actions.yml
+++ b/docker/profiles/docker-compose.actions.yml
@@ -6,7 +6,7 @@ x-datahub-actions-service: &datahub-actions-service
   environment:
     ACTIONS_EXTRA_PACKAGES: ${ACTIONS_EXTRA_PACKAGES:-}
     ACTIONS_CONFIG: ${ACTIONS_CONFIG:-}
-    KAFKA_BOOTSTRAP_SERVER: kafka-broker:29092
+    KAFKA_BOOTSTRAP_SERVER: broker:29092
     SCHEMA_REGISTRY_URL: http://datahub-gms:8080/schema-registry/api/
 
 x-datahub-actions-service-dev: &datahub-actions-service-dev

--- a/docker/profiles/docker-compose.frontend.yml
+++ b/docker/profiles/docker-compose.frontend.yml
@@ -6,7 +6,7 @@ x-datahub-frontend-service: &datahub-frontend-service
     - ${DATAHUB_MAPPED_FRONTEND_PORT:-9002}:9002
   env_file: datahub-frontend/env/docker.env
   environment: &datahub-frontend-service-env
-    KAFKA_BOOTSTRAP_SERVER: kafka-broker:29092
+    KAFKA_BOOTSTRAP_SERVER: broker:29092
   volumes:
     - ${HOME}/.datahub/plugins:/etc/datahub/plugins
 

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -36,7 +36,7 @@ x-search-datastore-elasticsearch-env: &search-datastore-env
   ELASTICSEARCH_USE_SSL: ${ELASTICSEARCH_USE_SSL:-false}
 
 x-kafka-env: &kafka-env
-  KAFKA_BOOTSTRAP_SERVER: kafka-broker:29092
+  KAFKA_BOOTSTRAP_SERVER: broker:29092
   # KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
   SCHEMA_REGISTRY_TYPE: INTERNAL
   KAFKA_SCHEMAREGISTRY_URL: http://datahub-gms:8080/schema-registry/api/

--- a/docker/profiles/docker-compose.prerequisites.yml
+++ b/docker/profiles/docker-compose.prerequisites.yml
@@ -219,8 +219,8 @@ services:
     volumes:
       - neo4jdata:/data
   kafka-broker:
-    container_name: kafka-broker
-    hostname: kafka-broker
+    container_name: broker
+    hostname: broker
     image: confluentinc/cp-kafka:7.4.0
     command:
       - /bin/bash
@@ -245,18 +245,18 @@ services:
     env_file: kafka-broker/env/docker.env
     environment:
       KAFKA_NODE_ID: 1
-      KAFKA_ADVERTISED_LISTENERS: BROKER://kafka-broker:29092,EXTERNAL://kafka-broker:9092
-      KAFKA_LISTENERS: BROKER://kafka-broker:29092,EXTERNAL://kafka-broker:9092,CONTROLLER://kafka-broker:39092
+      KAFKA_ADVERTISED_LISTENERS: BROKER://broker:29092,EXTERNAL://broker:9092
+      KAFKA_LISTENERS: BROKER://broker:29092,EXTERNAL://broker:9092,CONTROLLER://broker:39092
       KAFKA_INTER_BROKER_LISTENER_NAME: BROKER
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,BROKER:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_PROCESS_ROLES: controller, broker
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka-broker:39092
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:39092
       # https://github.com/confluentinc/cp-all-in-one/issues/120
       KAFKA_LOG4J_LOGGERS: 'org.apache.kafka.image.loader.MetadataLoader=WARN'
       KAFKA_ZOOKEEPER_CONNECT: null
     healthcheck:
-      test: nc -z kafka-broker $${DATAHUB_KAFKA_BROKER_PORT:-9092}
+      test: nc -z broker $${DATAHUB_KAFKA_BROKER_PORT:-9092}
       start_period: 60s
       interval: 1s
       retries: 5
@@ -271,7 +271,7 @@ services:
     env_file: kafka-setup/env/docker.env
     environment: &kafka-setup-env
       DATAHUB_PRECREATE_TOPICS: ${DATAHUB_PRECREATE_TOPICS:-false}
-      KAFKA_BOOTSTRAP_SERVER: kafka-broker:29092
+      KAFKA_BOOTSTRAP_SERVER: broker:29092
       USE_CONFLUENT_SCHEMA_REGISTRY: false
     depends_on:
       kafka-broker:


### PR DESCRIPTION
smoke tests and other code assumes broker instead of kafka-broker for the quickstart kafka broker hostname

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
