### PR TITLE
fix(forms) Prevent schema field prompts from being required

### DIFF
--- a/metadata-ingestion/src/datahub/api/entities/forms/forms.py
+++ b/metadata-ingestion/src/datahub/api/entities/forms/forms.py
@@ -174,7 +174,10 @@ class Forms(ConfigModel):
                     raise Exception(
                         f"Prompt type is {prompt.type} but no structured properties exist. Unable to create form."
                     )
-                if prompt.type == PromptType.FIELDS_STRUCTURED_PROPERTY.value and prompt.required:
+                if (
+                    prompt.type == PromptType.FIELDS_STRUCTURED_PROPERTY.value
+                    and prompt.required
+                ):
                     raise Exception(
                         "Schema field prompts cannot be marked as required. Ensure these prompts are not required."
                     )

--- a/metadata-ingestion/src/datahub/api/entities/forms/forms.py
+++ b/metadata-ingestion/src/datahub/api/entities/forms/forms.py
@@ -174,6 +174,10 @@ class Forms(ConfigModel):
                     raise Exception(
                         f"Prompt type is {prompt.type} but no structured properties exist. Unable to create form."
                     )
+                if prompt.type == PromptType.FIELDS_STRUCTURED_PROPERTY.value and prompt.required:
+                    raise Exception(
+                        "Schema field prompts cannot be marked as required. Ensure these prompts are not required."
+                    )
 
                 prompts.append(
                     FormPromptClass(


### PR DESCRIPTION
For now, prevent any schema field prompts from being required. This could change later.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
