### PR TITLE
fix(metadata-ingestion)glue connector failure when Optional field Type of PartitionKey is absent for a Table

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1042,7 +1042,9 @@ class GlueSource(StatefulIngestionSourceBase):
     def _extract_record(
         self, dataset_urn: str, table: Dict, table_name: str
     ) -> MetadataChangeEvent:
-        logger.debug(f"extract record from table={table_name} for dataset={dataset_urn}")
+        logger.debug(
+            f"extract record from table={table_name} for dataset={dataset_urn}"
+        )
 
         def get_owner() -> Optional[OwnershipClass]:
             owner = table.get("Owner")
@@ -1164,8 +1166,11 @@ class GlueSource(StatefulIngestionSourceBase):
             partition_keys = table.get("PartitionKeys", [])
             for partition_key in partition_keys:
                 if "Type" not in partition_key:
-                    self.report_warning(dataset_urn, f"No Type found for the PartitionKey={partition_key} on the "
-                                                     f"table={table_name}")
+                    self.report_warning(
+                        dataset_urn,
+                        f"No Type found for the PartitionKey={partition_key} on the "
+                        f"table={table_name}",
+                    )
                 schema_fields = get_schema_fields_for_hive_column(
                     hive_column_name=partition_key["Name"],
                     hive_column_type=partition_key.get("Type"),

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1173,7 +1173,7 @@ class GlueSource(StatefulIngestionSourceBase):
                     )
                 schema_fields = get_schema_fields_for_hive_column(
                     hive_column_name=partition_key["Name"],
-                    hive_column_type=partition_key.get("Type"),
+                    hive_column_type=partition_key.get("Type", "unknown"),
                     default_nullable=False,
                 )
                 assert schema_fields

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1042,6 +1042,8 @@ class GlueSource(StatefulIngestionSourceBase):
     def _extract_record(
         self, dataset_urn: str, table: Dict, table_name: str
     ) -> MetadataChangeEvent:
+        logger.debug(f"extract record from table={table_name} for dataset={dataset_urn}")
+
         def get_owner() -> Optional[OwnershipClass]:
             owner = table.get("Owner")
             if owner:
@@ -1161,9 +1163,12 @@ class GlueSource(StatefulIngestionSourceBase):
 
             partition_keys = table.get("PartitionKeys", [])
             for partition_key in partition_keys:
+                if "Type" not in partition_key:
+                    self.report_warning(dataset_urn, f"No Type found for the PartitionKey={partition_key} on the "
+                                                     f"table={table_name}")
                 schema_fields = get_schema_fields_for_hive_column(
                     hive_column_name=partition_key["Name"],
-                    hive_column_type=partition_key["Type"],
+                    hive_column_type=partition_key.get("Type"),
                     default_nullable=False,
                 )
                 assert schema_fields

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1165,12 +1165,6 @@ class GlueSource(StatefulIngestionSourceBase):
 
             partition_keys = table.get("PartitionKeys", [])
             for partition_key in partition_keys:
