### PR TITLE
fix(autocomplete): Filter default entity types based on those present in types map 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteForMultipleResolver.java
@@ -20,6 +20,7 @@ import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -67,7 +68,10 @@ public class AutoCompleteForMultipleResolver
     List<EntityType> types = getEntityTypes(input.getTypes(), maybeResolvedView);
     if (types != null && types.size() > 0) {
       return AutocompleteUtils.batchGetAutocompleteResults(
-          types.stream().map(_typeToEntity::get).collect(Collectors.toList()),
+          types.stream()
+              .map(_typeToEntity::get)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList()),
           sanitizedQuery,
           input,
           environment,
@@ -76,7 +80,10 @@ public class AutoCompleteForMultipleResolver
 
     // By default, autocomplete only against the Default Set of Autocomplete entities
     return AutocompleteUtils.batchGetAutocompleteResults(
-        AUTO_COMPLETE_ENTITY_TYPES.stream().map(_typeToEntity::get).collect(Collectors.toList()),
+        AUTO_COMPLETE_ENTITY_TYPES.stream()
+            .map(_typeToEntity::get)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toList()),
         sanitizedQuery,
         input,
         environment,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -88,7 +88,6 @@ public class SearchUtils {
           EntityType.TAG,
           EntityType.CORP_USER,
           EntityType.CORP_GROUP,
-          EntityType.ROLE,
           EntityType.NOTEBOOK,
           EntityType.DATA_PRODUCT);
 


### PR DESCRIPTION
Fixes an intermittent 500 coming from the search bar autocomplete query. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
