### PR TITLE
perf(entity-service): batch exists calls

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolver.java
@@ -24,10 +24,10 @@ import lombok.extern.slf4j.Slf4j;
 public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   public DeleteAssertionResolver(
-      final EntityClient entityClient, final EntityService entityService) {
+      final EntityClient entityClient, final EntityService<?> entityService) {
     _entityClient = entityClient;
     _entityService = entityService;
   }
@@ -41,7 +41,7 @@ public class DeleteAssertionResolver implements DataFetcher<CompletableFuture<Bo
         () -> {
 
           // 1. check the entity exists. If not, return false.
-          if (!_entityService.exists(assertionUrn)) {
+          if (!_entityService.exists(assertionUrn, true)) {
             return true;
           }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/deprecation/UpdateDeprecationResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/deprecation/UpdateDeprecationResolver.java
@@ -37,7 +37,7 @@ public class UpdateDeprecationResolver implements DataFetcher<CompletableFuture<
 
   private static final String EMPTY_STRING = "";
   private final EntityClient _entityClient;
-  private final EntityService
+  private final EntityService<?>
       _entityService; // TODO: Remove this when 'exists' added to EntityClient
 
   @Override
@@ -101,9 +101,10 @@ public class UpdateDeprecationResolver implements DataFetcher<CompletableFuture<
         orPrivilegeGroups);
   }
 
