### PR TITLE
fix(ui): show dataset display name in browse paths v2

### DIFF
--- a/datahub-web-react/src/graphql/browseV2.graphql
+++ b/datahub-web-react/src/graphql/browseV2.graphql
@@ -27,6 +27,11 @@ query getBrowseResultsV2($input: BrowseV2Input!) {
                     }
                     instanceId
                 }
+                ... on Dataset {
+                    properties {
+                        name
+                    }
+                }
             }
         }
         start

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1066,6 +1066,11 @@ fragment browsePathV2Fields on BrowsePathV2 {
                 }
                 instanceId
             }
+            ... on Dataset {
+                properties {
+                    name
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
With the (new) browse paths v2 it is possible to have in theory any entity as part of the browse path by referencing it via its urn. Unfortunately the UI is currently not "requesting" the display name of the dataset entity as part of the browse path v2, therefore only the URN is shown.

Most of the time it makes no sense to have datasets as part of the browse path (e.g., if you think of SQL databases, most of the time you have databases or schemas, which are ingested as containers, but there is no entity "below" a dataset), but in case of SAP BW (we are still working on a source for it ;-)) it makes sense to also have a dataset as part of the browse path because of the special relationship between InfoProviders and Queries (Queries in SAP BW cannot be compared to SQL queries in SQL databases):

![image](https://github.com/datahub-project/datahub/assets/13187726/2fc0be3d-e166-4084-b5ac-ce624cc0bd05)

0BW (InfoArea -> Ingested as a container with subtype InfoArea)
0BWTCT_STA (InfoArea -> Ingested as a container with subtype InfoArea, 0BW as a parent container)
0BWTC_C10 (InfoProvider -> Ingested as a dataset with subtype InfoProvider and MultiProvider, 0BWTCT_STA  as a container)
0BWTC_C10_Q001 (Query -> Ingested as a dataset with subtype Query, 0BWTCT_STA as a container)

Queries are defined on an InfoProvider and represent an own and persistent object (it is mostly comparable to a SQL view in SQL databases) and therefore have an upstream lineage aspect to the InfoProvider. Queries are always "shown" below an InfoProvider (the screenshot is taken from the modelling tools of SAP for SAP BW), therefore it also makes sense to show them below the InfoProvider in the browse path. However the container of the Query is not the InfoProvider, instead the Query has the same InfoArea as its InfoProvider.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
