### PR TITLE
infra(ui): Add a react context provider allowing sub-components to update theme conf

### DIFF
--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -1,20 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Cookies from 'js-cookie';
 import { message } from 'antd';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ApolloClient, ApolloProvider, createHttpLink, InMemoryCache, ServerError } from '@apollo/client';
 import { onError } from '@apollo/client/link/error';
-import { ThemeProvider } from 'styled-components';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import './App.less';
 import { Routes } from './app/Routes';
-import { Theme } from './conf/theme/types';
-import defaultThemeConfig from './conf/theme/theme_light.config.json';
 import { PageRoutes } from './conf/Global';
 import { isLoggedInVar } from './app/auth/checkAuthStatus';
 import { GlobalCfg } from './conf';
 import possibleTypesResult from './possibleTypes.generated';
 import { ErrorCodes } from './app/shared/constants';
+import CustomThemeProvider from './CustomThemeProvider';
+import { useCustomTheme } from './customThemeContext';
 
 /*
     Construct Apollo Client
@@ -71,33 +70,16 @@ const client = new ApolloClient({
 });
 
 export const InnerApp: React.VFC = () => {
-    const [dynamicThemeConfig, setDynamicThemeConfig] = useState<Theme>(defaultThemeConfig);
-
-    useEffect(() => {
-        if (import.meta.env.DEV) {
-            import(/* @vite-ignore */ `./conf/theme/${import.meta.env.REACT_APP_THEME_CONFIG}`).then((theme) => {
-                setDynamicThemeConfig(theme);
-            });
-        } else {
-            // Send a request to the server to get the theme config.
-            fetch(`/assets/conf/theme/${import.meta.env.REACT_APP_THEME_CONFIG}`)
-                .then((response) => response.json())
-                .then((theme) => {
-                    setDynamicThemeConfig(theme);
-                });
-        }
-    }, []);
-
     return (
         <HelmetProvider>
-            <Helmet>
-                <title>{dynamicThemeConfig.content.title}</title>
-            </Helmet>
-            <ThemeProvider theme={dynamicThemeConfig}>
+            <CustomThemeProvider>
+                <Helmet>
+                    <title>{useCustomTheme().theme?.content.title}</title>
+                </Helmet>
                 <Router>
                     <Routes />
                 </Router>
-            </ThemeProvider>
+            </CustomThemeProvider>
         </HelmetProvider>
     );
 };

--- a/datahub-web-react/src/CustomThemeProvider.tsx
+++ b/datahub-web-react/src/CustomThemeProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { Theme } from './conf/theme/types';
-import defaultThemeConfig from './conf/theme/theme_acryl.config.json';
+import defaultThemeConfig from './conf/theme/theme_light.config.json';
 import { CustomThemeContext } from './customThemeContext';
 
 const CustomThemeProvider = ({ children }: { children: React.ReactNode }) => {

--- a/datahub-web-react/src/CustomThemeProvider.tsx
+++ b/datahub-web-react/src/CustomThemeProvider.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+import { ThemeProvider } from 'styled-components';
+import { Theme } from './conf/theme/types';
+import defaultThemeConfig from './conf/theme/theme_acryl.config.json';
+import { CustomThemeContext } from './customThemeContext';
+
+const CustomThemeProvider = ({ children }: { children: React.ReactNode }) => {
+    const [currentTheme, setTheme] = useState<Theme>(defaultThemeConfig);
+
+    useEffect(() => {
+        if (import.meta.env.DEV) {
+            import(/* @vite-ignore */ `./conf/theme/${import.meta.env.REACT_APP_THEME_CONFIG}`).then((theme) => {
+                setTheme(theme);
+            });
+        } else {
+            // Send a request to the server to get the theme config.
+            fetch(`/assets/conf/theme/${import.meta.env.REACT_APP_THEME_CONFIG}`)
+                .then((response) => response.json())
+                .then((theme) => {
+                    setTheme(theme);
+                });
+        }
+    }, []);
+
+    return (
+        <CustomThemeContext.Provider value={{ theme: currentTheme, updateTheme: setTheme }}>
+            <ThemeProvider theme={currentTheme}>{children}</ThemeProvider>
+        </CustomThemeContext.Provider>
+    );
+};
+
+export default CustomThemeProvider;

--- a/datahub-web-react/src/customThemeContext.tsx
+++ b/datahub-web-react/src/customThemeContext.tsx
@@ -1,0 +1,10 @@
+import React, { useContext } from 'react';
+
+export const CustomThemeContext = React.createContext<{
+    theme: any;
+    updateTheme: (theme: any) => void;
+}>({ theme: undefined, updateTheme: (_) => null });
+
+export function useCustomTheme() {
+    return useContext(CustomThemeContext);
+}


### PR DESCRIPTION
- adding new context object which allows children to update theme conf variables 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