-  public static Boolean validateUpdateDeprecationInput(Urn entityUrn, EntityService entityService) {
+  public static Boolean validateUpdateDeprecationInput(
+      Urn entityUrn, EntityService<?> entityService) {
 
-    if (!entityService.exists(entityUrn)) {
+    if (!entityService.exists(entityUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to update deprecation for Entity %s. Entity does not exist.", entityUrn));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/SetDomainResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/SetDomainResolver.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SetDomainResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
-  private final EntityService
+  private final EntityService<?>
       _entityService; // TODO: Remove this when 'exists' added to EntityClient
 
   @Override
@@ -74,16 +74,16 @@ public class SetDomainResolver implements DataFetcher<CompletableFuture<Boolean>
   }
 
   public static Boolean validateSetDomainInput(
-      Urn entityUrn, Urn domainUrn, EntityService entityService) {
+      Urn entityUrn, Urn domainUrn, EntityService<?> entityService) {
 
-    if (!entityService.exists(domainUrn)) {
+    if (!entityService.exists(domainUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to add Entity %s to Domain %s. Domain does not exist.",
               entityUrn, domainUrn));
     }
 
-    if (!entityService.exists(entityUrn)) {
+    if (!entityService.exists(entityUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to add Entity %s to Domain %s. Entity does not exist.",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/UnsetDomainResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/domain/UnsetDomainResolver.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UnsetDomainResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
-  private final EntityService
+  private final EntityService<?>
       _entityService; // TODO: Remove this when 'exists' added to EntityClient
 
   @Override
@@ -71,9 +71,9 @@ public class UnsetDomainResolver implements DataFetcher<CompletableFuture<Boolea
         });
   }
 
-  public static Boolean validateUnsetDomainInput(Urn entityUrn, EntityService entityService) {
+  public static Boolean validateUnsetDomainInput(Urn entityUrn, EntityService<?> entityService) {
 
-    if (!entityService.exists(entityUrn)) {
+    if (!entityService.exists(entityUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to add Entity %s to Domain %s. Entity does not exist.", entityUrn));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolver.java
@@ -82,7 +82,7 @@ public class UpdateEmbedResolver implements DataFetcher<CompletableFuture<Boolea
    */
   private static void validateUpdateEmbedInput(
       @Nonnull final UpdateEmbedInput input, @Nonnull final EntityService entityService) {
-    if (!entityService.exists(UrnUtils.getUrn(input.getUrn()))) {
+    if (!entityService.exists(UrnUtils.getUrn(input.getUrn()), true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to update embed for entity with urn %s. Entity does not exist!",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolver.java
@@ -12,9 +12,9 @@ import java.util.concurrent.CompletableFuture;
 
 /** Resolver responsible for returning whether an entity exists. */
 public class EntityExistsResolver implements DataFetcher<CompletableFuture<Boolean>> {
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
-  public EntityExistsResolver(final EntityService entityService) {
+  public EntityExistsResolver(final EntityService<?> entityService) {
     _entityService = entityService;
   }
 
@@ -32,7 +32,7 @@ public class EntityExistsResolver implements DataFetcher<CompletableFuture<Boole
     return CompletableFuture.supplyAsync(
         () -> {
           try {
-            return _entityService.exists(entityUrn);
+            return _entityService.exists(entityUrn, true);
           } catch (Exception e) {
             throw new RuntimeException(
                 String.format("Failed to check whether entity %s exists", entityUrn.toString()));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolver.java
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AddRelatedTermsResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
@@ -91,7 +91,7 @@ public class AddRelatedTermsResolver implements DataFetcher<CompletableFuture<Bo
 
   public Boolean validateRelatedTermsInput(Urn urn, List<Urn> termUrns) {
     if (!urn.getEntityType().equals(Constants.GLOSSARY_TERM_ENTITY_NAME)
-        || !_entityService.exists(urn)) {
+        || !_entityService.exists(urn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to update %s. %s either does not exist or is not a glossaryTerm.", urn, urn));
@@ -104,7 +104,7 @@ public class AddRelatedTermsResolver implements DataFetcher<CompletableFuture<Bo
       } else if (!termUrn.getEntityType().equals(Constants.GLOSSARY_TERM_ENTITY_NAME)) {
         throw new IllegalArgumentException(
             String.format("Failed to update %s. %s is not a glossaryTerm.", urn, termUrn));
-      } else if (!_entityService.exists(termUrn)) {
+      } else if (!_entityService.exists(termUrn, true)) {
         throw new IllegalArgumentException(
             String.format("Failed to update %s. %s does not exist.", urn, termUrn));
       }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolver.java
@@ -15,10 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   public DeleteGlossaryEntityResolver(
-      final EntityClient entityClient, EntityService entityService) {
+      final EntityClient entityClient, EntityService<?> entityService) {
     _entityClient = entityClient;
     _entityService = entityService;
   }
@@ -33,7 +33,7 @@ public class DeleteGlossaryEntityResolver implements DataFetcher<CompletableFutu
     return CompletableFuture.supplyAsync(
         () -> {
           if (GlossaryUtils.canManageChildrenEntities(context, parentNodeUrn, _entityClient)) {
-            if (!_entityService.exists(entityUrn)) {
+            if (!_entityService.exists(entityUrn, true)) {
               throw new RuntimeException(String.format("This urn does not exist: %s", entityUrn));
             }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolver.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RemoveRelatedTermsResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
@@ -46,7 +46,7 @@ public class RemoveRelatedTermsResolver implements DataFetcher<CompletableFuture
                   input.getTermUrns().stream().map(UrnUtils::getUrn).collect(Collectors.toList());
 
               if (!urn.getEntityType().equals(Constants.GLOSSARY_TERM_ENTITY_NAME)
-                  || !_entityService.exists(urn)) {
+                  || !_entityService.exists(urn, true)) {
                 throw new IllegalArgumentException(
                     String.format(
                         "Failed to update %s. %s either does not exist or is not a glossaryTerm.",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lineage/UpdateLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lineage/UpdateLineageResolver.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UpdateLineageResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
   private final LineageService _lineageService;
 
   @Override
@@ -60,9 +60,11 @@ public class UpdateLineageResolver implements DataFetcher<CompletableFuture<Bool
 
     return CompletableFuture.supplyAsync(
         () -> {
+          final Set<Urn> existingDownstreamUrns = _entityService.exists(downstreamUrns, true);
+
           // build MCP for every downstreamUrn
           for (Urn downstreamUrn : downstreamUrns) {
-            if (!_entityService.exists(downstreamUrn)) {
+            if (!existingDownstreamUrns.contains(downstreamUrn)) {
               throw new IllegalArgumentException(
                   String.format(
                       "Cannot upsert lineage as downstream urn %s doesn't exist", downstreamUrn));
@@ -128,9 +130,11 @@ public class UpdateLineageResolver implements DataFetcher<CompletableFuture<Bool
           upstreamUrns.addAll(upstreamToDownstreamsToAdd.keySet());
           upstreamUrns.addAll(upstreamToDownstreamsToRemove.keySet());
 
+          final Set<Urn> existingUpstreamUrns = _entityService.exists(upstreamUrns, true);
+
           // build MCP for upstreamUrn if necessary
           for (Urn upstreamUrn : upstreamUrns) {
-            if (!_entityService.exists(upstreamUrn)) {
+            if (!existingUpstreamUrns.contains(upstreamUrn)) {
               throw new IllegalArgumentException(
                   String.format(
                       "Cannot upsert lineage as downstream urn %s doesn't exist", upstreamUrn));

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchUpdateSoftDeletedResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/BatchUpdateSoftDeletedResolver.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class BatchUpdateSoftDeletedResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
@@ -65,7 +65,7 @@ public class BatchUpdateSoftDeletedResolver implements DataFetcher<CompletableFu
       throw new AuthorizationException(
           "Unauthorized to perform this action. Please contact your DataHub administrator.");
     }
-    if (!_entityService.exists(urn)) {
+    if (!_entityService.exists(urn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to soft delete entity with urn %s. Entity does not exist.", urn));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
@@ -44,7 +44,7 @@ public class DescriptionUtils {
       Urn resourceUrn,
       String fieldPath,
       Urn actor,
-      EntityService entityService) {
+      EntityService<?> entityService) {
     EditableSchemaMetadata editableSchemaMetadata =
         (EditableSchemaMetadata)
             EntityUtils.getAspectFromEntity(
@@ -66,7 +66,7 @@ public class DescriptionUtils {
   }
 
   public static void updateContainerDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableContainerProperties containerProperties =
         (EditableContainerProperties)
             EntityUtils.getAspectFromEntity(
@@ -84,7 +84,7 @@ public class DescriptionUtils {
   }
 
   public static void updateDomainDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     DomainProperties domainProperties =
         (DomainProperties)
             EntityUtils.getAspectFromEntity(
@@ -107,7 +107,7 @@ public class DescriptionUtils {
   }
 
   public static void updateTagDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     TagProperties tagProperties =
         (TagProperties)
             EntityUtils.getAspectFromEntity(
@@ -123,7 +123,7 @@ public class DescriptionUtils {
   }
 
   public static void updateCorpGroupDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     CorpGroupEditableInfo corpGroupEditableInfo =
         (CorpGroupEditableInfo)
             EntityUtils.getAspectFromEntity(
@@ -143,7 +143,7 @@ public class DescriptionUtils {
   }
 
   public static void updateGlossaryTermDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     GlossaryTermInfo glossaryTermInfo =
         (GlossaryTermInfo)
             EntityUtils.getAspectFromEntity(
@@ -168,7 +168,7 @@ public class DescriptionUtils {
   }
 
   public static void updateGlossaryNodeDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     GlossaryNodeInfo glossaryNodeInfo =
         (GlossaryNodeInfo)
             EntityUtils.getAspectFromEntity(
@@ -189,7 +189,7 @@ public class DescriptionUtils {
   }
 
   public static void updateNotebookDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableNotebookProperties notebookProperties =
         (EditableNotebookProperties)
             EntityUtils.getAspectFromEntity(
@@ -212,8 +212,8 @@ public class DescriptionUtils {
       Urn resourceUrn,
       String subResource,
       SubResourceType subResourceType,
-      EntityService entityService) {
-    if (!entityService.exists(resourceUrn)) {
+      EntityService<?> entityService) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", resourceUrn, resourceUrn));
     }
@@ -223,8 +223,8 @@ public class DescriptionUtils {
     return true;
   }
 
-  public static Boolean validateDomainInput(Urn resourceUrn, EntityService entityService) {
-    if (!entityService.exists(resourceUrn)) {
+  public static Boolean validateDomainInput(Urn resourceUrn, EntityService<?> entityService) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", resourceUrn, resourceUrn));
     }
@@ -232,8 +232,8 @@ public class DescriptionUtils {
     return true;
   }
 
-  public static Boolean validateContainerInput(Urn resourceUrn, EntityService entityService) {
-    if (!entityService.exists(resourceUrn)) {
+  public static Boolean validateContainerInput(Urn resourceUrn, EntityService<?> entityService) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", resourceUrn, resourceUrn));
     }
@@ -241,24 +241,24 @@ public class DescriptionUtils {
     return true;
   }
 
-  public static Boolean validateLabelInput(Urn resourceUrn, EntityService entityService) {
-    if (!entityService.exists(resourceUrn)) {
+  public static Boolean validateLabelInput(Urn resourceUrn, EntityService<?> entityService) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", resourceUrn, resourceUrn));
     }
     return true;
   }
 
-  public static Boolean validateCorpGroupInput(Urn corpUserUrn, EntityService entityService) {
-    if (!entityService.exists(corpUserUrn)) {
+  public static Boolean validateCorpGroupInput(Urn corpUserUrn, EntityService<?> entityService) {
+    if (!entityService.exists(corpUserUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", corpUserUrn, corpUserUrn));
     }
     return true;
   }
 
-  public static Boolean validateNotebookInput(Urn notebookUrn, EntityService entityService) {
-    if (!entityService.exists(notebookUrn)) {
+  public static Boolean validateNotebookInput(Urn notebookUrn, EntityService<?> entityService) {
+    if (!entityService.exists(notebookUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", notebookUrn, notebookUrn));
     }
@@ -335,7 +335,7 @@ public class DescriptionUtils {
   }
 
   public static void updateMlModelDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableMLModelProperties editableProperties =
         (EditableMLModelProperties)
             EntityUtils.getAspectFromEntity(
@@ -355,7 +355,7 @@ public class DescriptionUtils {
   }
 
   public static void updateMlModelGroupDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableMLModelGroupProperties editableProperties =
         (EditableMLModelGroupProperties)
             EntityUtils.getAspectFromEntity(
@@ -375,7 +375,7 @@ public class DescriptionUtils {
   }
 
   public static void updateMlFeatureDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableMLFeatureProperties editableProperties =
         (EditableMLFeatureProperties)
             EntityUtils.getAspectFromEntity(
@@ -395,7 +395,7 @@ public class DescriptionUtils {
   }
 
   public static void updateMlFeatureTableDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableMLFeatureTableProperties editableProperties =
         (EditableMLFeatureTableProperties)
             EntityUtils.getAspectFromEntity(
@@ -415,7 +415,7 @@ public class DescriptionUtils {
   }
 
   public static void updateMlPrimaryKeyDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     EditableMLPrimaryKeyProperties editableProperties =
         (EditableMLPrimaryKeyProperties)
             EntityUtils.getAspectFromEntity(
@@ -435,7 +435,7 @@ public class DescriptionUtils {
   }
 
   public static void updateDataProductDescription(
-      String newDescription, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String newDescription, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     DataProductProperties properties =
         (DataProductProperties)
             EntityUtils.getAspectFromEntity(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MoveDomainResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MoveDomainResolver.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MoveDomainResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
   private final EntityClient _entityClient;
 
   @Override
@@ -67,7 +67,7 @@ public class MoveDomainResolver implements DataFetcher<CompletableFuture<Boolean
               if (!newParentDomainUrn.getEntityType().equals(Constants.DOMAIN_ENTITY_NAME)) {
                 throw new IllegalArgumentException("Parent entity is not a domain.");
               }
-              if (!_entityService.exists(newParentDomainUrn)) {
+              if (!_entityService.exists(newParentDomainUrn, true)) {
                 throw new IllegalArgumentException("Parent entity does not exist.");
               }
             }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateNameResolver.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
   private final EntityClient _entityClient;
 
   @Override
@@ -47,7 +47,7 @@ public class UpdateNameResolver implements DataFetcher<CompletableFuture<Boolean
 
     return CompletableFuture.supplyAsync(
         () -> {
-          if (!_entityService.exists(targetUrn)) {
+          if (!_entityService.exists(targetUrn, true)) {
             throw new IllegalArgumentException(
                 String.format("Failed to update %s. %s does not exist.", targetUrn, targetUrn));
           }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateParentNodeResolver.java
@@ -26,7 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
   private final EntityClient _entityClient;
 
   @Override
@@ -37,7 +37,7 @@ public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<B
     Urn targetUrn = Urn.createFromString(input.getResourceUrn());
     log.info("Updating parent node. input: {}", input.toString());
 
-    if (!_entityService.exists(targetUrn)) {
+    if (!_entityService.exists(targetUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to update %s. %s does not exist.", targetUrn, targetUrn));
     }
@@ -45,7 +45,7 @@ public class UpdateParentNodeResolver implements DataFetcher<CompletableFuture<B
     GlossaryNodeUrn parentNodeUrn = null;
     if (input.getParentNode() != null) {
       parentNodeUrn = GlossaryNodeUrn.createFromString(input.getParentNode());
-      if (!_entityService.exists(parentNodeUrn)
+      if (!_entityService.exists(parentNodeUrn, true)
           || !parentNodeUrn.getEntityType().equals(Constants.GLOSSARY_NODE_ENTITY_NAME)) {
         throw new IllegalArgumentException(
             String.format(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DomainUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/DomainUtils.java
@@ -77,7 +77,7 @@ public class DomainUtils {
       @Nullable Urn domainUrn,
       List<ResourceRefInput> resources,
       Urn actor,
-      EntityService entityService)
+      EntityService<?> entityService)
       throws Exception {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
     for (ResourceRefInput resource : resources) {
@@ -87,7 +87,10 @@ public class DomainUtils {
   }
 
   private static MetadataChangeProposal buildSetDomainProposal(
-      @Nullable Urn domainUrn, ResourceRefInput resource, Urn actor, EntityService entityService) {
+      @Nullable Urn domainUrn,
+      ResourceRefInput resource,
+      Urn actor,
+      EntityService<?> entityService) {
     Domains domains =
         (Domains)
             EntityUtils.getAspectFromEntity(
@@ -104,8 +107,8 @@ public class DomainUtils {
         UrnUtils.getUrn(resource.getResourceUrn()), Constants.DOMAINS_ASPECT_NAME, domains);
   }
 
-  public static void validateDomain(Urn domainUrn, EntityService entityService) {
-    if (!entityService.exists(domainUrn)) {
+  public static void validateDomain(Urn domainUrn, EntityService<?> entityService) {
+    if (!entityService.exists(domainUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to validate Domain with urn %s. Urn does not exist.", domainUrn));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
@@ -42,7 +42,11 @@ public class LabelUtils {
   private LabelUtils() {}
 
   public static void removeTermFromResource(
-      Urn labelUrn, Urn resourceUrn, String subResource, Urn actor, EntityService entityService) {
+      Urn labelUrn,
+      Urn resourceUrn,
+      String subResource,
+      Urn actor,
+      EntityService<?> entityService) {
     if (subResource == null || subResource.equals("")) {
       com.linkedin.common.GlossaryTerms terms =
           (com.linkedin.common.GlossaryTerms)
@@ -80,7 +84,7 @@ public class LabelUtils {
   }
 
   public static void removeTagsFromResources(
-      List<Urn> tags, List<ResourceRefInput> resources, Urn actor, EntityService entityService)
+      List<Urn> tags, List<ResourceRefInput> resources, Urn actor, EntityService<?> entityService)
       throws Exception {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
     for (ResourceRefInput resource : resources) {
@@ -90,7 +94,10 @@ public class LabelUtils {
   }
 
   public static void addTagsToResources(
-      List<Urn> tagUrns, List<ResourceRefInput> resources, Urn actor, EntityService entityService)
+      List<Urn> tagUrns,
+      List<ResourceRefInput> resources,
+      Urn actor,
+      EntityService<?> entityService)
       throws Exception {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
     for (ResourceRefInput resource : resources) {
@@ -100,7 +107,10 @@ public class LabelUtils {
   }
 
   public static void removeTermsFromResources(
-      List<Urn> termUrns, List<ResourceRefInput> resources, Urn actor, EntityService entityService)
+      List<Urn> termUrns,
+      List<ResourceRefInput> resources,
+      Urn actor,
+      EntityService<?> entityService)
       throws Exception {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
     for (ResourceRefInput resource : resources) {
@@ -110,7 +120,10 @@ public class LabelUtils {
   }
 
   public static void addTermsToResources(
-      List<Urn> termUrns, List<ResourceRefInput> resources, Urn actor, EntityService entityService)
+      List<Urn> termUrns,
+      List<ResourceRefInput> resources,
+      Urn actor,
+      EntityService<?> entityService)
       throws Exception {
     final List<MetadataChangeProposal> changes = new ArrayList<>();
     for (ResourceRefInput resource : resources) {
@@ -124,7 +137,7 @@ public class LabelUtils {
       Urn resourceUrn,
       String subResource,
       Urn actor,
-      EntityService entityService)
+      EntityService<?> entityService)
       throws URISyntaxException {
     if (subResource == null || subResource.equals("")) {
       com.linkedin.common.GlossaryTerms terms =
@@ -248,7 +261,7 @@ public class LabelUtils {
       String subResource,
       SubResourceType subResourceType,
       String labelEntityType,
-      EntityService entityService,
+      EntityService<?> entityService,
       Boolean isRemoving) {
     for (Urn urn : labelUrns) {
       validateResourceAndLabel(
@@ -263,14 +276,14 @@ public class LabelUtils {
   }
 
   public static void validateLabel(
-      Urn labelUrn, String labelEntityType, EntityService entityService) {
+      Urn labelUrn, String labelEntityType, EntityService<?> entityService) {
     if (!labelUrn.getEntityType().equals(labelEntityType)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to validate label with urn %s. Urn type does not match entity type %s..",
               labelUrn, labelEntityType));
     }
-    if (!entityService.exists(labelUrn)) {
+    if (!entityService.exists(labelUrn, true)) {
       throw new IllegalArgumentException(
           String.format("Failed to validate label with urn %s. Urn does not exist.", labelUrn));
     }
@@ -281,8 +294,8 @@ public class LabelUtils {
       Urn resourceUrn,
       String subResource,
       SubResourceType subResourceType,
-      EntityService entityService) {
-    if (!entityService.exists(resourceUrn)) {
+      EntityService<?> entityService) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to update resource with urn %s. Entity does not exist.", resourceUrn));
@@ -310,7 +323,7 @@ public class LabelUtils {
       String subResource,
       SubResourceType subResourceType,
       String labelEntityType,
-      EntityService entityService,
+      EntityService<?> entityService,
       Boolean isRemoving) {
     if (!isRemoving) {
       validateLabel(labelUrn, labelEntityType, entityService);
@@ -319,7 +332,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildAddTagsProposal(
-      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     if (resource.getSubResource() == null || resource.getSubResource().equals("")) {
       // Case 1: Adding tags to a top-level entity
@@ -331,7 +344,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildRemoveTagsProposal(
-      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     if (resource.getSubResource() == null || resource.getSubResource().equals("")) {
       // Case 1: Adding tags to a top-level entity
@@ -343,7 +356,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildRemoveTagsToEntityProposal(
-      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService entityService) {
+      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService) {
     com.linkedin.common.GlobalTags tags =
         (com.linkedin.common.GlobalTags)
             EntityUtils.getAspectFromEntity(
@@ -361,7 +374,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildRemoveTagsToSubResourceProposal(
-      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService entityService) {
+      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService) {
     com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
         (com.linkedin.schema.EditableSchemaMetadata)
             EntityUtils.getAspectFromEntity(
@@ -383,7 +396,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildAddTagsToEntityProposal(
-      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     com.linkedin.common.GlobalTags tags =
         (com.linkedin.common.GlobalTags)
@@ -402,7 +415,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildAddTagsToSubResourceProposal(
-      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> tagUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
         (com.linkedin.schema.EditableSchemaMetadata)
@@ -455,7 +468,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildAddTermsProposal(
-      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     if (resource.getSubResource() == null || resource.getSubResource().equals("")) {
       // Case 1: Adding terms to a top-level entity
@@ -467,7 +480,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildRemoveTermsProposal(
-      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     if (resource.getSubResource() == null || resource.getSubResource().equals("")) {
       // Case 1: Removing terms from a top-level entity
@@ -479,7 +492,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildAddTermsToEntityProposal(
-      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     com.linkedin.common.GlossaryTerms terms =
         (com.linkedin.common.GlossaryTerms)
@@ -500,7 +513,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildAddTermsToSubResourceProposal(
-      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService entityService)
+      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService)
       throws URISyntaxException {
     com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
         (com.linkedin.schema.EditableSchemaMetadata)
@@ -526,7 +539,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildRemoveTermsToEntityProposal(
-      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService entityService) {
+      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService) {
     com.linkedin.common.GlossaryTerms terms =
         (com.linkedin.common.GlossaryTerms)
             EntityUtils.getAspectFromEntity(
@@ -542,7 +555,7 @@ public class LabelUtils {
   }
 
   private static MetadataChangeProposal buildRemoveTermsToSubResourceProposal(
-      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService entityService) {
+      List<Urn> termUrns, ResourceRefInput resource, Urn actor, EntityService<?> entityService) {
     com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
         (com.linkedin.schema.EditableSchemaMetadata)
             EntityUtils.getAspectFromEntity(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtils.java
@@ -28,7 +28,11 @@ public class LinkUtils {
   private LinkUtils() {}
 
   public static void addLink(
-      String linkUrl, String linkLabel, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String linkUrl,
+      String linkLabel,
+      Urn resourceUrn,
+      Urn actor,
+      EntityService<?> entityService) {
     InstitutionalMemory institutionalMemoryAspect =
         (InstitutionalMemory)
             EntityUtils.getAspectFromEntity(
@@ -46,7 +50,7 @@ public class LinkUtils {
   }
 
   public static void removeLink(
-      String linkUrl, Urn resourceUrn, Urn actor, EntityService entityService) {
+      String linkUrl, Urn resourceUrn, Urn actor, EntityService<?> entityService) {
     InstitutionalMemory institutionalMemoryAspect =
         (InstitutionalMemory)
             EntityUtils.getAspectFromEntity(
@@ -109,7 +113,7 @@ public class LinkUtils {
   }
 
   public static Boolean validateAddRemoveInput(
-      String linkUrl, Urn resourceUrn, EntityService entityService) {
+      String linkUrl, Urn resourceUrn, EntityService<?> entityService) {
 
     try {
       new Url(linkUrl);
@@ -120,7 +124,7 @@ public class LinkUtils {
               resourceUrn));
     }
 
-    if (!entityService.exists(resourceUrn)) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change institutional memory for resource %s. Resource does not exist.",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -202,16 +202,16 @@ public class OwnerUtils {
   }
 
   public static void validateAddOwnerInput(
-      List<OwnerInput> owners, Urn resourceUrn, EntityService entityService) {
+      List<OwnerInput> owners, Urn resourceUrn, EntityService<?> entityService) {
     for (OwnerInput owner : owners) {
       validateAddOwnerInput(owner, resourceUrn, entityService);
     }
   }
 
   public static void validateAddOwnerInput(
-      OwnerInput owner, Urn resourceUrn, EntityService entityService) {
+      OwnerInput owner, Urn resourceUrn, EntityService<?> entityService) {
 
-    if (!entityService.exists(resourceUrn)) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource %s. Resource does not exist.", resourceUrn));
@@ -220,7 +220,7 @@ public class OwnerUtils {
     validateOwner(owner, entityService);
   }
 
-  public static void validateOwner(OwnerInput owner, EntityService entityService) {
+  public static void validateOwner(OwnerInput owner, EntityService<?> entityService) {
 
     OwnerEntityType ownerEntityType = owner.getOwnerEntityType();
     Urn ownerUrn = UrnUtils.getUrn(owner.getOwnerUrn());
@@ -241,7 +241,7 @@ public class OwnerUtils {
               ownerUrn));
     }
 
-    if (!entityService.exists(ownerUrn)) {
+    if (!entityService.exists(ownerUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource(s). Owner with urn %s does not exist.",
@@ -249,7 +249,7 @@ public class OwnerUtils {
     }
 
     if (owner.getOwnershipTypeUrn() != null
-        && !entityService.exists(UrnUtils.getUrn(owner.getOwnershipTypeUrn()))) {
+        && !entityService.exists(UrnUtils.getUrn(owner.getOwnershipTypeUrn()), true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource(s). Custom Ownership type with "
@@ -264,8 +264,8 @@ public class OwnerUtils {
     }
   }
 
-  public static void validateRemoveInput(Urn resourceUrn, EntityService entityService) {
-    if (!entityService.exists(resourceUrn)) {
+  public static void validateRemoveInput(Urn resourceUrn, EntityService<?> entityService) {
+    if (!entityService.exists(resourceUrn, true)) {
       throw new IllegalArgumentException(
           String.format(
               "Failed to change ownership for resource %s. Resource does not exist.", resourceUrn));
@@ -276,17 +276,18 @@ public class OwnerUtils {
       QueryContext context,
       String urn,
       OwnerEntityType ownerEntityType,
-      EntityService entityService) {
+      EntityService<?> entityService) {
     try {
       Urn actorUrn = CorpuserUrn.createFromString(context.getActorUrn());
       OwnershipType ownershipType = OwnershipType.TECHNICAL_OWNER;
-      if (!entityService.exists(UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())))) {
+      if (!entityService.exists(
+          UrnUtils.getUrn(mapOwnershipTypeToEntity(ownershipType.name())), true)) {
         log.warn("Technical owner does not exist, defaulting to None ownership.");
         ownershipType = OwnershipType.NONE;
       }
       String ownershipTypeUrn = mapOwnershipTypeToEntity(ownershipType.name());
 
-      if (!entityService.exists(UrnUtils.getUrn(ownershipTypeUrn))) {
+      if (!entityService.exists(UrnUtils.getUrn(ownershipTypeUrn), true)) {
         throw new RuntimeException(
             String.format("Unknown ownership type urn %s", ownershipTypeUrn));
       }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/tag/SetTagColorResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/tag/SetTagColorResolver.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SetTagColorResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityClient _entityClient;
-  private final EntityService
+  private final EntityService<?>
       _entityService; // TODO: Remove this when 'exists' added to EntityClient
 
   @Override
@@ -53,7 +53,7 @@ public class SetTagColorResolver implements DataFetcher<CompletableFuture<Boolea
           }
 
           // If tag does not exist, then throw exception.
-          if (!_entityService.exists(tagUrn)) {
+          if (!_entityService.exists(tagUrn, true)) {
             throw new IllegalArgumentException(
                 String.format("Failed to set Tag %s color. Tag does not exist.", tagUrn));
           }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/HyperParameterValueTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/HyperParameterValueTypeMapper.java
@@ -33,7 +33,7 @@ public class HyperParameterValueTypeMapper
     } else if (input.isDouble()) {
       result = new FloatBox(input.getDouble());
     } else if (input.isFloat()) {
-      result = new FloatBox(new Double(input.getFloat()));
+      result = new FloatBox(Double.valueOf(input.getFloat()));
     } else {
       throw new RuntimeException("Type is not one of the Union Types, Type: " + input.toString());
     }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/UpdateLineageResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/UpdateLineageResolverTest.java
@@ -2,10 +2,11 @@ package com.linkedin.datahub.graphql.resolvers;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
-import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.LineageEdge;
@@ -16,8 +17,10 @@ import com.linkedin.metadata.service.LineageService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import org.joda.time.DateTimeUtils;
 import org.mockito.Mockito;
@@ -64,10 +67,8 @@ public class UpdateLineageResolverTest {
     mockInputAndContext(edgesToAdd, edgesToRemove);
     UpdateLineageResolver resolver = new UpdateLineageResolver(_mockService, _lineageService);
 
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_1))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_2))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_3))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_4))).thenReturn(true);
+    Mockito.when(_mockService.exists(any(Collection.class), eq(true)))
+        .thenAnswer(args -> args.getArgument(0));
 
     assertTrue(resolver.get(_mockEnv).get());
   }
@@ -79,8 +80,7 @@ public class UpdateLineageResolverTest {
     mockInputAndContext(edgesToAdd, new ArrayList<>());
     UpdateLineageResolver resolver = new UpdateLineageResolver(_mockService, _lineageService);
 
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_1))).thenReturn(false);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_2))).thenReturn(false);
+    Mockito.when(_mockService.exists(any(Collection.class), eq(true))).thenAnswer(args -> Set.of());
 
     assertThrows(CompletionException.class, () -> resolver.get(_mockEnv).join());
   }
@@ -93,9 +93,8 @@ public class UpdateLineageResolverTest {
     mockInputAndContext(edgesToAdd, edgesToRemove);
     UpdateLineageResolver resolver = new UpdateLineageResolver(_mockService, _lineageService);
 
-    Mockito.when(_mockService.exists(Urn.createFromString(CHART_URN))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_2))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_1))).thenReturn(true);
+    Mockito.when(_mockService.exists(any(Collection.class), eq(true)))
+        .thenAnswer(args -> args.getArgument(0));
 
     assertTrue(resolver.get(_mockEnv).get());
   }
@@ -112,10 +111,8 @@ public class UpdateLineageResolverTest {
     mockInputAndContext(edgesToAdd, edgesToRemove);
     UpdateLineageResolver resolver = new UpdateLineageResolver(_mockService, _lineageService);
 
-    Mockito.when(_mockService.exists(Urn.createFromString(DASHBOARD_URN))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_2))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_1))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(CHART_URN))).thenReturn(true);
+    Mockito.when(_mockService.exists(any(Collection.class), eq(true)))
+        .thenAnswer(args -> args.getArgument(0));
 
     assertTrue(resolver.get(_mockEnv).get());
   }
@@ -133,11 +130,8 @@ public class UpdateLineageResolverTest {
     mockInputAndContext(edgesToAdd, edgesToRemove);
     UpdateLineageResolver resolver = new UpdateLineageResolver(_mockService, _lineageService);
 
-    Mockito.when(_mockService.exists(Urn.createFromString(DATAJOB_URN_1))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_2))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATAJOB_URN_2))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_1))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_3))).thenReturn(true);
+    Mockito.when(_mockService.exists(any(Collection.class), eq(true)))
+        .thenAnswer(args -> args.getArgument(0));
 
     assertTrue(resolver.get(_mockEnv).get());
   }
@@ -153,15 +147,13 @@ public class UpdateLineageResolverTest {
 
     QueryContext mockContext = getMockDenyContext();
     UpdateLineageInput input = new UpdateLineageInput(edgesToAdd, edgesToRemove);
-    Mockito.when(_mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(_mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(_mockEnv.getContext()).thenReturn(mockContext);
 
     UpdateLineageResolver resolver = new UpdateLineageResolver(_mockService, _lineageService);
 
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_1))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_2))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_3))).thenReturn(true);
-    Mockito.when(_mockService.exists(Urn.createFromString(DATASET_URN_4))).thenReturn(true);
+    Mockito.when(_mockService.exists(any(Collection.class), eq(true)))
+        .thenAnswer(args -> args.getArgument(0));
 
     assertThrows(AuthorizationException.class, () -> resolver.get(_mockEnv).join());
   }
@@ -169,7 +161,7 @@ public class UpdateLineageResolverTest {
   private void mockInputAndContext(List<LineageEdge> edgesToAdd, List<LineageEdge> edgesToRemove) {
     QueryContext mockContext = getMockAllowContext();
     UpdateLineageInput input = new UpdateLineageInput(edgesToAdd, edgesToRemove);
-    Mockito.when(_mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(_mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(_mockEnv.getContext()).thenReturn(mockContext);
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.assertion;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Authentication;
@@ -31,7 +32,8 @@ public class DeleteAssertionResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ASSERTION_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
+        .thenReturn(true);
     Mockito.when(
             mockService.getAspect(
                 Urn.createFromString(TEST_ASSERTION_URN), Constants.ASSERTION_INFO_ASPECT_NAME, 0L))
@@ -49,24 +51,23 @@ public class DeleteAssertionResolverTest {
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN);
+    Mockito.when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ASSERTION_URN);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertTrue(resolver.get(mockEnv).get());
 
     Mockito.verify(mockClient, Mockito.times(1))
         .deleteEntity(
-            Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)),
-            Mockito.any(Authentication.class));
+            eq(Urn.createFromString(TEST_ASSERTION_URN)), Mockito.any(Authentication.class));
 
     Mockito.verify(mockService, Mockito.times(1))
         .getAspect(
-            Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)),
-            Mockito.eq(Constants.ASSERTION_INFO_ASPECT_NAME),
-            Mockito.eq(0L));
+            eq(Urn.createFromString(TEST_ASSERTION_URN)),
+            eq(Constants.ASSERTION_INFO_ASPECT_NAME),
+            eq(0L));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)));
+        .exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true));
   }
 
   @Test
@@ -74,7 +75,8 @@ public class DeleteAssertionResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ASSERTION_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
+        .thenReturn(true);
     Mockito.when(
             mockService.getAspect(
                 Urn.createFromString(TEST_ASSERTION_URN), Constants.ASSERTION_INFO_ASPECT_NAME, 0L))
@@ -85,24 +87,23 @@ public class DeleteAssertionResolverTest {
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN);
+    Mockito.when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ASSERTION_URN);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertTrue(resolver.get(mockEnv).get());
 
     Mockito.verify(mockClient, Mockito.times(1))
         .deleteEntity(
-            Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)),
-            Mockito.any(Authentication.class));
+            eq(Urn.createFromString(TEST_ASSERTION_URN)), Mockito.any(Authentication.class));
 
     Mockito.verify(mockService, Mockito.times(1))
         .getAspect(
-            Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)),
-            Mockito.eq(Constants.ASSERTION_INFO_ASPECT_NAME),
-            Mockito.eq(0L));
+            eq(Urn.createFromString(TEST_ASSERTION_URN)),
+            eq(Constants.ASSERTION_INFO_ASPECT_NAME),
+            eq(0L));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)));
+        .exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true));
   }
 
   @Test
@@ -111,32 +112,32 @@ public class DeleteAssertionResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ASSERTION_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
+        .thenReturn(false);
 
     DeleteAssertionResolver resolver = new DeleteAssertionResolver(mockClient, mockService);
 
     // Execute resolver
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN);
+    Mockito.when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ASSERTION_URN);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertTrue(resolver.get(mockEnv).get());
 
     Mockito.verify(mockClient, Mockito.times(0))
         .deleteEntity(
-            Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)),
-            Mockito.any(Authentication.class));
+            eq(Urn.createFromString(TEST_ASSERTION_URN)), Mockito.any(Authentication.class));
 
     Mockito.verify(mockClient, Mockito.times(0))
         .batchGetV2(
-            Mockito.eq(Constants.ASSERTION_ENTITY_NAME),
-            Mockito.eq(ImmutableSet.of(Urn.createFromString(TEST_ASSERTION_URN))),
-            Mockito.eq(ImmutableSet.of(Constants.ASSERTION_INFO_ASPECT_NAME)),
+            eq(Constants.ASSERTION_ENTITY_NAME),
+            eq(ImmutableSet.of(Urn.createFromString(TEST_ASSERTION_URN))),
+            eq(ImmutableSet.of(Constants.ASSERTION_INFO_ASPECT_NAME)),
             Mockito.any(Authentication.class));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ASSERTION_URN)));
+        .exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true));
   }
 
   @Test
@@ -144,7 +145,8 @@ public class DeleteAssertionResolverTest {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ASSERTION_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
+        .thenReturn(true);
     Mockito.when(
             mockService.getAspect(
                 Urn.createFromString(TEST_ASSERTION_URN), Constants.ASSERTION_INFO_ASPECT_NAME, 0L))
@@ -161,7 +163,7 @@ public class DeleteAssertionResolverTest {
 
     // Execute resolver
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN);
+    Mockito.when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ASSERTION_URN);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -178,14 +180,15 @@ public class DeleteAssertionResolverTest {
         .deleteEntity(Mockito.any(), Mockito.any(Authentication.class));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ASSERTION_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
+        .thenReturn(true);
 
     DeleteAssertionResolver resolver = new DeleteAssertionResolver(mockClient, mockService);
 
     // Execute resolver
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     QueryContext mockContext = getMockAllowContext();
-    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_ASSERTION_URN);
+    Mockito.when(mockEnv.getArgument(eq("urn"))).thenReturn(TEST_ASSERTION_URN);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.delete;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -47,8 +48,10 @@ public class BatchUpdateSoftDeletedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 
@@ -94,8 +97,10 @@ public class BatchUpdateSoftDeletedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalStatus);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 
@@ -138,8 +143,10 @@ public class BatchUpdateSoftDeletedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/BatchUpdateDeprecationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/BatchUpdateDeprecationResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.deprecation;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -48,8 +49,10 @@ public class BatchUpdateDeprecationResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 
@@ -109,8 +112,10 @@ public class BatchUpdateDeprecationResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalDeprecation);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 
@@ -163,8 +168,10 @@ public class BatchUpdateDeprecationResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/UpdateDeprecationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/UpdateDeprecationResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.deprecation;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Authentication;
@@ -45,9 +46,9 @@ public class UpdateDeprecationResolverTest {
 
     Mockito.when(
             mockClient.batchGetV2(
-                Mockito.eq(Constants.DATASET_ENTITY_NAME),
-                Mockito.eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
-                Mockito.eq(ImmutableSet.of(Constants.DEPRECATION_ASPECT_NAME)),
+                eq(Constants.DATASET_ENTITY_NAME),
+                eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
+                eq(ImmutableSet.of(Constants.DEPRECATION_ASPECT_NAME)),
                 Mockito.any(Authentication.class)))
         .thenReturn(
             ImmutableMap.of(
@@ -58,7 +59,8 @@ public class UpdateDeprecationResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     UpdateDeprecationResolver resolver = new UpdateDeprecationResolver(mockClient, mockService);
 
@@ -66,7 +68,7 @@ public class UpdateDeprecationResolverTest {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     resolver.get(mockEnv).get();
 
@@ -81,10 +83,10 @@ public class UpdateDeprecationResolverTest {
             UrnUtils.getUrn(TEST_ENTITY_URN), DEPRECATION_ASPECT_NAME, newDeprecation);
 
     Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
+        .ingestProposal(eq(proposal), Mockito.any(Authentication.class), eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -101,9 +103,9 @@ public class UpdateDeprecationResolverTest {
 
     Mockito.when(
             mockClient.batchGetV2(
-                Mockito.eq(Constants.DATASET_ENTITY_NAME),
-                Mockito.eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
-                Mockito.eq(ImmutableSet.of(Constants.DEPRECATION_ASPECT_NAME)),
+                eq(Constants.DATASET_ENTITY_NAME),
+                eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
+                eq(ImmutableSet.of(Constants.DEPRECATION_ASPECT_NAME)),
                 Mockito.any(Authentication.class)))
         .thenReturn(
             ImmutableMap.of(
@@ -119,7 +121,8 @@ public class UpdateDeprecationResolverTest {
                                     .setValue(new Aspect(originalDeprecation.data())))))));
 
     EntityService mockService = Mockito.mock(EntityService.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     UpdateDeprecationResolver resolver = new UpdateDeprecationResolver(mockClient, mockService);
 
@@ -127,7 +130,7 @@ public class UpdateDeprecationResolverTest {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     resolver.get(mockEnv).get();
 
@@ -142,10 +145,10 @@ public class UpdateDeprecationResolverTest {
             UrnUtils.getUrn(TEST_ENTITY_URN), DEPRECATION_ASPECT_NAME, newDeprecation);
 
     Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
+        .ingestProposal(eq(proposal), Mockito.any(Authentication.class), eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -155,9 +158,9 @@ public class UpdateDeprecationResolverTest {
 
     Mockito.when(
             mockClient.batchGetV2(
-                Mockito.eq(Constants.DATASET_ENTITY_NAME),
-                Mockito.eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
-                Mockito.eq(ImmutableSet.of(Constants.DEPRECATION_ASPECT_NAME)),
+                eq(Constants.DATASET_ENTITY_NAME),
+                eq(new HashSet<>(ImmutableSet.of(Urn.createFromString(TEST_ENTITY_URN)))),
+                eq(ImmutableSet.of(Constants.DEPRECATION_ASPECT_NAME)),
                 Mockito.any(Authentication.class)))
         .thenReturn(
             ImmutableMap.of(
@@ -168,7 +171,8 @@ public class UpdateDeprecationResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = Mockito.mock(EntityService.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
 
     UpdateDeprecationResolver resolver = new UpdateDeprecationResolver(mockClient, mockService);
 
@@ -176,7 +180,7 @@ public class UpdateDeprecationResolverTest {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -193,7 +197,7 @@ public class UpdateDeprecationResolverTest {
 
     // Execute resolver
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -214,7 +218,7 @@ public class UpdateDeprecationResolverTest {
     // Execute resolver
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     QueryContext mockContext = getMockAllowContext();
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(TEST_DEPRECATION_INPUT);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/BatchSetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/BatchSetDomainResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -53,11 +54,15 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService);
 
@@ -88,7 +93,7 @@ public class BatchSetDomainResolverTest {
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_DOMAIN_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true));
   }
 
   @Test
@@ -113,11 +118,15 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalDomain);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService);
 
@@ -153,7 +162,7 @@ public class BatchSetDomainResolverTest {
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_DOMAIN_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true));
   }
 
   @Test
@@ -178,11 +187,15 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalDomain);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService);
 
@@ -222,8 +235,10 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_1_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
+        .thenReturn(false);
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService);
 
@@ -260,9 +275,12 @@ public class BatchSetDomainResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_DOMAIN_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_DOMAIN_1_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/MoveDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/MoveDomainResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -73,7 +74,8 @@ public class MoveDomainResolverTest {
   public void testGetSuccess() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(PARENT_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
@@ -92,7 +94,8 @@ public class MoveDomainResolverTest {
   public void testGetFailureEntityDoesNotExist() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(PARENT_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
@@ -115,7 +118,8 @@ public class MoveDomainResolverTest {
   public void testGetFailureParentDoesNotExist() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(PARENT_DOMAIN_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
+        .thenReturn(false);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
@@ -130,7 +134,8 @@ public class MoveDomainResolverTest {
   public void testGetFailureParentIsNotDomain() throws Exception {
     EntityService mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(PARENT_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INVALID_INPUT);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/SetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/SetDomainResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Authentication;
@@ -58,8 +59,10 @@ public class SetDomainResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_NEW_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
 
     SetDomainResolver resolver = new SetDomainResolver(mockClient, mockService);
 
@@ -82,10 +85,10 @@ public class SetDomainResolverTest {
         .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true));
   }
 
   @Test
@@ -119,8 +122,10 @@ public class SetDomainResolverTest {
                                     .setValue(new Aspect(originalDomains.data())))))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_NEW_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
 
     SetDomainResolver resolver = new SetDomainResolver(mockClient, mockService);
 
@@ -143,10 +148,10 @@ public class SetDomainResolverTest {
         .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true));
   }
 
   @Test
@@ -170,8 +175,10 @@ public class SetDomainResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_NEW_DOMAIN_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
+        .thenReturn(false);
 
     SetDomainResolver resolver = new SetDomainResolver(mockClient, mockService);
 
@@ -208,8 +215,10 @@ public class SetDomainResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_NEW_DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
 
     SetDomainResolver resolver = new SetDomainResolver(mockClient, mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/UnsetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/UnsetDomainResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.domain;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Authentication;
@@ -57,7 +58,8 @@ public class UnsetDomainResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     UnsetDomainResolver resolver = new UnsetDomainResolver(mockClient, mockService);
 
@@ -77,7 +79,7 @@ public class UnsetDomainResolverTest {
         .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -111,7 +113,8 @@ public class UnsetDomainResolverTest {
                                     .setValue(new Aspect(originalDomains.data())))))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     UnsetDomainResolver resolver = new UnsetDomainResolver(mockClient, mockService);
 
@@ -131,7 +134,7 @@ public class UnsetDomainResolverTest {
         .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -155,7 +158,8 @@ public class UnsetDomainResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
 
     UnsetDomainResolver resolver = new UnsetDomainResolver(mockClient, mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.embed;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Authentication;
@@ -47,7 +48,8 @@ public class UpdateEmbedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
 
@@ -68,7 +70,7 @@ public class UpdateEmbedResolverTest {
     ;
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -85,7 +87,8 @@ public class UpdateEmbedResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalEmbed);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
 
@@ -105,7 +108,7 @@ public class UpdateEmbedResolverTest {
     verifySingleIngestProposal(mockService, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -128,7 +131,8 @@ public class UpdateEmbedResolverTest {
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
 
     UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/entity/EntityExistsResolverTest.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.graphql.resolvers.entity;
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetchingEnvironment;
 import org.testng.annotations.BeforeMethod;
@@ -33,7 +34,7 @@ public class EntityExistsResolverTest {
   @Test
   public void testPasses() throws Exception {
     when(_dataFetchingEnvironment.getArgument("urn")).thenReturn(ENTITY_URN_STRING);
-    when(_entityService.exists(any())).thenReturn(true);
+    when(_entityService.exists(any(Urn.class), eq(true))).thenReturn(true);
 
     assertTrue(_resolver.get(_dataFetchingEnvironment).join());
   }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.datahub.graphql.TestUtils.getMockDenyContext;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -28,9 +29,9 @@ public class AddRelatedTermsResolverTest {
     EntityService mockService = getMockEntityService();
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
-                Mockito.eq(Constants.GLOSSARY_RELATED_TERM_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                eq(Constants.GLOSSARY_RELATED_TERM_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
     return mockService;
   }
@@ -39,9 +40,12 @@ public class AddRelatedTermsResolverTest {
   public void testGetSuccessIsRelatedNonExistent() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -52,26 +56,29 @@ public class AddRelatedTermsResolverTest {
             TEST_ENTITY_URN,
             ImmutableList.of(TEST_TERM_1_URN, TEST_TERM_2_URN),
             TermRelationshipType.isA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
     verifySingleIngestProposal(mockService, 1);
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_1_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true));
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_2_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true));
   }
 
   @Test
   public void testGetSuccessHasRelatedNonExistent() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -82,24 +89,25 @@ public class AddRelatedTermsResolverTest {
             TEST_ENTITY_URN,
             ImmutableList.of(TEST_TERM_1_URN, TEST_TERM_2_URN),
             TermRelationshipType.hasA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
     verifySingleIngestProposal(mockService, 1);
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_1_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true));
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_2_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true));
   }
 
   @Test
   public void testGetFailAddSelfAsRelatedTerm() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -108,7 +116,7 @@ public class AddRelatedTermsResolverTest {
     RelatedTermsInput input =
         new RelatedTermsInput(
             TEST_ENTITY_URN, ImmutableList.of(TEST_ENTITY_URN), TermRelationshipType.hasA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
@@ -119,7 +127,8 @@ public class AddRelatedTermsResolverTest {
   public void testGetFailAddNonTermAsRelatedTerm() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -128,7 +137,7 @@ public class AddRelatedTermsResolverTest {
     RelatedTermsInput input =
         new RelatedTermsInput(
             TEST_ENTITY_URN, ImmutableList.of(DATASET_URN), TermRelationshipType.hasA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
@@ -139,8 +148,10 @@ public class AddRelatedTermsResolverTest {
   public void testGetFailAddNonExistentTermAsRelatedTerm() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(false);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -149,7 +160,7 @@ public class AddRelatedTermsResolverTest {
     RelatedTermsInput input =
         new RelatedTermsInput(
             TEST_ENTITY_URN, ImmutableList.of(TEST_TERM_1_URN), TermRelationshipType.hasA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
@@ -160,8 +171,10 @@ public class AddRelatedTermsResolverTest {
   public void testGetFailAddToNonExistentUrn() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -170,7 +183,7 @@ public class AddRelatedTermsResolverTest {
     RelatedTermsInput input =
         new RelatedTermsInput(
             TEST_ENTITY_URN, ImmutableList.of(TEST_TERM_1_URN), TermRelationshipType.hasA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
@@ -181,8 +194,10 @@ public class AddRelatedTermsResolverTest {
   public void testGetFailAddToNonTerm() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(DATASET_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(DATASET_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -191,7 +206,7 @@ public class AddRelatedTermsResolverTest {
     RelatedTermsInput input =
         new RelatedTermsInput(
             DATASET_URN, ImmutableList.of(TEST_TERM_1_URN), TermRelationshipType.hasA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
@@ -202,9 +217,12 @@ public class AddRelatedTermsResolverTest {
   public void testFailNoPermissions() throws Exception {
     EntityService mockService = setUpService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddRelatedTermsResolver resolver = new AddRelatedTermsResolver(mockService);
 
@@ -215,7 +233,7 @@ public class AddRelatedTermsResolverTest {
             TEST_ENTITY_URN,
             ImmutableList.of(TEST_TERM_1_URN, TEST_TERM_2_URN),
             TermRelationshipType.isA);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockEntityService;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -26,7 +27,8 @@ public class DeleteGlossaryEntityResolverTest {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     EntityService mockService = getMockEntityService();
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_URN)), eq(true)))
+        .thenReturn(true);
 
     QueryContext mockContext = getMockAllowContext();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
@@ -50,7 +52,8 @@ public class DeleteGlossaryEntityResolverTest {
         .deleteEntity(Mockito.any(), Mockito.any(Authentication.class));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_URN)), eq(true)))
+        .thenReturn(true);
 
     DeleteGlossaryEntityResolver resolver =
         new DeleteGlossaryEntityResolver(mockClient, mockService);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -41,7 +42,8 @@ public class RemoveRelatedTermsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(relatedTerms);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     RemoveRelatedTermsResolver resolver = new RemoveRelatedTermsResolver(mockService);
 
@@ -56,7 +58,7 @@ public class RemoveRelatedTermsResolverTest {
     assertTrue(resolver.get(mockEnv).get());
     verifySingleIngestProposal(mockService, 1);
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -73,7 +75,8 @@ public class RemoveRelatedTermsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(relatedTerms);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     RemoveRelatedTermsResolver resolver = new RemoveRelatedTermsResolver(mockService);
 
@@ -88,7 +91,7 @@ public class RemoveRelatedTermsResolverTest {
     assertTrue(resolver.get(mockEnv).get());
     verifySingleIngestProposal(mockService, 1);
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -101,7 +104,8 @@ public class RemoveRelatedTermsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     RemoveRelatedTermsResolver resolver = new RemoveRelatedTermsResolver(mockService);
 
@@ -131,7 +135,8 @@ public class RemoveRelatedTermsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(relatedTerms);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     RemoveRelatedTermsResolver resolver = new RemoveRelatedTermsResolver(mockService);
 
@@ -146,6 +151,6 @@ public class RemoveRelatedTermsResolverTest {
     assertThrows(ExecutionException.class, () -> resolver.get(mockEnv).get());
     verifyNoIngestProposal(mockService);
     Mockito.verify(mockService, Mockito.times(0))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -61,7 +62,7 @@ public class UpdateNameResolverTest {
   public void testGetSuccess() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TERM_URN)), eq(true))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 
@@ -76,7 +77,7 @@ public class UpdateNameResolverTest {
   public void testGetSuccessForNode() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(NODE_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(NODE_URN)), eq(true))).thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_FOR_NODE);
 
@@ -106,7 +107,8 @@ public class UpdateNameResolverTest {
   public void testGetSuccessForDomain() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(DOMAIN_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(DOMAIN_URN)), eq(true)))
+        .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_FOR_DOMAIN);
 
@@ -148,7 +150,8 @@ public class UpdateNameResolverTest {
   public void testGetFailureEntityDoesNotExist() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TERM_URN)), eq(true)))
+        .thenReturn(false);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateParentNodeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateParentNodeResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -63,8 +64,9 @@ public class UpdateParentNodeResolverTest {
   public void testGetSuccess() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TERM_URN)), eq(true))).thenReturn(true);
+    Mockito.when(
+            mockService.exists(eq(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)), eq(true)))
         .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
@@ -80,8 +82,9 @@ public class UpdateParentNodeResolverTest {
   public void testGetSuccessForNode() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(NODE_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(NODE_URN)), eq(true))).thenReturn(true);
+    Mockito.when(
+            mockService.exists(eq(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)), eq(true)))
         .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT_WITH_NODE);
@@ -114,8 +117,10 @@ public class UpdateParentNodeResolverTest {
   public void testGetFailureEntityDoesNotExist() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TERM_URN)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(
+            mockService.exists(eq(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)), eq(true)))
         .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
@@ -131,8 +136,9 @@ public class UpdateParentNodeResolverTest {
   public void testGetFailureNodeDoesNotExist() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TERM_URN)), eq(true))).thenReturn(true);
+    Mockito.when(
+            mockService.exists(eq(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)), eq(true)))
         .thenReturn(false);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INPUT);
@@ -148,8 +154,9 @@ public class UpdateParentNodeResolverTest {
   public void testGetFailureParentIsNotNode() throws Exception {
     EntityService mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    Mockito.when(mockService.exists(Urn.createFromString(TERM_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TERM_URN)), eq(true))).thenReturn(true);
+    Mockito.when(
+            mockService.exists(eq(GlossaryNodeUrn.createFromString(PARENT_NODE_URN)), eq(true)))
         .thenReturn(true);
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getArgument("input")).thenReturn(INVALID_INPUT);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/BatchGetEntitiesResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/load/BatchGetEntitiesResolverTest.java
@@ -13,6 +13,7 @@ import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -79,7 +80,8 @@ public class BatchGetEntitiesResolverTest {
         CompletableFuture.completedFuture(
             ImmutableList.of(mockResponseEntity2, mockResponseEntity1));
     when(mockDataLoader.loadMany(any())).thenReturn(mockFuture);
-    when(_entityService.exists(any())).thenReturn(true);
+    when(_entityService.exists(any(List.class), eq(true)))
+        .thenAnswer(args -> Set.of(args.getArgument(0)));
     List<Entity> batchGetResponse = resolver.get(_dataFetchingEnvironment).join();
     assertEquals(batchGetResponse.size(), 2);
     assertEquals(batchGetResponse.get(0), mockResponseEntity1);
@@ -108,7 +110,8 @@ public class BatchGetEntitiesResolverTest {
     CompletableFuture mockFuture =
         CompletableFuture.completedFuture(ImmutableList.of(mockResponseEntity));
     when(mockDataLoader.loadMany(any())).thenReturn(mockFuture);
-    when(_entityService.exists(any())).thenReturn(true);
+    when(_entityService.exists(any(List.class), eq(true)))
+        .thenAnswer(args -> Set.of(args.getArgument(0)));
     List<Entity> batchGetResponse = resolver.get(_dataFetchingEnvironment).join();
     assertEquals(batchGetResponse.size(), 2);
     assertEquals(batchGetResponse.get(0), mockResponseEntity);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateUserSettingResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateUserSettingResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.mutate;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -22,7 +23,8 @@ public class UpdateUserSettingResolverTest {
   @Test
   public void testWriteCorpUserSettings() throws Exception {
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_USER_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_USER_URN)), eq(true)))
+        .thenReturn(true);
 
     UpdateUserSettingResolver resolver = new UpdateUserSettingResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
@@ -1,6 +1,8 @@
 package com.linkedin.datahub.graphql.resolvers.owner;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -45,16 +47,21 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true)))
+        .thenReturn(true);
 
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
@@ -84,10 +91,10 @@ public class AddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true));
   }
 
   @Test
@@ -112,15 +119,19 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldOwnership);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
+        .thenReturn(true);
 
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
@@ -147,7 +158,7 @@ public class AddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
   }
 
   @Test
@@ -172,15 +183,16 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldOwnership);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(any(Urn.class), eq(true))).thenReturn(true);
 
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
@@ -207,7 +219,7 @@ public class AddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
   }
 
   @Test
@@ -232,24 +244,32 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldOwnership);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_2_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_3_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_3_URN)), eq(true)))
+        .thenReturn(true);
 
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
@@ -288,13 +308,13 @@ public class AddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_2_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_3_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_3_URN)), eq(true));
   }
 
   @Test
@@ -308,8 +328,10 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
+        .thenReturn(false);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
 
@@ -343,8 +365,10 @@ public class AddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_1_URN)), eq(true)))
+        .thenReturn(true);
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
 
@@ -398,7 +422,7 @@ public class AddOwnersResolverTest {
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)
-        .ingestProposal(Mockito.any(AspectsBatchImpl.class), Mockito.anyBoolean());
+        .ingestProposal(any(AspectsBatchImpl.class), Mockito.anyBoolean());
 
     AddOwnersResolver resolver = new AddOwnersResolver(Mockito.mock(EntityService.class));
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchAddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchAddOwnersResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.owner;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -52,18 +53,24 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
+        .thenReturn(true);
 
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService);
@@ -99,10 +106,10 @@ public class BatchAddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_1)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_2)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true));
   }
 
   @Test
@@ -131,26 +138,34 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalOwnership);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_2))).thenReturn(true);
-
-    Mockito.when(
-            mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
-                            .name()))))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
         .thenReturn(true);
 
     Mockito.when(
             mockService.exists(
-                Urn.createFromString(
-                    OwnerUtils.mapOwnershipTypeToEntity(
-                        com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
-                            .name()))))
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.TECHNICAL_OWNER
+                                .name()))),
+                eq(true)))
+        .thenReturn(true);
+
+    Mockito.when(
+            mockService.exists(
+                eq(
+                    Urn.createFromString(
+                        OwnerUtils.mapOwnershipTypeToEntity(
+                            com.linkedin.datahub.graphql.generated.OwnershipType.BUSINESS_OWNER
+                                .name()))),
+                eq(true)))
         .thenReturn(true);
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService);
@@ -186,10 +201,10 @@ public class BatchAddOwnersResolverTest {
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_1)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_2)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true));
   }
 
   @Test
@@ -203,8 +218,10 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(false);
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService);
 
@@ -256,9 +273,12 @@ public class BatchAddOwnersResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(true);
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchRemoveOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchRemoveOwnersResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.owner;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -37,22 +38,26 @@ public class BatchRemoveOwnersResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.OWNERSHIP_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.OWNERSHIP_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService);
 
@@ -66,7 +71,7 @@ public class BatchRemoveOwnersResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
@@ -88,9 +93,9 @@ public class BatchRemoveOwnersResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.OWNERSHIP_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(oldOwners1);
 
     final Ownership oldOwners2 =
@@ -104,16 +109,20 @@ public class BatchRemoveOwnersResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.OWNERSHIP_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(oldOwners2);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_2)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService);
 
@@ -127,7 +136,7 @@ public class BatchRemoveOwnersResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
@@ -140,20 +149,23 @@ public class BatchRemoveOwnersResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.OWNERSHIP_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.OWNERSHIP_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.OWNERSHIP_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_OWNER_URN_1))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_OWNER_URN_1)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService);
 
