### PR TITLE
feat(ingest/patch): add helper for auto-quoting

### DIFF
--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -42,8 +42,8 @@ task installPackageOnly(type: Exec, dependsOn: runPreFlightScript) {
   def sentinel_file = "${venv_name}/.build_install_package_only_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
-  commandLine 'bash', '-x', '-c',
-    "source ${venv_name}/bin/activate && " +
+  commandLine 'bash', '-c',
+    "source ${venv_name}/bin/activate && set -x && " +
     "uv pip install -e . &&" +
     "touch ${sentinel_file}"
 }
@@ -52,8 +52,8 @@ task installPackage(type: Exec, dependsOn: installPackageOnly) {
   def sentinel_file = "${venv_name}/.build_install_package_sentinel"
   inputs.file file('setup.py')
   outputs.file(sentinel_file)
-  commandLine 'bash', '-x', '-c',
-    "source ${venv_name}/bin/activate && " +
+  commandLine 'bash', '-c',
+    "source ${venv_name}/bin/activate && set -x && " +
     "uv pip install -e . ${extra_pip_requirements} && " +
     "touch ${sentinel_file}"
 }
@@ -71,7 +71,7 @@ task customPackageGenerate(type: Exec, dependsOn: [environmentSetup, installPack
   def package_name = project.findProperty('package_name')
   def package_version = project.findProperty('package_version')
   commandLine 'bash', '-c',
-    "source ${venv_name}/bin/activate && " +
+    "source ${venv_name}/bin/activate && set -x && " +
     "uv pip install build && " +
     "./scripts/custom_package_codegen.sh '${package_name}' '${package_version}'"
 }

--- a/metadata-ingestion/src/datahub/emitter/mcp_patch_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp_patch_builder.py
@@ -1,7 +1,7 @@
 import json
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
 
 from datahub.emitter.aspect import JSON_PATCH_CONTENT_TYPE
 from datahub.emitter.serialization_helper import pre_json_transform
@@ -62,7 +62,12 @@ class MetadataPatchProposal:
     def quote(cls, value: str) -> str:
         return value.replace("~", "~0").replace("/", "~1")
 
-    def _add_patch(self, aspect_name: str, op: str, path: str, value: Any) -> None:
+    def _add_patch(
+        self, aspect_name: str, op: str, path: Union[str, Sequence[str]], value: Any
+    ) -> None:
+        if isinstance(path, list):
+            path = "/" + "/".join(self.quote(p) for p in path)
+
         # TODO: Validate that aspectName is a valid aspect for this entityType
         self.patches[aspect_name].append(_Patch(op, path, value))
 

--- a/metadata-ingestion/src/datahub/emitter/mcp_patch_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp_patch_builder.py
@@ -65,7 +65,7 @@ class MetadataPatchProposal:
     def _add_patch(
         self, aspect_name: str, op: str, path: Union[str, Sequence[str]], value: Any
     ) -> None:
-        if isinstance(path, list):
+        if not isinstance(path, str):
             path = "/" + "/".join(self.quote(p) for p in path)
 
         # TODO: Validate that aspectName is a valid aspect for this entityType

--- a/metadata-ingestion/src/datahub/specific/chart.py
+++ b/metadata-ingestion/src/datahub/specific/chart.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Dict, List, Optional, Union
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
 from datahub.metadata.schema_classes import (
@@ -19,8 +19,6 @@ from datahub.specific.custom_properties import CustomPropertiesPatchHelper
 from datahub.specific.ownership import OwnershipPatchHelper
 from datahub.utilities.urns.tag_urn import TagUrn
 from datahub.utilities.urns.urn import Urn
-
-T = TypeVar("T", bound=MetadataPatchProposal)
 
 
 class ChartPatchBuilder(MetadataPatchProposal):

--- a/metadata-ingestion/src/datahub/specific/custom_properties.py
+++ b/metadata-ingestion/src/datahub/specific/custom_properties.py
@@ -2,20 +2,20 @@ from typing import Generic, TypeVar
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
 
-T = TypeVar("T", bound=MetadataPatchProposal)
+_Parent = TypeVar("_Parent", bound=MetadataPatchProposal)
 
 
-class CustomPropertiesPatchHelper(Generic[T]):
+class CustomPropertiesPatchHelper(Generic[_Parent]):
     def __init__(
         self,
-        parent: T,
+        parent: _Parent,
         aspect_name: str,
     ) -> None:
         self.aspect_name = aspect_name
         self._parent = parent
         self.aspect_field = "customProperties"
 
-    def parent(self) -> T:
+    def parent(self) -> _Parent:
         return self._parent
 
     def add_property(self, key: str, value: str) -> "CustomPropertiesPatchHelper":

--- a/metadata-ingestion/src/datahub/specific/dashboard.py
+++ b/metadata-ingestion/src/datahub/specific/dashboard.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Dict, List, Optional, Union
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
 from datahub.metadata.schema_classes import (
@@ -19,8 +19,6 @@ from datahub.specific.custom_properties import CustomPropertiesPatchHelper
 from datahub.specific.ownership import OwnershipPatchHelper
 from datahub.utilities.urns.tag_urn import TagUrn
 from datahub.utilities.urns.urn import Urn
-
-T = TypeVar("T", bound=MetadataPatchProposal)
 
 
 class DashboardPatchBuilder(MetadataPatchProposal):
@@ -165,7 +163,7 @@ class DashboardPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DashboardInfo.ASPECT_NAME,
             "add",
-            path=f"/datasetEdges/{MetadataPatchProposal.quote(dataset_urn)}",
+            path=f"/datasetEdges/{self.quote(dataset_urn)}",
             value=dataset_edge,
         )
         return self
@@ -248,7 +246,7 @@ class DashboardPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DashboardInfo.ASPECT_NAME,
             "add",
-            path=f"/chartEdges/{MetadataPatchProposal.quote(chart_urn)}",
+            path=f"/chartEdges/{self.quote(chart_urn)}",
             value=chart_edge,
         )
         return self

--- a/metadata-ingestion/src/datahub/specific/datajob.py
+++ b/metadata-ingestion/src/datahub/specific/datajob.py
@@ -1,5 +1,5 @@
 import time
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Dict, List, Optional, Union
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
 from datahub.metadata.schema_classes import (
@@ -20,8 +20,6 @@ from datahub.specific.custom_properties import CustomPropertiesPatchHelper
 from datahub.specific.ownership import OwnershipPatchHelper
 from datahub.utilities.urns.tag_urn import TagUrn
 from datahub.utilities.urns.urn import Urn
-
-T = TypeVar("T", bound=MetadataPatchProposal)
 
 
 class DataJobPatchBuilder(MetadataPatchProposal):
@@ -164,7 +162,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",
-            path=f"/inputDatajobEdges/{MetadataPatchProposal.quote(input_urn)}",
+            path=f"/inputDatajobEdges/{self.quote(input_urn)}",
             value=input_edge,
         )
         return self
@@ -247,7 +245,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",
-            path=f"/inputDatasetEdges/{MetadataPatchProposal.quote(input_urn)}",
+            path=f"/inputDatasetEdges/{self.quote(input_urn)}",
             value=input_edge,
         )
         return self
