### PR TITLE
feat(roles): Add support for roles in groups in GMS

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/CreateGroupResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/CreateGroupResolver.java
@@ -43,9 +43,10 @@ public class CreateGroupResolver implements DataFetcher<CompletableFuture<String
             // Create the Group key.
             final CorpGroupKey key = new CorpGroupKey();
             final String id = input.getId() != null ? input.getId() : UUID.randomUUID().toString();
+            final String description = input.getDescription() != null ? input.getDescription() : "";
             key.setName(id); // 'name' in the key really reflects nothing more than a stable "id".
             return _groupService.createNativeGroup(
-                key, input.getName(), input.getDescription(), authentication);
+                key, input.getName(), description, authentication);
           } catch (Exception e) {
             throw new RuntimeException("Failed to create group", e);
           }

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/RoleMembership.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/RoleMembership.pdl
@@ -3,7 +3,7 @@ namespace com.linkedin.identity
 import com.linkedin.common.Urn
 
 /**
- * Carries information about which roles a user is assigned to.
+ * Carries information about which roles a user or group is assigned to.
  */
 @Aspect = {
   "name": "roleMembership"

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -184,6 +184,7 @@ entities:
       - ownership
       - status
       - origin
+      - roleMembership
   - name: domain
     doc: A data domain within an organization.
     category: core

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/PolicyEngineTest.java
@@ -83,7 +83,11 @@ public class PolicyEngineTest {
     when(_entityClient.batchGetV2(
             eq(CORP_USER_ENTITY_NAME),
             eq(Collections.singleton(authorizedUserUrn)),
-            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)),
+            eq(
+                ImmutableSet.of(
+                    ROLE_MEMBERSHIP_ASPECT_NAME,
+                    GROUP_MEMBERSHIP_ASPECT_NAME,
+                    NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)),
             any()))
         .thenReturn(authorizedEntityResponseMap);
 