@@ -167,7 +179,7 @@ public class BatchRemoveOwnersResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -189,7 +201,7 @@ public class BatchRemoveOwnersResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -217,7 +229,7 @@ public class BatchRemoveOwnersResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -42,9 +43,12 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 
@@ -73,10 +77,10 @@ public class AddTagsResolverTest {
     verifyIngestProposal(mockService, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
   }
 
   @Test
@@ -97,9 +101,12 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalTags);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 
@@ -128,10 +135,10 @@ public class AddTagsResolverTest {
     verifyIngestProposal(mockService, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
   }
 
   @Test
@@ -145,8 +152,10 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(false);
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 
@@ -173,8 +182,10 @@ public class AddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -53,11 +54,15 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -92,10 +97,10 @@ public class BatchAddTagsResolverTest {
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
   }
 
   @Test
@@ -123,11 +128,15 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(originalTags);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -162,10 +171,10 @@ public class BatchAddTagsResolverTest {
     verifyIngestProposal(mockService, 1, List.of(proposal1, proposal2));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true));
   }
 
   @Test
@@ -179,8 +188,10 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(false);
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -216,9 +227,12 @@ public class BatchAddTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -55,11 +56,15 @@ public class BatchRemoveTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 
@@ -127,11 +132,15 @@ public class BatchRemoveTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldTags2);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 
@@ -178,9 +187,12 @@ public class BatchRemoveTagsResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TAG_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TAG_1_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/SetTagColorResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/SetTagColorResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.tag;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
 import static com.linkedin.metadata.Constants.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Authentication;