@@ -265,7 +263,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "remove",
-            path=f"/inputDatasetEdges/{MetadataPatchProposal.quote(str(input))}",
+            path=f"/inputDatasetEdges/{self.quote(str(input))}",
             value={},
         )
         return self
@@ -332,7 +330,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",
-            path=f"/outputDatasetEdges/{MetadataPatchProposal.quote(str(input))}",
+            path=f"/outputDatasetEdges/{self.quote(str(input))}",
             value=output_edge,
         )
         return self
@@ -350,7 +348,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "remove",
-            path=f"/outputDatasetEdges/{output}",
+            path=f"/outputDatasetEdges/{self.quote(str(output))}",
             value={},
         )
         return self
@@ -417,7 +415,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",
-            path=f"/inputDatasetFields/{MetadataPatchProposal.quote(input_urn)}",
+            path=f"/inputDatasetFields/{self.quote(input_urn)}",
             value=input_edge,
         )
         return self
@@ -438,7 +436,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "remove",
-            path=f"/inputDatasetFields/{MetadataPatchProposal.quote(input_urn)}",
+            path=f"/inputDatasetFields/{self.quote(input_urn)}",
             value={},
         )
         return self
@@ -505,7 +503,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",
-            path=f"/outputDatasetFields/{MetadataPatchProposal.quote(output_urn)}",
+            path=f"/outputDatasetFields/{self.quote(output_urn)}",
             value=output_edge,
         )
         return self
@@ -526,7 +524,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "remove",
-            path=f"/outputDatasetFields/{MetadataPatchProposal.quote(output_urn)}",
+            path=f"/outputDatasetFields/{self.quote(output_urn)}",
             value={},
         )
         return self

