### PR TITLE
docs(observe): add upsert assertion monitor graphql examples

### DIFF
--- a/docs/managed-datahub/observe/column-assertions.md
+++ b/docs/managed-datahub/observe/column-assertions.md
@@ -340,6 +340,91 @@ This entity defines _when_ to run the check (Using CRON format - every 8th hour)
 
 After creating the monitor, the new assertion will start to be evaluated every 8 hours in your selected timezone.
 
+Alternatively you can use `upsertDatasetFieldAssertionMonitor` graphql endpoint for creating a Column Assertion and corresponding Monitor for a dataset. 
+
+```json
+mutation upsertDatasetFieldAssertionMonitor {
+  upsertDatasetFieldAssertionMonitor(
+    input: {
+      entityUrn: "<urn of entity being monitored>"
+      type: FIELD_VALUES,
+      fieldValuesAssertion: {
+        field: {
+          path: "<name of the column to be monitored>",
+          type: "NUMBER",
+          nativeType: "NUMBER(38,0)"
+        },
+        operator: GREATER_THAN,
+        parameters: {
+          value: {
+            type: NUMBER,
+            value: "10"
+          }
+        },
+        failThreshold: {
+          type: COUNT,
+          value: 0
+        },
+        excludeNulls: true
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles"
+        cron: "0 */8 * * *"
+      }
+      evaluationParameters: {
+        sourceType: ALL_ROWS_QUERY
+      }
+      mode: ACTIVE
+    }
+  ){
+    urn
+  }
+}
+```
+
+You can use same endpoint with assertion urn input to update an existing Column Assertion and corresponding Monitor.
+
+```json
+mutation upsertDatasetFieldAssertionMonitor {
+  upsertDatasetFieldAssertionMonitor(
+    assertionUrn: "<urn of assertion created in earlier query>"
+    input: {
+      entityUrn: "<urn of entity being monitored>"
+      type: FIELD_VALUES,
+      fieldValuesAssertion: {
+        field: {
+          path: "<name of the column to be monitored>",
+          type: "NUMBER",
+          nativeType: "NUMBER(38,0)"
+        },
+        operator: GREATER_THAN_OR_EQUAL_TO,
+        parameters: {
+          value: {
+            type: NUMBER,
+            value: "10"
+          }
+        },
+        failThreshold: {
+          type: COUNT,
+          value: 0
+        },
+        excludeNulls: true
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles"
+        cron: "0 */8 * * *"
+      }
+      evaluationParameters: {
+        sourceType: ALL_ROWS_QUERY
+      }
+      mode: ACTIVE
+    }
+  ){
+    urn
+  }
+}
+```
+
 You can delete assertions along with their monitors using GraphQL mutations: `deleteAssertion` and `deleteMonitor`.
 
 ### Tips

--- a/docs/managed-datahub/observe/custom-sql-assertions.md
+++ b/docs/managed-datahub/observe/custom-sql-assertions.md
@@ -297,6 +297,65 @@ This entity defines _when_ to run the check (Using CRON format - every 8th hour)
 
 After creating the monitor, the new assertion will start to be evaluated every 8 hours in your selected timezone.
 
+Alternatively you can use `upsertDatasetSqlAssertionMonitor` graphql endpoint for creating a Custom SQL Assertion and corresponding Monitor for a dataset. 
+
+```json
+mutation upsertDatasetSqlAssertionMonitor {
+  upsertDatasetSqlAssertionMonitor(
+    input: {
+      entityUrn: "<urn of entity being monitored>"
+      type: METRIC,
+      description: "<description of the custom assertion>",
+      statement: "<SQL query to be evaluated>",
+      operator: GREATER_THAN_OR_EQUAL_TO,
+      parameters: {
+        value: {
+          value: "100",
+          type: NUMBER
+        }
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles"
+        cron: "0 */8 * * *"
+      }
+      mode: ACTIVE   
+    }
+  ) {
+    urn
+  }
+}
+```
+
+You can use same endpoint with assertion urn input to update an existing Custom SQL Assertion and corresponding Monitor.
+
+```json
+mutation upsertDatasetSqlAssertionMonitor {
+  upsertDatasetSqlAssertionMonitor(
+    assertionUrn: "<urn of assertion created in earlier query>"
+    input: {
+      entityUrn: "<urn of entity being monitored>"
+      type: METRIC,
+      description: "<description of the custom assertion>",
+      statement: "<SQL query to be evaluated>",
+      operator: GREATER_THAN_OR_EQUAL_TO,
+      parameters: {
+        value: {
+          value: "100",
+          type: NUMBER
+        }
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles"
+        cron: "0 */6 * * *"
+      }
+      mode: ACTIVE   
+    }
+  ) {
+    urn
+  }
+}
+```
+
 You can delete assertions along with their monitors using GraphQL mutations: `deleteAssertion` and `deleteMonitor`.
 
 ### Tips