@@ -47,7 +48,8 @@ public class SetTagColorResolverTest {
                 Mockito.eq(0L)))
         .thenReturn(oldTagProperties);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     SetTagColorResolver resolver = new SetTagColorResolver(mockClient, mockService);
 
@@ -69,7 +71,7 @@ public class SetTagColorResolverTest {
         .ingestProposal(Mockito.eq(proposal), Mockito.any(Authentication.class), Mockito.eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)));
+        .exists(Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
   }
 
   @Test
@@ -86,7 +88,8 @@ public class SetTagColorResolverTest {
                 Mockito.eq(0)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
 
     SetTagColorResolver resolver = new SetTagColorResolver(mockClient, mockService);
 
@@ -131,7 +134,8 @@ public class SetTagColorResolverTest {
                                 Constants.TAG_PROPERTIES_ASPECT_NAME, oldTagPropertiesAspect)))));
 
     EntityService mockService = getMockEntityService();
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
 
     SetTagColorResolver resolver = new SetTagColorResolver(mockClient, mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.term;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -34,14 +35,17 @@ public class AddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -51,19 +55,19 @@ public class AddTermsResolverTest {
     AddTermsInput input =
         new AddTermsInput(
             ImmutableList.of(TEST_TERM_1_URN, TEST_TERM_2_URN), TEST_ENTITY_URN, null, null);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
     // Unable to easily validate exact payload due to the injected timestamp
     Mockito.verify(mockService, Mockito.times(1))
-        .ingestProposal(Mockito.any(AspectsBatchImpl.class), Mockito.eq(false));
+        .ingestProposal(Mockito.any(AspectsBatchImpl.class), eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_1_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_2_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true));
   }
 
   @Test
