### PR TITLE
feat(ui): sort partition keys to the top of the table for better visibility

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
@@ -148,8 +148,15 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
         }
     }, [hasValueSchema, hasKeySchema, setShowKeySchema]);
 
+    const sortedFields = schemaMetadata?.fields?.slice().sort((a, b) => {
+        if (a.isPartitioningKey === b.isPartitioningKey) {
+            return 0;
+        }
+        return a.isPartitioningKey ? -1 : 1;
+    });
+
     const { filteredRows, expandedRowsFromFilter } = filterSchemaRows(
-        schemaMetadata?.fields,
+        sortedFields,
         editableSchemaMetadata,
         filterText,
         entityRegistry,


### PR DESCRIPTION
Move partition keys to the top of the schema table so that users can easily see all available partition keys on the table at first glance.

(Love the move to Vite folks! ❤️ )


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
