### PR TITLE
fix(frontend): exclude plugins/frontend/auth/user.props config does not exist warnings from log

### DIFF
--- a/datahub-frontend/conf/logback.xml
+++ b/datahub-frontend/conf/logback.xml
@@ -13,6 +13,7 @@
     <filter class="com.linkedin.metadata.utils.log.LogMessageFilter">
       <excluded>Unable to renew the session. The session store may not support this feature</excluded>
       <excluded>Preferred JWS algorithm: null not available. Using all metadata algorithms:</excluded>
+      <excluded>Config does not exist: file:///etc/datahub/plugins/frontend/auth/user.props</excluded>
     </filter>
   </appender>
 

--- a/datahub-frontend/run/logback.xml
+++ b/datahub-frontend/run/logback.xml
@@ -13,6 +13,7 @@
     <filter class="com.linkedin.metadata.utils.log.LogMessageFilter">
       <excluded>Unable to renew the session. The session store may not support this feature</excluded>
       <excluded>Preferred JWS algorithm: null not available. Using all metadata algorithms:</excluded>
+      <excluded>Config does not exist: file:///etc/datahub/plugins/frontend/auth/user.props</excluded>
     </filter>
   </appender>
 


### PR DESCRIPTION
When no user.props file is provided in the plugins directory for the datahub-frontend (/etc/datahub/plugins/frontend/auth/user.props) a warning is logged that the config does not exist. Since version 0.13.0 there is not only a warning, instead the stack trace of the corresponding exception is logged:

```
2024-03-13 08:50:08,988 [application-akka.actor.default-dispatcher-10] WARN  o.e.j.j.spi.PropertyFileLoginModule - Exception starting propertyUserStore /etc/datahub/plugins/frontend/auth/user.props 
java.lang.IllegalStateException: Config does not exist: file:///etc/datahub/plugins/frontend/auth/user.props
	at org.eclipse.jetty.security.PropertyUserStore.loadUsers(PropertyUserStore.java:219)
	at org.eclipse.jetty.security.PropertyUserStore.doStart(PropertyUserStore.java:285)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93)
	at org.eclipse.jetty.jaas.spi.PropertyFileLoginModule.setupPropertyUserStore(PropertyFileLoginModule.java:105)
	at org.eclipse.jetty.jaas.spi.PropertyFileLoginModule.initialize(PropertyFileLoginModule.java:56)
	at java.base/javax.security.auth.login.LoginContext.invoke(LoginContext.java:745)
	at java.base/javax.security.auth.login.LoginContext$4.run(LoginContext.java:679)
	at java.base/javax.security.auth.login.LoginContext$4.run(LoginContext.java:677)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.base/javax.security.auth.login.LoginContext.invokePriv(LoginContext.java:677)
	at java.base/javax.security.auth.login.LoginContext.login(LoginContext.java:587)
	at security.AuthenticationManager.authenticateJaasUser(AuthenticationManager.java:33)
	at controllers.AuthenticationController.tryLogin(AuthenticationController.java:355)
	at controllers.AuthenticationController.logIn(AuthenticationController.java:183)
	at router.Routes$$anonfun$routes$1.$anonfun$applyOrElse$17(Routes.scala:705)
	at play.core.routing.HandlerInvokerFactory$$anon$8.resultCall(HandlerInvoker.scala:150)
	at play.core.routing.HandlerInvokerFactory$$anon$8.resultCall(HandlerInvoker.scala:149)
	at play.core.routing.HandlerInvokerFactory$JavaActionInvokerFactory$$anon$3$$anon$4$$anon$5.invocation(HandlerInvoker.scala:115)
	at play.core.j.JavaAction$$anon$1.call(JavaAction.scala:119)
	at play.http.DefaultActionCreator$1.call(DefaultActionCreator.java:31)
	at play.core.j.JavaAction.$anonfun$apply$8(JavaAction.scala:175)
	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
	at scala.util.Success.$anonfun$map$1(Try.scala:255)
	at scala.util.Success.map(Try.scala:213)
	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at play.core.j.HttpExecutionContext.$anonfun$execute$1(HttpExecutionContext.scala:64)
	at play.api.libs.streams.Execution$trampoline$.execute(Execution.scala:70)
	at play.core.j.HttpExecutionContext.execute(HttpExecutionContext.scala:59)
	at scala.concurrent.impl.CallbackRunnable.executeWithValue(Promise.scala:72)
	at scala.concurrent.impl.Promise$KeptPromise$Kept.onComplete(Promise.scala:372)
	at scala.concurrent.impl.Promise$KeptPromise$Kept.onComplete$(Promise.scala:371)
	at scala.concurrent.impl.Promise$KeptPromise$Successful.onComplete(Promise.scala:379)
	at scala.concurrent.impl.Promise.transform(Promise.scala:33)
	at scala.concurrent.impl.Promise.transform$(Promise.scala:31)
	at scala.concurrent.impl.Promise$KeptPromise$Successful.transform(Promise.scala:379)
	at scala.concurrent.Future.map(Future.scala:292)
	at scala.concurrent.Future.map$(Future.scala:292)
	at scala.concurrent.impl.Promise$KeptPromise$Successful.map(Promise.scala:379)
	at scala.concurrent.Future$.apply(Future.scala:659)
	at play.core.j.JavaAction.apply(JavaAction.scala:176)
	at play.api.mvc.Action.$anonfun$apply$4(Action.scala:82)
	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:63)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:100)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:100)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:49)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:48)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

I don't think there is a possibility to prevent the warning resp. the IllegalStateException, except filtering the log message:

https://github.com/dekellum/jetty/blob/3dc0120d573816de7d6a83e2d6a97035288bdd4a/jetty-plus/src/main/java/org/eclipse/jetty/plus/jaas/spi/PropertyFileLoginModule.java#L80

https://github.com/jetty/jetty.project/blob/c25e1aa7ff0df0ca26662dab19ed3fe78de4adb8/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/PropertyUserStore.java#L158

An alternative would be to create an empty user.props file in /etc/datahub/plugins/frontend/auth/, however this is also not really nice solution, therefore I think it would be the best to exclude the log message...

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