-                if "Type" not in partition_key:
-                    self.report_warning(
-                        dataset_urn,
-                        f"No Type found for the PartitionKey={partition_key} on the "
-                        f"table={table_name}",
-                    )
                 schema_fields = get_schema_fields_for_hive_column(
                     hive_column_name=partition_key["Name"],
                     hive_column_type=partition_key.get("Type", "unknown"),

--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -261,7 +261,7 @@ def get_avro_schema_for_hive_column(
 
 def get_schema_fields_for_hive_column(
     hive_column_name: str,
-    hive_column_type: Optional[str] = None,
+    hive_column_type: str = None,
     description: Optional[str] = None,
     default_nullable: bool = False,
     is_part_of_key: bool = False,

--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -261,7 +261,7 @@ def get_avro_schema_for_hive_column(
 
 def get_schema_fields_for_hive_column(
     hive_column_name: str,
-    hive_column_type: str,
+    hive_column_type: Optional[str] = None,
     description: Optional[str] = None,
     default_nullable: bool = False,
     is_part_of_key: bool = False,

--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -230,6 +230,8 @@ class HiveColumnToAvroConverter:
     def get_avro_schema_for_hive_column(
         cls, hive_column_name: str, hive_column_type: str
     ) -> Union[object, Dict[str, object]]:
+        if hive_column_type is None:
+            return {"type": "null"}
         converter = cls()
         # Below Record structure represents the dataset level
         # Inner fields represent the complex field (struct/array/map/union)
@@ -286,7 +288,9 @@ def get_schema_fields_for_hive_column(
         ]
 
     assert schema_fields
-    if HiveColumnToAvroConverter.is_primitive_hive_type(hive_column_type):
+    if hive_column_type is None or HiveColumnToAvroConverter.is_primitive_hive_type(
+        hive_column_type
+    ):
         # Primitive avro schema does not have any field names. Append it to fieldPath.
         schema_fields[0].fieldPath += f".{hive_column_name}"
     if description:

--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -28,6 +28,7 @@ class HiveColumnToAvroConverter:
         "bigint": "long",
         "varchar": "string",
         "char": "string",
+        "unknown": "null",
     }
 
     _COMPLEX_TYPE = re.compile("^(struct|map|array|uniontype)")
@@ -230,8 +231,6 @@ class HiveColumnToAvroConverter:
     def get_avro_schema_for_hive_column(
         cls, hive_column_name: str, hive_column_type: str
     ) -> Union[object, Dict[str, object]]:
-        if hive_column_type is None:
-            return {"type": "null"}
         converter = cls()
         # Below Record structure represents the dataset level
         # Inner fields represent the complex field (struct/array/map/union)
@@ -261,7 +260,7 @@ def get_avro_schema_for_hive_column(
 
 def get_schema_fields_for_hive_column(
     hive_column_name: str,
-    hive_column_type: str = None,
+    hive_column_type: str,
     description: Optional[str] = None,
     default_nullable: bool = False,
     is_part_of_key: bool = False,
@@ -288,9 +287,7 @@ def get_schema_fields_for_hive_column(
         ]
 
     assert schema_fields
-    if hive_column_type is None or HiveColumnToAvroConverter.is_primitive_hive_type(
-        hive_column_type
-    ):
+    if HiveColumnToAvroConverter.is_primitive_hive_type(hive_column_type):
         # Primitive avro schema does not have any field names. Append it to fieldPath.
         schema_fields[0].fieldPath += f".{hive_column_name}"
     if description:

--- a/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
+++ b/metadata-ingestion/src/datahub/utilities/hive_schema_to_avro.py
@@ -28,7 +28,6 @@ class HiveColumnToAvroConverter:
         "bigint": "long",
         "varchar": "string",
         "char": "string",
-        "unknown": "null",
     }
 
     _COMPLEX_TYPE = re.compile("^(struct|map|array|uniontype)")

--- a/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
+++ b/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
@@ -42,5 +42,4 @@ def test_get_avro_schema_for_null_type_hive_column():
         hive_column_name="test", hive_column_type="unknown"
     )
     assert schema_fields[0].type.type == NullTypeClass()
-    assert schema_fields[0].fieldPath == "test"
     assert len(schema_fields) == 1

--- a/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
+++ b/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
@@ -35,3 +35,10 @@ def test_get_avro_schema_for_struct_hive_with_duplicate_column2():
     assert schema_fields[0].type.type == NullTypeClass()
     assert schema_fields[0].fieldPath == "test"
     assert schema_fields[0].nativeDataType == invalid_schema
+
+
+def test_get_avro_schema_for_null_type_hive_column():
+    schema_fields = get_schema_fields_for_hive_column("test", None)
+    assert schema_fields[0].type.type == NullTypeClass()
+    assert schema_fields[0].fieldPath == "test"
+    assert len(schema_fields) == 1

--- a/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
+++ b/metadata-ingestion/tests/unit/utilities/test_hive_schema_to_avro.py
@@ -38,7 +38,9 @@ def test_get_avro_schema_for_struct_hive_with_duplicate_column2():
 
 
 def test_get_avro_schema_for_null_type_hive_column():
-    schema_fields = get_schema_fields_for_hive_column("test", None)
+    schema_fields = get_schema_fields_for_hive_column(
+        hive_column_name="test", hive_column_type="unknown"
+    )
     assert schema_fields[0].type.type == NullTypeClass()
     assert schema_fields[0].fieldPath == "test"
     assert len(schema_fields) == 1


### PR DESCRIPTION
**Issue**:
When the Optional field `Type` of `PartintionKeys` (`PartitionKey["Type"]`) is missing of a Table, the glue connector is failing with below exception.

```
  File "/datahub-ingestion/.local/lib/python3.10/site-packages/datahub/ingestion/source/aws/glue.py", line 1168, in get_schema_metadata
    hive_column_type=partition_key["Type"],
KeyError: 'Type'
```
**Fix**: 
When the Optional`Type` field of `Partitionkey` is missing, we are mapping(avro schema mapping) the `unknown` Type with `null` Type for producing the MCE.

UI screenshot:
<img width="1501" alt="Screenshot 2024-03-18 at 11 36 31" src="https://github.com/datahub-project/datahub/assets/68184387/0b5876b8-c5ba-46c5-bf63-0b563df78401">

Additionally, adding a debug logger while extracting data from tables, which will help to debug any issue when connector failed to process data for a particular table.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
