### PR TITLE
fix(search): fix inequality filters for count fields

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -599,16 +599,16 @@ public class ESUtils {
     String documentFieldName;
     if (fieldTypes.contains(BOOLEAN_FIELD_TYPE)) {
       criterionValue = Boolean.parseBoolean(criterionValueString);
-      documentFieldName = criterion.getField();
+      documentFieldName = fieldName;
     } else if (fieldTypes.contains(LONG_FIELD_TYPE) || fieldTypes.contains(DATE_FIELD_TYPE)) {
       criterionValue = Long.parseLong(criterionValueString);
-      documentFieldName = criterion.getField();
+      documentFieldName = fieldName;
     } else if (fieldTypes.contains(DOUBLE_FIELD_TYPE)) {
       criterionValue = Double.parseDouble(criterionValueString);
-      documentFieldName = criterion.getField();
+      documentFieldName = fieldName;
     } else {
       criterionValue = criterionValueString;
-      documentFieldName = toKeywordField(criterion.getField(), isTimeseries);
+      documentFieldName = toKeywordField(fieldName, isTimeseries);
     }
 
     // Set up QueryBuilder based on condition


### PR DESCRIPTION
Opted for the simpler fix here since we're likely refactoring how Filters are constructed soon anyway. The core issue here is that in ResolverUtils we append ".keyword" blindly and then on ESUtils we're doing manual fixup in spots where we don't need it using the toFacetField method. This logic is intertwined in large swathes of code so makes sense to fix it up in a larger refactor rather than a bug fix.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
