### PR TITLE
feat(pluginRegistry): add configuration to reduce runnable frequency

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/PluginEntityRegistryLoader.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/PluginEntityRegistryLoader.java
@@ -28,6 +28,7 @@ public class PluginEntityRegistryLoader {
   private static int _MAXLOADFAILURES = 5;
   private final Boolean scanningEnabled;
   private final String pluginDirectory;
+  private final int loadDelaySeconds;
   // Registry Name -> Registry Version -> (Registry, LoadResult)
   private final Map<String, Map<ComparableVersion, Pair<EntityRegistry, EntityRegistryLoadResult>>>
       patchRegistries;
@@ -38,7 +39,7 @@ public class PluginEntityRegistryLoader {
   private boolean booted = false;
   private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
-  public PluginEntityRegistryLoader(String pluginDirectory) {
+  public PluginEntityRegistryLoader(String pluginDirectory, int loadDelaySeconds) {
     File directory = new File(pluginDirectory);
     if (!directory.exists() || !directory.isDirectory()) {
       log.warn(
@@ -50,6 +51,7 @@ public class PluginEntityRegistryLoader {
     }
     this.pluginDirectory = pluginDirectory;
     this.patchRegistries = new HashMap<>();
+    this.loadDelaySeconds = loadDelaySeconds;
   }
 
   public Map<String, Map<ComparableVersion, Pair<EntityRegistry, EntityRegistryLoadResult>>>
@@ -133,7 +135,7 @@ public class PluginEntityRegistryLoader {
           }
         },
         0,
-        5,
+        loadDelaySeconds,
         TimeUnit.SECONDS);
     started = true;
     if (waitForInitialization) {

--- a/entity-registry/src/test/java/com/linkedin/metadata/models/registry/PluginEntityRegistryLoaderTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/models/registry/PluginEntityRegistryLoaderTest.java
@@ -76,7 +76,7 @@ public class PluginEntityRegistryLoaderTest {
 
     MergedEntityRegistry configEntityRegistry = new MergedEntityRegistry(baseEntityRegistry);
     PluginEntityRegistryLoader pluginEntityRegistryLoader =
-        new PluginEntityRegistryLoader(TestConstants.BASE_DIRECTORY)
+        new PluginEntityRegistryLoader(TestConstants.BASE_DIRECTORY, 60)
             .withBaseRegistry(configEntityRegistry)
             .start(true);
     assertEquals(pluginEntityRegistryLoader.getPatchRegistries().size(), 1);
@@ -170,7 +170,7 @@ public class PluginEntityRegistryLoaderTest {
 
     MergedEntityRegistry mergedEntityRegistry = new MergedEntityRegistry(getBaseEntityRegistry());
     PluginEntityRegistryLoader pluginEntityRegistryLoader =
-        new PluginEntityRegistryLoader(BASE_DIRECTORY)
+        new PluginEntityRegistryLoader(BASE_DIRECTORY, 60)
             .withBaseRegistry(mergedEntityRegistry)
             .start(true);
     assertEquals(pluginEntityRegistryLoader.getPatchRegistries().size(), 1);
@@ -215,7 +215,7 @@ public class PluginEntityRegistryLoaderTest {
     String multiversionPluginDir = "src/test_plugins/";
 
     PluginEntityRegistryLoader pluginEntityRegistryLoader =
-        new PluginEntityRegistryLoader(multiversionPluginDir)
+        new PluginEntityRegistryLoader(multiversionPluginDir, 60)
             .withBaseRegistry(mergedEntityRegistry)
             .start(true);
     Map<String, Map<ComparableVersion, Pair<EntityRegistry, EntityRegistryLoadResult>>>

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/EntityRegistryPluginConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/EntityRegistryPluginConfiguration.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class EntityRegistryPluginConfiguration {
   String path;
+  int loadDelaySeconds;
 }

--- a/metadata-service/configuration/src/main/resources/application.yml
+++ b/metadata-service/configuration/src/main/resources/application.yml
@@ -84,6 +84,7 @@ datahub:
     pluginSecurityMode: ${PLUGIN_SECURITY_MODE:RESTRICTED} # Possible value RESTRICTED or LENIENT, default to RESTRICTED
     entityRegistry:
       path: ${ENTITY_REGISTRY_PLUGIN_PATH:/etc/datahub/plugins/models}
+      loadDelaySeconds: ${ENTITY_REGISTRY_PLUGIN_LOAD_DELAY_SECONDS:60} # Rate at which plugin runnable executes, will run every N seconds.
     retention:
       path: ${RETENTION_PLUGIN_PATH:/etc/datahub/plugins/retention}
     auth:

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/PluginEntityRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/PluginEntityRegistryFactory.java
@@ -1,17 +1,16 @@
 package com.linkedin.gms.factory.entityregistry;
 
+import com.linkedin.gms.factory.config.ConfigurationProvider;
+import com.linkedin.metadata.config.EntityRegistryPluginConfiguration;
 import com.linkedin.metadata.models.registry.PluginEntityRegistryLoader;
-import com.linkedin.metadata.spring.YamlPropertySourceFactory;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 
 @Configuration
-@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
 public class PluginEntityRegistryFactory {
 
   @Value("${datahub.plugin.entityRegistry.path}")
@@ -19,8 +18,11 @@ public class PluginEntityRegistryFactory {
 
   @Bean(name = "pluginEntityRegistry")
   @Nonnull
-  protected PluginEntityRegistryLoader getInstance()
+  protected PluginEntityRegistryLoader getInstance(ConfigurationProvider configurationProvider)
       throws FileNotFoundException, MalformedURLException {
-    return new PluginEntityRegistryLoader(pluginRegistryPath);
+    EntityRegistryPluginConfiguration pluginConfiguration =
+        configurationProvider.getDatahub().getPlugin().getEntityRegistry();
+    return new PluginEntityRegistryLoader(
+        pluginConfiguration.getPath(), pluginConfiguration.getLoadDelaySeconds());
   }
 }

--- a/metadata-service/openapi-entity-servlet/src/test/java/io/datahubproject/openapi/config/OpenAPIEntityTestConfiguration.java
+++ b/metadata-service/openapi-entity-servlet/src/test/java/io/datahubproject/openapi/config/OpenAPIEntityTestConfiguration.java
@@ -97,7 +97,7 @@ public class OpenAPIEntityTestConfiguration {
       dependency.
     */
     PluginEntityRegistryLoader custom =
-        new PluginEntityRegistryLoader(getClass().getResource("/custom-model").getFile());
+        new PluginEntityRegistryLoader(getClass().getResource("/custom-model").getFile(), 60);
 
     ConfigEntityRegistry standard =
         new ConfigEntityRegistry(


### PR DESCRIPTION
Runnable was running every 5 seconds with no way to configure it, reduced default execution rate to every minute and added config

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
