### PR TITLE
feat(ingest/dynamoDB): flatten struct fields

### DIFF
--- a/metadata-ingestion/tests/integration/dynamodb/dynamodb_default_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dynamodb/dynamodb_default_platform_instance_mces_golden.json
@@ -47,9 +47,93 @@
                     "isPartOfKey": false
                 },
                 {
+                    "fieldPath": "contactNumbers",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.ArrayType": {}
+                        }
+                    },
+                    "nativeDataType": "List",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
                     "fieldPath": "partitionKey",
                     "nullable": false,
                     "description": "Partition Key",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "String",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.RecordType": {}
+                        }
+                    },
+                    "nativeDataType": "Map",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.hours",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.RecordType": {}
+                        }
+                    },
+                    "nativeDataType": "Map",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.hours.close",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "String",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.hours.open",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "String",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.parking",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BooleanType": {}
+                        }
+                    },
+                    "nativeDataType": "Boolean",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.wifi",
+                    "nullable": true,
                     "type": {
                         "type": {
                             "com.linkedin.schema.StringType": {}
@@ -76,7 +160,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -95,7 +180,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -111,7 +197,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -126,7 +213,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/dynamodb/dynamodb_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dynamodb/dynamodb_platform_instance_mces_golden.json
@@ -47,9 +47,93 @@
                     "isPartOfKey": false
                 },
                 {
+                    "fieldPath": "contactNumbers",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.ArrayType": {}
+                        }
+                    },
+                    "nativeDataType": "List",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
                     "fieldPath": "partitionKey",
                     "nullable": false,
                     "description": "Partition Key",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "String",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.RecordType": {}
+                        }
+                    },
+                    "nativeDataType": "Map",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.hours",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.RecordType": {}
+                        }
+                    },
+                    "nativeDataType": "Map",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.hours.close",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "String",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.hours.open",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "String",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.parking",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BooleanType": {}
+                        }
+                    },
+                    "nativeDataType": "Boolean",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "services.wifi",
+                    "nullable": true,
                     "type": {
                         "type": {
                             "com.linkedin.schema.StringType": {}
@@ -76,7 +160,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -95,7 +180,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -111,7 +197,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -126,7 +213,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1693396800000,
-        "runId": "dynamodb-test"
+        "runId": "dynamodb-test",
+        "lastRunId": "no-run-id-provided"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/dynamodb/test_dynamodb.py
+++ b/metadata-ingestion/tests/integration/dynamodb/test_dynamodb.py
@@ -15,7 +15,7 @@ FROZEN_TIME = "2023-08-30 12:00:00"
 @freeze_time(FROZEN_TIME)
 @mock_dynamodb
 @pytest.mark.integration
-def test_dynamodb(pytestconfig, tmp_path, mock_time):
+def test_dynamodb(pytestconfig, tmp_path):
     boto3.setup_default_session()
     client = boto3.client("dynamodb", region_name="us-west-2")
     client.create_table(
@@ -35,6 +35,21 @@ def test_dynamodb(pytestconfig, tmp_path, mock_time):
             "city": {"S": "San Francisco"},
             "address": {"S": "1st Market st"},
             "zip": {"N": "94000"},
+            "contactNumbers": {  # List type
+                "L": [
+                    {"S": "+14150000000"},
+                    {"S": "+14151111111"},
+                ]
+            },
+            "services": {  # Map type
+                "M": {
+                    "parking": {"BOOL": True},
+                    "wifi": {"S": "Free"},
+                    "hours": {  # Map type inside Map for nested structure
+                        "M": {"open": {"S": "08:00"}, "close": {"S": "22:00"}}
+                    },
+                }
+            },
         },
     )
 


### PR DESCRIPTION
This PR implements flattening the `map` attribute type when scanning table items for DynamoDB ingestion. The majority of expanding nested field code logic is adopted from
`metadata-ingestion/src/datahub/ingestion/source/schema_inference/object.py`, where it recursively calls `append_schema` for `map` data type field and constructs the field path delimited by `FIELD_DELIMITER`.

According to data types supported in DynamoDB in aws [docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes), `List` and `Map` type both support recursive structure and since it would add more complexity for expanding list or list of maps, for now we'll only expand `Map` type and will handle expanding list in the future.

This PR also adopts a
[fix](https://github.com/datahub-project/datahub/pull/9612) in MongoDB to sort by `count` and `delimiter_name` when downsampling the table schema

Updated `test_dynamodb.py` to add `List` and `Map` type items into test table and `Map` type nested fields are ingested correctly

---------


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
