### PR TITLE
fix(forms) Set form prompts default not required

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/form/FormPrompt.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/form/FormPrompt.pdl
@@ -49,5 +49,5 @@ record FormPrompt {
   /**
    * Whether the prompt is required to be completed, in order for the form to be marked as complete.
    */
-   required: boolean = true
+   required: boolean = false
 }


### PR DESCRIPTION
This PR default sets form prompts as not required so that users have to explicitly say what's required for a form to be complete.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
