### PR TITLE
feat(docs): disable last update timestamps

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -26,7 +26,11 @@ jobs:
   gh-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: acryldata/sane-checkout-action@v3
+      # We explicitly don't use acryldata/sane-checkout-action because docusaurus runs
+      # git commands to determine the last change date for each file.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -238,8 +238,8 @@ module.exports = {
           }),
           numberPrefixParser: false,
           // TODO: make these work correctly with the doc generation
-          showLastUpdateAuthor: true,
-          showLastUpdateTime: true,
+          showLastUpdateAuthor: false,
+          showLastUpdateTime: false,
         },
         blog: false,
         theme: {


### PR DESCRIPTION
Possibly a regression from https://github.com/datahub-project/datahub/pull/9937 

This fixes the massive huge build times that we were seeing in CI.

Debugging in https://github.com/hsheth2/datahub/pull/4

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
