### PR TITLE
refactor(react): Provide option to skip importing theme in CustomThemeProvider; rearrange toplevel components

### DIFF
--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -59,7 +59,8 @@ const client = new ApolloClient({
                     },
                 },
             },
-        }, // need to define possibleTypes to allow us to use Apollo cache with union types
+        },
+        // need to define possibleTypes to allow us to use Apollo cache with union types
         possibleTypes: possibleTypesResult.possibleTypes,
     }),
     credentials: 'include',
@@ -75,23 +76,23 @@ const client = new ApolloClient({
 
 export const InnerApp: React.VFC = () => {
     return (
-        <Router>
-            <Routes />
-        </Router>
+        <HelmetProvider>
+            <CustomThemeProvider>
+                <Helmet>
+                    <title>{useCustomTheme().theme?.content.title}</title>
+                </Helmet>
+                <Router>
+                    <Routes />
+                </Router>
+            </CustomThemeProvider>
+        </HelmetProvider>
     );
 };
 
 export const App: React.VFC = () => {
     return (
         <ApolloProvider client={client}>
-            <HelmetProvider>
-                <CustomThemeProvider>
-                    <Helmet>
-                        <title>{useCustomTheme().theme?.content.title}</title>
-                    </Helmet>
-                    <InnerApp />
-                </CustomThemeProvider>
-            </HelmetProvider>
+            <InnerApp />
         </ApolloProvider>
     );
 };

--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -59,8 +59,7 @@ const client = new ApolloClient({
                     },
                 },
             },
-        },
-        // need to define possibleTypes to allow us to use Apollo cache with union types
+        }, // need to define possibleTypes to allow us to use Apollo cache with union types
         possibleTypes: possibleTypesResult.possibleTypes,
     }),
     credentials: 'include',