@@ -80,14 +84,17 @@ public class AddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(originalTerms);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -97,19 +104,19 @@ public class AddTermsResolverTest {
     AddTermsInput input =
         new AddTermsInput(
             ImmutableList.of(TEST_TERM_1_URN, TEST_TERM_2_URN), TEST_ENTITY_URN, null, null);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
     // Unable to easily validate exact payload due to the injected timestamp
     Mockito.verify(mockService, Mockito.times(1))
-        .ingestProposal(Mockito.any(AspectsBatchImpl.class), Mockito.eq(false));
+        .ingestProposal(Mockito.any(AspectsBatchImpl.class), eq(false));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_1_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_TERM_2_URN)));
+        .exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true));
   }
 
   @Test
@@ -118,13 +125,15 @@ public class AddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(false);
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -133,7 +142,7 @@ public class AddTermsResolverTest {
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     AddTermsInput input =
         new AddTermsInput(ImmutableList.of(TEST_TERM_1_URN), TEST_ENTITY_URN, null, null);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -147,13 +156,15 @@ public class AddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -162,7 +173,7 @@ public class AddTermsResolverTest {
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     AddTermsInput input =
         new AddTermsInput(ImmutableList.of(TEST_TERM_1_URN), TEST_ENTITY_URN, null, null);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -180,7 +191,7 @@ public class AddTermsResolverTest {
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     AddTermsInput input =
         new AddTermsInput(ImmutableList.of(TEST_TERM_1_URN), TEST_ENTITY_URN, null, null);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -204,7 +215,7 @@ public class AddTermsResolverTest {
     QueryContext mockContext = getMockAllowContext();
     AddTermsInput input =
         new AddTermsInput(ImmutableList.of(TEST_TERM_1_URN), TEST_ENTITY_URN, null, null);
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchAddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchAddTermsResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.term;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -37,24 +38,26 @@ public class BatchAddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
         .thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true)))
         .thenReturn(true);
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
@@ -68,17 +71,17 @@ public class BatchAddTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)));
+        .exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)));
+        .exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true));
   }
 
   @Test
@@ -95,24 +98,26 @@ public class BatchAddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(originalTerms);
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(originalTerms);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
         .thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true)))
         .thenReturn(true);
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
@@ -126,17 +131,17 @@ public class BatchAddTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
     verifyIngestProposal(mockService, 1);
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)));
+        .exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true));
 
     Mockito.verify(mockService, Mockito.times(1))
