### PR TITLE
fix(pr): make prs only pull changes from pr branch instead of head merge

### DIFF
--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -59,7 +59,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -59,7 +59,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       elasticsearch_setup_change: ${{ steps.ci-optimize.outputs.elasticsearch-setup-change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
 
@@ -61,7 +61,7 @@ jobs:
         with:
           timezoneLinux: ${{ matrix.timezone }}
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -105,7 +105,7 @@ jobs:
     if: ${{ needs.setup.outputs.docker_change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       elasticsearch_setup_change: ${{ steps.ci-optimize.outputs.elasticsearch-setup-change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
 
@@ -61,7 +61,7 @@ jobs:
         with:
           timezoneLinux: ${{ matrix.timezone }}
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -105,7 +105,7 @@ jobs:
     if: ${{ needs.setup.outputs.docker_change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/check-datahub-jars.yml
+++ b/.github/workflows/check-datahub-jars.yml
@@ -27,7 +27,7 @@ jobs:
         command: ["datahub-client", "datahub-protobuf", "spark-lineage"]
     runs-on: ubuntu-latest
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/check-datahub-jars.yml
+++ b/.github/workflows/check-datahub-jars.yml
@@ -27,7 +27,7 @@ jobs:
         command: ["datahub-client", "datahub-protobuf", "spark-lineage"]
     runs-on: ubuntu-latest
     steps:
-      - uses: hsheth2/sane-checkout-action@v1
+      - uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/docker-ingestion-smoke.yml
+++ b/.github/workflows/docker-ingestion-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       python_release_version: ${{ steps.python_release_version.outputs.release_version }}
     steps:
       - name: Checkout
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Compute Tag
         id: tag
         run: |
@@ -50,7 +50,7 @@ jobs:
     if: ${{ needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:

--- a/.github/workflows/docker-ingestion-smoke.yml
+++ b/.github/workflows/docker-ingestion-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       python_release_version: ${{ steps.python_release_version.outputs.release_version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Compute Tag
         id: tag
         run: |
@@ -50,7 +50,7 @@ jobs:
     if: ${{ needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:

--- a/.github/workflows/docker-postgres-setup.yml
+++ b/.github/workflows/docker-postgres-setup.yml
@@ -27,7 +27,7 @@ jobs:
       publish: ${{ steps.publish.outputs.publish }}
     steps:
       - name: Checkout
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Compute Tag
         id: tag
         run: |
@@ -46,7 +46,7 @@ jobs:
     needs: setup
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:

--- a/.github/workflows/docker-postgres-setup.yml
+++ b/.github/workflows/docker-postgres-setup.yml
@@ -27,7 +27,7 @@ jobs:
       publish: ${{ steps.publish.outputs.publish }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Compute Tag
         id: tag
         run: |
@@ -46,7 +46,7 @@ jobs:
     needs: setup
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -82,7 +82,7 @@ jobs:
       elasticsearch_setup_change: ${{ steps.ci-optimize.outputs.elasticsearch-setup-change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Compute Tag
         id: tag
         run: |
@@ -148,7 +148,7 @@ jobs:
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -212,7 +212,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -248,7 +248,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Pre-build artifacts for docker image
         run: |
           ./gradlew :metadata-jobs:mce-consumer-job:build -x test --parallel
@@ -276,7 +276,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -312,7 +312,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Pre-build artifacts for docker image
         run: |
           ./gradlew :datahub-upgrade:build -x test --parallel
@@ -340,7 +340,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -376,7 +376,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Pre-build artifacts for docker image
         run: |
           ./gradlew :datahub-frontend:dist -x test -x yarnTest -x yarnLint --parallel
@@ -436,7 +436,7 @@ jobs:
     if: ${{ needs.setup.outputs.kafka_setup_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -457,7 +457,7 @@ jobs:
     if: ${{ needs.setup.outputs.mysql_setup_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -478,7 +478,7 @@ jobs:
     if: ${{ needs.setup.outputs.elasticsearch_setup_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -501,7 +501,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -534,7 +534,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -575,7 +575,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -624,7 +624,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -674,7 +674,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Download image Slim Image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.datahub_ingestion_slim_build.outputs.needs_artifact_download == 'true' }}
@@ -713,7 +713,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -762,7 +762,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Download image Full Image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.datahub_ingestion_full_build.outputs.needs_artifact_download == 'true' }}
@@ -829,7 +829,7 @@ jobs:
       - name: Disk Check
         run: df -h . && docker images
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -82,7 +82,7 @@ jobs:
       elasticsearch_setup_change: ${{ steps.ci-optimize.outputs.elasticsearch-setup-change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Compute Tag
         id: tag
         run: |
@@ -148,7 +148,7 @@ jobs:
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -212,7 +212,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -248,7 +248,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Pre-build artifacts for docker image
         run: |
           ./gradlew :metadata-jobs:mce-consumer-job:build -x test --parallel
@@ -276,7 +276,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -312,7 +312,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Pre-build artifacts for docker image
         run: |
           ./gradlew :datahub-upgrade:build -x test --parallel
@@ -340,7 +340,7 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Download image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.setup.outputs.publish != 'true' }}
@@ -376,7 +376,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Pre-build artifacts for docker image
         run: |
           ./gradlew :datahub-frontend:dist -x test -x yarnTest -x yarnLint --parallel
@@ -436,7 +436,7 @@ jobs:
     if: ${{ needs.setup.outputs.kafka_setup_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -457,7 +457,7 @@ jobs:
     if: ${{ needs.setup.outputs.mysql_setup_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -478,7 +478,7 @@ jobs:
     if: ${{ needs.setup.outputs.elasticsearch_setup_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -501,7 +501,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -534,7 +534,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -575,7 +575,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -624,7 +624,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -674,7 +674,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Download image Slim Image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.datahub_ingestion_slim_build.outputs.needs_artifact_download == 'true' }}
@@ -713,7 +713,7 @@ jobs:
           java-version: 17
       - uses: gradle/gradle-build-action@v2
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -762,7 +762,7 @@ jobs:
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
       - name: Checkout # adding checkout step just to make trivy upload happy
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Download image Full Image
         uses: ishworkh/docker-image-artifact-download@v1
         if: ${{ needs.datahub_ingestion_full_build.outputs.needs_artifact_download == 'true' }}
@@ -829,7 +829,7 @@ jobs:
       - name: Disk Check
         run: df -h . && docker images
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
   gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,7 @@ jobs:
   gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -10,7 +10,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-pr-review

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -10,7 +10,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - uses: reviewdog/action-actionlint@v1
         with:
           reporter: github-pr-review

--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -50,7 +50,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -50,7 +50,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -39,7 +39,7 @@ jobs:
       elasticsearch_setup_change: ${{ steps.ci-optimize.outputs.elasticsearch-setup-change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: hsheth2/sane-checkout-action@v1
+        uses: acryldata/sane-checkout-action@v3rc1
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
   build:
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 60
     needs: setup
     steps:
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/metadata-io.yml
+++ b/.github/workflows/metadata-io.yml
@@ -39,7 +39,7 @@ jobs:
       elasticsearch_setup_change: ${{ steps.ci-optimize.outputs.elasticsearch-setup-change == 'true' }}
     steps:
       - name: Check out the repo
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - uses: ./.github/actions/ci-optimization
         id: ci-optimize
   build:
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 60
     needs: setup
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/gradle-build-action@v2
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/publish-datahub-jars.yml
+++ b/.github/workflows/publish-datahub-jars.yml
@@ -36,7 +36,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: acryldata/sane-checkout-action@v3rc1
       - name: Compute Tag
         id: tag
         run: |
@@ -48,7 +48,7 @@ jobs:
     needs: ["check-secret", "setup"]
     if: ${{ needs.check-secret.outputs.publish-enabled == 'true' }}
     steps:
-      - uses: hsheth2/sane-checkout-action@v1
+      - uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish-datahub-jars.yml
+++ b/.github/workflows/publish-datahub-jars.yml
@@ -36,7 +36,7 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout
-        uses: acryldata/sane-checkout-action@v3rc1
+        uses: acryldata/sane-checkout-action@v3
       - name: Compute Tag
         id: tag
         run: |
@@ -48,7 +48,7 @@ jobs:
     needs: ["check-secret", "setup"]
     if: ${{ needs.check-secret.outputs.publish-enabled == 'true' }}
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -14,7 +14,7 @@ jobs:
   qodana:
     runs-on: ubuntu-latest
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - name: "Qodana Scan"
         uses: JetBrains/qodana-action@v2022.3.4
       - uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/qodana-scan.yml
+++ b/.github/workflows/qodana-scan.yml
@@ -14,7 +14,7 @@ jobs:
   qodana:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: acryldata/sane-checkout-action@v3rc1
       - name: "Qodana Scan"
         uses: JetBrains/qodana-action@v2022.3.4
       - uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/spark-smoke-test.yml
+++ b/.github/workflows/spark-smoke-test.yml
@@ -29,7 +29,7 @@ jobs:
   spark-smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: hsheth2/sane-checkout-action@v1
+      - uses: acryldata/sane-checkout-action@v3rc1
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/spark-smoke-test.yml
+++ b/.github/workflows/spark-smoke-test.yml
@@ -29,7 +29,7 @@ jobs:
   spark-smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: acryldata/sane-checkout-action@v3rc1
+      - uses: acryldata/sane-checkout-action@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
https://github.com/acryldata/sane-checkout-action/commit/ceba7e47efaeb2b3b1124f4ad45d50f7d7fbe08e

Uses treeless clone to optimize checkout action while still getting full tag details and only pull PR changes instead of merging with main prior to building. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
