### PR TITLE
feat(recommendations): Correct searchable entities for top platform

### DIFF
--- a/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/recommendation/candidatesource/TopPlatformsSource.java
@@ -6,6 +6,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.dataplatform.DataPlatformInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
 import com.linkedin.metadata.recommendation.ScenarioType;
@@ -67,7 +68,8 @@ public class TopPlatformsSource extends EntitySearchAggregationSource {
     return requestContext.getScenario() == ScenarioType.HOME;
   }
 
-  protected List<String> getEntityNames() {
+  @Override
+  protected List<String> getEntityNames(EntityRegistry entityRegistry) {
     return SEARCHABLE_ENTITY_TYPES;
   }
 


### PR DESCRIPTION
Tested this works by deploying DataHub locally, ingesting the default MCPs via: `datahub ingest mcps metadata-ingestion/examples/mce_files/bootstrap_mce.json` and great expectations does not show up as a top platform whereas before it did.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