-        .exists(Mockito.eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)));
+        .exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_2_URN)), eq(true));
   }
 
   @Test
@@ -145,13 +150,14 @@ public class BatchAddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
         .thenReturn(false);
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
@@ -163,7 +169,7 @@ public class BatchAddTermsResolverTest {
         new BatchAddTermsInput(
             ImmutableList.of(TEST_GLOSSARY_TERM_1_URN, TEST_GLOSSARY_TERM_2_URN),
             ImmutableList.of(new ResourceRefInput(TEST_ENTITY_URN_1, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -176,20 +182,22 @@ public class BatchAddTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)))
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_GLOSSARY_TERM_1_URN)), eq(true)))
         .thenReturn(true);
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
@@ -203,7 +211,7 @@ public class BatchAddTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -224,7 +232,7 @@ public class BatchAddTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -249,7 +257,7 @@ public class BatchAddTermsResolverTest {
         new BatchAddTermsInput(
             ImmutableList.of(TEST_GLOSSARY_TERM_1_URN),
             ImmutableList.of(new ResourceRefInput(TEST_ENTITY_URN_1, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchRemoveTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchRemoveTermsResolverTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.term;
 
 import static com.linkedin.datahub.graphql.TestUtils.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableList;
@@ -37,22 +38,26 @@ public class BatchRemoveTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 
@@ -65,7 +70,7 @@ public class BatchRemoveTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
@@ -88,9 +93,9 @@ public class BatchRemoveTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(oldTerms1);
 
     final GlossaryTerms oldTerms2 =
@@ -103,16 +108,20 @@ public class BatchRemoveTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(oldTerms2);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_2_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_2_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 
@@ -125,7 +134,7 @@ public class BatchRemoveTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     assertTrue(resolver.get(mockEnv).get());
 
@@ -138,20 +147,23 @@ public class BatchRemoveTermsResolverTest {
 
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_1)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
     Mockito.when(
             mockService.getAspect(
-                Mockito.eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
-                Mockito.eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
-                Mockito.eq(0L)))
+                eq(UrnUtils.getUrn(TEST_ENTITY_URN_2)),
+                eq(Constants.GLOSSARY_TERMS_ASPECT_NAME),
+                eq(0L)))
         .thenReturn(null);
 
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_1))).thenReturn(false);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_ENTITY_URN_2))).thenReturn(true);
-    Mockito.when(mockService.exists(Urn.createFromString(TEST_TERM_1_URN))).thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_1)), eq(true)))
+        .thenReturn(false);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_ENTITY_URN_2)), eq(true)))
+        .thenReturn(true);
+    Mockito.when(mockService.exists(eq(Urn.createFromString(TEST_TERM_1_URN)), eq(true)))
+        .thenReturn(true);
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 
@@ -164,7 +176,7 @@ public class BatchRemoveTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
@@ -185,7 +197,7 @@ public class BatchRemoveTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     QueryContext mockContext = getMockDenyContext();
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
@@ -212,7 +224,7 @@ public class BatchRemoveTermsResolverTest {
             ImmutableList.of(
                 new ResourceRefInput(TEST_ENTITY_URN_1, null, null),
                 new ResourceRefInput(TEST_ENTITY_URN_2, null, null)));
