### PR TITLE
feat(lineage) Restrict lineage nodes in the lineage graph if user lacks view permissions

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1464,7 +1464,12 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.datasetType))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher(
                         "platform",
                         new LoadableTypeResolver<>(
@@ -1831,7 +1836,10 @@ public class GmsGraphQLEngine {
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dashboardType))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration))
                 .dataFetcher(
                     "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                 .dataFetcher(
@@ -1958,7 +1966,10 @@ public class GmsGraphQLEngine {
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.chartType))
                 .dataFetcher(
                     "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration))
                 .dataFetcher(
                     "platform",
                     new LoadableTypeResolver<>(
@@ -2080,7 +2091,12 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataJobType))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                     .dataFetcher(
@@ -2152,7 +2168,10 @@ public class GmsGraphQLEngine {
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataFlowType))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration))
                 .dataFetcher(
                     "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                 .dataFetcher(
@@ -2196,7 +2215,12 @@ public class GmsGraphQLEngine {
                         "browsePaths", new EntityBrowsePathsResolver(this.mlFeatureTableType))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher(
                         "platform",
@@ -2279,7 +2303,12 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlModelType))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
@@ -2324,7 +2353,12 @@ public class GmsGraphQLEngine {
                         "browsePaths", new EntityBrowsePathsResolver(this.mlModelGroupType))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher(
                         "platform",
                         new LoadableTypeResolver<>(
@@ -2347,7 +2381,12 @@ public class GmsGraphQLEngine {
                 typeWiring
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
@@ -2367,7 +2406,12 @@ public class GmsGraphQLEngine {
                 typeWiring
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                    .dataFetcher(
+                        "lineage",
+                        new EntityLineageResultResolver(
+                            siblingGraphService,
+                            restrictedService,
+                            this.authorizationConfiguration))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
@@ -2664,7 +2708,10 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration))
                 .dataFetcher(
                     "state",
                     new TimeSeriesAspectResolver(
@@ -2773,7 +2820,10 @@ public class GmsGraphQLEngine {
         "Restricted",
         typeWiring ->
             typeWiring
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                .dataFetcher(
+                    "lineage",
+                    new EntityLineageResultResolver(
+                        siblingGraphService, restrictedService, this.authorizationConfiguration))
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -321,6 +321,7 @@ import com.linkedin.datahub.graphql.types.notebook.NotebookType;
 import com.linkedin.datahub.graphql.types.ownership.OwnershipType;
 import com.linkedin.datahub.graphql.types.policy.DataHubPolicyType;
 import com.linkedin.datahub.graphql.types.query.QueryType;
+import com.linkedin.datahub.graphql.types.restricted.RestrictedType;
 import com.linkedin.datahub.graphql.types.role.DataHubRoleType;
 import com.linkedin.datahub.graphql.types.rolemetadata.RoleType;
 import com.linkedin.datahub.graphql.types.schemafield.SchemaFieldType;
@@ -349,6 +350,7 @@ import com.linkedin.metadata.service.FormService;
 import com.linkedin.metadata.service.LineageService;
 import com.linkedin.metadata.service.OwnershipTypeService;
 import com.linkedin.metadata.service.QueryService;
+import com.linkedin.metadata.service.RestrictedService;
 import com.linkedin.metadata.service.SettingsService;
 import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.timeline.TimelineService;
@@ -416,6 +418,7 @@ public class GmsGraphQLEngine {
   private final QueryService queryService;
   private final DataProductService dataProductService;
   private final FormService formService;
+  private final RestrictedService restrictedService;
 
   private final FeatureFlags featureFlags;
 
@@ -468,6 +471,7 @@ public class GmsGraphQLEngine {
   private final EntityTypeType entityTypeType;
   private final FormType formType;
   private final IncidentType incidentType;
+  private final RestrictedType restrictedType;
 
   private final int graphQLQueryComplexityLimit;
   private final int graphQLQueryDepthLimit;
@@ -527,6 +531,7 @@ public class GmsGraphQLEngine {
     this.queryService = args.queryService;
     this.dataProductService = args.dataProductService;
     this.formService = args.formService;
+    this.restrictedService = args.restrictedService;
 
     this.ingestionConfiguration = Objects.requireNonNull(args.ingestionConfiguration);
     this.authenticationConfiguration = Objects.requireNonNull(args.authenticationConfiguration);
@@ -576,6 +581,7 @@ public class GmsGraphQLEngine {
     this.entityTypeType = new EntityTypeType(entityClient);
     this.formType = new FormType(entityClient);
     this.incidentType = new IncidentType(entityClient);
+    this.restrictedType = new RestrictedType(entityClient, restrictedService);
 
     this.graphQLQueryComplexityLimit = args.graphQLQueryComplexityLimit;
     this.graphQLQueryDepthLimit = args.graphQLQueryDepthLimit;
@@ -619,7 +625,8 @@ public class GmsGraphQLEngine {
             dataTypeType,
             entityTypeType,
             formType,
-            incidentType);
+            incidentType,
+            restrictedType);
     this.loadableTypes = new ArrayList<>(entityTypes);
     // Extend loadable types with types from the plugins
     // This allows us to offer search and browse capabilities out of the box for those types
@@ -709,6 +716,7 @@ public class GmsGraphQLEngine {
     configureStructuredPropertyResolvers(builder);
     configureFormResolvers(builder);
     configureIncidentResolvers(builder);
+    configureRestrictedResolvers(builder);
   }
 
   private void configureOrganisationRoleResolvers(RuntimeWiring.Builder builder) {
@@ -1456,7 +1464,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.datasetType))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher(
                         "platform",
                         new LoadableTypeResolver<>(
@@ -1823,7 +1831,7 @@ public class GmsGraphQLEngine {
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dashboardType))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                 .dataFetcher(
                     "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                 .dataFetcher(
@@ -1950,7 +1958,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.chartType))
                 .dataFetcher(
                     "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                 .dataFetcher(
                     "platform",
                     new LoadableTypeResolver<>(
@@ -2072,7 +2080,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataJobType))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                     .dataFetcher(
@@ -2144,7 +2152,7 @@ public class GmsGraphQLEngine {
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
                 .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.dataFlowType))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                 .dataFetcher(
                     "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                 .dataFetcher(
@@ -2188,7 +2196,7 @@ public class GmsGraphQLEngine {
                         "browsePaths", new EntityBrowsePathsResolver(this.mlFeatureTableType))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher(
                         "platform",
@@ -2271,7 +2279,7 @@ public class GmsGraphQLEngine {
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
                     .dataFetcher("browsePaths", new EntityBrowsePathsResolver(this.mlModelType))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
@@ -2316,7 +2324,7 @@ public class GmsGraphQLEngine {
                         "browsePaths", new EntityBrowsePathsResolver(this.mlModelGroupType))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher(
                         "platform",
                         new LoadableTypeResolver<>(
@@ -2339,7 +2347,7 @@ public class GmsGraphQLEngine {
                 typeWiring
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
@@ -2359,7 +2367,7 @@ public class GmsGraphQLEngine {
                 typeWiring
                     .dataFetcher(
                         "relationships", new EntityRelationshipsResultResolver(graphClient))
-                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                    .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                     .dataFetcher(
                         "aspects", new WeaklyTypedAspectsResolver(entityClient, entityRegistry))
                     .dataFetcher("exists", new EntityExistsResolver(entityService))
@@ -2656,7 +2664,7 @@ public class GmsGraphQLEngine {
         typeWiring ->
             typeWiring
                 .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient))
-                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService))
+                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
                 .dataFetcher(
                     "state",
                     new TimeSeriesAspectResolver(
@@ -2758,5 +2766,14 @@ public class GmsGraphQLEngine {
           typeWiring ->
               typeWiring.dataFetcher("incidents", new EntityIncidentsResolver(entityClient)));
     }
+  }
+
+  private void configureRestrictedResolvers(final RuntimeWiring.Builder builder) {
+    builder.type(
+        "Restricted",
+        typeWiring ->
+            typeWiring
+                .dataFetcher("lineage", new EntityLineageResultResolver(siblingGraphService, restrictedService))
+                .dataFetcher("relationships", new EntityRelationshipsResultResolver(graphClient)));
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngineArgs.java
@@ -29,6 +29,7 @@ import com.linkedin.metadata.service.FormService;
 import com.linkedin.metadata.service.LineageService;
 import com.linkedin.metadata.service.OwnershipTypeService;
 import com.linkedin.metadata.service.QueryService;
+import com.linkedin.metadata.service.RestrictedService;
 import com.linkedin.metadata.service.SettingsService;
 import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.timeline.TimelineService;
@@ -75,6 +76,7 @@ public class GmsGraphQLEngineArgs {
   FeatureFlags featureFlags;
   DataProductService dataProductService;
   FormService formService;
+  RestrictedService restrictedService;
   int graphQLQueryComplexityLimit;
   int graphQLQueryDepthLimit;
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/authorization/AuthorizationUtils.java
@@ -25,10 +25,10 @@ public class AuthorizationUtils {
   private static final Clock CLOCK = Clock.systemUTC();
 
   /*
-  These two privileges should be logically the same for search even
-  if one might allow search but not the entity page view at some point.
-  This list should mimic the list in ESAccessControlUtil - update both places.
-*/
+    These two privileges should be logically the same for search even
+    if one might allow search but not the entity page view at some point.
+    This list should mimic the list in ESAccessControlUtil - update both places.
+  */
   private static final Set<String> FILTER_PRIVILEGES =
       Set.of(
           PoliciesConfig.VIEW_ENTITY_PRIVILEGE.getType(),
@@ -209,7 +209,8 @@ public class AuthorizationUtils {
     final Authorizer authorizer = context.getAuthorizer();
     final String actor = context.getActorUrn();
     final String entityType = entityUrn.getEntityType();
-    final Optional<EntitySpec> resourceSpec = Optional.of(new EntitySpec(entityType, entityUrn.toString()));
+    final Optional<EntitySpec> resourceSpec =
+        Optional.of(new EntitySpec(entityType, entityUrn.toString()));
 
     return AuthUtil.isAuthorized(authorizer, actor, resourceSpec, orGroup);
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
@@ -3,17 +3,25 @@ package com.linkedin.datahub.graphql.resolvers.load;
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityLineageResult;
+import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.LineageDirection;
 import com.linkedin.datahub.graphql.generated.LineageInput;
 import com.linkedin.datahub.graphql.generated.LineageRelationship;
+import com.linkedin.datahub.graphql.generated.Restricted;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.graph.SiblingGraphService;
+import com.linkedin.metadata.service.RestrictedService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.net.URISyntaxException;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -29,15 +37,22 @@ public class EntityLineageResultResolver
     implements DataFetcher<CompletableFuture<EntityLineageResult>> {
 
   private final SiblingGraphService _siblingGraphService;
+  private final RestrictedService _restrictedService;
 
-  public EntityLineageResultResolver(final SiblingGraphService siblingGraphService) {
+  public EntityLineageResultResolver(final SiblingGraphService siblingGraphService, final RestrictedService restrictedService) {
     _siblingGraphService = siblingGraphService;
+    _restrictedService = restrictedService;
   }
 
   @Override
   public CompletableFuture<EntityLineageResult> get(DataFetchingEnvironment environment) {
-    final String urn = ((Entity) environment.getSource()).getUrn();
+    final QueryContext context = environment.getContext();
+    Urn urn = UrnUtils.getUrn(((Entity) environment.getSource()).getUrn());
     final LineageInput input = bindArgument(environment.getArgument("input"), LineageInput.class);
+
+    if (urn.getEntityType().equals(Constants.RESTRICTED_ENTITY_NAME)) {
+      urn = _restrictedService.decryptRestrictedUrn(urn);
+    }
 
     final LineageDirection lineageDirection = input.getDirection();
     @Nullable final Integer start = input.getStart(); // Optional!
@@ -49,29 +64,39 @@ public class EntityLineageResultResolver
     com.linkedin.metadata.graph.LineageDirection resolvedDirection =
         com.linkedin.metadata.graph.LineageDirection.valueOf(lineageDirection.toString());
 
+    final Urn finalUrn = urn;
     return CompletableFuture.supplyAsync(
         () -> {
           try {
-            return mapEntityRelationships(
-                _siblingGraphService.getLineage(
-                    Urn.createFromString(urn),
-                    resolvedDirection,
-                    start != null ? start : 0,
-                    count != null ? count : 100,
-                    1,
-                    separateSiblings != null ? input.getSeparateSiblings() : false,
-                    new HashSet<>(),
-                    startTimeMillis,
-                    endTimeMillis));
-          } catch (URISyntaxException e) {
-            log.error("Failed to fetch lineage for {}", urn);
-            throw new RuntimeException(String.format("Failed to fetch lineage for {}", urn), e);
+            com.linkedin.metadata.graph.EntityLineageResult entityLineageResult = _siblingGraphService.getLineage(
+                finalUrn,
+                resolvedDirection,
+                start != null ? start : 0,
+                count != null ? count : 100,
+                1,
+                separateSiblings != null ? input.getSeparateSiblings() : false,
+                new HashSet<>(),
+                startTimeMillis,
+                endTimeMillis);
+
+              Set<Urn> restrictedUrns = new HashSet<>();
+              entityLineageResult.getRelationships().forEach(rel -> {
+                // check flag here
+                if (!AuthorizationUtils.canViewEntity(rel.getEntity(), context)) {
+                  restrictedUrns.add(rel.getEntity());
+                }
+              });
+
+              return mapEntityRelationships(entityLineageResult, restrictedUrns);
+          } catch (Exception e) {
+            log.error("Failed to fetch lineage for {}", finalUrn);
+            throw new RuntimeException(String.format("Failed to fetch lineage for {}", finalUrn), e);
           }
         });
   }
 
   private EntityLineageResult mapEntityRelationships(
-      final com.linkedin.metadata.graph.EntityLineageResult entityLineageResult) {
+      final com.linkedin.metadata.graph.EntityLineageResult entityLineageResult, final Set<Urn> restrictedUrns) {
     final EntityLineageResult result = new EntityLineageResult();
     result.setStart(entityLineageResult.getStart());
     result.setCount(entityLineageResult.getCount());
@@ -79,17 +104,26 @@ public class EntityLineageResultResolver
     result.setFiltered(entityLineageResult.getFiltered());
     result.setRelationships(
         entityLineageResult.getRelationships().stream()
-            .map(this::mapEntityRelationship)
+            .map(r -> mapEntityRelationship(r, restrictedUrns))
             .collect(Collectors.toList()));
     return result;
   }
 
   private LineageRelationship mapEntityRelationship(
-      final com.linkedin.metadata.graph.LineageRelationship lineageRelationship) {
+      final com.linkedin.metadata.graph.LineageRelationship lineageRelationship, final Set<Urn> restrictedUrns) {
     final LineageRelationship result = new LineageRelationship();
-    final Entity partialEntity = UrnToEntityMapper.map(lineageRelationship.getEntity());
-    if (partialEntity != null) {
-      result.setEntity(partialEntity);
+    if (restrictedUrns.contains(lineageRelationship.getEntity())) {
+      final Restricted restrictedEntity = new Restricted();
+      restrictedEntity.setType(EntityType.RESTRICTED);
+      String restrictedUrnString = _restrictedService.encryptRestrictedUrn(lineageRelationship.getEntity()).toString();
+
+      restrictedEntity.setUrn(restrictedUrnString);
+      result.setEntity(restrictedEntity);
+    } else {
+      final Entity partialEntity = UrnToEntityMapper.map(lineageRelationship.getEntity());
+      if (partialEntity != null) {
+        result.setEntity(partialEntity);
+      }
     }
     result.setType(lineageRelationship.getType());
     result.setDegree(lineageRelationship.getDegree());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/UrnToEntityMapper.java
@@ -31,6 +31,7 @@ import com.linkedin.datahub.graphql.generated.MLPrimaryKey;
 import com.linkedin.datahub.graphql.generated.Notebook;
 import com.linkedin.datahub.graphql.generated.OwnershipTypeEntity;
 import com.linkedin.datahub.graphql.generated.QueryEntity;
+import com.linkedin.datahub.graphql.generated.Restricted;
 import com.linkedin.datahub.graphql.generated.Role;
 import com.linkedin.datahub.graphql.generated.SchemaFieldEntity;
 import com.linkedin.datahub.graphql.generated.StructuredPropertyEntity;
@@ -203,6 +204,11 @@ public class UrnToEntityMapper implements ModelMapper<com.linkedin.common.urn.Ur
       partialEntity = new QueryEntity();
       ((QueryEntity) partialEntity).setUrn(input.toString());
       ((QueryEntity) partialEntity).setType(EntityType.QUERY);
+    }
+    if (input.getEntityType().equals(RESTRICTED_ENTITY_NAME)) {
+      partialEntity = new Restricted();
+      ((Restricted) partialEntity).setUrn(input.toString());
+      ((Restricted) partialEntity).setType(EntityType.RESTRICTED);
     }
     return partialEntity;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeMapper.java
@@ -43,6 +43,7 @@ public class EntityTypeMapper {
           .put(EntityType.SCHEMA_FIELD, "schemaField")
           .put(EntityType.STRUCTURED_PROPERTY, Constants.STRUCTURED_PROPERTY_ENTITY_NAME)
           .put(EntityType.ASSERTION, Constants.ASSERTION_ENTITY_NAME)
+          .put(EntityType.RESTRICTED, Constants.RESTRICTED_ENTITY_NAME)
           .build();
 
   private static final Map<String, EntityType> ENTITY_NAME_TO_TYPE =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedMapper.java
@@ -1,0 +1,30 @@
+package com.linkedin.datahub.graphql.types.restricted;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.Restricted;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.metadata.service.RestrictedService;
+
+import javax.annotation.Nonnull;
+
+public class RestrictedMapper {
+
+    public static final RestrictedMapper INSTANCE = new RestrictedMapper();
+
+    public static Restricted map(@Nonnull final EntityResponse entityResponse, @Nonnull final RestrictedService restrictedService) {
+        return INSTANCE.apply(entityResponse, restrictedService);
+    }
+
+    public Restricted apply(@Nonnull final EntityResponse entityResponse, @Nonnull final RestrictedService restrictedService) {
+        final Restricted result = new Restricted();
+        Urn entityUrn = entityResponse.getUrn();
+        String restrictedUrnString = restrictedService.encryptRestrictedUrn(entityUrn).toString();
+
+        result.setUrn(restrictedUrnString);
+        result.setType(EntityType.RESTRICTED);
+
+        return result;
+    }
+}
+

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedMapper.java
@@ -5,26 +5,28 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.Restricted;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.metadata.service.RestrictedService;
-
 import javax.annotation.Nonnull;
 
 public class RestrictedMapper {
 
-    public static final RestrictedMapper INSTANCE = new RestrictedMapper();
+  public static final RestrictedMapper INSTANCE = new RestrictedMapper();
 
-    public static Restricted map(@Nonnull final EntityResponse entityResponse, @Nonnull final RestrictedService restrictedService) {
-        return INSTANCE.apply(entityResponse, restrictedService);
-    }
+  public static Restricted map(
+      @Nonnull final EntityResponse entityResponse,
+      @Nonnull final RestrictedService restrictedService) {
+    return INSTANCE.apply(entityResponse, restrictedService);
+  }
 
-    public Restricted apply(@Nonnull final EntityResponse entityResponse, @Nonnull final RestrictedService restrictedService) {
-        final Restricted result = new Restricted();
-        Urn entityUrn = entityResponse.getUrn();
-        String restrictedUrnString = restrictedService.encryptRestrictedUrn(entityUrn).toString();
+  public Restricted apply(
+      @Nonnull final EntityResponse entityResponse,
+      @Nonnull final RestrictedService restrictedService) {
+    final Restricted result = new Restricted();
+    Urn entityUrn = entityResponse.getUrn();
+    String restrictedUrnString = restrictedService.encryptRestrictedUrn(entityUrn).toString();
 
-        result.setUrn(restrictedUrnString);
-        result.setType(EntityType.RESTRICTED);
+    result.setUrn(restrictedUrnString);
+    result.setType(EntityType.RESTRICTED);
 
-        return result;
-    }
+    return result;
+  }
 }
-

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedType.java
@@ -1,0 +1,96 @@
+package com.linkedin.datahub.graphql.types.restricted;
+
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Entity;
+import com.linkedin.datahub.graphql.generated.Restricted;
+import com.linkedin.datahub.graphql.types.EntityType;
+import com.linkedin.entity.EntityResponse;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.service.RestrictedService;
+import graphql.execution.DataFetcherResult;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class RestrictedType implements EntityType<Restricted, String> {
+    public static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of();
+
+    private final EntityClient _entityClient;
+    private final RestrictedService _restrictedService;
+
+    @Override
+    public com.linkedin.datahub.graphql.generated.EntityType type() {
+        return com.linkedin.datahub.graphql.generated.EntityType.RESTRICTED;
+    }
+
+    @Override
+    public Function<Entity, String> getKeyProvider() {
+        return Entity::getUrn;
+    }
+
+    @Override
+    public Class<Restricted> objectClass() {
+        return Restricted.class;
+    }
+
+    @Override
+    public List<DataFetcherResult<Restricted>> batchLoad(
+            @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+        final List<Urn> restrictedUrns =
+                urns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+        final List<Urn> entityUrns =
+                restrictedUrns.stream().map(_restrictedService::decryptRestrictedUrn).collect(Collectors.toList());
+
+        // Create a map for entityType: entityUrns so we can fetch by entity type below
+        final Map<String, List<Urn>> entityTypeToUrns = createEntityTypeToUrnsMap(entityUrns);
+
+        try {
+            // Fetch from the DB for each entity type and add to one result map
+            final Map<Urn, EntityResponse> entities = new HashMap<>();
+            entityTypeToUrns.keySet().forEach(entityType -> {
+                try {
+                    entities.putAll(_entityClient.batchGetV2(
+                        entityType,
+                        new HashSet<>(entityTypeToUrns.get(entityType)),
+                        ASPECTS_TO_FETCH,
+                        context.getAuthentication()));
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to fetch restricted entities", e);
+                }
+            });
+
+            final List<EntityResponse> gmsResults = new ArrayList<>();
+            for (Urn urn : entityUrns) {
+                gmsResults.add(entities.getOrDefault(urn, null));
+            }
+            return gmsResults.stream()
+                    .map(
+                            gmsResult ->
+                                    gmsResult == null
+                                            ? null
+                                            : DataFetcherResult.<Restricted>newResult()
+                                            .data(RestrictedMapper.map(gmsResult, _restrictedService))
+                                            .build())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to batch load Queries", e);
+        }
+    }
+
+    private Map<String, List<Urn>> createEntityTypeToUrnsMap(final List<Urn> urns) {
+        final Map<String, List<Urn>> entityTypeToUrns = new HashMap<>();
+        urns.forEach(urn -> {
+            String entityType = urn.getEntityType();
+            List<Urn> existingUrns = entityTypeToUrns.computeIfAbsent(entityType, k -> new ArrayList<>());
+            existingUrns.add(urn);
+        });
+        return entityTypeToUrns;
+    }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/restricted/RestrictedType.java
@@ -11,86 +11,93 @@ import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.service.RestrictedService;
 import graphql.execution.DataFetcherResult;
-import lombok.RequiredArgsConstructor;
-
-import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class RestrictedType implements EntityType<Restricted, String> {
-    public static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of();
+  public static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of();
 
-    private final EntityClient _entityClient;
-    private final RestrictedService _restrictedService;
+  private final EntityClient _entityClient;
+  private final RestrictedService _restrictedService;
 
-    @Override
-    public com.linkedin.datahub.graphql.generated.EntityType type() {
-        return com.linkedin.datahub.graphql.generated.EntityType.RESTRICTED;
-    }
+  @Override
+  public com.linkedin.datahub.graphql.generated.EntityType type() {
+    return com.linkedin.datahub.graphql.generated.EntityType.RESTRICTED;
+  }
 
-    @Override
-    public Function<Entity, String> getKeyProvider() {
-        return Entity::getUrn;
-    }
+  @Override
+  public Function<Entity, String> getKeyProvider() {
+    return Entity::getUrn;
+  }
 
-    @Override
-    public Class<Restricted> objectClass() {
-        return Restricted.class;
-    }
+  @Override
+  public Class<Restricted> objectClass() {
+    return Restricted.class;
+  }
 
-    @Override
-    public List<DataFetcherResult<Restricted>> batchLoad(
-            @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
-        final List<Urn> restrictedUrns =
-                urns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
-        final List<Urn> entityUrns =
-                restrictedUrns.stream().map(_restrictedService::decryptRestrictedUrn).collect(Collectors.toList());
+  @Override
+  public List<DataFetcherResult<Restricted>> batchLoad(
+      @Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+    final List<Urn> restrictedUrns =
+        urns.stream().map(UrnUtils::getUrn).collect(Collectors.toList());
+    final List<Urn> entityUrns =
+        restrictedUrns.stream()
+            .map(_restrictedService::decryptRestrictedUrn)
+            .collect(Collectors.toList());
 
-        // Create a map for entityType: entityUrns so we can fetch by entity type below
-        final Map<String, List<Urn>> entityTypeToUrns = createEntityTypeToUrnsMap(entityUrns);
+    // Create a map for entityType: entityUrns so we can fetch by entity type below
+    final Map<String, List<Urn>> entityTypeToUrns = createEntityTypeToUrnsMap(entityUrns);
 
-        try {
-            // Fetch from the DB for each entity type and add to one result map
-            final Map<Urn, EntityResponse> entities = new HashMap<>();
-            entityTypeToUrns.keySet().forEach(entityType -> {
+    try {
+      // Fetch from the DB for each entity type and add to one result map
+      final Map<Urn, EntityResponse> entities = new HashMap<>();
+      entityTypeToUrns
+          .keySet()
+          .forEach(
+              entityType -> {
                 try {
-                    entities.putAll(_entityClient.batchGetV2(
-                        entityType,
-                        new HashSet<>(entityTypeToUrns.get(entityType)),
-                        ASPECTS_TO_FETCH,
-                        context.getAuthentication()));
+                  entities.putAll(
+                      _entityClient.batchGetV2(
+                          entityType,
+                          new HashSet<>(entityTypeToUrns.get(entityType)),
+                          ASPECTS_TO_FETCH,
+                          context.getAuthentication()));
                 } catch (Exception e) {
-                    throw new RuntimeException("Failed to fetch restricted entities", e);
+                  throw new RuntimeException("Failed to fetch restricted entities", e);
                 }
-            });
+              });
 
-            final List<EntityResponse> gmsResults = new ArrayList<>();
-            for (Urn urn : entityUrns) {
-                gmsResults.add(entities.getOrDefault(urn, null));
-            }
-            return gmsResults.stream()
-                    .map(
-                            gmsResult ->
-                                    gmsResult == null
-                                            ? null
-                                            : DataFetcherResult.<Restricted>newResult()
-                                            .data(RestrictedMapper.map(gmsResult, _restrictedService))
-                                            .build())
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to batch load Queries", e);
-        }
+      final List<EntityResponse> gmsResults = new ArrayList<>();
+      for (Urn urn : entityUrns) {
+        gmsResults.add(entities.getOrDefault(urn, null));
+      }
+      return gmsResults.stream()
+          .map(
+              gmsResult ->
+                  gmsResult == null
+                      ? null
+                      : DataFetcherResult.<Restricted>newResult()
+                          .data(RestrictedMapper.map(gmsResult, _restrictedService))
+                          .build())
+          .collect(Collectors.toList());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to batch load Queries", e);
     }
+  }
 
-    private Map<String, List<Urn>> createEntityTypeToUrnsMap(final List<Urn> urns) {
-        final Map<String, List<Urn>> entityTypeToUrns = new HashMap<>();
-        urns.forEach(urn -> {
-            String entityType = urn.getEntityType();
-            List<Urn> existingUrns = entityTypeToUrns.computeIfAbsent(entityType, k -> new ArrayList<>());
-            existingUrns.add(urn);
+  private Map<String, List<Urn>> createEntityTypeToUrnsMap(final List<Urn> urns) {
+    final Map<String, List<Urn>> entityTypeToUrns = new HashMap<>();
+    urns.forEach(
+        urn -> {
+          String entityType = urn.getEntityType();
+          List<Urn> existingUrns =
+              entityTypeToUrns.computeIfAbsent(entityType, k -> new ArrayList<>());
+          existingUrns.add(urn);
         });
-        return entityTypeToUrns;
-    }
+    return entityTypeToUrns;
+  }
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -961,6 +961,11 @@ enum EntityType {
     """
     ENTITY_TYPE
 
+    """"
+    A type of entity that is restricted to the user
+    """
+    RESTRICTED
+
     """
     Another entity type - refer to a provided entity type urn.
     """
@@ -11828,4 +11833,30 @@ type EntityTypeInfo {
     The description of this type
     """
     description: String
+}
+
+"""
+A restricted entity that the user does not have full permissions to view.
+This entity type does not relate to an entity type in the database.
+"""
+type Restricted implements Entity & EntityWithRelationships {
+    """
+    The primary key of the restricted entity
+    """
+    urn: String!
+
+    """
+    The standard Entity Type
+    """
+    type: EntityType!
+
+    """
+    Edges extending from this entity
+    """
+    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+
+    """
+    Edges extending from this entity grouped by direction in the lineage graph
+    """
+    lineage(input: LineageInput!): EntityLineageResult
 }

--- a/datahub-web-react/src/app/buildEntityRegistry.ts
+++ b/datahub-web-react/src/app/buildEntityRegistry.ts
@@ -20,6 +20,7 @@ import { DataPlatformEntity } from './entity/dataPlatform/DataPlatformEntity';
 import { DataProductEntity } from './entity/dataProduct/DataProductEntity';
 import { DataPlatformInstanceEntity } from './entity/dataPlatformInstance/DataPlatformInstanceEntity';
 import { RoleEntity } from './entity/Access/RoleEntity';
+import { RestrictedEntity } from './entity/restricted/RestrictedEntity';
 
 export default function buildEntityRegistry() {
     const registry = new EntityRegistry();
@@ -44,5 +45,6 @@ export default function buildEntityRegistry() {
     registry.register(new DataPlatformEntity());
     registry.register(new DataProductEntity());
     registry.register(new DataPlatformInstanceEntity());
+    registry.register(new RestrictedEntity());
     return registry;
 }

--- a/datahub-web-react/src/app/entity/restricted/RestrictedEntity.tsx
+++ b/datahub-web-react/src/app/entity/restricted/RestrictedEntity.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { QuestionOutlined } from '@ant-design/icons';
+import { EntityType, Restricted, SearchResult } from '../../../types.generated';
+import { Entity, IconStyleType, PreviewType } from '../Entity';
+import { getDataForEntityType } from '../shared/containers/profile/utils';
+import RestrictedIcon from '../../../images/restricted.svg';
+import { RestrictedEntityProfile } from './RestrictedEntityProfile';
+
+/**
+ * Definition of the DataHub Data Product entity.
+ */
+export class RestrictedEntity implements Entity<Restricted> {
+    type: EntityType = EntityType.Restricted;
+
+    icon = (fontSize: number, styleType: IconStyleType, color?: string) => {
+        if (styleType === IconStyleType.TAB_VIEW) {
+            return <QuestionOutlined />;
+        }
+
+        if (styleType === IconStyleType.HIGHLIGHT) {
+            return <QuestionOutlined style={{ fontSize, color: color || '#B37FEB' }} />;
+        }
+
+        return (
+            <QuestionOutlined
+                style={{
+                    fontSize,
+                    color: color || '#BFBFBF',
+                }}
+            />
+        );
+    };
+
+    isSearchEnabled = () => false;
+
+    isBrowseEnabled = () => false;
+
+    isLineageEnabled = () => true;
+
+    getAutoCompleteFieldName = () => 'name';
+
+    getPathName = () => 'restricted';
+
+    getEntityName = () => 'Restricted';
+
+    getCollectionName = () => 'Restricted Assets';
+
+    renderProfile = (_: string) => <RestrictedEntityProfile />;
+
+    renderPreview = (_: PreviewType, _data: Restricted) => {
+        return <RestrictedEntityProfile />;
+    };
+
+    renderSearch = (_result: SearchResult) => {
+        return <RestrictedEntityProfile />;
+    };
+
+    getLineageVizConfig = (entity: Restricted) => {
+        return {
+            urn: entity?.urn,
+            name: 'Restricted Asset',
+            type: EntityType.Restricted,
+            icon: RestrictedIcon,
+        };
+    };
+
+    displayName = (_data: Restricted) => {
+        return 'Restricted Asset';
+    };
+
+    getOverridePropertiesFromEntity = (_data: Restricted) => {
+        return {};
+    };
+
+    getGenericEntityProperties = (data: Restricted) => {
+        return getDataForEntityType({
+            data,
+            entityType: this.type,
+            getOverrideProperties: this.getOverridePropertiesFromEntity,
+        });
+    };
+
+    supportedCapabilities = () => {
+        return new Set([]);
+    };
+
+    getGraphName = () => {
+        return 'restricted';
+    };
+}

--- a/datahub-web-react/src/app/entity/restricted/RestrictedEntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/restricted/RestrictedEntityProfile.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+    LogoIcon,
+    PlatformContentWrapper,
+    PlatformText,
+    PreviewImage,
+} from '../shared/containers/profile/header/PlatformContent/PlatformContentView';
+import RestrictedIcon from '../../../images/restricted.svg';
+import { EntityTitle } from '../shared/containers/profile/header/EntityName';
+import styled from 'styled-components';
+
+const SubHeader = styled.div`
+    margin-top: 8px;
+    font-size: 14px;
+`;
+
+export function RestrictedEntityProfile() {
+    return (
+        <>
+            <PlatformContentWrapper>
+                <LogoIcon>
+                    <PreviewImage preview={false} src={RestrictedIcon} alt="restricted" />
+                </LogoIcon>
+                <PlatformText>Restricted</PlatformText>
+            </PlatformContentWrapper>
+            <EntityTitle level={3}>Restricted Asset</EntityTitle>
+            <SubHeader>This asset is Restricted. Please request access to see more.</SubHeader>
+        </>
+    );
+}

--- a/datahub-web-react/src/app/entity/restricted/RestrictedEntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/restricted/RestrictedEntityProfile.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import {
     LogoIcon,
     PlatformContentWrapper,
@@ -7,7 +8,6 @@ import {
 } from '../shared/containers/profile/header/PlatformContent/PlatformContentView';
 import RestrictedIcon from '../../../images/restricted.svg';
 import { EntityTitle } from '../shared/containers/profile/header/EntityName';
-import styled from 'styled-components';
 
 const SubHeader = styled.div`
     margin-top: 8px;

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityName.tsx
@@ -7,7 +7,7 @@ import { useEntityRegistry } from '../../../../../useEntityRegistry';
 import { useEntityData, useRefetch } from '../../../EntityContext';
 import { useGlossaryEntityData } from '../../../GlossaryEntityContext';
 
-const EntityTitle = styled(Typography.Title)`
+export const EntityTitle = styled(Typography.Title)`
     margin-right: 10px;
 
     &&& {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/PlatformContent/PlatformContentView.tsx
@@ -13,20 +13,20 @@ import {
 } from './ParentNodesView';
 import ParentEntities from '../../../../../../search/filters/ParentEntities';
 
-const LogoIcon = styled.span`
+export const LogoIcon = styled.span`
     display: flex;
     gap: 4px;
     margin-right: 8px;
 `;
 
-const PreviewImage = styled(Image)`
+export const PreviewImage = styled(Image)`
     max-height: 17px;
     width: auto;
     object-fit: contain;
     background-color: transparent;
 `;
 
-const PlatformContentWrapper = styled.div`
+export const PlatformContentWrapper = styled.div`
     display: flex;
     align-items: center;
     margin: 0 8px 6px 0;
@@ -34,7 +34,7 @@ const PlatformContentWrapper = styled.div`
     flex: 1;
 `;
 
-const PlatformText = styled(Typography.Text)`
+export const PlatformText = styled(Typography.Text)`
     font-size: 12px;
     line-height: 20px;
     font-weight: 700;

--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -220,9 +220,11 @@ export default function LineageExplorer({ urn, type }: Props) {
                             <Button onClick={handleClose} type="text">
                                 Close
                             </Button>
-                            <Button href={entityRegistry.getEntityUrl(selectedEntity.type, selectedEntity.urn)}>
-                                <InfoCircleOutlined /> View details
-                            </Button>
+                            {selectedEntity.type !== EntityType.Restricted && (
+                                <Button href={entityRegistry.getEntityUrl(selectedEntity.type, selectedEntity.urn)}>
+                                    <InfoCircleOutlined /> View details
+                                </Button>
+                            )}
                         </FooterButtonGroup>
                     )
                 }

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -269,6 +269,10 @@ fragment lineageNodeProperties on EntityWithRelationships {
     ... on MLPrimaryKey {
         ...nonRecursiveMLPrimaryKey
     }
+    ... on Restricted {
+        urn
+        type
+    }
 }
 
 fragment lineageFields on EntityWithRelationships {

--- a/datahub-web-react/src/images/restricted.svg
+++ b/datahub-web-react/src/images/restricted.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none"><path stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 5.636a9 9 0 1 0 12.728 12.728M5.636 5.636a9 9 0 1 1 12.728 12.728M5.636 5.636 12 12l6.364 6.364"/></svg>

--- a/li-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/li-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -86,6 +86,7 @@ public class Constants {
   public static final String DATA_TYPE_ENTITY_NAME = "dataType";
   public static final String ENTITY_TYPE_ENTITY_NAME = "entityType";
   public static final String FORM_ENTITY_NAME = "form";
+  public static final String RESTRICTED_ENTITY_NAME = "restricted";
 
   /** Aspects */
   // Common

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESAccessControlUtil.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESAccessControlUtil.java
@@ -46,6 +46,7 @@ public class ESAccessControlUtil {
   /*
     These two privileges should be logically the same for search even
     if one might allow search but not the entity page view at some point.
+    This list should mimic the list in AuthorizationUtils - update both places.
   */
   private static final Set<String> FILTER_PRIVILEGES =
       Set.of(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -153,6 +153,7 @@ public class ESUtils {
               or ->
                   finalQueryBuilder.should(
                       ESUtils.buildConjunctiveFilterQuery(or, isTimeseries, searchableFieldTypes)));
+      finalQueryBuilder.minimumShouldMatch(1);
     } else if (filter.getCriteria() != null) {
       // Otherwise, build boolean query from the deprecated "criteria" field.
       log.warn("Received query Filter with a deprecated field 'criteria'. Use 'or' instead.");
@@ -169,6 +170,7 @@ public class ESUtils {
                 }
               });
       finalQueryBuilder.should(andQueryBuilder);
+      finalQueryBuilder.minimumShouldMatch(1);
     }
     return finalQueryBuilder;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/cache/CacheableSearcherTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/cache/CacheableSearcherTest.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Streams;
 import com.linkedin.common.urn.TestEntityUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.models.registry.EntityRegistry;
-import com.linkedin.metadata.query.SearchFlags;
+import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.AggregationMetadataArray;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/cache/CacheableSearcherTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/cache/CacheableSearcherTest.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Streams;
 import com.linkedin.common.urn.TestEntityUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.models.registry.EntityRegistry;
-import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.search.AggregationMetadataArray;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchEntityArray;

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SearchContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SearchContext.java
@@ -16,19 +16,7 @@ import lombok.Getter;
 public class SearchContext implements ContextInterface {
 
   public static SearchContext EMPTY =
-      SearchContext.builder()
-          .indexConvention(IndexConventionImpl.NO_PREFIX)
-          .searchFlags(SEARCH_CONTEXT_DEFAULT)
-          .build();
-
-  public static SearchContext withFlagDefaults(
-      @Nonnull SearchContext searchContext,
-      @Nonnull Function<SearchFlags, SearchFlags> flagDefaults) {
-    return searchContext.toBuilder()
-        // update search flags
-        .searchFlags(flagDefaults.apply(searchContext.getSearchFlags()))
-        .build();
-  }
+      SearchContext.builder().indexConvention(IndexConventionImpl.NO_PREFIX).build();
 
   public static SearchContext withFlagDefaults(
       @Nonnull SearchContext searchContext,

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SearchContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SearchContext.java
@@ -16,7 +16,19 @@ import lombok.Getter;
 public class SearchContext implements ContextInterface {
 
   public static SearchContext EMPTY =
-      SearchContext.builder().indexConvention(IndexConventionImpl.NO_PREFIX).build();
+      SearchContext.builder()
+          .indexConvention(IndexConventionImpl.NO_PREFIX)
+          .searchFlags(SEARCH_CONTEXT_DEFAULT)
+          .build();
+
+  public static SearchContext withFlagDefaults(
+      @Nonnull SearchContext searchContext,
+      @Nonnull Function<SearchFlags, SearchFlags> flagDefaults) {
+    return searchContext.toBuilder()
+        // update search flags
+        .searchFlags(flagDefaults.apply(searchContext.getSearchFlags()))
+        .build();
+  }
 
   public static SearchContext withFlagDefaults(
       @Nonnull SearchContext searchContext,

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/RestrictedServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/RestrictedServiceFactory.java
@@ -1,0 +1,30 @@
+package com.linkedin.gms.factory.auth;
+
+import com.linkedin.metadata.secret.SecretService;
+import com.linkedin.metadata.service.RestrictedService;
+import com.linkedin.metadata.spring.YamlPropertySourceFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.Scope;
+
+import javax.annotation.Nonnull;
+
+@Configuration
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class RestrictedServiceFactory {
+
+  @Autowired
+  @Qualifier("dataHubSecretService")
+  private SecretService _secretService;
+
+  @Bean(name = "restrictedService")
+  @Scope("singleton")
+  @Nonnull
+  protected RestrictedService getInstance() throws Exception {
+    return new RestrictedService(_secretService);
+  }
+}
+

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/RestrictedServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/auth/RestrictedServiceFactory.java
@@ -3,14 +3,13 @@ package com.linkedin.gms.factory.auth;
 import com.linkedin.metadata.secret.SecretService;
 import com.linkedin.metadata.service.RestrictedService;
 import com.linkedin.metadata.spring.YamlPropertySourceFactory;
+import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.Scope;
-
-import javax.annotation.Nonnull;
 
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
@@ -27,4 +26,3 @@ public class RestrictedServiceFactory {
     return new RestrictedService(_secretService);
   }
 }
-

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -32,6 +32,7 @@ import com.linkedin.metadata.service.FormService;
 import com.linkedin.metadata.service.LineageService;
 import com.linkedin.metadata.service.OwnershipTypeService;
 import com.linkedin.metadata.service.QueryService;
+import com.linkedin.metadata.service.RestrictedService;
 import com.linkedin.metadata.service.SettingsService;
 import com.linkedin.metadata.service.ViewService;
 import com.linkedin.metadata.timeline.TimelineService;
@@ -167,6 +168,10 @@ public class GraphQLEngineFactory {
   @Qualifier("formService")
   private FormService formService;
 
+  @Autowired
+  @Qualifier("restrictedService")
+  private RestrictedService restrictedService;
+
   @Value("${platformAnalytics.enabled}") // TODO: Migrate to DATAHUB_ANALYTICS_ENABLED
   private Boolean isAnalyticsEnabled;
 
@@ -213,6 +218,7 @@ public class GraphQLEngineFactory {
     args.setQueryService(queryService);
     args.setFeatureFlags(configProvider.getFeatureFlags());
     args.setFormService(formService);
+    args.setRestrictedService(restrictedService);
     args.setDataProductService(dataProductService);
     args.setGraphQLQueryComplexityLimit(
         configProvider.getGraphQL().getQuery().getComplexityLimit());

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/RestrictedService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/RestrictedService.java
@@ -1,0 +1,31 @@
+package com.linkedin.metadata.service;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.secret.SecretService;
+
+import javax.annotation.Nonnull;
+
+public class RestrictedService {
+
+  private final SecretService _secretService;
+
+  public RestrictedService(@Nonnull SecretService secretService) {
+    this._secretService = secretService;
+  }
+
+  public Urn encryptRestrictedUrn(@Nonnull final Urn entityUrn) {
+    final String encryptedEntityUrn = this._secretService.encrypt(entityUrn.toString());
+    try {
+      return new Urn("restricted", encryptedEntityUrn);
+    } catch (Exception e) {
+      throw new RuntimeException("Error when creating restricted entity urn", e);
+    }
+  }
+
+  public Urn decryptRestrictedUrn(@Nonnull final Urn restrictedUrn) {
+    final String encryptedUrn = restrictedUrn.getId();
+    return UrnUtils.getUrn(this._secretService.decrypt(encryptedUrn));
+  }
+
+}

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/RestrictedService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/RestrictedService.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.service;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.secret.SecretService;
-
 import javax.annotation.Nonnull;
 
 public class RestrictedService {
@@ -27,5 +26,4 @@ public class RestrictedService {
     final String encryptedUrn = restrictedUrn.getId();
     return UrnUtils.getUrn(this._secretService.decrypt(encryptedUrn));
   }
-
 }

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/service/RestrictedServiceTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/service/RestrictedServiceTest.java
@@ -1,0 +1,37 @@
+package com.linkedin.metadata.service;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.secret.SecretService;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RestrictedServiceTest {
+
+  private static final Urn TEST_DATASET_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:foo,bar,baz1)");
+  private static final String ENCRYPED_DATASET_URN = "12d3as456tgs";
+  private static final Urn TEST_RESTRICTED_URN =
+      UrnUtils.getUrn(String.format("urn:li:restricted:%s", ENCRYPED_DATASET_URN));
+
+  @Test
+  private void testEncryptRestrictedUrn() throws Exception {
+    SecretService mockSecretService = Mockito.mock(SecretService.class);
+    Mockito.when(mockSecretService.encrypt(TEST_DATASET_URN.toString()))
+        .thenReturn(ENCRYPED_DATASET_URN);
+    final RestrictedService service = new RestrictedService(mockSecretService);
+
+    Assert.assertEquals(service.encryptRestrictedUrn(TEST_DATASET_URN), TEST_RESTRICTED_URN);
+  }
+
+  @Test
+  private void testDecryptRestrictedUrn() throws Exception {
+    SecretService mockSecretService = Mockito.mock(SecretService.class);
+    Mockito.when(mockSecretService.decrypt(ENCRYPED_DATASET_URN))
+        .thenReturn(TEST_DATASET_URN.toString());
+    final RestrictedService service = new RestrictedService(mockSecretService);
+
+    Assert.assertEquals(service.decryptRestrictedUrn(TEST_RESTRICTED_URN), TEST_DATASET_URN);
+  }
+}


### PR DESCRIPTION
This PR adds a new graphql entity type that will map back obfuscated entities to the UI. The main purpose of this right now is to allow us to restrict lineage nodes in our lineage graph.

Adds a check in the entity lineage resolver, which is used to populate this graph, to map back entities the user doesn't have view permissions on to a Restricted entity. This Restricted entity will also include encrypting the urn so that we don't give any relevant info to the user.

We can then decrypt this urn to make lineage requests and keep our graph full.

Screenshots:

<img width="1722" alt="image" src="https://github.com/datahub-project/datahub/assets/28656603/77fd6149-93dc-4ca3-bf57-a464de4fed77">

<img width="1725" alt="image" src="https://github.com/datahub-project/datahub/assets/28656603/1d1355af-15c1-44fe-8b96-2394290ddaba">

<img width="1726" alt="image" src="https://github.com/datahub-project/datahub/assets/28656603/859afabd-1ed4-418a-a33a-ec06c5c016f1">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
