### PR TITLE
feat(ui) Support auto-render aspects on remaining entity types

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -88,6 +88,7 @@ export const user1 = {
     editableInfo: null,
     properties: null,
     editableProperties: null,
+    autoRenderAspects: [],
 };
 
 const user2 = {
@@ -295,6 +296,7 @@ export const dataset1 = {
     statsSummary: null,
     embed: null,
     browsePathV2: { path: [{ name: 'test', entity: null }], __typename: 'BrowsePathV2' },
+    autoRenderAspects: [],
 };
 
 export const dataset2 = {
@@ -390,6 +392,7 @@ export const dataset2 = {
     statsSummary: null,
     embed: null,
     browsePathV2: { path: [{ name: 'test', entity: null }], __typename: 'BrowsePathV2' },
+    autoRenderAspects: [],
 };
 
 export const dataset3 = {
@@ -595,7 +598,7 @@ export const dataset3 = {
     viewProperties: null,
     autoRenderAspects: [
         {
-            __typename: 'AutoRenderAspect',
+            __typename: 'RawAspect',
             aspectName: 'autoRenderAspect',
             payload: '{ "values": [{ "autoField1": "autoValue1", "autoField2": "autoValue2" }] }',
             renderSpec: {
@@ -962,6 +965,7 @@ export const container1 = {
         externalUrl: null,
         __typename: 'ContainerProperties',
     },
+    autoRenderAspects: [],
     __typename: 'Container',
 } as Container;
 
@@ -976,6 +980,7 @@ export const container2 = {
         externalUrl: null,
         __typename: 'ContainerProperties',
     },
+    autoRenderAspects: [],
     __typename: 'Container',
 } as Container;
 
@@ -1023,6 +1028,7 @@ export const glossaryTerm1 = {
     },
     parentNodes: null,
     deprecation: null,
+    autoRenderAspects: [],
 } as GlossaryTerm;
 
 const glossaryTerm2 = {
@@ -1095,6 +1101,7 @@ const glossaryTerm2 = {
         __typename: 'EntityRelationshipsResult',
     },
     parentNodes: null,
+    autoRenderAspects: [],
     __typename: 'GlossaryTerm',
 };
 
@@ -1161,6 +1168,7 @@ const glossaryTerm3 = {
         __typename: 'GlossaryRelatedTerms',
     },
     deprecation: null,
+    autoRenderAspects: [],
     __typename: 'GlossaryTerm',
 } as GlossaryTerm;
 
@@ -1257,6 +1265,7 @@ export const sampleTag = {
         description: 'sample tag description',
         colorHex: 'sample tag color',
     },
+    autoRenderAspects: [],
 };
 
 export const dataFlow1 = {
@@ -1328,6 +1337,7 @@ export const dataFlow1 = {
     },
     domain: null,
     deprecation: null,
+    autoRenderAspects: [],
 } as DataFlow;
 
 export const dataJob1 = {
@@ -1414,6 +1424,7 @@ export const dataJob1 = {
     domain: null,
     status: null,
     deprecation: null,
+    autoRenderAspects: [],
 } as DataJob;
 
 export const dataJob2 = {
@@ -1483,6 +1494,7 @@ export const dataJob2 = {
     upstream: null,
     downstream: null,
     deprecation: null,
+    autoRenderAspects: [],
 } as DataJob;
 
 export const dataJob3 = {
@@ -1555,6 +1567,7 @@ export const dataJob3 = {
     downstream: null,
     status: null,
     deprecation: null,
+    autoRenderAspects: [],
 } as DataJob;
 
 export const mlModel = {
@@ -1636,6 +1649,7 @@ export const mlModel = {
     downstream: null,
     status: null,
     deprecation: null,
+    autoRenderAspects: [],
 } as MlModel;
 
 export const dataset1FetchedEntity = {

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -103,6 +103,9 @@ query getChart($urn: String!) {
         subTypes {
             typeNames
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/container.graphql
+++ b/datahub-web-react/src/graphql/container.graphql
@@ -54,5 +54,8 @@ query getContainer($urn: String!) {
         status {
             removed
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/dashboard.graphql
+++ b/datahub-web-react/src/graphql/dashboard.graphql
@@ -7,6 +7,9 @@ query getDashboard($urn: String!) {
         datasets: relationships(input: { types: ["Consumes"], direction: OUTGOING, start: 0, count: 100 }) {
             ...fullRelationshipResults
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -102,6 +102,9 @@ query getDataFlow($urn: String!) {
                 }
             }
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/dataJob.graphql
+++ b/datahub-web-react/src/graphql/dataJob.graphql
@@ -6,6 +6,9 @@ query getDataJob($urn: String!) {
             start
             total
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/dataProduct.graphql
+++ b/datahub-web-react/src/graphql/dataProduct.graphql
@@ -1,6 +1,9 @@
 query getDataProduct($urn: String!) {
     dataProduct(urn: $urn) {
         ...dataProductFields
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -112,13 +112,7 @@ fragment nonSiblingDatasetFields on Dataset {
     }
     ...viewProperties
     autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
-        aspectName
-        payload
-        renderSpec {
-            displayType
-            displayName
-            key
-        }
+        ...autoRenderAspectFields
     }
     status {
         removed

--- a/datahub-web-react/src/graphql/domain.graphql
+++ b/datahub-web-react/src/graphql/domain.graphql
@@ -27,6 +27,9 @@ query getDomain($urn: String!) {
                 }
             }
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
         ...domainEntitiesFields
     }
 }

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1162,3 +1162,13 @@ fragment entityDisplayNameFields on Entity {
         instanceId
     }
 }
+
+fragment autoRenderAspectFields on RawAspect {
+    aspectName
+    payload
+    renderSpec {
+        displayType
+        displayName
+        key
+    }
+}

--- a/datahub-web-react/src/graphql/glossaryNode.graphql
+++ b/datahub-web-react/src/graphql/glossaryNode.graphql
@@ -27,6 +27,9 @@ query getGlossaryNode($urn: String!) {
             canManageEntity
             canManageChildren
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
         children: relationships(
             input: {
                 types: ["IsPartOf"]

--- a/datahub-web-react/src/graphql/glossaryTerm.graphql
+++ b/datahub-web-react/src/graphql/glossaryTerm.graphql
@@ -87,6 +87,9 @@ query getGlossaryTerm($urn: String!, $start: Int, $count: Int) {
         privileges {
             canManageEntity
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/group.graphql
+++ b/datahub-web-react/src/graphql/group.graphql
@@ -24,6 +24,9 @@ query getGroup($urn: String!, $membersCount: Int!) {
             email
             slack
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
         ownership {
             ...ownershipFields
         }

--- a/datahub-web-react/src/graphql/mlFeature.graphql
+++ b/datahub-web-react/src/graphql/mlFeature.graphql
@@ -4,5 +4,8 @@ query getMLFeature($urn: String!) {
         featureTables: relationships(input: { types: ["Contains"], direction: INCOMING, start: 0, count: 100 }) {
             ...fullRelationshipResults
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/mlFeatureTable.graphql
+++ b/datahub-web-react/src/graphql/mlFeatureTable.graphql
@@ -1,5 +1,8 @@
 query getMLFeatureTable($urn: String!) {
     mlFeatureTable(urn: $urn) {
         ...nonRecursiveMLFeatureTable
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/mlModel.graphql
+++ b/datahub-web-react/src/graphql/mlModel.graphql
@@ -18,5 +18,8 @@ query getMLModel($urn: String!) {
                 }
             }
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/mlModelGroup.graphql
+++ b/datahub-web-react/src/graphql/mlModelGroup.graphql
@@ -21,5 +21,8 @@ query getMLModelGroup($urn: String!) {
         ) {
             ...fullRelationshipResults
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/mlPrimaryKey.graphql
+++ b/datahub-web-react/src/graphql/mlPrimaryKey.graphql
@@ -4,5 +4,8 @@ query getMLPrimaryKey($urn: String!) {
         featureTables: relationships(input: { types: ["KeyedBy"], direction: INCOMING, start: 0, count: 100 }) {
             ...fullRelationshipResults
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }

--- a/datahub-web-react/src/graphql/tag.graphql
+++ b/datahub-web-react/src/graphql/tag.graphql
@@ -11,6 +11,9 @@ query getTag($urn: String!) {
         ownership {
             ...ownershipFields
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
     }
 }
 

--- a/datahub-web-react/src/graphql/user.graphql
+++ b/datahub-web-react/src/graphql/user.graphql
@@ -27,6 +27,9 @@ query getUser($urn: String!, $groupsCount: Int!) {
         globalTags {
             ...globalTagsFields
         }
+        autoRenderAspects: aspects(input: { autoRenderOnly: true }) {
+            ...autoRenderAspectFields
+        }
         groups: relationships(
             input: {
                 types: ["IsMemberOfGroup", "IsMemberOfNativeGroup"]


### PR DESCRIPTION
This PR adds support in the UI for auto-render aspects for the remaining entity types outside of datasets. We simply needed to fetch the data appropriately and the backend is already wired up for it.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
