### PR TITLE
fix(ingestions/snowflake): stop pinning transitive spacy dependency

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -186,8 +186,6 @@ snowflake_common = {
     "cryptography",
     "msal",
     "acryl-datahub-classify==0.0.9",
-    # spacy version restricted to reduce backtracking, used by acryl-datahub-classify,
-    "spacy==3.4.3",
 }
 
 trino = {


### PR DESCRIPTION
This is already a dependency of acryl-datahub-classify, which has a broader range.  If someone is running into pip resolution issue they can try heuristics like this with a constraint file.


## Checklist

- [x ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
