### PR TITLE
fix(opensearch): Rollover usage events at a file size rather than time-based manner

### DIFF
--- a/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
+++ b/metadata-service/restli-servlet-impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
@@ -3,15 +3,14 @@
     "policy_id": "PREFIXdatahub_usage_event_policy",
     "description": "Datahub Usage Event Policy",
     "default_state": "Rollover",
-    "schema_version": 3,
+    "schema_version": 4,
     "states": [
       {
         "name": "Rollover",
         "actions": [
           {
             "rollover": {
-              "min_size": "5gb",
-              "min_index_age": "1d"
+              "min_size": "5gb"
             }
           }
         ],


### PR DESCRIPTION
The [rollover](https://opensearch.org/docs/latest/im-plugin/ism/policies/#rollover) operation rolls an alias over to a new index when the managed index meets **_one_** of the rollover conditions. Since the rollover conditions are `min_index_age: 1d` and `min_size: 5gb` conditions, the index ends up being rolled over every day since the minimum index age condition will evaluate to true.

Instead of time-based rollover, this changes the rollover condition to only be based on the minimum size.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
