### PR TITLE
bump(docker-compose): migrate to v2 docker compose cli

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,7 +64,7 @@ successful release on Github will automatically publish the images.
 To build the full images (that we are going to publish), you need to run the following:
 
 ```
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -p datahub build
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -p datahub build
 ```
 
 This is because we're relying on builtkit for multistage builds. It does not hurt also set `DATAHUB_VERSION` to

--- a/docker/airflow/local_airflow.md
+++ b/docker/airflow/local_airflow.md
@@ -54,7 +54,7 @@ curl -L 'https://raw.githubusercontent.com/datahub-project/datahub/master/metada
 First you need to initialize airflow in order to create initial database tables and the initial airflow user.
 
 ```
-docker-compose up airflow-init
+docker compose up airflow-init
 ```
 
 You should see the following final initialization message
@@ -66,10 +66,10 @@ airflow_install_airflow-init_1 exited with code 0
 
 ```
 
-Afterwards you need to start the airflow docker-compose
+Afterwards you need to start the airflow docker compose
 
 ```
-docker-compose up
+docker compose up
 ```
 
 You should see a host of messages as Airflow starts up.

--- a/docker/dev-with-cassandra.sh
+++ b/docker/dev-with-cassandra.sh
@@ -23,13 +23,13 @@ fi
 # YOU MUST BUILD VIA GRADLE BEFORE RUNNING THIS.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR && \
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose \
     -f docker-compose-with-cassandra.yml \
     -f docker-compose.dev.yml \
     $CONSUMERS_COMPOSE $MONITORING_COMPOSE $M1_COMPOSE \
     pull \
 && \
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose -p datahub \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose -p datahub \
     -f docker-compose-with-cassandra.yml \
     -f docker-compose.dev.yml \
     $CONSUMERS_COMPOSE $MONITORING_COMPOSE $M1_COMPOSE \

--- a/docker/dev-without-neo4j.sh
+++ b/docker/dev-without-neo4j.sh
@@ -23,13 +23,13 @@ fi
 # Launches dev instances of DataHub images. See documentation for more details.
 # YOU MUST BUILD VIA GRADLE BEFORE RUNNING THIS.
 cd "${DIR}/../.." && \
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose \
     -f "${DIR}/docker-compose-without-neo4j.yml" \
     -f "${DIR}/docker-compose-without-neo4j.override.yml" \
     -f "${DIR}/docker-compose.dev.yml" \
     $CONSUMERS_COMPOSE $MONITORING_COMPOSE $M1_COMPOSE pull \
 && \
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose -p datahub \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose -p datahub \
     -f "${DIR}/docker-compose-without-neo4j.yml" \
     -f "${DIR}/docker-compose-without-neo4j.override.yml" \
     -f "${DIR}/docker-compose.dev.yml" \

--- a/docker/dev.sh
+++ b/docker/dev.sh
@@ -23,13 +23,13 @@ fi
 # YOU MUST BUILD VIA GRADLE BEFORE RUNNING THIS.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR && \
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose \
     -f docker-compose.yml \
     -f docker-compose.override.yml \
     -f docker-compose.dev.yml \
     $CONSUMERS_COMPOSE $MONITORING_COMPOSE $M1_COMPOSE pull \
 && \
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose -p datahub \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose -p datahub \
     -f docker-compose.yml \
     -f docker-compose.override.yml \
     -f docker-compose.dev.yml \

--- a/docker/ingestion/ingestion.sh
+++ b/docker/ingestion/ingestion.sh
@@ -2,4 +2,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export DATAHUB_VERSION=${DATAHUB_VERSION:-head}
-cd $DIR && docker-compose pull && docker-compose -p datahub up
+cd $DIR && docker compose pull && docker compose -p datahub up

--- a/docker/nuke.sh
+++ b/docker/nuke.sh
@@ -4,8 +4,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 
 # Tear down and clean up all DataHub-related containers, volumes, and network
-docker-compose -p datahub down -v
-docker-compose rm -f -v
+docker compose -p datahub down -v
+docker compose rm -f -v
 
 # Tear down ingestion container
-(cd ingestion && docker-compose -p datahub down -v)
+(cd ingestion && docker compose -p datahub down -v)

--- a/docker/quickstart.sh
+++ b/docker/quickstart.sh
@@ -33,11 +33,11 @@ echo "Quickstarting DataHub: version ${DATAHUB_VERSION}"
 if docker volume ls | grep -c -q datahub_neo4jdata
 then
   echo "Datahub Neo4j volume found, starting with neo4j as graph service"
-  cd $DIR && docker-compose pull && docker-compose -p datahub up
+  cd $DIR && docker compose pull && docker compose -p datahub up
 else
   echo "No Datahub Neo4j volume found, starting with elasticsearch as graph service"
   cd $DIR && \
-  DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker-compose -p datahub \
+  DOCKER_DEFAULT_PLATFORM="$(uname -m)" docker compose -p datahub \
     -f quickstart/docker-compose-without-neo4j.quickstart.yml \
     $MONITORING_COMPOSE $CONSUMERS_COMPOSE $M1_COMPOSE up $@
 fi

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -101,13 +101,13 @@ Replace whatever container you want in the existing deployment.
 I.e, replacing datahub's backend (GMS):
 
 ```shell
-(cd docker && COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -p datahub -f docker-compose-without-neo4j.yml -f docker-compose-without-neo4j.override.yml -f docker-compose.dev.yml up -d --no-deps --force-recreate --build datahub-gms)
+(cd docker && COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -p datahub -f docker-compose-without-neo4j.yml -f docker-compose-without-neo4j.override.yml -f docker-compose.dev.yml up -d --no-deps --force-recreate --build datahub-gms)
 ```
 
 Running the local version of the frontend
 
 ```shell
-(cd docker && COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -p datahub -f docker-compose-without-neo4j.yml -f docker-compose-without-neo4j.override.yml -f docker-compose.dev.yml up -d --no-deps --force-recreate --build datahub-frontend-react)
+(cd docker && COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -p datahub -f docker-compose-without-neo4j.yml -f docker-compose-without-neo4j.override.yml -f docker-compose.dev.yml up -d --no-deps --force-recreate --build datahub-frontend-react)
 ```
 
 ## IDE Support

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -274,7 +274,7 @@ It is not intended for a production environment. This recommendation is based on
 
 #### Default Credentials
 
-`quickstart` uses docker-compose configuration which includes default credentials for both DataHub, and it's underlying
+`quickstart` uses docker compose configuration which includes default credentials for both DataHub, and it's underlying
 prerequisite data stores, such as MySQL. Additionally, other components are unauthenticated out of the box. This is a
 design choice to make development easier and is not best practice for a production environment.
 


### PR DESCRIPTION

v1 `docker-compose` is deprecated as of July 2023

Notes:

docker-compose vs docker compose
Unlike Compose V1, Compose V2 integrates into the Docker CLI platform and the recommended command-line syntax is docker compose.

Ref: https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