--- a/metadata-ingestion/src/datahub/specific/dataproduct.py
+++ b/metadata-ingestion/src/datahub/specific/dataproduct.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, TypeVar, Union
+from typing import Dict, List, Optional, Union
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
 from datahub.metadata.schema_classes import (
@@ -17,8 +17,6 @@ from datahub.specific.custom_properties import CustomPropertiesPatchHelper
 from datahub.specific.ownership import OwnershipPatchHelper
 from datahub.utilities.urns.tag_urn import TagUrn
 from datahub.utilities.urns.urn import Urn
-
-T = TypeVar("T", bound=MetadataPatchProposal)
 
 
 class DataProductPatchBuilder(MetadataPatchProposal):

--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -24,17 +24,17 @@ from datahub.specific.structured_properties import StructuredPropertiesPatchHelp
 from datahub.utilities.urns.tag_urn import TagUrn
 from datahub.utilities.urns.urn import Urn
 
-T = TypeVar("T", bound=MetadataPatchProposal)
+_Parent = TypeVar("_Parent", bound=MetadataPatchProposal)
 
 
-class FieldPatchHelper(Generic[T]):
+class FieldPatchHelper(Generic[_Parent]):
     def __init__(
         self,
-        parent: T,
+        parent: _Parent,
         field_path: str,
         editable: bool = True,
     ) -> None:
-        self._parent: T = parent
+        self._parent: _Parent = parent
         self.field_path = field_path
         self.aspect_name = (
             EditableSchemaMetadata.ASPECT_NAME
@@ -83,7 +83,7 @@ class FieldPatchHelper(Generic[T]):
         )
         return self
 
-    def parent(self) -> T:
+    def parent(self) -> _Parent:
         return self._parent
 
 

--- a/metadata-ingestion/src/datahub/specific/ownership.py
+++ b/metadata-ingestion/src/datahub/specific/ownership.py
@@ -7,15 +7,15 @@ from datahub.metadata.schema_classes import (
     OwnershipTypeClass,
 )
 
-T = TypeVar("T", bound=MetadataPatchProposal)
+_Parent = TypeVar("_Parent", bound=MetadataPatchProposal)
 
 
-class OwnershipPatchHelper(Generic[T]):
-    def __init__(self, parent: T) -> None:
+class OwnershipPatchHelper(Generic[_Parent]):
+    def __init__(self, parent: _Parent) -> None:
         self._parent = parent
         self.aspect_field = OwnershipClass.ASPECT_NAME
 
-    def parent(self) -> T:
+    def parent(self) -> _Parent:
         return self._parent
 
     def add_owner(self, owner: OwnerClass) -> "OwnershipPatchHelper":

--- a/metadata-ingestion/src/datahub/specific/structured_properties.py
+++ b/metadata-ingestion/src/datahub/specific/structured_properties.py
@@ -6,20 +6,20 @@ from datahub.utilities.urns.structured_properties_urn import (
     make_structured_property_urn,
 )
 
-T = TypeVar("T", bound=MetadataPatchProposal)
+_Parent = TypeVar("_Parent", bound=MetadataPatchProposal)
 
 
-class StructuredPropertiesPatchHelper(Generic[T]):
+class StructuredPropertiesPatchHelper(Generic[_Parent]):
     def __init__(
         self,
-        parent: T,
+        parent: _Parent,
         aspect_name: str = "structuredProperties",
     ) -> None:
         self.aspect_name = aspect_name
         self._parent = parent
         self.aspect_field = "properties"
 
-    def parent(self) -> T:
+    def parent(self) -> _Parent:
         return self._parent
 
     def set_property(
@@ -33,7 +33,7 @@ class StructuredPropertiesPatchHelper(Generic[T]):
         self._parent._add_patch(
             self.aspect_name,
             "remove",
-            path=f"/{self.aspect_field}/{make_structured_property_urn(key)}",
+            path=(self.aspect_field, make_structured_property_urn(key)),
             value={},
         )
         return self
@@ -44,7 +44,7 @@ class StructuredPropertiesPatchHelper(Generic[T]):
         self._parent._add_patch(
             self.aspect_name,
             "add",
-            path=f"/{self.aspect_field}/{make_structured_property_urn(key)}",
+            path=(self.aspect_field, make_structured_property_urn(key)),
             value=StructuredPropertyValueAssignmentClass(
                 propertyUrn=make_structured_property_urn(key),
                 values=value if isinstance(value, list) else [value],


### PR DESCRIPTION
Passing a tuple to `_add_patch` does this automatically. I only modified a few instances to use the tuple form - we can do the cleanup later.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
