### PR TITLE
fix(ingest/mongodb): Fix downsampling the collection schema output undetermined

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -421,7 +421,7 @@ class MongoDBSource(StatefulIngestionSourceBase):
                         )
                         collection_fields = sorted(
                             collection_schema.values(),
-                            key=lambda x: x["count"],
+                            key=lambda x: (x["count"], x["delimited_name"]),
                             reverse=True,
                         )[0:max_schema_size]
                         # Add this information to the custom properties so user can know they are looking at downsampled schema


### PR DESCRIPTION
We noticed from recurring ingestion of MongoDB that there are changes of fields in the dataset while there is no modification of the source data. 

The root cause is the ingestion will downsample the collection schema based on `max_schema_size` we set in the config. The collection fields are sorted by count but there is no further sorting applied when the count is the same. We should add a secondary element delimited_name to the sorted function so the output is consistent

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
