### PR TITLE
Remove first slash from assets url

### DIFF
--- a/datahub-web-react/vite.config.ts
+++ b/datahub-web-react/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig(({ mode }) => {
         // optimizeDeps: {
         //     include: ['@ant-design/colors', '@ant-design/icons', 'lodash-es', '@ant-design/icons/es/icons'],
         // },
+        base : '',
         envPrefix: 'REACT_APP_',
         build: {
             outDir: 'dist',


### PR DESCRIPTION
The reason for this PR is that vite default base is '/' which creates an absolute url that looks like this:
`<script defer="defer" src="/assets/static/js/vendors.afc5a025.js"></script>`

This causes issues when datahub is deployed on internal networks behind a specific path. Removing the initial slash fixes this issue as now the url is considered relative and will look like this:
`<script defer="defer" src="assets/static/js/vendors.afc5a025.js"></script>`

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
