### PR TITLE
PRD-1067 | added owner in gen_datahub_groups and condition for maximu…

### DIFF
--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -3,7 +3,6 @@ import sys
 import tempfile
 from typing import Any, Dict, Iterable, List
 
-import pytest
 import yaml
 from click.testing import CliRunner, Result
 from datahub.api.entities.corpgroup.corpgroup import CorpGroup

--- a/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
+++ b/smoke-test/tests/cli/user_groups_cmd/test_group_cmd.py
@@ -42,6 +42,7 @@ def gen_datahub_groups(num_groups: int) -> Iterable[CorpGroup]:
             description=f"The Group {i}",
             picture_link=f"https://images.google.com/group{i}.jpg",
             slack=f"@group{i}",
+            owners=["user1"],
             members=["user2"],
         )
         yield group
@@ -79,7 +80,6 @@ def get_group_membership(user_urn: str) -> List[str]:
     return [entity.urn for entity in entities]
 
 
-@pytest.mark.skip(reason="Functionality and test needs to be validated for correctness")
 def test_group_upsert(wait_for_healthchecks: Any) -> None:
     num_groups: int = 10
     for i, datahub_group in enumerate(gen_datahub_groups(num_groups)):

--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -31,7 +31,7 @@ def wait_for_writes_to_sync(max_timeout_in_sec: int = 120) -> None:
         result = str(completed_process.stdout)
         lines = result.splitlines()
         lag_values = [int(line) for line in lines if line != ""]
-        maximum_lag = max(lag_values)
+        maximum_lag = max(lag_values) if lag_values else 0
         if maximum_lag == 0:
             lag_zero = True
 


### PR DESCRIPTION
…m_lag


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
