### PR TITLE
feat(ingest): add DataHubGraph.emit_all method

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -1,8 +1,35 @@
 # Updating DataHub
 
+<!--
+
+## <version number>
+
+### Breaking Changes
+
+### Potential Downtime
+
+### Deprecations
+
+### Other Notable Changes
+
+-->
+
 This file documents any backwards-incompatible changes in DataHub and assists people when migrating to a new version.
 
 ## Next
+
+### Breaking Changes
+
+- #9934 - The stateful_ingestion is now enabled by default, if datahub-rest sink is used or if a `datahub_api` is specified
+- #10002 - The `DataHubGraph` client no longer makes a request to the backend during initialization. If you want to preserve the old behavior, call `graph.test_connection()` after constructing the client.
+
+### Potential Downtime
+
+### Deprecations
+
+### Other Notable Changes
+
+## 0.13.0
 
 ### Breaking Changes
 
@@ -36,7 +63,6 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - #9601 - The Unity Catalog(UC) ingestion source config `include_hive_metastore` is now enabled by default. This requires config `warehouse_id` to be set. You can disable `include_hive_metastore` by setting it to `False` to avoid ingesting legacy hive metastore catalog in Databricks.
 - #9904 - The default Redshift `table_lineage_mode` is now MIXED, instead of `STL_SCAN_BASED`. Improved lineage generation is also available by enabling `use_lineaege_v2`. This v2 implementation will become the default in a future release.
-- #9934 - The stateful_ingestion is now enabled by default, if datahub-rest sink is used or if a `datahub_api` is specified
 
 ### Potential Downtime
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -20,7 +20,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Breaking Changes
 
-- #9934 - The stateful_ingestion is now enabled by default, if datahub-rest sink is used or if a `datahub_api` is specified
+- #9934 - Stateful ingestion is now enabled by default if datahub-rest sink is used or if a `datahub_api` is specified. It will still be disabled by default when any other sink type is used.
 - #10002 - The `DataHubGraph` client no longer makes a request to the backend during initialization. If you want to preserve the old behavior, call `graph.test_connection()` after constructing the client.
 
 ### Potential Downtime

--- a/metadata-ingestion/src/datahub/cli/specific/user_cli.py
+++ b/metadata-ingestion/src/datahub/cli/specific/user_cli.py
@@ -42,12 +42,14 @@ def upsert(file: Path, override_editable: bool) -> None:
         for user_config in user_configs:
             try:
                 datahub_user: CorpUser = CorpUser.parse_obj(user_config)
