### PR TITLE
fix(ingestion): Handle Redshift string length limit in Serverless mode

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -822,7 +822,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                 WHERE
                     qs.step_name = 'scan' AND
                     qs.source = 'Redshift(local)' AND
-                    qt.sequence < 320 AND -- See https://stackoverflow.com/questions/72770890/redshift-result-size-exceeds-listagg-limit-on-svl-statementtext
+                    qt.sequence < 16 AND -- See https://stackoverflow.com/questions/72770890/redshift-result-size-exceeds-listagg-limit-on-svl-statementtext
                     sti.database = '{db_name}' AND -- this was required to not retrieve some internal redshift tables, try removing to see what happens
                     sui.user_name <> 'rdsdb' -- not entirely sure about this filter
                 GROUP BY sti.schema, sti.table, qs.table_id, qs.query_id, sui.user_name
@@ -909,7 +909,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                     cluster = '{db_name}' AND
                     qd.start_time >= '{start_time}' AND
                     qd.start_time < '{end_time}' AND
-                    qt.sequence < 320 AND -- See https://stackoverflow.com/questions/72770890/redshift-result-size-exceeds-listagg-limit-on-svl-statementtext
+                    qt.sequence < 16 AND -- See https://stackoverflow.com/questions/72770890/redshift-result-size-exceeds-listagg-limit-on-svl-statementtext
                     ld.query_id IS NULL -- filter out queries which are also stored in SYS_LOAD_DETAIL
                 ORDER BY target_table ASC
             )
@@ -994,7 +994,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                                             query_type IN ('DDL', 'CTAS', 'OTHER', 'COMMAND')
                                             AND qh.start_time >= '{start_time_str}'
                                             AND qh.start_time < '{end_time_str}'
-                                            AND qt.sequence < 320
+                                            AND qt.sequence < 16
                                     GROUP BY qh.start_time, qh.session_id, qh.transaction_id, qh.user_id
                                     ORDER BY qh.start_time, qh.session_id, qh.transaction_id, qh.user_id ASC
                             )


### PR DESCRIPTION
According to https://stackoverflow.com/questions/72770890/redshift-result-size-exceeds-listagg-limit-on-svl-statementtext Redshift limits strings to be 64k in length. Since `text` field in `SYS_QUERY_TEXT` table can have at most 4k characters and then is split into chunks ordered by `sequence` we can allow at most 16 (16*4 = 64) chunks to be included.