### PR TITLE
fix(consumer): wait for internal schema registry

### DIFF
--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -33,6 +33,9 @@ fi
 if [[ ${GRAPH_SERVICE_IMPL:-} != elasticsearch ]] && [[ ${SKIP_NEO4J_CHECK:-false} != true ]]; then
   dockerize_args+=("-wait" "$NEO4J_HOST")
 fi
+if [[ "${KAFKA_SCHEMAREGISTRY_URL:-}" && ${SKIP_SCHEMA_REGISTRY_CHECK:-false} != true ]]; then
+  dockerize_args+=("-wait" "$KAFKA_SCHEMAREGISTRY_URL")
+fi
 
 JAVA_TOOL_OPTIONS="${JDK_JAVA_OPTIONS:-}${JAVA_OPTS:+ $JAVA_OPTS}${JMX_OPTS:+ $JMX_OPTS}"
 if [[ ${ENABLE_OTEL:-false} == true ]]; then

--- a/docker/datahub-mce-consumer/start.sh
+++ b/docker/datahub-mce-consumer/start.sh
@@ -5,6 +5,11 @@ if [[ $SKIP_KAFKA_CHECK != true ]]; then
   WAIT_FOR_KAFKA=" -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') "
 fi
 
+WAIT_FOR_SCHEMA_REGISTRY=""
+if [[ "$KAFKA_SCHEMAREGISTRY_URL" && $SKIP_SCHEMA_REGISTRY_CHECK != true ]]; then
+  WAIT_FOR_SCHEMA_REGISTRY="-wait $KAFKA_SCHEMAREGISTRY_URL"
+fi
+
 OTEL_AGENT=""
 if [[ $ENABLE_OTEL == true ]]; then
   OTEL_AGENT="-javaagent:opentelemetry-javaagent.jar "
@@ -17,5 +22,6 @@ fi
 
 exec dockerize \
   $WAIT_FOR_KAFKA \
+  $WAIT_FOR_SCHEMA_REGISTRY \
   -timeout 240s \
   java $JAVA_OPTS $JMX_OPTS $OTEL_AGENT $PROMETHEUS_AGENT -jar /datahub/datahub-mce-consumer/bin/mce-consumer-job.jar


### PR DESCRIPTION
Kafka consumers in `datahub-{mce|mae}-consumer` need the Schema Registry to be up and ready before they start consuming. This change delays the start of the consumers until Schema Registry is ready.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