-                for mcp in datahub_user.generate_mcp(
-                    generation_config=CorpUserGenerationConfig(
-                        override_editable=override_editable
+
+                emitter.emit_all(
+                    datahub_user.generate_mcp(
+                        generation_config=CorpUserGenerationConfig(
+                            override_editable=override_editable
+                        )
                     )
-                ):
-                    emitter.emit(mcp)
+                )
                 click.secho(f"Update succeeded for urn {datahub_user.urn}.", fg="green")
             except Exception as e:
                 click.secho(

--- a/metadata-ingestion/src/datahub/configuration/source_common.py
+++ b/metadata-ingestion/src/datahub/configuration/source_common.py
@@ -38,7 +38,8 @@ class EnvConfigMixin(ConfigModel):
 
     _env_deprecation = pydantic_field_deprecated(
         "env",
-        message="env is deprecated and will be removed in a future release. Please use platform_instance instead.",
+        message="We recommend using platform_instance instead of env. "
+        "While specifying env does still work, we intend to deprecate it in the future.",
     )
 
     @validator("env")

--- a/metadata-ingestion/src/datahub/emitter/mcp.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 
-from datahub.emitter.aspect import ASPECT_MAP, JSON_CONTENT_TYPE, TIMESERIES_ASPECT_MAP
+from datahub.emitter.aspect import ASPECT_MAP, JSON_CONTENT_TYPE
 from datahub.emitter.serialization_helper import post_json_transform, pre_json_transform
 from datahub.metadata.schema_classes import (
     ChangeTypeClass,
@@ -244,21 +244,9 @@ class MetadataChangeProposalWrapper:
     ) -> "MetadataWorkUnit":
         from datahub.ingestion.api.workunit import MetadataWorkUnit
 
-        if self.aspect and self.aspectName in TIMESERIES_ASPECT_MAP:
-            # TODO: Make this a cleaner interface.
-            ts = getattr(self.aspect, "timestampMillis", None)
-            assert ts is not None
-
-            # If the aspect is a timeseries aspect, include the timestampMillis in the ID.
-            return MetadataWorkUnit(
-                id=f"{self.entityUrn}-{self.aspectName}-{ts}",
-                mcp=self,
-                treat_errors_as_warnings=treat_errors_as_warnings,
-                is_primary_source=is_primary_source,
-            )
-
+        id = MetadataWorkUnit.generate_workunit_id(self)
         return MetadataWorkUnit(
-            id=f"{self.entityUrn}-{self.aspectName}",
+            id=id,
             mcp=self,
             treat_errors_as_warnings=treat_errors_as_warnings,
             is_primary_source=is_primary_source,

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -158,14 +158,14 @@ class DataHubRestEmitter(Closeable, Emitter):
             timeout=(self._connect_timeout_sec, self._read_timeout_sec),
         )
 
-    def test_connection(self) -> dict:
+    def test_connection(self) -> None:
         url = f"{self._gms_server}/config"
         response = self._session.get(url)
         if response.status_code == 200:
             config: dict = response.json()
             if config.get("noCode") == "true":
                 self.server_config = config
-                return config
+                return
 
             else:
                 # Looks like we either connected to an old GMS or to some other service. Let's see if we can determine which before raising an error
@@ -194,6 +194,10 @@ class DataHubRestEmitter(Closeable, Emitter):
                 message = f"Unable to connect to {url} with status_code: {response.status_code}."
             message += "\nPlease check your configuration and make sure you are talking to the DataHub GMS (usually <datahub-gms-host>:8080) or Frontend GMS API (usually <frontend>:9002/api/gms)."
             raise ConfigurationError(message)
+
+    def get_server_config(self) -> dict:
+        self.test_connection()
+        return self.server_config
 
     def to_graph(self) -> "DataHubGraph":
         from datahub.ingestion.graph.client import DataHubGraph

--- a/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py
@@ -53,7 +53,10 @@ def auto_workunit(
 
     for item in stream:
         if isinstance(item, MetadataChangeEventClass):
-            yield MetadataWorkUnit(id=f"{item.proposedSnapshot.urn}/mce", mce=item)
+            yield MetadataWorkUnit(
+                id=MetadataWorkUnit.generate_workunit_id(item),
+                mce=item,
+            )
         else:
             yield item.as_workunit()
 

--- a/metadata-ingestion/src/datahub/ingestion/api/workunit.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/workunit.py
@@ -100,11 +100,14 @@ class MetadataWorkUnit(WorkUnit):
 
     @classmethod
     def generate_workunit_id(
-        cls, item: Union[MetadataChangeEvent, MetadataChangeProposalWrapper]
+        cls,
+        item: Union[
+            MetadataChangeEvent, MetadataChangeProposal, MetadataChangeProposalWrapper
+        ],
     ) -> str:
         if isinstance(item, MetadataChangeEvent):
             return f"{item.proposedSnapshot.urn}/mce"
-        elif isinstance(item, MetadataChangeProposalWrapper):
+        elif isinstance(item, (MetadataChangeProposalWrapper, MetadataChangeProposal)):
             if item.aspect and item.aspectName in TIMESERIES_ASPECT_MAP:
                 # TODO: Make this a cleaner interface.
                 ts = getattr(item.aspect, "timestampMillis", None)

--- a/metadata-ingestion/src/datahub/ingestion/api/workunit.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/workunit.py
@@ -4,6 +4,7 @@ from typing import Iterable, Optional, Type, TypeVar, Union, overload
 
 from deprecated import deprecated
 
+from datahub.emitter.aspect import TIMESERIES_ASPECT_MAP
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import WorkUnit
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
@@ -96,6 +97,25 @@ class MetadataWorkUnit(WorkUnit):
         else:
             assert self.metadata.entityUrn
             return self.metadata.entityUrn
+
+    @classmethod
+    def generate_workunit_id(
+        cls, item: Union[MetadataChangeEvent, MetadataChangeProposalWrapper]
+    ) -> str:
+        if isinstance(item, MetadataChangeEvent):
+            return f"{item.proposedSnapshot.urn}/mce"
+        elif isinstance(item, MetadataChangeProposalWrapper):
+            if item.aspect and item.aspectName in TIMESERIES_ASPECT_MAP:
+                # TODO: Make this a cleaner interface.
+                ts = getattr(item.aspect, "timestampMillis", None)
+                assert ts is not None
+
+                # If the aspect is a timeseries aspect, include the timestampMillis in the ID.
+                return f"{item.entityUrn}-{item.aspectName}-{ts}"
+
+            return f"{item.entityUrn}-{item.aspectName}"
+        else:
+            raise ValueError(f"Unexpected type {type(item)}")
 
     def get_aspect_of_type(self, aspect_cls: Type[T_Aspect]) -> Optional[T_Aspect]:
         aspects: list

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -213,6 +213,7 @@ class Pipeline:
         with _add_init_error_context("connect to DataHub"):
             if self.config.datahub_api:
                 self.graph = DataHubGraph(self.config.datahub_api)
+                self.graph.test_connection()
 
             telemetry.telemetry_instance.update_capture_exception_context(
                 server=self.graph

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -91,12 +91,11 @@ class DatahubRestSink(Sink[DatahubRestSinkConfig, DataHubRestSinkReport]):
             disable_ssl_verification=self.config.disable_ssl_verification,
         )
         try:
-            gms_config = self.emitter.test_connection()
+            gms_config = self.emitter.get_server_config()
         except Exception as exc:
             raise ConfigurationError(
-                f"💥 Failed to connect to DataHub@{self.config.server} (token:{'XXX-redacted' if self.config.token else 'empty'}) over REST",
-                exc,
-            )
+                f"💥 Failed to connect to DataHub with {repr(self.emitter)}"
+            ) from exc
 
         self.report.gms_version = (
             gms_config.get("versions", {})


### PR DESCRIPTION
- Makes the DataHubGraph init method not call test_connection.
- Refactors some of the workunit id generation logic.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
