### PR TITLE
fix(mysql-setup): specify charset and collation when creating table

### DIFF
--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -14,7 +14,7 @@ create table if not exists metadata_aspect_v2 (
   createdfor                    varchar(255),
   constraint pk_metadata_aspect_v2 primary key (urn,aspect,version),
   INDEX timeIndex (createdon)
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- create default records for datahub user if not exists
 DROP TABLE if exists temp_metadata_aspect_v2;


### PR DESCRIPTION
Instead of relying on the database's default charset and collation. Increases resilience to cases where the database might have been previously created with a different charset/collation.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
