### PR TITLE
fix(ui) Add min width to the usage stats component

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldUsageStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldUsageStats.tsx
@@ -49,7 +49,12 @@ export default function FieldUsageStats({ expandedField }: Props) {
             <SectionHeader>Usage</SectionHeader>
             <UsageBarWrapper>
                 <UsageBarBackground>
-                    <UsageBar width={((relevantUsageStats.count || 0) / maxFieldUsageCount) * USAGE_BAR_MAX_WIDTH} />
+                    <UsageBar
+                        width={Math.max(
+                            ((relevantUsageStats.count || 0) / maxFieldUsageCount) * USAGE_BAR_MAX_WIDTH,
+                            4,
+                        )}
+                    />
                 </UsageBarBackground>
                 <UsageTextWrapper>{relevantUsageStats.count || 0} queries / month</UsageTextWrapper>
             </UsageBarWrapper>


### PR DESCRIPTION
Adds a min-width to the usage stats in the schema field sidebar so we always see something even when the percentage is super small.

<img width="295" alt="image" src="https://github.com/datahub-project/datahub/assets/28656603/f69383b9-8783-4f30-9555-5cca6abc1e60">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