@@ -76,23 +75,23 @@ const client = new ApolloClient({
 
 export const InnerApp: React.VFC = () => {
     return (
-        <HelmetProvider>
-            <CustomThemeProvider>
-                <Helmet>
-                    <title>{useCustomTheme().theme?.content.title}</title>
-                </Helmet>
-                <Router>
-                    <Routes />
-                </Router>
-            </CustomThemeProvider>
-        </HelmetProvider>
+        <Router>
+            <Routes />
+        </Router>
     );
 };
 
 export const App: React.VFC = () => {
     return (
         <ApolloProvider client={client}>
-            <InnerApp />
+            <HelmetProvider>
+                <CustomThemeProvider>
+                    <Helmet>
+                        <title>{useCustomTheme().theme?.content.title}</title>
+                    </Helmet>
+                    <InnerApp />
+                </CustomThemeProvider>
+            </HelmetProvider>
         </ApolloProvider>
     );
 };

--- a/datahub-web-react/src/AppConfigProvider.tsx
+++ b/datahub-web-react/src/AppConfigProvider.tsx
@@ -39,7 +39,11 @@ const AppConfigProvider = ({ children }: { children: React.ReactNode }) => {
 
     return (
         <AppConfigContext.Provider
-            value={{ config: appConfigData?.appConfig || DEFAULT_APP_CONFIG, refreshContext: refreshAppConfig }}
+            value={{
+                config: appConfigData?.appConfig || DEFAULT_APP_CONFIG,
+                loaded: !!appConfigData,
+                refreshContext: refreshAppConfig,
+            }}
         >
             {children}
         </AppConfigContext.Provider>

--- a/datahub-web-react/src/CustomThemeProvider.tsx
+++ b/datahub-web-react/src/CustomThemeProvider.tsx
@@ -4,7 +4,12 @@ import { Theme } from './conf/theme/types';
 import defaultThemeConfig from './conf/theme/theme_light.config.json';
 import { CustomThemeContext } from './customThemeContext';
 
-const CustomThemeProvider = ({ children }: { children: React.ReactNode }) => {
+interface Props {
+    children: React.ReactNode;
+    skipSetTheme?: boolean;
+}
+
+const CustomThemeProvider = ({ children, skipSetTheme }: Props) => {
     const [currentTheme, setTheme] = useState<Theme>(defaultThemeConfig);
 
     useEffect(() => {
@@ -12,7 +17,7 @@ const CustomThemeProvider = ({ children }: { children: React.ReactNode }) => {
             import(/* @vite-ignore */ `./conf/theme/${import.meta.env.REACT_APP_THEME_CONFIG}`).then((theme) => {
                 setTheme(theme);
             });
-        } else {
+        } else if (!skipSetTheme) {
             // Send a request to the server to get the theme config.
             fetch(`/assets/conf/theme/${import.meta.env.REACT_APP_THEME_CONFIG}`)
                 .then((response) => response.json())
@@ -20,7 +25,7 @@ const CustomThemeProvider = ({ children }: { children: React.ReactNode }) => {
                     setTheme(theme);
                 });
         }
-    }, []);
+    }, [skipSetTheme]);
 
     return (
         <CustomThemeContext.Provider value={{ theme: currentTheme, updateTheme: setTheme }}>

--- a/datahub-web-react/src/app/ProtectedRoutes.tsx
+++ b/datahub-web-react/src/app/ProtectedRoutes.tsx
@@ -3,7 +3,6 @@ import { Switch, Route } from 'react-router-dom';
 import { Layout } from 'antd';
 import { HomePage } from './home/HomePage';
 import { SearchRoutes } from './SearchRoutes';
-import AppProviders from './AppProviders';
 import EmbedRoutes from './EmbedRoutes';
 import { PageRoutes } from '../conf/Global';
 
@@ -12,14 +11,12 @@ import { PageRoutes } from '../conf/Global';
  */
 export const ProtectedRoutes = (): JSX.Element => {
     return (
-        <AppProviders>
-            <Layout>
-                <Switch>
-                    <Route exact path="/" render={() => <HomePage />} />
-                    <Route path={PageRoutes.EMBED} render={() => <EmbedRoutes />} />
-                    <Route path="/*" render={() => <SearchRoutes />} />
-                </Switch>
-            </Layout>
-        </AppProviders>
+        <Layout>
+            <Switch>
+                <Route exact path="/" render={() => <HomePage />} />
+                <Route path={PageRoutes.EMBED} render={() => <EmbedRoutes />} />
+                <Route path="/*" render={() => <SearchRoutes />} />
+            </Switch>
+        </Layout>
     );
 };

--- a/datahub-web-react/src/app/Routes.tsx
+++ b/datahub-web-react/src/app/Routes.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Switch, Route, RouteProps } from 'react-router-dom';
 import { useReactiveVar } from '@apollo/client';
+import AppProviders from './AppProviders';
 import { LogIn } from './auth/LogIn';
 import { SignUp } from './auth/SignUp';
 import { ResetCredentials } from './auth/ResetCredentials';
@@ -36,7 +37,14 @@ export const Routes = (): JSX.Element => {
             <Route path={PageRoutes.LOG_IN} component={LogIn} />
             <Route path={PageRoutes.SIGN_UP} component={SignUp} />
             <Route path={PageRoutes.RESET_CREDENTIALS} component={ResetCredentials} />
-            <ProtectedRoute isLoggedIn={isLoggedIn} render={() => <ProtectedRoutes />} />
+            <ProtectedRoute
+                isLoggedIn={isLoggedIn}
+                render={() => (
+                    <AppProviders>
+                        <ProtectedRoutes />
+                    </AppProviders>
+                )}
+            />
             <Route path="/*" component={NoPageFound} />
         </Switch>
     );

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -56,5 +56,6 @@ export const DEFAULT_APP_CONFIG = {
 
 export const AppConfigContext = React.createContext<{
     config: AppConfig;
+    loaded: boolean;
     refreshContext: () => void;
-}>({ config: DEFAULT_APP_CONFIG, refreshContext: () => null });
+}>({ config: DEFAULT_APP_CONFIG, loaded: false, refreshContext: () => null });


### PR DESCRIPTION
This will allow loading the theme based on a local variable instead.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