-    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(input);
+    Mockito.when(mockEnv.getArgument(eq("input"))).thenReturn(input);
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -625,7 +625,7 @@ public class JavaEntityClient implements EntityClient {
   @Override
   public boolean exists(@Nonnull Urn urn, @Nonnull final Authentication authentication)
       throws RemoteInvocationException {
-    return _entityService.exists(urn);
+    return _entityService.exists(urn, true);
   }
 
   @SneakyThrows

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -93,6 +93,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1782,7 +1783,8 @@ public class EntityServiceImpl implements EntityService<MCPUpsertBatchItem> {
     return response;
   }
 
-  private Map<String, Set<String>> buildEntityToValidAspects(final EntityRegistry entityRegistry) {
+  private static Map<String, Set<String>> buildEntityToValidAspects(
+      final EntityRegistry entityRegistry) {
     return entityRegistry.getEntitySpecs().values().stream()
         .collect(
             Collectors.toMap(
@@ -1950,36 +1952,53 @@ public class EntityServiceImpl implements EntityService<MCPUpsertBatchItem> {
   }
 
   /**
-   * Returns true if the entity exists (has materialized aspects)
+   * Returns a set of urns of entities that exist (has materialized aspects).
    *
-   * @param urn the urn of the entity to check
-   * @return true if the entity exists, false otherwise
+   * @param urns the list of urns of the entities to check
+   * @param includeSoftDeleted whether to consider soft delete
+   * @return a set of urns of entities that exist.
    */
   @Override
-  public Boolean exists(Urn urn) {
-    final Set<String> aspectsToFetch = getEntityAspectNames(urn);
-    final List<EntityAspectIdentifier> dbKeys =
-        aspectsToFetch.stream()
+  public Set<Urn> exists(@Nonnull final Collection<Urn> urns, boolean includeSoftDeleted) {
+    final Set<EntityAspectIdentifier> dbKeys =
+        urns.stream()
             .map(
-                aspectName ->
-                    new EntityAspectIdentifier(urn.toString(), aspectName, ASPECT_LATEST_VERSION))
-            .collect(Collectors.toList());
+                urn ->
+                    new EntityAspectIdentifier(
+                        urn.toString(),
+                        _entityRegistry
+                            .getEntitySpec(urn.getEntityType())
+                            .getKeyAspectSpec()
+                            .getName(),
+                        ASPECT_LATEST_VERSION))
+            .collect(Collectors.toSet());
 
-    Map<EntityAspectIdentifier, EntityAspect> aspects = _aspectDao.batchGet(new HashSet(dbKeys));
-    return aspects.values().stream().anyMatch(aspect -> aspect != null);
-  }
+    final Map<EntityAspectIdentifier, EntityAspect> aspects = _aspectDao.batchGet(dbKeys);
+    final Set<String> existingUrnStrings =
+        aspects.values().stream()
+            .filter(aspect -> aspect != null)
+            .map(aspect -> aspect.getUrn())
+            .collect(Collectors.toSet());
 
-  /**
-   * Returns true if an entity is soft-deleted.
-   *
-   * @param urn the urn to check
-   * @return true is the entity is soft deleted, false otherwise.
-   */
-  @Override
-  public Boolean isSoftDeleted(@Nonnull final Urn urn) {
-    Objects.requireNonNull(urn, "urn is required");
-    final RecordTemplate statusAspect = getLatestAspect(urn, STATUS_ASPECT_NAME);
-    return statusAspect != null && ((Status) statusAspect).isRemoved();
+    Set<Urn> existing =
+        urns.stream()
+            .filter(urn -> existingUrnStrings.contains(urn.toString()))
+            .collect(Collectors.toSet());
+
+    if (includeSoftDeleted) {
+      return existing;
+    } else {
+      // Additionally exclude status.removed == true
+      Map<Urn, List<RecordTemplate>> statusResult =
+          getLatestAspects(existing, Set.of(STATUS_ASPECT_NAME));
+      return existing.stream()
+          .filter(
+              urn ->
+                  !statusResult.containsKey(urn)
+                      || statusResult.get(urn).isEmpty()
+                      || !((Status) statusResult.get(urn).get(0)).isRemoved())
+          .collect(Collectors.toSet());
+    }
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
@@ -6,11 +6,9 @@ import static com.linkedin.metadata.utils.PegasusUtils.urnToEntityName;
 import com.datahub.util.RecordUtils;
 import com.google.common.base.Preconditions;
 import com.linkedin.common.AuditStamp;
-import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
 import com.linkedin.metadata.entity.validation.EntityRegistryUrnValidator;
 import com.linkedin.metadata.entity.validation.RecordTemplateValidator;
@@ -155,27 +153,6 @@ public class EntityUtils {
       return response;
     }
     return RecordUtils.toRecordTemplate(SystemMetadata.class, jsonSystemMetadata);
-  }
-
-  /** Check if entity is removed (removed=true in Status aspect) and exists */
-  public static boolean checkIfRemoved(EntityService entityService, Urn entityUrn) {
-    try {
-
-      if (!entityService.exists(entityUrn)) {
-        return false;
-      }
-
-      EnvelopedAspect statusAspect =
-          entityService.getLatestEnvelopedAspect(entityUrn.getEntityType(), entityUrn, "status");
-      if (statusAspect == null) {
-        return false;
-      }
-      Status status = new Status(statusAspect.getValue().data());
-      return status.isRemoved();
-    } catch (Exception e) {
-      log.error("Error while checking if {} is removed", entityUrn, e);
-      return false;
-    }
   }
 
   public static RecordTemplate buildKeyAspect(

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
@@ -4,15 +4,11 @@ import com.codahale.metrics.Timer;
 import com.datahub.util.exception.ESQueryException;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventConstants;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventType;
 import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.entity.EntityUtils;
-import com.linkedin.metadata.recommendation.EntityProfileParams;
 import com.linkedin.metadata.recommendation.RecommendationContent;
-import com.linkedin.metadata.recommendation.RecommendationParams;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
 import com.linkedin.metadata.recommendation.ScenarioType;
@@ -22,7 +18,6 @@ import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -37,12 +32,13 @@ import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.opensearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 @Slf4j
 @RequiredArgsConstructor
-public class MostPopularSource implements RecommendationSource {
+public class MostPopularSource implements EntityRecommendationSource {
   /** Entity Types that should be in scope for this type of recommendation. */
   private static final Set<String> SUPPORTED_ENTITY_TYPES =
       ImmutableSet.of(
@@ -59,7 +55,7 @@ public class MostPopularSource implements RecommendationSource {
 
   private final RestHighLevelClient _searchClient;
   private final IndexConvention _indexConvention;
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   private static final String DATAHUB_USAGE_INDEX = "datahub_usage_event";
   private static final String ENTITY_AGG_NAME = "entity";
@@ -107,16 +103,22 @@ public class MostPopularSource implements RecommendationSource {
           _searchClient.search(searchRequest, RequestOptions.DEFAULT);
       // extract results
       ParsedTerms parsedTerms = searchResponse.getAggregations().get(ENTITY_AGG_NAME);
-      return parsedTerms.getBuckets().stream()
-          .map(bucket -> buildContent(bucket.getKeyAsString()))
-          .filter(Optional::isPresent)
-          .map(Optional::get)
+      List<String> bucketUrns =
+          parsedTerms.getBuckets().stream()
+              .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+              .collect(Collectors.toList());
+      return buildContent(bucketUrns, _entityService)
           .limit(MAX_CONTENT)
           .collect(Collectors.toList());
     } catch (Exception e) {
       log.error("Search query to get most popular entities failed", e);
       throw new ESQueryException("Search query failed:", e);
     }
+  }
+
+  @Override
+  public Set<String> getSupportedEntityTypes() {
+    return SUPPORTED_ENTITY_TYPES;
   }
 
   private SearchRequest buildSearchRequest(@Nonnull Urn userUrn) {
@@ -141,21 +143,5 @@ public class MostPopularSource implements RecommendationSource {
     request.source(source);
     request.indices(_indexConvention.getIndexName(DATAHUB_USAGE_INDEX));
     return request;
-  }
-
-  private Optional<RecommendationContent> buildContent(@Nonnull String entityUrn) {
-    Urn entity = UrnUtils.getUrn(entityUrn);
-    if (EntityUtils.checkIfRemoved(_entityService, entity)
-        || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
-      return Optional.empty();
-    }
-
-    return Optional.of(
-        new RecommendationContent()
-            .setEntity(entity)
-            .setValue(entityUrn)
-            .setParams(
-                new RecommendationParams()
-                    .setEntityProfileParams(new EntityProfileParams().setUrn(entity))));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyEditedSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyEditedSource.java
@@ -4,15 +4,11 @@ import com.codahale.metrics.Timer;
 import com.datahub.util.exception.ESQueryException;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventConstants;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventType;
 import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.entity.EntityUtils;
-import com.linkedin.metadata.recommendation.EntityProfileParams;
 import com.linkedin.metadata.recommendation.RecommendationContent;
-import com.linkedin.metadata.recommendation.RecommendationParams;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
 import com.linkedin.metadata.recommendation.ScenarioType;
@@ -22,7 +18,6 @@ import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -38,12 +33,13 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.AggregationBuilders;
 import org.opensearch.search.aggregations.BucketOrder;
+import org.opensearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.opensearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 @Slf4j
 @RequiredArgsConstructor
-public class RecentlyEditedSource implements RecommendationSource {
+public class RecentlyEditedSource implements EntityRecommendationSource {
   /** Entity Types that should be in scope for this type of recommendation. */
   private static final Set<String> SUPPORTED_ENTITY_TYPES =
       ImmutableSet.of(
@@ -60,7 +56,7 @@ public class RecentlyEditedSource implements RecommendationSource {
 
   private final RestHighLevelClient _searchClient;
   private final IndexConvention _indexConvention;
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   private static final String DATAHUB_USAGE_INDEX = "datahub_usage_event";
   private static final String ENTITY_AGG_NAME = "entity";
@@ -108,16 +104,22 @@ public class RecentlyEditedSource implements RecommendationSource {
           _searchClient.search(searchRequest, RequestOptions.DEFAULT);
       // extract results
       ParsedTerms parsedTerms = searchResponse.getAggregations().get(ENTITY_AGG_NAME);
-      return parsedTerms.getBuckets().stream()
-          .map(bucket -> buildContent(bucket.getKeyAsString()))
-          .filter(Optional::isPresent)
-          .map(Optional::get)
+      List<String> bucketUrns =
+          parsedTerms.getBuckets().stream()
+              .map(MultiBucketsAggregation.Bucket::getKeyAsString)
+              .collect(Collectors.toList());
+      return buildContent(bucketUrns, _entityService)
           .limit(MAX_CONTENT)
           .collect(Collectors.toList());
     } catch (Exception e) {
       log.error("Search query to get most recently edited entities failed", e);
       throw new ESQueryException("Search query failed:", e);
     }
+  }
+
+  @Override
+  public Set<String> getSupportedEntityTypes() {
+    return SUPPORTED_ENTITY_TYPES;
   }
 
   private SearchRequest buildSearchRequest(@Nonnull Urn userUrn) {
@@ -146,21 +148,5 @@ public class RecentlyEditedSource implements RecommendationSource {
     request.source(source);
     request.indices(_indexConvention.getIndexName(DATAHUB_USAGE_INDEX));
     return request;
-  }
-
-  private Optional<RecommendationContent> buildContent(@Nonnull String entityUrn) {
-    Urn entity = UrnUtils.getUrn(entityUrn);
-    if (EntityUtils.checkIfRemoved(_entityService, entity)
-        || !RecommendationUtils.isSupportedEntityType(entity, SUPPORTED_ENTITY_TYPES)) {
-      return Optional.empty();
-    }
-
-    return Optional.of(
-        new RecommendationContent()
-            .setEntity(entity)
-            .setValue(entityUrn)
-            .setParams(
-                new RecommendationParams()
-                    .setEntityProfileParams(new EntityProfileParams().setUrn(entity))));
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
@@ -19,6 +19,7 @@ import com.linkedin.metadata.graph.LineageRelationship;
 import com.linkedin.metadata.graph.LineageRelationshipArray;
 import com.linkedin.metadata.graph.SiblingGraphService;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -60,12 +61,13 @@ public class SiblingGraphServiceTest {
 
   private GraphService _graphService;
   private SiblingGraphService _client;
-  EntityService _mockEntityService;
+  EntityService<?> _mockEntityService;
 
   @BeforeClass
   public void setup() {
     _mockEntityService = Mockito.mock(EntityService.class);
-    when(_mockEntityService.exists(any())).thenReturn(true);
+    when(_mockEntityService.exists(any(Collection.class), any(Boolean.class)))
+        .thenAnswer(args -> new HashSet<>(args.getArgument(0)));
     _graphService = Mockito.mock(GraphService.class);
     _client = new SiblingGraphService(_mockEntityService, _graphService);
   }

--- a/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SampleDataFixtureConfiguration.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/fixtures/search/SampleDataFixtureConfiguration.java
@@ -40,6 +40,8 @@ import io.datahubproject.test.search.config.SearchCommonTestConfiguration;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.opensearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -276,7 +278,20 @@ public class SampleDataFixtureConfiguration {
 
     AspectDao mockAspectDao = mock(AspectDao.class);
     when(mockAspectDao.batchGet(anySet()))
-        .thenReturn(Map.of(mock(EntityAspectIdentifier.class), mock(EntityAspect.class)));
+        .thenAnswer(
+            args -> {
+              Set<EntityAspectIdentifier> ids = args.getArgument(0);
+              return ids.stream()
+                  .map(
+                      id -> {
+                        EntityAspect mockEntityAspect = mock(EntityAspect.class);
+                        when(mockEntityAspect.getUrn()).thenReturn(id.getUrn());
+                        when(mockEntityAspect.getAspect()).thenReturn(id.getAspect());
+                        when(mockEntityAspect.getVersion()).thenReturn(id.getVersion());
+                        return Map.entry(id, mockEntityAspect);
+                      })
+                  .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            });
 
     PreProcessHooks preProcessHooks = new PreProcessHooks();
     preProcessHooks.setUiEnabled(true);

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/group/GroupService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/group/GroupService.java
@@ -39,12 +39,12 @@ import javax.annotation.Nonnull;
 
 public class GroupService {
   private final EntityClient _entityClient;
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
   private final GraphClient _graphClient;
 
   public GroupService(
       @Nonnull EntityClient entityClient,
-      @Nonnull EntityService entityService,
+      @Nonnull EntityService<?> entityService,
       @Nonnull GraphClient graphClient) {
     Objects.requireNonNull(entityClient, "entityClient must not be null!");
     Objects.requireNonNull(entityService, "entityService must not be null!");
@@ -57,7 +57,7 @@ public class GroupService {
 
   public boolean groupExists(@Nonnull Urn groupUrn) {
     Objects.requireNonNull(groupUrn, "groupUrn must not be null");
-    return _entityService.exists(groupUrn);
+    return _entityService.exists(groupUrn, true);
   }
 
   public Origin getGroupOrigin(@Nonnull final Urn groupUrn) {
@@ -73,7 +73,7 @@ public class GroupService {
     Objects.requireNonNull(groupUrn, "groupUrn must not be null");
 
     // Verify the user exists
-    if (!_entityService.exists(userUrn)) {
+    if (!_entityService.exists(userUrn, true)) {
       throw new RuntimeException("Failed to add member to group. User does not exist.");
     }
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/StatefulTokenService.java
@@ -63,7 +63,7 @@ public class StatefulTokenService extends StatelessTokenService {
                   public Boolean load(final String key) {
                     final Urn accessUrn =
                         Urn.createFromTuple(Constants.ACCESS_TOKEN_ENTITY_NAME, key);
-                    return !_entityService.exists(accessUrn);
+                    return !_entityService.exists(accessUrn, true);
                   }
                 });
     this.salt = salt;

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/user/NativeUserService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/user/NativeUserService.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NativeUserService {
   private static final long ONE_DAY_MILLIS = TimeUnit.DAYS.toMillis(1);
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
   private final EntityClient _entityClient;
   private final SecretService _secretService;
   private final AuthenticationConfiguration _authConfig;
@@ -51,7 +51,7 @@ public class NativeUserService {
     Objects.requireNonNull(authentication, "authentication must not be null!");
 
     final Urn userUrn = Urn.createFromString(userUrnString);
-    if (_entityService.exists(userUrn)
+    if (_entityService.exists(userUrn, true)
         // Should never fail these due to Controller level check, but just in case more usages get
         // put in
         || userUrn.toString().equals(SYSTEM_ACTOR)

--- a/metadata-service/auth-impl/src/main/java/com/datahub/telemetry/TrackingService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/telemetry/TrackingService.java
@@ -146,7 +146,7 @@ public class TrackingService {
 
     Urn clientIdUrn = UrnUtils.getUrn(CLIENT_ID_URN);
     // Create a new client id if it doesn't exist
-    if (!_entityService.exists(clientIdUrn)) {
+    if (!_entityService.exists(clientIdUrn, true)) {
       return createClientIdIfNotPresent(_entityService);
     }
 

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/authenticator/DataHubTokenAuthenticatorTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/authenticator/DataHubTokenAuthenticatorTest.java
@@ -8,6 +8,7 @@ import static com.datahub.authentication.token.TokenClaims.ACTOR_ID_CLAIM_NAME;
 import static com.datahub.authentication.token.TokenClaims.ACTOR_TYPE_CLAIM_NAME;
 import static com.datahub.authentication.token.TokenClaims.TOKEN_TYPE_CLAIM_NAME;
 import static com.datahub.authentication.token.TokenClaims.TOKEN_VERSION_CLAIM_NAME;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
@@ -151,7 +152,7 @@ public class DataHubTokenAuthenticatorTest {
         configEntityRegistry.getEntitySpec(Constants.ACCESS_TOKEN_ENTITY_NAME).getKeyAspectSpec();
     Mockito.when(mockService.getKeyAspectSpec(Mockito.eq(Constants.ACCESS_TOKEN_ENTITY_NAME)))
         .thenReturn(keyAspectSpec);
-    Mockito.when(mockService.exists(Mockito.any(Urn.class))).thenReturn(true);
+    Mockito.when(mockService.exists(Mockito.any(Urn.class), eq(true))).thenReturn(true);
     Mockito.when(mockService.getEntityRegistry()).thenReturn(configEntityRegistry);
 
     final DataHubTokenAuthenticator authenticator = new DataHubTokenAuthenticator();

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/group/GroupServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/group/GroupServiceTest.java
@@ -55,7 +55,7 @@ public class GroupServiceTest {
   private static EntityRelationships _entityRelationships;
 
   private EntityClient _entityClient;
-  private EntityService _entityService;
+  private EntityService<?> _entityService;
   private GraphClient _graphClient;
   private GroupService _groupService;
 
@@ -121,7 +121,7 @@ public class GroupServiceTest {
 
   @Test
   public void testGroupExistsPasses() {
-    when(_entityService.exists(_groupUrn)).thenReturn(true);
+    when(_entityService.exists(eq(_groupUrn), eq(true))).thenReturn(true);
     assertTrue(_groupService.groupExists(_groupUrn));
   }
 
@@ -147,7 +147,7 @@ public class GroupServiceTest {
 
   @Test
   public void testAddUserToNativeGroupPasses() throws Exception {
-    when(_entityService.exists(USER_URN)).thenReturn(true);
+    when(_entityService.exists(eq(USER_URN), eq(true))).thenReturn(true);
     when(_entityClient.batchGetV2(
             eq(CORP_USER_ENTITY_NAME), any(), any(), eq(SYSTEM_AUTHENTICATION)))
         .thenReturn(_entityResponseMap);
@@ -232,7 +232,7 @@ public class GroupServiceTest {
     when(_entityClient.batchGetV2(
             eq(CORP_USER_ENTITY_NAME), any(), any(), eq(SYSTEM_AUTHENTICATION)))
         .thenReturn(_entityResponseMap);
-    when(_entityService.exists(USER_URN)).thenReturn(true);
+    when(_entityService.exists(eq(USER_URN), eq(true))).thenReturn(true);
 
     _groupService.migrateGroupMembershipToNativeGroupMembership(
         Urn.createFromString(EXTERNAL_GROUP_URN_STRING),

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/token/StatefulTokenServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/token/StatefulTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.datahub.authentication.token;
 
 import static com.datahub.authentication.token.TokenClaims.*;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.testng.Assert.*;
 
 import com.datahub.authentication.Actor;
@@ -180,7 +181,7 @@ public class StatefulTokenServiceTest {
     Mockito.when(mockService.getEntityRegistry()).thenReturn(configEntityRegistry);
     Mockito.when(mockService.getKeyAspectSpec(Mockito.eq(Constants.ACCESS_TOKEN_ENTITY_NAME)))
         .thenReturn(keyAspectSpec);
-    Mockito.when(mockService.exists(Mockito.any(Urn.class))).thenReturn(true);
+    Mockito.when(mockService.exists(Mockito.any(Urn.class), eq(true))).thenReturn(true);
     final RollbackRunResult result = new RollbackRunResult(ImmutableList.of(), 0);
     Mockito.when(mockService.deleteUrn(Mockito.any(Urn.class))).thenReturn(result);
 

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/user/NativeUserServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/user/NativeUserServiceTest.java
@@ -85,7 +85,7 @@ public class NativeUserServiceTest {
       expectedExceptionsMessageRegExp = "This user already exists! Cannot create a new user.")
   public void testCreateNativeUserUserAlreadyExists() throws Exception {
     // The user already exists
-    when(_entityService.exists(any())).thenReturn(true);
+    when(_entityService.exists(any(Urn.class), eq(true))).thenReturn(true);
 
     _nativeUserService.createNativeUser(
         USER_URN_STRING, FULL_NAME, EMAIL, TITLE, PASSWORD, SYSTEM_AUTHENTICATION);
@@ -109,7 +109,7 @@ public class NativeUserServiceTest {
 
   @Test
   public void testCreateNativeUserPasses() throws Exception {
-    when(_entityService.exists(any())).thenReturn(false);
+    when(_entityService.exists(any(), any())).thenReturn(false);
     when(_secretService.generateSalt(anyInt())).thenReturn(SALT);
     when(_secretService.encrypt(any())).thenReturn(ENCRYPTED_SALT);
     when(_secretService.getHashedPassword(any(), any())).thenReturn(HASHED_PASSWORD);

--- a/metadata-service/auth-impl/src/test/java/com/datahub/telemetry/TrackingServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/telemetry/TrackingServiceTest.java
@@ -76,7 +76,7 @@ public class TrackingServiceTest {
   @Test
   public void testEmitAnalyticsEvent() throws IOException {
     when(_secretService.hashString(eq(ACTOR_URN_STRING))).thenReturn(HASHED_ACTOR_URN_STRING);
-    when(_entityService.exists(_clientIdUrn)).thenReturn(true);
+    when(_entityService.exists(eq(_clientIdUrn), eq(true))).thenReturn(true);
     when(_entityService.getLatestAspect(eq(_clientIdUrn), eq(CLIENT_ID_ASPECT)))
         .thenReturn(TELEMETRY_CLIENT_ID);
     when(_mixpanelMessageBuilder.event(eq(CLIENT_ID), eq(EVENT_TYPE), any()))
@@ -99,7 +99,7 @@ public class TrackingServiceTest {
 
   @Test
   public void testGetClientIdAlreadyExists() {
-    when(_entityService.exists(_clientIdUrn)).thenReturn(true);
+    when(_entityService.exists(eq(_clientIdUrn), eq(true))).thenReturn(true);
     when(_entityService.getLatestAspect(eq(_clientIdUrn), eq(CLIENT_ID_ASPECT)))
         .thenReturn(TELEMETRY_CLIENT_ID);
 
@@ -108,7 +108,7 @@ public class TrackingServiceTest {
 
   @Test
   public void testGetClientIdDoesNotExist() {
-    when(_entityService.exists(_clientIdUrn)).thenReturn(false);
+    when(_entityService.exists(eq(_clientIdUrn), eq(true))).thenReturn(false);
 
     assertNotNull(_trackingService.getClientId());
     verify(_entityService, times(1))

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRetentionPoliciesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRetentionPoliciesStep.java
@@ -28,8 +28,8 @@ import org.springframework.core.io.ClassPathResource;
 @RequiredArgsConstructor
 public class IngestRetentionPoliciesStep implements BootstrapStep {
 
-  private final RetentionService _retentionService;
-  private final EntityService _entityService;
+  private final RetentionService<?> _retentionService;
+  private final EntityService<?> _entityService;
   private final boolean _enableRetention;
   private final boolean _applyOnBootstrap;
   private final String pluginPath;
@@ -63,7 +63,7 @@ public class IngestRetentionPoliciesStep implements BootstrapStep {
   @Override
   public void execute() throws IOException, URISyntaxException {
     // 0. Execute preflight check to see whether we need to ingest policies
-    if (_entityService.exists(UPGRADE_ID_URN)) {
+    if (_entityService.exists(UPGRADE_ID_URN, true)) {
       log.info("Retention was applied. Skipping.");
       return;
     }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RemoveClientIdAspectStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RemoveClientIdAspectStep.java
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RemoveClientIdAspectStep implements BootstrapStep {
 
-  private final EntityService _entityService;
+  private final EntityService<?> _entityService;
 
   private static final String UPGRADE_ID = "remove-unknown-aspects";
   private static final String INVALID_TELEMETRY_ASPECT_NAME = "clientId";
@@ -27,7 +27,7 @@ public class RemoveClientIdAspectStep implements BootstrapStep {
   @Override
   public void execute() throws Exception {
     try {
-      if (_entityService.exists(REMOVE_UNKNOWN_ASPECTS_URN)) {
+      if (_entityService.exists(REMOVE_UNKNOWN_ASPECTS_URN, true)) {
         log.info("Unknown aspects have been removed. Skipping...");
         return;
       }

--- a/metadata-service/openapi-entity-servlet/src/main/java/io/datahubproject/openapi/delegates/EntityApiDelegateImpl.java
+++ b/metadata-service/openapi-entity-servlet/src/main/java/io/datahubproject/openapi/delegates/EntityApiDelegateImpl.java
@@ -136,7 +136,7 @@ public class EntityApiDelegateImpl<I, O, S> {
   public ResponseEntity<Void> head(String urn) {
     try {
       Urn entityUrn = Urn.createFromString(urn);
-      if (_entityService.exists(entityUrn)) {
+      if (_entityService.exists(entityUrn, true)) {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
       } else {
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/metadata-service/openapi-servlet/src/test/java/mock/MockEntityService.java
+++ b/metadata-service/openapi-servlet/src/test/java/mock/MockEntityService.java
@@ -42,6 +42,7 @@ import com.linkedin.schema.SchemaMetadata;
 import com.linkedin.schema.StringType;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -212,7 +213,7 @@ public class MockEntityService extends EntityServiceImpl {
   }
 
   @Override
-  public Boolean exists(Urn urn) {
-    return null;
+  public Set<Urn> exists(@NotNull Collection<Urn> urns) {
+    return Set.of();
   }
 }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -1057,6 +1057,6 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
     }
     log.info("EXISTS for {}", urnStr);
     return RestliUtil.toTask(
-        () -> _entityService.exists(urn), MetricRegistry.name(this.getClass(), "exists"));
+        () -> _entityService.exists(urn, true), MetricRegistry.name(this.getClass(), "exists"));
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -25,6 +25,7 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -312,9 +313,27 @@ public interface EntityService<U extends UpsertItem> {
   IngestResult ingestProposal(
       MetadataChangeProposal proposal, AuditStamp auditStamp, final boolean async);
 
-  Boolean exists(Urn urn);
+  /**
+   * Returns a set of urns of entities that exist (has materialized aspects).
+   *
+   * @param urns the list of urns of the entities to check
+   * @return a set of urns of entities that exist.
+   */
+  Set<Urn> exists(@Nonnull final Collection<Urn> urns, boolean includeSoftDelete);
 
-  Boolean isSoftDeleted(@Nonnull final Urn urn);
+  /**
+   * Returns a set of urns of entities that exist (has materialized aspects).
+   *
+   * @param urns the list of urns of the entities to check
+   * @return a set of urns of entities that exist.
+   */
+  default Set<Urn> exists(@Nonnull final Collection<Urn> urns) {
+    return exists(urns, true);
+  }
+
+  default boolean exists(@Nonnull Urn urn, boolean includeSoftDelete) {
+    return exists(List.of(urn), includeSoftDelete).contains(urn);
+  }
 
   void setWritable(boolean canWrite);
 

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntityRecommendationSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/EntityRecommendationSource.java
@@ -1,0 +1,37 @@
+package com.linkedin.metadata.recommendation.candidatesource;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.recommendation.EntityProfileParams;
+import com.linkedin.metadata.recommendation.RecommendationContent;
+import com.linkedin.metadata.recommendation.RecommendationParams;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+
+public interface EntityRecommendationSource extends RecommendationSource {
+  Set<String> getSupportedEntityTypes();
+
+  default RecommendationContent buildContent(@Nonnull Urn urn) {
+    return new RecommendationContent()
+        .setEntity(urn)
+        .setValue(urn.toString())
+        .setParams(
+            new RecommendationParams()
+                .setEntityProfileParams(new EntityProfileParams().setUrn(urn)));
+  }
+
+  default Stream<RecommendationContent> buildContent(
+      @Nonnull List<String> entityUrns, EntityService<?> entityService) {
+    List<Urn> entities =
+        entityUrns.stream()
+            .map(UrnUtils::getUrn)
+            .filter(urn -> getSupportedEntityTypes().contains(urn.getEntityType()))
+            .toList();
+    Set<Urn> existingNonRemoved = entityService.exists(entities, false);
+
+    return entities.stream().filter(existingNonRemoved::contains).map(this::buildContent);
+  }
+}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/shared/ValidationUtils.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/shared/ValidationUtils.java
@@ -1,20 +1,29 @@
 package com.linkedin.metadata.shared;
 
 import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.AbstractArrayTemplate;
 import com.linkedin.metadata.browse.BrowseResult;
+import com.linkedin.metadata.browse.BrowseResultEntity;
 import com.linkedin.metadata.browse.BrowseResultEntityArray;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.EntityLineageResult;
+import com.linkedin.metadata.graph.LineageRelationship;
 import com.linkedin.metadata.graph.LineageRelationshipArray;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.search.LineageScrollResult;
+import com.linkedin.metadata.search.LineageSearchEntity;
 import com.linkedin.metadata.search.LineageSearchEntityArray;
 import com.linkedin.metadata.search.LineageSearchResult;
 import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ValidationUtils {
 
   public static SearchResult validateSearchResult(
-      final SearchResult searchResult, @Nonnull final EntityService entityService) {
+      final SearchResult searchResult, @Nonnull final EntityService<?> entityService) {
     if (searchResult == null) {
       return null;
     }
@@ -37,16 +46,16 @@ public class ValidationUtils {
             .setNumEntities(searchResult.getNumEntities());
 
     SearchEntityArray validatedEntities =
-        searchResult.getEntities().stream()
-            .filter(searchEntity -> entityService.exists(searchEntity.getEntity()))
+        validatedUrns(searchResult.getEntities(), SearchEntity::getEntity, entityService, true)
             .collect(Collectors.toCollection(SearchEntityArray::new));
+
     validatedSearchResult.setEntities(validatedEntities);
 
     return validatedSearchResult;
   }
 
   public static ScrollResult validateScrollResult(
-      final ScrollResult scrollResult, @Nonnull final EntityService entityService) {
+      final ScrollResult scrollResult, @Nonnull final EntityService<?> entityService) {
     if (scrollResult == null) {
       return null;
     }
@@ -62,16 +71,16 @@ public class ValidationUtils {
     }
 
     SearchEntityArray validatedEntities =
-        scrollResult.getEntities().stream()
-            .filter(searchEntity -> entityService.exists(searchEntity.getEntity()))
+        validatedUrns(scrollResult.getEntities(), SearchEntity::getEntity, entityService, true)
             .collect(Collectors.toCollection(SearchEntityArray::new));
+
     validatedScrollResult.setEntities(validatedEntities);
 
     return validatedScrollResult;
   }
 
   public static BrowseResult validateBrowseResult(
-      final BrowseResult browseResult, @Nonnull final EntityService entityService) {
+      final BrowseResult browseResult, @Nonnull final EntityService<?> entityService) {
     if (browseResult == null) {
       return null;
     }
@@ -88,16 +97,16 @@ public class ValidationUtils {
             .setNumElements(browseResult.getNumElements());
 
     BrowseResultEntityArray validatedEntities =
-        browseResult.getEntities().stream()
-            .filter(browseResultEntity -> entityService.exists(browseResultEntity.getUrn()))
+        validatedUrns(browseResult.getEntities(), BrowseResultEntity::getUrn, entityService, true)
             .collect(Collectors.toCollection(BrowseResultEntityArray::new));
+
     validatedBrowseResult.setEntities(validatedEntities);
 
     return validatedBrowseResult;
   }
 
   public static ListResult validateListResult(
-      final ListResult listResult, @Nonnull final EntityService entityService) {
+      final ListResult listResult, @Nonnull final EntityService<?> entityService) {
     if (listResult == null) {
       return null;
     }
@@ -110,16 +119,17 @@ public class ValidationUtils {
             .setTotal(listResult.getTotal());
 
     UrnArray validatedEntities =
-        listResult.getEntities().stream()
-            .filter(entityService::exists)
+        validatedUrns(listResult.getEntities(), Function.identity(), entityService, true)
             .collect(Collectors.toCollection(UrnArray::new));
+
     validatedListResult.setEntities(validatedEntities);
 
     return validatedListResult;
   }
 
   public static LineageSearchResult validateLineageSearchResult(
-      final LineageSearchResult lineageSearchResult, @Nonnull final EntityService entityService) {
+      final LineageSearchResult lineageSearchResult,
+      @Nonnull final EntityService<?> entityService) {
     if (lineageSearchResult == null) {
       return null;
     }
@@ -133,9 +143,13 @@ public class ValidationUtils {
             .setNumEntities(lineageSearchResult.getNumEntities());
 
     LineageSearchEntityArray validatedEntities =
-        lineageSearchResult.getEntities().stream()
-            .filter(entity -> entityService.exists(entity.getEntity()))
+        validatedUrns(
+                lineageSearchResult.getEntities(),
+                LineageSearchEntity::getEntity,
+                entityService,
+                true)
             .collect(Collectors.toCollection(LineageSearchEntityArray::new));
+
     validatedLineageSearchResult.setEntities(validatedEntities);
 
     return validatedLineageSearchResult;
@@ -143,7 +157,7 @@ public class ValidationUtils {
 
   public static EntityLineageResult validateEntityLineageResult(
       @Nullable final EntityLineageResult entityLineageResult,
-      @Nonnull final EntityService entityService) {
+      @Nonnull final EntityService<?> entityService) {
     if (entityLineageResult == null) {
       return null;
     }
@@ -155,10 +169,12 @@ public class ValidationUtils {
             .setCount(entityLineageResult.getCount())
             .setTotal(entityLineageResult.getTotal());
 
-    final LineageRelationshipArray validatedRelationships =
-        entityLineageResult.getRelationships().stream()
-            .filter(relationship -> entityService.exists(relationship.getEntity()))
-            .filter(relationship -> !entityService.isSoftDeleted(relationship.getEntity()))
+    LineageRelationshipArray validatedRelationships =
+        validatedUrns(
+                entityLineageResult.getRelationships(),
+                LineageRelationship::getEntity,
+                entityService,
+                false)
             .collect(Collectors.toCollection(LineageRelationshipArray::new));
 
     validatedEntityLineageResult.setFiltered(
@@ -173,7 +189,8 @@ public class ValidationUtils {
   }
 
   public static LineageScrollResult validateLineageScrollResult(
-      final LineageScrollResult lineageScrollResult, @Nonnull final EntityService entityService) {
+      final LineageScrollResult lineageScrollResult,
+      @Nonnull final EntityService<?> entityService) {
     if (lineageScrollResult == null) {
       return null;
     }
@@ -189,12 +206,28 @@ public class ValidationUtils {
     }
 
     LineageSearchEntityArray validatedEntities =
-        lineageScrollResult.getEntities().stream()
-            .filter(entity -> entityService.exists(entity.getEntity()))
+        validatedUrns(
+                lineageScrollResult.getEntities(),
+                LineageSearchEntity::getEntity,
+                entityService,
+                true)
             .collect(Collectors.toCollection(LineageSearchEntityArray::new));
+
     validatedLineageScrollResult.setEntities(validatedEntities);
 
     return validatedLineageScrollResult;
+  }
+
+  private static <T> Stream<T> validatedUrns(
+      final AbstractArrayTemplate<T> array,
+      Function<T, Urn> urnFunction,
+      @Nonnull final EntityService<?> entityService,
+      boolean includeSoftDeleted) {
+
+    Set<Urn> existingUrns =
+        entityService.exists(
+            array.stream().map(urnFunction).collect(Collectors.toList()), includeSoftDeleted);
+    return array.stream().filter(item -> existingUrns.contains(urnFunction.apply(item)));
   }
 
   private ValidationUtils() {}


### PR DESCRIPTION

Matching the requests for checking the existence of entities, re-implementing PR #8208 along with test updates.

Not only does this PR batch the sql requests for multiple urns, it also reduces the number of id lookups drastically. The existence check was precomputing every possible aspect name.

One of the fixture tests was requesting the existence of 9 dataset urns. The number of valid aspects possible was 240+ and the old implementation means the query was looking for the existence of 240 rows.

The code is now restricted to just looking for the entity's key aspect to determine if the urn exists. This means a 1:1 ratio between the number of urns and the rows queried.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
