### PR TITLE
fix(internal schema): changes to make internal schema registry more compatible with other schema registries

### DIFF
--- a/metadata-service/schema-registry-servlet/src/main/java/io/datahubproject/openapi/schema/registry/SchemaRegistryController.java
+++ b/metadata-service/schema-registry-servlet/src/main/java/io/datahubproject/openapi/schema/registry/SchemaRegistryController.java
@@ -1,6 +1,7 @@
 package io.datahubproject.openapi.schema.registry;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.gms.factory.kafka.schemaregistry.InternalSchemaRegistryFactory;
 import com.linkedin.metadata.registry.SchemaRegistryService;
 import io.datahubproject.schema_registry.openapi.generated.CompatibilityCheckResponse;
@@ -23,9 +24,11 @@ import io.swagger.api.SubjectsApi;
 import io.swagger.api.V1Api;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -56,6 +59,8 @@ public class SchemaRegistryController
   private final ObjectMapper objectMapper;
 
   private final HttpServletRequest request;
+
+  private static final Set<String> SCHEMA_VERSIONS = ImmutableSet.of("1", "latest");
 
   @Qualifier("schemaRegistryService")
   private final SchemaRegistryService _schemaRegistryService;
@@ -109,8 +114,30 @@ public class SchemaRegistryController
   @Override
   public ResponseEntity<Schema> getSchemaByVersion(
       String subject, String version, Boolean deleted) {
-    log.error("[SubjectsApi] getSchemaByVersion method not implemented");
-    return SubjectsApi.super.getSchemaByVersion(subject, version, deleted);
+    final String topicName = subject.replaceFirst("-value", "");
+
+    if (!SCHEMA_VERSIONS.contains(version)) {
+      log.error(
+          "[SubjectsApi] getSchemaByVersion subject {} version {} not found.", subject, version);
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    return _schemaRegistryService
+        .getSchemaForTopic(topicName)
+        .map(
+            schema -> {
+              Schema result = new Schema();
+              result.setSubject(subject);
+              result.setVersion(1);
+              result.setId(_schemaRegistryService.getSchemaIdForTopic(topicName).get());
+              result.setSchema(schema.toString());
+              return new ResponseEntity<>(result, HttpStatus.OK);
+            })
+        .orElseGet(
+            () -> {
+              log.error("[SubjectsApi] getSchemaByVersion couldn't find topic {}.", topicName);
+              return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            });
   }
 
   @Override
@@ -129,8 +156,18 @@ public class SchemaRegistryController
   @Override
   public ResponseEntity<List<Integer>> listVersions(
       String subject, Boolean deleted, Boolean deletedOnly) {
-    log.error("[SubjectsApi] listVersions method not implemented");
-    return SubjectsApi.super.listVersions(subject, deleted, deletedOnly);
+    final String topicName = subject.replaceFirst("-value", "");
+    return _schemaRegistryService
+        .getSchemaForTopic(topicName)
+        .map(
+            schema -> {
+              return new ResponseEntity<>(Arrays.asList(1), HttpStatus.OK);
+            })
+        .orElseGet(
+            () -> {
+              log.error("[SubjectsApi] listVersions couldn't find topic with name {}.", topicName);
+              return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            });
   }
 
   @Override

--- a/metadata-service/schema-registry-servlet/src/main/java/io/datahubproject/openapi/schema/registry/SchemaRegistryController.java
+++ b/metadata-service/schema-registry-servlet/src/main/java/io/datahubproject/openapi/schema/registry/SchemaRegistryController.java
@@ -311,8 +311,9 @@ public class SchemaRegistryController
         .map(
             schema -> {
               SchemaString result = new SchemaString();
-              result.setMaxId(id);
-              result.setSchemaType("AVRO");
+              if (fetchMaxId) {
+                result.setMaxId(id);
+              }
               result.setSchema(schema.toString());
               return new ResponseEntity<>(result, HttpStatus.OK);
             })


### PR DESCRIPTION
- Implementation for the Schema Registry APIs [`/subjects/{subject}/versions/{version}`](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions-(versionId-%20version)) (`getSchemaByVersion`) and [`/subjects/{subject}/versions`](https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions) ( `listVersions`) which are used by [Apache Gobblin](https://gobblin.apache.org/) to get the latest version of a registered schema. Since schema versions are always `1`, these methods are rather straightforward. `getSchemaByVersion` with version `1` or `latest` returns the schema registered for a requested subject, otherwise it returns not found. `listVersions` returns version `1` if a schema registered with the requested subject exists, otherwise it returns not found.
- Since schemas are not registered with a `schemaType`, this field is not currently returned when an external Schema Registry is used and is thus removed from the response for compatibility. Additionally, the maxId field should only be returned when requested.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
