### PR TITLE
fix(ingest/teradata): small teradata improvements

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/teradata.py
@@ -502,7 +502,7 @@ class TeradataSource(TwoTierSQLAlchemySource):
 
     TABLES_AND_VIEWS_QUERY: str = """
 SELECT
-    t.DatabaseName,
+    t.DataBaseName,
     t.TableName as name,
     t.CommentString as description,
     CASE t.TableKind
@@ -517,8 +517,8 @@ SELECT
     t.LastAlterName,
     t.LastAlterTimeStamp,
     t.RequestText
-FROM dbc.Tables t
-WHERE DatabaseName NOT IN (
+FROM dbc.TablesV t
+WHERE DataBaseName NOT IN (
                 'All',
                 'Crashdumps',
                 'Default',
@@ -564,7 +564,7 @@ WHERE DatabaseName NOT IN (
                 'dbc'
 )
 AND t.TableKind in ('T', 'V', 'Q', 'O')
-ORDER by DatabaseName, TableName;
+ORDER by DataBaseName, TableName;
      """.strip()
 
     _tables_cache: MutableMapping[str, List[TeradataTable]] = defaultdict(list)
@@ -779,7 +779,7 @@ ORDER by DatabaseName, TableName;
         engine = self.get_metadata_engine()
         for entry in engine.execute(self.TABLES_AND_VIEWS_QUERY):
             table = TeradataTable(
-                database=entry.DatabaseName.strip(),
+                database=entry.DataBaseName.strip(),
                 name=entry.name.strip(),
                 description=entry.description.strip() if entry.description else None,
                 object_type=entry.object_type,


### PR DESCRIPTION
- Adding support for PERIOD types
-  Using QryLogV and QryLogSqlV instead of DBQLogTbl and DBQLSqlTbl
- Disabling our optimized view definition extraction as it only works if the last ddl against the table was the create ddl

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
