### PR TITLE
docs(ingest): document remote for ingest deploy

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -135,7 +135,7 @@ datahub ingest -c ./examples/recipes/example_to_datahub_rest.dhub.yml -n --previ
 
 The `ingest deploy` command instructs the cli to upload an ingestion recipe to DataHub to be run by DataHub's [UI Ingestion](./ui-ingestion.md).
 This command can also be used to schedule the ingestion while uploading or even to update existing sources. It will upload to the remote instance the
-CLI is connected to, not the sink of the recipe. Use `datahub init` to set the remote, if not already set.
+CLI is connected to, not the sink of the recipe. Use `datahub init` to set the remote if not already set.
 
 To schedule a recipe called "test", to run at 5am everyday, London time with the recipe configured in a local `recipe.yaml` file: 
 ````shell

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,7 +134,8 @@ datahub ingest -c ./examples/recipes/example_to_datahub_rest.dhub.yml -n --previ
 #### ingest deploy
 
 The `ingest deploy` command instructs the cli to upload an ingestion recipe to DataHub to be run by DataHub's [UI Ingestion](./ui-ingestion.md).
-This command can also be used to schedule the ingestion while uploading or even to update existing sources.
+This command can also be used to schedule the ingestion while uploading or even to update existing sources. It will upload to the remote instance the
+CLI is connected to, not the sink of the recipe. Use `datahub init` to set the remote, if not already set.
 
 To schedule a recipe called "test", to run at 5am everyday, London time with the recipe configured in a local `recipe.yaml` file: 
 ````shell


### PR DESCRIPTION
Saw some confusion from users of this. It's unclear since `datahub ingest -c` will use the sink in the recipe, but `ingest deploy` will prefer the sink of the CLI.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
