### PR TITLE
ci(github): timezone action is deprecated

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 60
     needs: setup
     steps:
-      - uses: szenius/set-timezone@v1.2
+      - uses: MathRobin/timezone-action@v1.1
         with:
           timezoneLinux: ${{ matrix.timezone }}
       - name: Check out the repo


### PR DESCRIPTION
`szenius/set-timezone` action is not maintained and uses node 16 which will be deprecated soon in github actions (cf. [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)).

I've made a fork and will keep it up-to-date. It uses node 20.

![2024-02-23_10-01](https://github.com/datahub-project/datahub/assets/1046585/ca5a52ec-8c8e-4597-ac41-af5c208f14f2)
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
