### PR TITLE
refactor(graphql): consolidate cache for stats

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -219,5 +219,13 @@ public class AuthorizationUtils {
     return AuthUtil.isAuthorized(authorizer, actor, Optional.of(resourceSpec), privilegeGroup);
   }
 
+  public static boolean isViewDatasetUsageAuthorized(
+      final Urn resourceUrn, final QueryContext context) {
+    return isAuthorized(
+        context,
+        Optional.of(new EntitySpec(resourceUrn.getEntityType(), resourceUrn.toString())),
+        PoliciesConfig.VIEW_DATASET_USAGE_PRIVILEGE);
+  }
+
   private AuthorizationUtils() {}
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/chart/ChartStatsSummaryResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/chart/ChartStatsSummaryResolver.java
@@ -1,14 +1,10 @@
 package com.linkedin.datahub.graphql.resolvers.chart;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.generated.ChartStatsSummary;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -16,12 +12,9 @@ public class ChartStatsSummaryResolver
     implements DataFetcher<CompletableFuture<ChartStatsSummary>> {
 
   private final TimeseriesAspectService timeseriesAspectService;
-  private final Cache<Urn, ChartStatsSummary> summaryCache;
 
   public ChartStatsSummaryResolver(final TimeseriesAspectService timeseriesAspectService) {
     this.timeseriesAspectService = timeseriesAspectService;
-    this.summaryCache =
-        CacheBuilder.newBuilder().maximumSize(10000).expireAfterWrite(6, TimeUnit.HOURS).build();
   }
 
   @Override

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetUsageStatsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetUsageStatsResolver.java
@@ -1,19 +1,17 @@
 package com.linkedin.datahub.graphql.resolvers.dataset;
 
-import com.datahub.authorization.EntitySpec;
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.isViewDatasetUsageAuthorized;
+
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.UsageQueryResult;
 import com.linkedin.datahub.graphql.types.usage.UsageQueryResultMapper;
-import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.usage.UsageClient;
 import com.linkedin.usage.UsageTimeRange;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,7 +33,7 @@ public class DatasetUsageStatsResolver implements DataFetcher<CompletableFuture<
 
     return CompletableFuture.supplyAsync(
         () -> {
-          if (!isAuthorized(resourceUrn, context)) {
+          if (!isViewDatasetUsageAuthorized(resourceUrn, context)) {
             log.debug(
                 "User {} is not authorized to view usage information for dataset {}",
                 context.getActorUrn(),
@@ -51,12 +49,5 @@ public class DatasetUsageStatsResolver implements DataFetcher<CompletableFuture<
                 String.format("Failed to load Usage Stats for resource %s", resourceUrn), e);
           }
         });
-  }
-
-  private boolean isAuthorized(final Urn resourceUrn, final QueryContext context) {
-    return AuthorizationUtils.isAuthorized(
-        context,
-        Optional.of(new EntitySpec(resourceUrn.getEntityType(), resourceUrn.toString())),
-        PoliciesConfig.VIEW_DATASET_USAGE_PRIVILEGE);
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardStatsSummaryTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dashboard/DashboardStatsSummaryTest.java
@@ -1,8 +1,13 @@
 package com.linkedin.datahub.graphql.resolvers.dashboard;
 
 import static com.linkedin.datahub.graphql.resolvers.dashboard.DashboardUsageStatsUtils.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.datahub.authentication.Authentication;
+import com.datahub.authorization.AuthorizationResult;
+import com.datahub.plugins.auth.authorization.Authorizer;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.dashboard.DashboardUsageStatistics;
@@ -49,6 +54,12 @@ public class DashboardStatsSummaryTest {
     // Execute resolver
     DashboardStatsSummaryResolver resolver = new DashboardStatsSummaryResolver(mockClient);
     QueryContext mockContext = Mockito.mock(QueryContext.class);
+    Authorizer mockAuthorizor = mock(Authorizer.class);
+    when(mockAuthorizor.authorize(any()))
+        .thenAnswer(
+            args ->
+                new AuthorizationResult(args.getArgument(0), AuthorizationResult.Type.ALLOW, ""));
+    when(mockContext.getAuthorizer()).thenReturn(mockAuthorizor);
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     Mockito.when(mockEnv.getSource()).thenReturn(TEST_SOURCE);
@@ -84,16 +95,6 @@ public class DashboardStatsSummaryTest {
                 Mockito.eq(1),
                 Mockito.eq(filterForLatestStats)))
         .thenReturn(ImmutableList.of(newResult));
-
-    // Then verify that the new result is _not_ returned (cache hit)
-    DashboardStatsSummary cachedResult = resolver.get(mockEnv).get();
-    Assert.assertEquals((int) cachedResult.getViewCount(), 20);
-    Assert.assertEquals((int) cachedResult.getTopUsersLast30Days().size(), 2);
-    Assert.assertEquals(
-        (String) cachedResult.getTopUsersLast30Days().get(0).getUrn(), TEST_USER_URN_2);
-    Assert.assertEquals(
-        (String) cachedResult.getTopUsersLast30Days().get(1).getUrn(), TEST_USER_URN_1);
-    Assert.assertEquals((int) cachedResult.getUniqueUserCountLast30Days(), 2);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetStatsSummaryResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/dataset/DatasetStatsSummaryResolverTest.java
@@ -87,16 +87,6 @@ public class DatasetStatsSummaryResolverTest {
             mockClient.getUsageStats(
                 Mockito.eq(TEST_DATASET_URN), Mockito.eq(UsageTimeRange.MONTH)))
         .thenReturn(newResult);
-
-    // Then verify that the new result is _not_ returned (cache hit)
-    DatasetStatsSummary cachedResult = resolver.get(mockEnv).get();
-    Assert.assertEquals((int) cachedResult.getQueryCountLast30Days(), 10);
-    Assert.assertEquals((int) cachedResult.getTopUsersLast30Days().size(), 2);
-    Assert.assertEquals(
-        (String) cachedResult.getTopUsersLast30Days().get(0).getUrn(), TEST_USER_URN_2);
-    Assert.assertEquals(
-        (String) cachedResult.getTopUsersLast30Days().get(1).getUrn(), TEST_USER_URN_1);
-    Assert.assertEquals((int) cachedResult.getUniqueUserCountLast30Days(), 5);
   }
 
   @Test

--- a/metadata-service/configuration/src/main/resources/application.yml
+++ b/metadata-service/configuration/src/main/resources/application.yml
@@ -402,6 +402,13 @@ cache:
         structuredProperty:
           propertyDefinition: 86400 # 1 day
           structuredPropertyKey: 86400 # 1 day
+        chart:
+          usageFeatures: 21600 # 6hrs
+        dataset:
+          usageFeatures: 21600 # 6hrs
+          storageFeatures: 21600 # 6hrs
+        dashboard:
+          dashboardUsageStatistics: 21600 # 6hrs
 
 graphQL:
   query:

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClientCache.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClientCache.java
@@ -94,7 +94,7 @@ public class EntityClientCache {
       Function<Iterable<? extends Key>, Map<Key, EnvelopedAspect>> loader =
           (Iterable<? extends Key> keys) -> {
             Map<String, Set<Key>> keysByEntity =
-                StreamSupport.stream(keys.spliterator(), true)
+                StreamSupport.stream(keys.spliterator(), false)
                     .collect(Collectors.groupingBy(Key::getEntityName, Collectors.toSet()));
 
             Map<Key, EnvelopedAspect> results =

--- a/metadata-service/restli-client/src/main/java/com/linkedin/usage/UsageClientCache.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/usage/UsageClientCache.java
@@ -42,7 +42,7 @@ public class UsageClientCache {
       // batch loads data from usage client
       Function<Iterable<? extends Key>, Map<Key, UsageQueryResult>> loader =
           (Iterable<? extends Key> keys) ->
-              StreamSupport.stream(keys.spliterator(), true)
+              StreamSupport.stream(keys.spliterator(), false)
                   .map(k -> Map.entry(k, loadFunction.apply(k.getResource(), k.getRange())))
                   .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 


### PR DESCRIPTION
* remove parallel stream from cache loader
* remove duplicate cache in graphql stats resolvers


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