@@ -94,7 +98,11 @@ public class PolicyEngineTest {
     when(_entityClient.batchGetV2(
             eq(CORP_USER_ENTITY_NAME),
             eq(Collections.singleton(unauthorizedUserUrn)),
-            eq(Collections.singleton(ROLE_MEMBERSHIP_ASPECT_NAME)),
+            eq(
+                ImmutableSet.of(
+                    ROLE_MEMBERSHIP_ASPECT_NAME,
+                    GROUP_MEMBERSHIP_ASPECT_NAME,
+                    NATIVE_GROUP_MEMBERSHIP_ASPECT_NAME)),
             any()))
         .thenReturn(unauthorizedEntityResponseMap);
 

--- a/smoke-test/tests/privileges/test_privileges.py
+++ b/smoke-test/tests/privileges/test_privileges.py
@@ -451,3 +451,63 @@ def test_privilege_to_create_and_manage_policies():
 
     # Ensure that user can't create a policy after privilege is removed by admin
     _ensure_cant_perform_action(user_session, create_policy,"createPolicy")
+
+
+@pytest.mark.dependency(depends=["test_healthchecks"])
+def test_privilege_from_group_role_can_create_and_manage_tokens():
+
+    (admin_user, admin_pass) = get_admin_credentials()
+    admin_session = login_as(admin_user, admin_pass)
+    user_session = login_as("user", "user")
+    secret_urn = "urn:li:dataHubSecret:TestSecretName"
+
+    # Verify new user can't create secrets
+    create_secret = {
+        "query": """mutation createSecret($input: CreateSecretInput!) {\n
+            createSecret(input: $input)\n}""",
+        "variables": {
+            "input":{
+                "name":"TestSecretName",
+                "value":"Test Secret Value",
+                "description":"Test Secret Description"
+            }
+        },
+    }
+    _ensure_cant_perform_action(user_session, create_secret,"createSecret")
+
+    # Create group and grant it the admin role.
+    group_urn = create_group(admin_session, "Test Group")
+
+    # Assign admin role to group
+    assign_role(admin_session,"urn:li:dataHubRole:Admin", [group_urn])
+
+    # Assign user to group
+    assign_user_to_group(admin_session, group_urn, ["urn:li:corpuser:user"])
+
+    # Verify new user with admin group can create and manage secrets
+    # Create a secret
+    _ensure_can_create_secret(user_session, create_secret, secret_urn)
+
+    # Remove a secret
+    remove_secret = {
+        "query": """mutation deleteSecret($urn: String!) {\n
+            deleteSecret(urn: $urn)\n}""",
+        "variables": {
+            "urn": secret_urn
+        },
+    }
+
+    remove_secret_response = user_session.post(f"{get_frontend_url()}/api/v2/graphql", json=remove_secret)
+    remove_secret_response.raise_for_status()
+    secret_data = remove_secret_response.json()
+
+    assert secret_data
+    assert secret_data["data"]
+    assert secret_data["data"]["deleteSecret"]
+    assert secret_data["data"]["deleteSecret"] == secret_urn
+
+    # Delete group which removes the user's admin capabilities
+    remove_group(admin_session, group_urn)
+
+    # Ensure user can't create secret after policy is removed
+    _ensure_cant_perform_action(user_session, create_secret,"createSecret")

--- a/smoke-test/tests/privileges/test_privileges.py
+++ b/smoke-test/tests/privileges/test_privileges.py
@@ -454,7 +454,7 @@ def test_privilege_to_create_and_manage_policies():
 
 
 @pytest.mark.dependency(depends=["test_healthchecks"])
-def test_privilege_from_group_role_can_create_and_manage_tokens():
+def test_privilege_from_group_role_can_create_and_manage_secret():
 
     (admin_user, admin_pass) = get_admin_credentials()
     admin_session = login_as(admin_user, admin_pass)

--- a/smoke-test/tests/privileges/utils.py
+++ b/smoke-test/tests/privileges/utils.py
@@ -262,37 +262,6 @@ def create_user_policy(user_urn, privileges, session):
     assert res_data["data"]["createPolicy"]
     return res_data["data"]["createPolicy"]
 
-def create_user_policy(user_urn, privileges, session):
-    policy = {
-        "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
-            createPolicy(input: $input) }""",
-        "variables": {
-            "input": {
-                "type": "PLATFORM",
-                "name": "Policy Name",
-                "description": "Policy Description",
-                "state": "ACTIVE",
-                "resources": {"filter":{"criteria":[]}},
-                "privileges": privileges,
-                "actors": {
-                    "users": [user_urn],
-                    "resourceOwners": False,
-                    "allUsers": False,
-                    "allGroups": False,
-                },
-            }
-        },
-    }
-
-    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=policy)
-    response.raise_for_status()
-    res_data = response.json()
-
-    assert res_data
-    assert res_data["data"]
-    assert res_data["data"]["createPolicy"]
-    return res_data["data"]["createPolicy"]
-
 def remove_policy(urn, session):
     remove_policy_json = {
         "query": """mutation deletePolicy($urn: String!) {\n

--- a/smoke-test/tests/privileges/utils.py
+++ b/smoke-test/tests/privileges/utils.py
@@ -170,6 +170,98 @@ def remove_user(session, urn):
     response.raise_for_status()
     return response.json()
 
+def create_group(session, name):
+    json = {
+        "query": """mutation createGroup($input: CreateGroupInput!) {\n
+            createGroup(input: $input)
+        }""",
+        "variables": {"input": {"name": name}},
+    }
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    response.raise_for_status()
+    res_data = response.json()
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["createGroup"]
+    return res_data["data"]["createGroup"]
+
+def remove_group(session, urn):
+    json = {
+        "query": """mutation removeGroup($urn: String!) {\n
+            removeGroup(urn: $urn)
+        }""",
+        "variables": {"urn": urn},
+    }
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    response.raise_for_status()
+    res_data = response.json()
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["removeGroup"]
+    return res_data["data"]["removeGroup"]
+
+def assign_user_to_group(session, group_urn, user_urns):
+    json = {
+        "query": """mutation addGroupMembers($groupUrn: String!, $userUrns: [String!]!) {\n
+            addGroupMembers(input: { groupUrn: $groupUrn, userUrns: $userUrns })
+        }""",
+        "variables": {"groupUrn": group_urn, "userUrns": user_urns},
+    }
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    response.raise_for_status()
+    res_data = response.json()
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["addGroupMembers"]
+    return res_data["data"]["addGroupMembers"]
+
+def assign_role(session, role_urn, actor_urns):
+    json = {
+        "query": """mutation batchAssignRole($input: BatchAssignRoleInput!) {\n
+            batchAssignRole(input: $input)
+        }""",
+        "variables": {"input": {"roleUrn": role_urn, "actors": actor_urns}},
+    }
+
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=json)
+    response.raise_for_status()
+    res_data = response.json()
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["batchAssignRole"]
+    return res_data["data"]["batchAssignRole"]
+
+def create_user_policy(user_urn, privileges, session):
+    policy = {
+        "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n
+            createPolicy(input: $input) }""",
+        "variables": {
+            "input": {
+                "type": "PLATFORM",
+                "name": "Policy Name",
+                "description": "Policy Description",
+                "state": "ACTIVE",
+                "resources": {"filter":{"criteria":[]}},
+                "privileges": privileges,
+                "actors": {
+                    "users": [user_urn],
+                    "resourceOwners": False,
+                    "allUsers": False,
+                    "allGroups": False,
+                },
+            }
+        },
+    }
+
+    response = session.post(f"{get_frontend_url()}/api/v2/graphql", json=policy)
+    response.raise_for_status()
+    res_data = response.json()
+
+    assert res_data
+    assert res_data["data"]
+    assert res_data["data"]["createPolicy"]
+    return res_data["data"]["createPolicy"]
+
 def create_user_policy(user_urn, privileges, session):
     policy = {
         "query": """mutation createPolicy($input: PolicyUpdateInput!) {\n


### PR DESCRIPTION
### Details
- Adds support for roles to be assigned roles by adding `roleMembership` aspect to the CorpGroup entity.
- Updates policy engine to check for roles assigned to the groups of a given actor by:
    - Quering for group membership (native and non-native) when resolving roles for a given actor alongside user role membership.
    - Batch quering for each group membership type for their respective role memberships.
    - Finally, merge all groups together and check permissions based on that.
- Fixes a bug in CreateGroupResolver which was not accounting for `description` to be an optional field when creating groups.

### Tests
- [x] Adds unit test in `DataHubAuthorizerTest` for new permission check. New test fails if policy engine logic does not account for group-level roles.
- [x] Adds smoke test for the feature.
- [x] Manual check in local deployment with a Loom Recording: https://www.loom.com/share/baa7e7ca835540e987dea740255ff209?sid=a3e2fdee-3b40-4af7-abf7-4997144607a6

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