--- a/docs/managed-datahub/observe/freshness-assertions.md
+++ b/docs/managed-datahub/observe/freshness-assertions.md
@@ -346,6 +346,59 @@ This entity defines _when_ to run the check (Using CRON format - every 8th hour)
 
 After creating the monitor, the new assertion will start to be evaluated every 8 hours in your selected timezone. 
 
+Alternatively you can use `upsertDatasetFreshnessAssertionMonitor` graphql endpoint for creating a Freshness Assertion and corresponding Monitor for a dataset. 
+
+```json
+mutation upsertDatasetFreshnessAssertionMonitor {
+  upsertDatasetFreshnessAssertionMonitor(
+    input: {
+      entityUrn: "<urn of entity being monitored>",
+      schedule: {
+        type: FIXED_INTERVAL,
+        fixedInterval: { unit: HOUR, multiple: 8 }
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles",
+        cron: "0 */8 * * *"
+      }
+      evaluationParameters: {
+        sourceType: INFORMATION_SCHEMA
+      }
+      mode: ACTIVE      
+    }
+  ){
+    urn
+  }
+}
+```
+
+You can use same endpoint with assertion urn input to update an existing Freshness Assertion and corresponding Monitor.
+
+```json
+mutation upsertDatasetFreshnessAssertionMonitor {
+  upsertDatasetFreshnessAssertionMonitor(
+    assertionUrn: "<urn of assertion created in earlier query>"
+    input: {
+      entityUrn: "<urn of entity being monitored>",
+      schedule: {
+        type: FIXED_INTERVAL,
+        fixedInterval: { unit: HOUR, multiple: 6 }
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles",
+        cron: "0 */6 * * *"
+      }
+      evaluationParameters: {
+        sourceType: INFORMATION_SCHEMA
+      }
+      mode: ACTIVE      
+    }
+  ){
+    urn
+  }
+}
+```
+
 You can delete assertions along with their monitors using GraphQL mutations: `deleteAssertion` and `deleteMonitor`.
 
 ### Reporting Operations via API

--- a/docs/managed-datahub/observe/volume-assertions.md
+++ b/docs/managed-datahub/observe/volume-assertions.md
@@ -337,6 +337,79 @@ This entity defines _when_ to run the check (Using CRON format - every 8th hour)
 
 After creating the monitor, the new assertion will start to be evaluated every 8 hours in your selected timezone.
 
+Alternatively you can use `upsertDatasetVolumeAssertionMonitor` graphql endpoint for creating a Volume Assertion and corresponding Monitor. 
+
+```json
+mutation upsertDatasetVolumeAssertionMonitor {
+  upsertDatasetVolumeAssertionMonitor(
+    input: {
+      entityUrn: "<urn of entity being monitored>"
+      type: ROW_COUNT_TOTAL
+      rowCountTotal: {
+        operator: BETWEEN
+        parameters: {
+          minValue: {
+            value: "10"
+            type: NUMBER
+          }
+          maxValue: {
+            value: "20"
+            type: NUMBER
+          }
+        }
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles"
+        cron: "0 */8 * * *"
+      }
+      evaluationParameters: {
+        sourceType: INFORMATION_SCHEMA
+      }
+      mode: ACTIVE
+    }
+  ) {
+    urn
+  }
+}
+```
+
+You can use same endpoint with assertion urn input to update an existing Volume Assertion and corresponding Monitor.
+
+```json
+mutation upsertDatasetVolumeAssertionMonitor {
+  upsertDatasetVolumeAssertionMonitor(
+    assertionUrn: "<urn of assertion created in earlier query>"
+    input: {
+      entityUrn: "<urn of entity being monitored>"
+      type: ROW_COUNT_TOTAL
+      rowCountTotal: {
+        operator: BETWEEN
+        parameters: {
+          minValue: {
+            value: "10"
+            type: NUMBER
+          }
+          maxValue: {
+            value: "20"
+            type: NUMBER
+          }
+        }
+      }
+      evaluationSchedule: {
+        timezone: "America/Los_Angeles"
+        cron: "0 */6 * * *"
+      }
+      evaluationParameters: {
+        sourceType: INFORMATION_SCHEMA
+      }
+      mode: ACTIVE
+    }
+  ) {
+    urn
+  }
+}
+```
+
 You can delete assertions along with their monitors using GraphQL mutations: `deleteAssertion` and `deleteMonitor`.
 
 ### Tips


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
