### PR TITLE
feat(lineage): add a parameter to allow limiting the per hop exploration of lineage search

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,7 @@ jobs:
           ./gradlew build \
             -x :metadata-ingestion:build \
             -x :metadata-ingestion:check \
-            -x docs-website:build \
+            -x :docs-website:build \
             -x :metadata-integration:java:spark-lineage:test \
             -x :metadata-io:test \
             -x :metadata-ingestion-modules:airflow-plugin:build \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,7 +85,7 @@ jobs:
             -x :metadata-ingestion-modules:airflow-plugin:build \
             -x :metadata-ingestion-modules:airflow-plugin:check \
             -x :metadata-ingestion-modules:dagster-plugin:build \
-            -x :metadata-ingestion-modules:dagster-plugin:check \            
+            -x :metadata-ingestion-modules:dagster-plugin:check \
             -x :datahub-frontend:build \
             -x :datahub-web-react:build \
             --parallel

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
@@ -5,6 +5,7 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import com.datahub.authorization.AuthorizationConfiguration;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
 import com.linkedin.datahub.graphql.generated.Entity;
@@ -16,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.LineageRelationship;
 import com.linkedin.datahub.graphql.generated.Restricted;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
 import com.linkedin.metadata.graph.SiblingGraphService;
+import com.linkedin.metadata.query.LineageFlags;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.services.RestrictedService;
@@ -77,8 +79,9 @@ public class EntityLineageResultResolver
                     1,
                     separateSiblings != null ? input.getSeparateSiblings() : false,
                     new HashSet<>(),
-                    startTimeMillis,
-                    endTimeMillis);
+                    new LineageFlags()
+                        .setStartTimeMillis(startTimeMillis, SetMode.REMOVE_IF_NULL)
+                        .setEndTimeMillis(endTimeMillis, SetMode.REMOVE_IF_NULL));
 
             Set<Urn> restrictedUrns = new HashSet<>();
             entityLineageResult
@@ -96,7 +99,7 @@ public class EntityLineageResultResolver
           } catch (Exception e) {
             log.error("Failed to fetch lineage for {}", finalUrn);
             throw new RuntimeException(
-                String.format("Failed to fetch lineage for {}", finalUrn), e);
+                String.format("Failed to fetch lineage for %s", finalUrn), e);
           }
         });
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
@@ -12,9 +12,11 @@ import com.linkedin.datahub.graphql.generated.LineageDirection;
 import com.linkedin.datahub.graphql.generated.ScrollAcrossLineageInput;
 import com.linkedin.datahub.graphql.generated.ScrollAcrossLineageResults;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.common.mappers.LineageFlagsInputMapper;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.datahub.graphql.types.mappers.UrnScrollAcrossLineageResultsMapper;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.r2.RemoteInvocationException;
 import graphql.schema.DataFetcher;
@@ -73,10 +75,19 @@ public class ScrollAcrossLineageResolver
     String keepAlive = input.getKeepAlive() != null ? input.getKeepAlive() : "5m";
 
     @Nullable
-    final Long startTimeMillis =
-        input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
+    Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
-    final Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
+    Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
+
+    final LineageFlags lineageFlags = LineageFlagsInputMapper.map(input.getLineageFlags());
+    if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {
+      lineageFlags.setStartTimeMillis(startTimeMillis);
+    }
+
+    if (lineageFlags.getEndTimeMillis() == null && endTimeMillis != null) {
+      lineageFlags.setEndTimeMillis(endTimeMillis);
+    }
+    ;
 
     com.linkedin.metadata.graph.LineageDirection resolvedDirection =
         com.linkedin.metadata.graph.LineageDirection.valueOf(lineageDirection.toString());
@@ -110,7 +121,8 @@ public class ScrollAcrossLineageResolver
                 _entityClient.scrollAcrossLineage(
                     context
                         .getOperationContext()
-                        .withSearchFlags(flags -> searchFlags != null ? searchFlags : flags),
+                        .withSearchFlags(flags -> searchFlags != null ? searchFlags : flags)
+                        .withLineageFlags(flags -> lineageFlags != null ? lineageFlags : flags),
                     urn,
                     resolvedDirection,
                     entityNames,
@@ -120,9 +132,7 @@ public class ScrollAcrossLineageResolver
                     null,
                     scrollId,
                     keepAlive,
-                    count,
-                    startTimeMillis,
-                    endTimeMillis));
+                    count));
           } catch (RemoteInvocationException e) {
             log.error(
                 "Failed to execute scroll across relationships: source urn {}, direction {}, entity types {}, query {}, filters: {}, start: {}, count: {}",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
@@ -79,7 +79,7 @@ public class ScrollAcrossLineageResolver
     @Nullable
     Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
 
-    final LineageFlags lineageFlags = LineageFlagsInputMapper.map(input.getLineageFlags());
+    final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {
       lineageFlags.setStartTimeMillis(startTimeMillis);
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
@@ -14,12 +14,14 @@ import com.linkedin.datahub.graphql.generated.LineageDirection;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageInput;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResults;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.common.mappers.LineageFlagsInputMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.SearchFlagsInputMapper;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.datahub.graphql.types.mappers.UrnSearchAcrossLineageResultsMapper;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.LineageSearchResult;
@@ -106,10 +108,18 @@ public class SearchAcrossLineageResolver
     final Integer maxHops = getMaxHops(facetFilters);
 
     @Nullable
-    final Long startTimeMillis =
-        input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
+    Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
-    final Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
+    Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
+
+    final LineageFlags lineageFlags = LineageFlagsInputMapper.map(input.getLineageFlags());
+    if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {
+      lineageFlags.setStartTimeMillis(startTimeMillis);
+    }
+
+    if (lineageFlags.getEndTimeMillis() == null && endTimeMillis != null) {
+      lineageFlags.setEndTimeMillis(endTimeMillis);
+    }
 
     com.linkedin.metadata.graph.LineageDirection resolvedDirection =
         com.linkedin.metadata.graph.LineageDirection.valueOf(lineageDirection.toString());
@@ -140,7 +150,10 @@ public class SearchAcrossLineageResolver
             }
             LineageSearchResult salResults =
                 _entityClient.searchAcrossLineage(
-                    context.getOperationContext().withSearchFlags(flags -> searchFlags),
+                    context
+                        .getOperationContext()
+                        .withSearchFlags(flags -> searchFlags)
+                        .withLineageFlags(flags -> lineageFlags),
                     urn,
                     resolvedDirection,
                     entityNames,
@@ -149,9 +162,7 @@ public class SearchAcrossLineageResolver
                     filter,
                     null,
                     start,
-                    count,
-                    startTimeMillis,
-                    endTimeMillis);
+                    count);
 
             return UrnSearchAcrossLineageResultsMapper.map(context, salResults);
           } catch (RemoteInvocationException e) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
@@ -112,7 +112,7 @@ public class SearchAcrossLineageResolver
     @Nullable
     Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
 
-    final LineageFlags lineageFlags = LineageFlagsInputMapper.map(input.getLineageFlags());
+    final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {
       lineageFlags.setStartTimeMillis(startTimeMillis);
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
@@ -1,0 +1,69 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.UrnArrayMap;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.generated.EntityTypeToPlatforms;
+import com.linkedin.datahub.graphql.generated.LineageFlags;
+import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
+import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Maps GraphQL SearchFlags to Pegasus
+ *
+ * <p>To be replaced by auto-generated mappers implementations
+ */
+public class LineageFlagsInputMapper
+    implements ModelMapper<LineageFlags, com.linkedin.metadata.query.LineageFlags> {
+
+  public static final LineageFlagsInputMapper INSTANCE = new LineageFlagsInputMapper();
+
+  @Nonnull
+  public static com.linkedin.metadata.query.LineageFlags map(
+      @Nonnull final LineageFlags lineageFlags) {
+    return INSTANCE.apply(lineageFlags);
+  }
+
+  @Override
+  public com.linkedin.metadata.query.LineageFlags apply(@Nullable final LineageFlags lineageFlags) {
+    com.linkedin.metadata.query.LineageFlags result =
+        new com.linkedin.metadata.query.LineageFlags();
+    if (lineageFlags == null) {
+      return result;
+    }
+    if (lineageFlags.getIgnoreAsHops() != null) {
+      result.setIgnoreAsHops(mapIgnoreAsHops(lineageFlags.getIgnoreAsHops()));
+    }
+    if (lineageFlags.getEndTimeMillis() != null) {
+      result.setEndTimeMillis(lineageFlags.getEndTimeMillis());
+    }
+    if (lineageFlags.getStartTimeMillis() != null) {
+      result.setStartTimeMillis(lineageFlags.getStartTimeMillis());
+    }
+    if (lineageFlags.getEntitiesExploredPerHopLimit() != null) {
+      result.setEntitiesExploredPerHopLimit(lineageFlags.getEntitiesExploredPerHopLimit());
+    }
+    return result;
+  }
+
+  private static UrnArrayMap mapIgnoreAsHops(List<EntityTypeToPlatforms> ignoreAsHops) {
+    UrnArrayMap result = new UrnArrayMap();
+    ignoreAsHops.forEach(
+        ignoreAsHop ->
+            result.put(
+                EntityTypeMapper.getName(ignoreAsHop.getEntityType()),
+                new UrnArray(
+                    Optional.ofNullable(ignoreAsHop.getPlatforms())
+                        .orElse(Collections.emptyList())
+                        .stream()
+                        .map(UrnUtils::getUrn)
+                        .collect(Collectors.toList()))));
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
@@ -3,6 +3,7 @@ package com.linkedin.datahub.graphql.types.common.mappers;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.UrnArrayMap;
 import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.EntityTypeToPlatforms;
 import com.linkedin.datahub.graphql.generated.LineageFlags;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
@@ -26,12 +27,13 @@ public class LineageFlagsInputMapper
 
   @Nonnull
   public static com.linkedin.metadata.query.LineageFlags map(
-      @Nonnull final LineageFlags lineageFlags) {
-    return INSTANCE.apply(lineageFlags);
+      QueryContext queryContext, @Nonnull final LineageFlags lineageFlags) {
+    return INSTANCE.apply(queryContext, lineageFlags);
   }
 
   @Override
-  public com.linkedin.metadata.query.LineageFlags apply(@Nullable final LineageFlags lineageFlags) {
+  public com.linkedin.metadata.query.LineageFlags apply(
+      QueryContext context, @Nullable final LineageFlags lineageFlags) {
     com.linkedin.metadata.query.LineageFlags result =
         new com.linkedin.metadata.query.LineageFlags();
     if (lineageFlags == null) {

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -165,6 +165,43 @@ input  SearchFlags {
 }
 
 """
+Flags to control lineage behavior
+"""
+input LineageFlags {
+  """
+  Limits the number of results explored per hop, still gets all edges each time a hop happens
+  """
+  entitiesExploredPerHopLimit: Int
+
+  """
+  An optional starting time to filter on
+  """
+  startTimeMillis: Long
+  """
+  An optional ending time to filter on
+  """
+  endTimeMillis: Long
+
+  """
+  Map of entity types to platforms to ignore when counting hops during graph walk. Note: this can potentially cause
+  a large amount of additional hops to occur and should be used with caution.
+  """
+  ignoreAsHops: [EntityTypeToPlatforms!]
+}
+
+input EntityTypeToPlatforms {
+  """
+  Entity type to ignore as hops, if no platform is applied applies to all entities of this type.
+  """
+  entityType: EntityType!
+
+  """
+  List of platforms to ignore as hops, empty implies all. Must be a valid platform urn
+  """
+  platforms: [String!]
+}
+
+"""
 Input arguments for a full text search query across entities
 """
 input SearchAcrossEntitiesInput {
@@ -345,16 +382,21 @@ input SearchAcrossLineageInput {
   """
   An optional starting time to filter on
   """
-  startTimeMillis: Long
+  startTimeMillis: Long @deprecated(reason: "Use LineageFlags instead")
   """
   An optional ending time to filter on
   """
-  endTimeMillis: Long
+  endTimeMillis: Long @deprecated(reason: "Use LineageFlags instead")
 
   """
   Flags controlling search options
   """
   searchFlags: SearchFlags
+
+  """
+  Flags controlling the lineage query
+  """
+  lineageFlags: LineageFlags
 }
 
 """
@@ -415,6 +457,11 @@ input ScrollAcrossLineageInput {
   Flags controlling search options
   """
   searchFlags: SearchFlags
+
+  """
+  Flags controlling the lineage query
+  """
+  lineageFlags: LineageFlags
 }
 
 """

--- a/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/client/JavaEntityClient.java
@@ -60,13 +60,13 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.net.URISyntaxException;
 import java.time.Clock;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -119,6 +119,7 @@ public class JavaEntityClient implements EntityClient {
   }
 
   @Nonnull
+  @Deprecated
   public Entity get(@Nonnull final Urn urn, @Nonnull final Authentication authentication) {
     return entityService.getEntity(urn, ImmutableSet.of());
   }
@@ -149,6 +150,7 @@ public class JavaEntityClient implements EntityClient {
   }
 
   @Nonnull
+  @Deprecated
   public Map<Urn, Entity> batchGet(
       @Nonnull final Set<Urn> urns, @Nonnull final Authentication authentication) {
     return entityService.getEntities(urns, ImmutableSet.of());
@@ -162,7 +164,7 @@ public class JavaEntityClient implements EntityClient {
    * @param field field of the dataset to autocomplete against
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   public AutoCompleteResult autoComplete(
@@ -170,7 +172,7 @@ public class JavaEntityClient implements EntityClient {
       @Nonnull String entityType,
       @Nonnull String query,
       @Nullable Filter requestFilters,
-      @Nonnull int limit,
+      int limit,
       @Nullable String field)
       throws RemoteInvocationException {
     return cachingEntitySearchService.autoComplete(
@@ -184,7 +186,7 @@ public class JavaEntityClient implements EntityClient {
    * @param query search query
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   public AutoCompleteResult autoComplete(
@@ -192,7 +194,7 @@ public class JavaEntityClient implements EntityClient {
       @Nonnull String entityType,
       @Nonnull String query,
       @Nullable Filter requestFilters,
-      @Nonnull int limit)
+      int limit)
       throws RemoteInvocationException {
     return cachingEntitySearchService.autoComplete(
         opContext, entityType, query, "", filterOrDefaultEmptyFilter(requestFilters), limit);
@@ -206,10 +208,9 @@ public class JavaEntityClient implements EntityClient {
    * @param requestFilters browse filters
    * @param start start offset of first dataset
    * @param limit max number of datasets
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
-  @Nonnull
   public BrowseResult browse(
       @Nonnull OperationContext opContext,
       @Nonnull String entityType,
@@ -233,7 +234,6 @@ public class JavaEntityClient implements EntityClient {
    * @param input search query
    * @param start start offset of first group
    * @param count max number of results requested
-   * @throws RemoteInvocationException
    */
   @Nonnull
   public BrowseResultV2 browseV2(
@@ -257,7 +257,6 @@ public class JavaEntityClient implements EntityClient {
    * @param input search query
    * @param start start offset of first group
    * @param count max number of results requested
-   * @throws RemoteInvocationException
    */
   @Nonnull
   public BrowseResultV2 browseV2(
@@ -312,8 +311,7 @@ public class JavaEntityClient implements EntityClient {
     AuditStamp auditStamp = new AuditStamp();
     auditStamp.setActor(Urn.createFromString(authentication.getActor().toUrnStr()));
     auditStamp.setTime(Clock.systemUTC().millis());
-    entityService.ingestEntities(
-        entities.stream().collect(Collectors.toList()), auditStamp, ImmutableList.of());
+    entityService.ingestEntities(new ArrayList<>(entities), auditStamp, ImmutableList.of());
   }
 
   /**
@@ -324,9 +322,8 @@ public class JavaEntityClient implements EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of search results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   @WithSpan
   @Override
   public SearchResult search(
@@ -353,11 +350,10 @@ public class JavaEntityClient implements EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of list results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Deprecated
-  @Nonnull
   public ListResult list(
       @Nonnull OperationContext opContext,
       @Nonnull String entity,
@@ -386,9 +382,8 @@ public class JavaEntityClient implements EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   @Override
   public SearchResult search(
       @Nonnull OperationContext opContext,
@@ -431,10 +426,9 @@ public class JavaEntityClient implements EntityClient {
    * @param facets list of facets we want aggregations for
    * @param sortCriterion sorting criterion
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
-  @Nonnull
   public SearchResult searchAcrossEntities(
       @Nonnull OperationContext opContext,
       @Nonnull List<String> entities,
@@ -484,7 +478,6 @@ public class JavaEntityClient implements EntityClient {
         entityService);
   }
 
-  @Nonnull
   @Override
   public LineageSearchResult searchAcrossLineage(
       @Nonnull OperationContext opContext,
@@ -509,42 +502,7 @@ public class JavaEntityClient implements EntityClient {
             filter,
             sortCriterion,
             start,
-            count,
-            null,
-            null),
-        entityService);
-  }
-
-  @Nonnull
-  @Override
-  public LineageSearchResult searchAcrossLineage(
-      @Nonnull OperationContext opContext,
-      @Nonnull Urn sourceUrn,
-      @Nonnull LineageDirection direction,
-      @Nonnull List<String> entities,
-      @Nullable String input,
-      @Nullable Integer maxHops,
-      @Nullable Filter filter,
-      @Nullable SortCriterion sortCriterion,
-      int start,
-      int count,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis)
-      throws RemoteInvocationException {
-    return ValidationUtils.validateLineageSearchResult(
-        lineageSearchService.searchAcrossLineage(
-            opContext,
-            sourceUrn,
-            direction,
-            entities,
-            input,
-            maxHops,
-            filter,
-            sortCriterion,
-            start,
-            count,
-            startTimeMillis,
-            endTimeMillis),
+            count),
         entityService);
   }
 
@@ -561,14 +519,14 @@ public class JavaEntityClient implements EntityClient {
       @Nullable SortCriterion sortCriterion,
       @Nullable String scrollId,
       @Nonnull String keepAlive,
-      int count,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis)
+      int count)
       throws RemoteInvocationException {
 
     return ValidationUtils.validateLineageScrollResult(
         lineageSearchService.scrollAcrossLineage(
-            opContext.withSearchFlags(flags -> flags.setFulltext(true).setSkipCache(true)),
+            opContext
+                .withSearchFlags(flags -> flags.setFulltext(true).setSkipCache(true))
+                .withLineageFlags(flags -> flags),
             sourceUrn,
             direction,
             entities,
@@ -578,9 +536,7 @@ public class JavaEntityClient implements EntityClient {
             sortCriterion,
             scrollId,
             keepAlive,
-            count,
-            startTimeMillis,
-            endTimeMillis),
+            count),
         entityService);
   }
 
@@ -589,7 +545,7 @@ public class JavaEntityClient implements EntityClient {
    *
    * @param urn urn for the entity
    * @return list of paths given urn
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -636,7 +592,6 @@ public class JavaEntityClient implements EntityClient {
     withRetry(() -> deleteEntityService.deleteReferencesTo(urn, false), "deleteEntityReferences");
   }
 
-  @Nonnull
   @Override
   public SearchResult filter(
       @Nonnull OperationContext opContext,
@@ -665,6 +620,7 @@ public class JavaEntityClient implements EntityClient {
 
   @SneakyThrows
   @Override
+  @Deprecated
   public VersionedAspect getAspect(
       @Nonnull String urn,
       @Nonnull String aspect,
@@ -676,6 +632,7 @@ public class JavaEntityClient implements EntityClient {
 
   @SneakyThrows
   @Override
+  @Deprecated
   public VersionedAspect getAspectOrNull(
       @Nonnull String urn,
       @Nonnull String aspect,
@@ -756,6 +713,7 @@ public class JavaEntityClient implements EntityClient {
 
   @SneakyThrows
   @Override
+  @Deprecated
   public <T extends RecordTemplate> Optional<T> getVersionedAspect(
       @Nonnull String urn,
       @Nonnull String aspect,
@@ -776,6 +734,7 @@ public class JavaEntityClient implements EntityClient {
   }
 
   @SneakyThrows
+  @Deprecated
   public DataMap getRawAspect(
       @Nonnull String urn,
       @Nonnull String aspect,
@@ -789,8 +748,7 @@ public class JavaEntityClient implements EntityClient {
     }
 
     if (entity.hasAspect()) {
-      DataMap rawAspect = ((DataMap) entity.data().get("aspect"));
-      return rawAspect;
+      return ((DataMap) entity.data().get("aspect"));
     }
 
     return null;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/SiblingGraphService.java
@@ -10,6 +10,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.validation.ValidationUtils;
+import com.linkedin.metadata.query.LineageFlags;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -37,8 +38,7 @@ public class SiblingGraphService {
       int count,
       int maxHops) {
     return ValidationUtils.validateEntityLineageResult(
-        getLineage(
-            entityUrn, direction, offset, count, maxHops, false, new HashSet<>(), null, null),
+        getLineage(entityUrn, direction, offset, count, maxHops, false, new HashSet<>(), null),
         _entityService);
   }
 
@@ -58,12 +58,10 @@ public class SiblingGraphService {
       int maxHops,
       boolean separateSiblings,
       @Nonnull Set<Urn> visitedUrns,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis) {
+      @Nullable LineageFlags lineageFlags) {
     if (separateSiblings) {
       return ValidationUtils.validateEntityLineageResult(
-          _graphService.getLineage(
-              entityUrn, direction, offset, count, maxHops, startTimeMillis, endTimeMillis),
+          _graphService.getLineage(entityUrn, direction, offset, count, maxHops, lineageFlags),
           _entityService);
     }
 
@@ -74,8 +72,7 @@ public class SiblingGraphService {
     }
 
     EntityLineageResult entityLineage =
-        _graphService.getLineage(
-            entityUrn, direction, offset, count, maxHops, startTimeMillis, endTimeMillis);
+        _graphService.getLineage(entityUrn, direction, offset, count, maxHops, lineageFlags);
 
     Siblings siblingAspectOfEntity =
         (Siblings) _entityService.getLatestAspect(entityUrn, SIBLINGS_ASPECT_NAME);
@@ -83,7 +80,7 @@ public class SiblingGraphService {
     // if you have siblings, we want to fetch their lineage too and merge it in
     if (siblingAspectOfEntity != null && siblingAspectOfEntity.hasSiblings()) {
       UrnArray siblingUrns = siblingAspectOfEntity.getSiblings();
-      Set<Urn> allSiblingsInGroup = siblingUrns.stream().collect(Collectors.toSet());
+      Set<Urn> allSiblingsInGroup = new HashSet<>(siblingUrns);
       allSiblingsInGroup.add(entityUrn);
 
       // remove your siblings from your lineage
@@ -114,8 +111,7 @@ public class SiblingGraphService {
                     maxHops,
                     false,
                     visitedUrns,
-                    startTimeMillis,
-                    endTimeMillis),
+                    lineageFlags),
                 entityLineage);
 
         // Update offset and count to fetch the correct number of edges from the next sibling node

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.UrnArrayArray;
+import com.linkedin.common.UrnArrayMap;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.IntegerArray;
@@ -19,6 +20,7 @@ import com.linkedin.metadata.graph.LineageDirection;
 import com.linkedin.metadata.graph.LineageRelationship;
 import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.models.registry.LineageRegistry.EdgeInfo;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.Criterion;
@@ -29,11 +31,13 @@ import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.search.elasticsearch.query.request.SearchAfterWrapper;
 import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.utils.ConcurrencyUtils;
+import com.linkedin.metadata.utils.DataPlatformInstanceUtils;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -45,11 +49,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -108,7 +114,7 @@ public class ESGraphQueryDAO {
     rootQuery.filter(orQuery);
   }
 
-  private SearchResponse executeSearchQuery(
+  private SearchResponse executeLineageSearchQuery(
       @Nonnull final QueryBuilder query, final int offset, final int count) {
     SearchRequest searchRequest = new SearchRequest();
 
@@ -135,7 +141,7 @@ public class ESGraphQueryDAO {
     }
   }
 
-  private SearchResponse executeSearchQuery(
+  private SearchResponse executeLineageSearchQuery(
       @Nonnull final QueryBuilder query,
       @Nullable Object[] sort,
       @Nullable String pitId,
@@ -179,7 +185,7 @@ public class ESGraphQueryDAO {
             relationshipTypes,
             relationshipFilter);
 
-    return executeSearchQuery(finalQuery, offset, count);
+    return executeLineageSearchQuery(finalQuery, offset, count);
   }
 
   public static BoolQueryBuilder buildQuery(
@@ -261,8 +267,7 @@ public class ESGraphQueryDAO {
       int offset,
       int count,
       int maxHops,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis) {
+      @Nullable LineageFlags lineageFlags) {
     Map<Urn, LineageRelationship> result = new HashMap<>();
     long currentTime = System.currentTimeMillis();
     long remainingTime = graphQueryConfiguration.getTimeoutSeconds() * 1000;
@@ -291,34 +296,21 @@ public class ESGraphQueryDAO {
       }
 
       // Do one hop on the lineage graph
-      List<LineageRelationship> oneHopRelationships =
-          getLineageRelationshipsInBatches(
+      Stream<Urn> intermediateStream =
+          processOneHopLineage(
               currentLevel,
+              remainingTime,
               direction,
+              maxHops,
               graphFilters,
               visitedEntities,
               viaEntities,
-              i + 1,
-              maxHops - (i + 1),
-              remainingTime,
               existingPaths,
-              startTimeMillis,
-              endTimeMillis,
-              exploreMultiplePaths);
-      for (LineageRelationship oneHopRelnship : oneHopRelationships) {
-        if (result.containsKey(oneHopRelnship.getEntity())) {
-          log.debug("Urn encountered again during graph walk {}", oneHopRelnship.getEntity());
-          result.put(
-              oneHopRelnship.getEntity(),
-              mergeLineageRelationships(result.get(oneHopRelnship.getEntity()), oneHopRelnship));
-        } else {
-          result.put(oneHopRelnship.getEntity(), oneHopRelnship);
-        }
-      }
-      currentLevel =
-          oneHopRelationships.stream()
-              .map(LineageRelationship::getEntity)
-              .collect(Collectors.toList());
+              exploreMultiplePaths,
+              result,
+              lineageFlags,
+              i);
+      currentLevel = intermediateStream.collect(Collectors.toList());
       currentTime = System.currentTimeMillis();
       remainingTime = timeoutTime - currentTime;
     }
@@ -336,6 +328,106 @@ public class ESGraphQueryDAO {
     }
 
     return new LineageResponse(response.getTotal(), subList);
+  }
+
+  private Stream<Urn> processOneHopLineage(
+      List<Urn> currentLevel,
+      Long remainingTime,
+      LineageDirection direction,
+      int maxHops,
+      GraphFilters graphFilters,
+      Set<Urn> visitedEntities,
+      Set<Urn> viaEntities,
+      Map<Urn, UrnArrayArray> existingPaths,
+      boolean exploreMultiplePaths,
+      Map<Urn, LineageRelationship> result,
+      LineageFlags lineageFlags,
+      int i) {
+
+    // Do one hop on the lineage graph
+    List<LineageRelationship> oneHopRelationships =
+        getLineageRelationshipsInBatches(
+            currentLevel,
+            direction,
+            graphFilters,
+            visitedEntities,
+            viaEntities,
+            i + 1,
+            maxHops - (i + 1),
+            remainingTime,
+            existingPaths,
+            exploreMultiplePaths,
+            lineageFlags);
+    for (LineageRelationship oneHopRelnship : oneHopRelationships) {
+      if (result.containsKey(oneHopRelnship.getEntity())) {
+        log.debug("Urn encountered again during graph walk {}", oneHopRelnship.getEntity());
+        result.put(
+            oneHopRelnship.getEntity(),
+            mergeLineageRelationships(result.get(oneHopRelnship.getEntity()), oneHopRelnship));
+      } else {
+        result.put(oneHopRelnship.getEntity(), oneHopRelnship);
+      }
+    }
+    Stream<Urn> intermediateStream =
+        oneHopRelationships.stream().map(LineageRelationship::getEntity);
+    if (lineageFlags != null) {
+
+      // Recursively increase the size of the list and append
+      if (lineageFlags.getIgnoreAsHops() != null) {
+        List<Urn> additionalCurrentLevel = new ArrayList<>();
+        UrnArrayMap ignoreAsHops = lineageFlags.getIgnoreAsHops();
+        oneHopRelationships.stream()
+            .filter(
+                lineageRelationship ->
+                    lineageFlags.getIgnoreAsHops().keySet().stream()
+                        .anyMatch(
+                            entityType ->
+                                entityType.equals(lineageRelationship.getEntity().getEntityType())
+                                    && (CollectionUtils.isEmpty(ignoreAsHops.get(entityType))
+                                        || platformMatches(
+                                            lineageRelationship.getEntity(),
+                                            ignoreAsHops.get(entityType)))))
+            .forEach(
+                lineageRelationship -> additionalCurrentLevel.add(lineageRelationship.getEntity()));
+        if (!additionalCurrentLevel.isEmpty()) {
+          Stream<Urn> ignoreAsHopUrns =
+              processOneHopLineage(
+                  additionalCurrentLevel,
+                  remainingTime,
+                  direction,
+                  maxHops,
+                  graphFilters,
+                  visitedEntities,
+                  viaEntities,
+                  existingPaths,
+                  exploreMultiplePaths,
+                  result,
+                  lineageFlags,
+                  i);
+          intermediateStream = Stream.concat(intermediateStream, ignoreAsHopUrns);
+        }
+      }
+      // We limit after adding all the relationships at the previous level so each hop is fully
+      // returned,
+      // but we only explore a limited number of entities per hop, sort to make the truncation
+      // consistent
+      if (lineageFlags.getEntitiesExploredPerHopLimit() != null) {
+        intermediateStream =
+            intermediateStream
+                .sorted(Comparator.comparing(Urn::toString))
+                .limit(lineageFlags.getEntitiesExploredPerHopLimit());
+      }
+    }
+    return intermediateStream;
+  }
+
+  private boolean platformMatches(Urn urn, UrnArray platforms) {
+    return platforms.stream()
+        .anyMatch(
+            platform ->
+                DataPlatformInstanceUtils.getDataPlatform(urn)
+                    .toString()
+                    .equals(platform.toString()));
   }
 
   /**
@@ -383,9 +475,8 @@ public class ESGraphQueryDAO {
       int remainingHops,
       long remainingTime,
       Map<Urn, UrnArrayArray> existingPaths,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis,
-      boolean exploreMultiplePaths) {
+      boolean exploreMultiplePaths,
+      @Nullable LineageFlags lineageFlags) {
     List<List<Urn>> batches = Lists.partition(entityUrns, graphQueryConfiguration.getBatchSize());
     return ConcurrencyUtils.getAllCompleted(
             batches.stream()
@@ -402,9 +493,8 @@ public class ESGraphQueryDAO {
                                     numHops,
                                     remainingHops,
                                     existingPaths,
-                                    startTimeMillis,
-                                    endTimeMillis,
-                                    exploreMultiplePaths)))
+                                    exploreMultiplePaths,
+                                    lineageFlags)))
                 .collect(Collectors.toList()),
             remainingTime,
             TimeUnit.MILLISECONDS)
@@ -424,9 +514,8 @@ public class ESGraphQueryDAO {
       int numHops,
       int remainingHops,
       Map<Urn, UrnArrayArray> existingPaths,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis,
-      boolean exploreMultiplePaths) {
+      boolean exploreMultiplePaths,
+      @Nullable LineageFlags lineageFlags) {
     Map<String, List<Urn>> urnsPerEntityType =
         entityUrns.stream().collect(Collectors.groupingBy(Urn::getEntityType));
     Map<String, List<EdgeInfo>> edgesPerEntityType =
@@ -437,10 +526,9 @@ public class ESGraphQueryDAO {
                     entityType -> lineageRegistry.getLineageRelationships(entityType, direction)));
 
     QueryBuilder finalQuery =
-        getLineageQuery(
-            urnsPerEntityType, edgesPerEntityType, graphFilters, startTimeMillis, endTimeMillis);
+        getLineageQuery(urnsPerEntityType, edgesPerEntityType, graphFilters, lineageFlags);
     SearchResponse response =
-        executeSearchQuery(finalQuery, 0, graphQueryConfiguration.getMaxResult());
+        executeLineageSearchQuery(finalQuery, 0, graphQueryConfiguration.getMaxResult());
     Set<Urn> entityUrnSet = new HashSet<>(entityUrns);
     // Get all valid edges given the set of urns to hop from
     Set<Pair<String, EdgeInfo>> validEdges =
@@ -466,8 +554,7 @@ public class ESGraphQueryDAO {
       @Nonnull Map<String, List<Urn>> urnsPerEntityType,
       @Nonnull Map<String, List<EdgeInfo>> edgesPerEntityType,
       @Nonnull GraphFilters graphFilters,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis) {
+      @Nullable LineageFlags lineageFlags) {
     BoolQueryBuilder entityTypeQueries = QueryBuilders.boolQuery();
     // Get all relation types relevant to the set of urns to hop from
     urnsPerEntityType.forEach(
@@ -489,13 +576,14 @@ public class ESGraphQueryDAO {
     /*
      * Optional - Add edge filtering based on time windows.
      */
-    if (startTimeMillis != null && endTimeMillis != null) {
-      finalQuery.filter(TimeFilterUtils.getEdgeTimeFilterQuery(startTimeMillis, endTimeMillis));
+    if (lineageFlags != null
+        && lineageFlags.getStartTimeMillis() != null
+        && lineageFlags.getEndTimeMillis() != null) {
+      finalQuery.filter(
+          TimeFilterUtils.getEdgeTimeFilterQuery(
+              lineageFlags.getStartTimeMillis(), lineageFlags.getEndTimeMillis()));
     } else {
-      log.debug(
-          String.format(
-              "Empty time filter range provided: start time %s, end time: %s. Skipping application of time filters",
-              startTimeMillis, endTimeMillis));
+      log.debug("Empty time filter range provided. Skipping application of time filters");
     }
 
     return finalQuery;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ElasticSearchGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ElasticSearchGraphService.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.graph.RelatedEntitiesResult;
 import com.linkedin.metadata.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.graph.RelatedEntity;
 import com.linkedin.metadata.models.registry.LineageRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
 import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
@@ -184,6 +185,7 @@ public class ElasticSearchGraphService implements GraphService, ElasticSearchInd
   @Nonnull
   @WithSpan
   @Override
+  @Deprecated
   public EntityLineageResult getLineage(
       @Nonnull Urn entityUrn,
       @Nonnull LineageDirection direction,
@@ -192,8 +194,7 @@ public class ElasticSearchGraphService implements GraphService, ElasticSearchInd
       int count,
       int maxHops) {
     ESGraphQueryDAO.LineageResponse lineageResponse =
-        _graphReadDAO.getLineage(
-            entityUrn, direction, graphFilters, offset, count, maxHops, null, null);
+        _graphReadDAO.getLineage(entityUrn, direction, graphFilters, offset, count, maxHops, null);
     return new EntityLineageResult()
         .setRelationships(new LineageRelationshipArray(lineageResponse.getLineageRelationships()))
         .setStart(offset)
@@ -211,18 +212,10 @@ public class ElasticSearchGraphService implements GraphService, ElasticSearchInd
       int offset,
       int count,
       int maxHops,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis) {
+      @Nullable LineageFlags lineageFlags) {
     ESGraphQueryDAO.LineageResponse lineageResponse =
         _graphReadDAO.getLineage(
-            entityUrn,
-            direction,
-            graphFilters,
-            offset,
-            count,
-            maxHops,
-            startTimeMillis,
-            endTimeMillis);
+            entityUrn, direction, graphFilters, offset, count, maxHops, lineageFlags);
     return new EntityLineageResult()
         .setRelationships(new LineageRelationshipArray(lineageResponse.getLineageRelationships()))
         .setStart(offset)

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/EntityLineageResultCacheKey.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/EntityLineageResultCacheKey.java
@@ -2,8 +2,6 @@ package com.linkedin.metadata.search;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.graph.LineageDirection;
-import java.time.Instant;
-import java.time.temporal.TemporalUnit;
 import javax.annotation.Nonnull;
 import lombok.Data;
 
@@ -12,32 +10,19 @@ public class EntityLineageResultCacheKey {
   private final String contextId;
   private final Urn sourceUrn;
   private final LineageDirection direction;
-  private final Long startTimeMillis;
-  private final Long endTimeMillis;
   private final Integer maxHops;
+  private final Integer entitiesExploredPerHopLimit;
 
   public EntityLineageResultCacheKey(
       @Nonnull String contextId,
       Urn sourceUrn,
       LineageDirection direction,
-      Long startTimeMillis,
-      Long endTimeMillis,
       Integer maxHops,
-      TemporalUnit resolution) {
+      Integer entitiesExploredPerHopLimit) {
     this.contextId = contextId;
     this.sourceUrn = sourceUrn;
     this.direction = direction;
     this.maxHops = maxHops;
-    long endOffset = resolution.getDuration().getSeconds() * 1000;
-    this.startTimeMillis =
-        startTimeMillis == null
-            ? null
-            : Instant.ofEpochMilli(startTimeMillis).truncatedTo(resolution).toEpochMilli();
-    this.endTimeMillis =
-        endTimeMillis == null
-            ? null
-            : Instant.ofEpochMilli(endTimeMillis + endOffset)
-                .truncatedTo(resolution)
-                .toEpochMilli();
+    this.entitiesExploredPerHopLimit = entitiesExploredPerHopLimit;
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/dgraph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/dgraph/DgraphGraphServiceTest.java
@@ -849,4 +849,9 @@ public class DgraphGraphServiceTest extends GraphServiceTestBaseNoVia {
     super.testFindRelatedEntitiesSourceType(
         datasetType, relationshipTypes, relationships, expectedRelatedEntities);
   }
+
+  @Override
+  public void testHighlyConnectedGraphWalk() throws Exception {
+    // TODO: explore limit not supported for DGraph
+  }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/neo4j/Neo4jGraphServiceTest.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.graph.RelatedEntitiesResult;
 import com.linkedin.metadata.graph.RelatedEntity;
 import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
 import java.util.Arrays;
@@ -318,7 +319,13 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBaseNoVia {
 
     // with time filtering
     EntityLineageResult upstreamLineageTwoHopsWithTimeFilter =
-        service.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 1000, 2, 10L, 12L);
+        service.getLineage(
+            datasetFourUrn,
+            LineageDirection.UPSTREAM,
+            0,
+            1000,
+            2,
+            new LineageFlags().setStartTimeMillis(10L).setEndTimeMillis(12L));
     assertEquals(upstreamLineageTwoHopsWithTimeFilter.getTotal().intValue(), 1);
     assertEquals(upstreamLineageTwoHopsWithTimeFilter.getRelationships().size(), 1);
     assertEquals(
@@ -327,7 +334,13 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBaseNoVia {
 
     // with time filtering
     EntityLineageResult upstreamLineageTimeFilter =
-        service.getLineage(datasetTwoUrn, LineageDirection.UPSTREAM, 0, 1000, 4, 2L, 6L);
+        service.getLineage(
+            datasetTwoUrn,
+            LineageDirection.UPSTREAM,
+            0,
+            1000,
+            4,
+            new LineageFlags().setStartTimeMillis(2L).setEndTimeMillis(6L));
     assertEquals(upstreamLineageTimeFilter.getTotal().intValue(), 2);
     assertEquals(upstreamLineageTimeFilter.getRelationships().size(), 2);
     assertEquals(
@@ -338,7 +351,13 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBaseNoVia {
 
     // with time filtering
     EntityLineageResult downstreamLineageTimeFilter =
-        service.getLineage(datasetOneUrn, LineageDirection.DOWNSTREAM, 0, 1000, 4, 0L, 4L);
+        service.getLineage(
+            datasetOneUrn,
+            LineageDirection.DOWNSTREAM,
+            0,
+            1000,
+            4,
+            new LineageFlags().setStartTimeMillis(0L).setEndTimeMillis(4L));
     assertEquals(downstreamLineageTimeFilter.getTotal().intValue(), 1);
     assertEquals(downstreamLineageTimeFilter.getRelationships().size(), 1);
     assertEquals(
@@ -373,12 +392,23 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBaseNoVia {
 
     // with time filtering, shorter path from d3 to d1 is excluded so longer path is returned
     EntityLineageResult upstreamLineageTimeFiltering =
-        service.getLineage(datasetThreeUrn, LineageDirection.UPSTREAM, 0, 1000, 3, 3L, 17L);
+        service.getLineage(
+            datasetThreeUrn,
+            LineageDirection.UPSTREAM,
+            0,
+            1000,
+            3,
+            new LineageFlags().setStartTimeMillis(3L).setEndTimeMillis(17L));
     assertEquals(
         getPathUrnArraysFromLineageResult(upstreamLineageTimeFiltering),
         Set.of(
             new UrnArray(datasetThreeUrn, datasetTwoUrn),
             new UrnArray(datasetThreeUrn, datasetTwoUrn, dataJobOneUrn),
             new UrnArray(datasetThreeUrn, datasetTwoUrn, dataJobOneUrn, datasetOneUrn)));
+  }
+
+  @Override
+  public void testHighlyConnectedGraphWalk() throws Exception {
+    // TODO: explore limit not supported for Neo4J
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/search/ESGraphQueryDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/search/ESGraphQueryDAOTest.java
@@ -11,6 +11,7 @@ import com.linkedin.metadata.config.search.GraphQueryConfiguration;
 import com.linkedin.metadata.graph.GraphFilters;
 import com.linkedin.metadata.graph.elastic.ESGraphQueryDAO;
 import com.linkedin.metadata.models.registry.LineageRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -107,19 +108,21 @@ public class ESGraphQueryDAOTest {
 
     QueryBuilder fullBuilder =
         graphQueryDAO.getLineageQuery(
-            urnsPerEntityType, edgesPerEntityType, graphFilters, startTime, endTime);
+            urnsPerEntityType,
+            edgesPerEntityType,
+            graphFilters,
+            new LineageFlags().setEndTimeMillis(endTime).setStartTimeMillis(startTime));
 
     QueryBuilder fullBuilderEmptyFilters =
         graphQueryDAO.getLineageQuery(
-            urnsPerEntityType, edgesPerEntityType, GraphFilters.emptyGraphFilters, null, null);
+            urnsPerEntityType, edgesPerEntityType, GraphFilters.emptyGraphFilters, null);
 
     QueryBuilder fullBuilderMultipleFilters =
         graphQueryDAO.getLineageQuery(
             urnsPerEntityTypeMultiple,
             edgesPerEntityTypeMultiple,
             graphFiltersMultiple,
-            startTime,
-            endTime);
+            new LineageFlags().setEndTimeMillis(endTime).setStartTimeMillis(startTime));
 
     Assert.assertEquals(limitedBuilder.toString(), expectedQueryLimited);
     Assert.assertEquals(fullBuilder.toString(), expectedQueryFull);

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/search/SearchGraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/search/SearchGraphServiceTestBase.java
@@ -9,6 +9,7 @@ import com.linkedin.common.urn.DataPlatformUrn;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.SetMode;
 import com.linkedin.metadata.config.search.GraphQueryConfiguration;
 import com.linkedin.metadata.graph.Edge;
 import com.linkedin.metadata.graph.EntityLineageResult;
@@ -25,6 +26,7 @@ import com.linkedin.metadata.models.registry.EntityRegistryException;
 import com.linkedin.metadata.models.registry.LineageRegistry;
 import com.linkedin.metadata.models.registry.MergedEntityRegistry;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
@@ -40,6 +42,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.junit.Assert;
 import org.opensearch.client.RestHighLevelClient;
 import org.testng.SkipException;
@@ -444,7 +447,7 @@ public abstract class SearchGraphServiceTestBase extends GraphServiceTestBase {
    * @return The Upstream lineage for urn from the window from startTime to endTime
    */
   private EntityLineageResult getUpstreamLineage(Urn urn, Long startTime, Long endTime) {
-    return getLineage(urn, LineageDirection.UPSTREAM, startTime, endTime);
+    return getLineage(urn, LineageDirection.UPSTREAM, startTime, endTime, null);
   }
 
   /**
@@ -456,7 +459,7 @@ public abstract class SearchGraphServiceTestBase extends GraphServiceTestBase {
    * @return The Downstream lineage for urn from the window from startTime to endTime
    */
   private EntityLineageResult getDownstreamLineage(Urn urn, Long startTime, Long endTime) {
-    return getLineage(urn, LineageDirection.DOWNSTREAM, startTime, endTime);
+    return getLineage(urn, LineageDirection.DOWNSTREAM, startTime, endTime, null);
   }
 
   /**
@@ -469,7 +472,22 @@ public abstract class SearchGraphServiceTestBase extends GraphServiceTestBase {
    * @return The lineage for urn from the window from startTime to endTime in direction
    */
   private EntityLineageResult getLineage(
-      Urn urn, LineageDirection direction, Long startTime, Long endTime) {
-    return getGraphService().getLineage(urn, direction, 0, 0, 3, startTime, endTime);
+      Urn urn,
+      LineageDirection direction,
+      Long startTime,
+      Long endTime,
+      @Nullable Integer entitiesExploredPerHopLimit) {
+    return getGraphService()
+        .getLineage(
+            urn,
+            direction,
+            0,
+            0,
+            3,
+            new LineageFlags()
+                .setStartTimeMillis(startTime, SetMode.REMOVE_IF_NULL)
+                .setEndTimeMillis(endTime, SetMode.REMOVE_IF_NULL)
+                .setEntitiesExploredPerHopLimit(
+                    entitiesExploredPerHopLimit, SetMode.REMOVE_IF_NULL));
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/sibling/SiblingGraphServiceTest.java
@@ -108,7 +108,7 @@ public class SiblingGraphServiceTest {
     mockResult.setFiltered(0);
     mockResult.setRelationships(relationships);
 
-    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null, null))
+    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null))
         .thenReturn(mockResult);
 
     when(_mockEntityService.getLatestAspect(datasetFourUrn, SIBLINGS_ASPECT_NAME)).thenReturn(null);
@@ -153,7 +153,7 @@ public class SiblingGraphServiceTest {
     mockResult.setFiltered(0);
     mockResult.setRelationships(relationships);
 
-    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null, null))
+    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null))
         .thenReturn(mockResult);
 
     siblingMockResult.setStart(0);
@@ -161,7 +161,7 @@ public class SiblingGraphServiceTest {
     siblingMockResult.setCount(0);
     siblingMockResult.setRelationships(new LineageRelationshipArray());
 
-    when(_graphService.getLineage(datasetFiveUrn, LineageDirection.UPSTREAM, 0, 97, 1, null, null))
+    when(_graphService.getLineage(datasetFiveUrn, LineageDirection.UPSTREAM, 0, 97, 1, null))
         .thenReturn(siblingMockResult);
 
     Siblings noRelevantSiblingsResponse = new Siblings();
@@ -235,10 +235,10 @@ public class SiblingGraphServiceTest {
     siblingMockResult.setCount(0);
     siblingMockResult.setRelationships(new LineageRelationshipArray());
 
-    when(_graphService.getLineage(datasetThreeUrn, LineageDirection.UPSTREAM, 0, 98, 1, null, null))
+    when(_graphService.getLineage(datasetThreeUrn, LineageDirection.UPSTREAM, 0, 98, 1, null))
         .thenReturn(siblingMockResult);
 
-    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null, null))
+    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null))
         .thenReturn(mockResult);
 
     Siblings siblingInSearchResult = new Siblings();
@@ -347,7 +347,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> siblingMockResult.clone());
 
@@ -357,7 +356,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> mockResult.clone());
 
@@ -451,10 +449,10 @@ public class SiblingGraphServiceTest {
     siblingMockResult.setCount(2);
     siblingMockResult.setRelationships(siblingRelationships);
 
-    when(_graphService.getLineage(datasetThreeUrn, LineageDirection.UPSTREAM, 0, 99, 1, null, null))
+    when(_graphService.getLineage(datasetThreeUrn, LineageDirection.UPSTREAM, 0, 99, 1, null))
         .thenReturn(siblingMockResult);
 
-    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null, null))
+    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 100, 1, null))
         .thenReturn(mockResult);
 
     Siblings siblingInSearchResult = new Siblings();
@@ -502,11 +500,10 @@ public class SiblingGraphServiceTest {
     // assert your lineage will not contain two siblings
     assertEquals(upstreamLineage, expectedResult);
 
-    when(_graphService.getLineage(
-            datasetThreeUrn, LineageDirection.UPSTREAM, 0, 100, 1, null, null))
+    when(_graphService.getLineage(datasetThreeUrn, LineageDirection.UPSTREAM, 0, 100, 1, null))
         .thenReturn(siblingMockResult);
 
-    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 99, 1, null, null))
+    when(_graphService.getLineage(datasetFourUrn, LineageDirection.UPSTREAM, 0, 99, 1, null))
         .thenReturn(mockResult);
 
     siblingInSearchResult = new Siblings();
@@ -572,7 +569,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .thenReturn(emptyLineageResult);
 
@@ -582,7 +578,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .thenReturn(emptyLineageResult);
 
@@ -592,7 +587,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .thenReturn(mockResult);
 
@@ -704,7 +698,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> siblingMockResult.clone());
 
@@ -714,7 +707,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> mockResult.clone());
 
@@ -859,7 +851,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> mockAlternateUpstreamResult.clone());
 
@@ -875,7 +866,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> mockAlternateDownstreamResult.clone());
 
@@ -902,7 +892,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> mockPrimaryUpstreamResult.clone());
 
@@ -925,7 +914,6 @@ public class SiblingGraphServiceTest {
             Mockito.anyInt(),
             Mockito.anyInt(),
             Mockito.eq(1),
-            Mockito.eq(null),
             Mockito.eq(null)))
         .then(invocation -> mockPrimaryDownstreamResult.clone());
 
@@ -936,7 +924,7 @@ public class SiblingGraphServiceTest {
     // Tests for separateSiblings = true: primary sibling
     EntityLineageResult primaryDownstreamSeparated =
         service.getLineage(
-            primarySiblingUrn, LineageDirection.DOWNSTREAM, 0, 100, 1, true, Set.of(), null, null);
+            primarySiblingUrn, LineageDirection.DOWNSTREAM, 0, 100, 1, true, Set.of(), null);
 
     LineageRelationshipArray expectedRelationships = new LineageRelationshipArray();
     expectedRelationships.add(relationship);
@@ -952,7 +940,7 @@ public class SiblingGraphServiceTest {
 
     EntityLineageResult primaryUpstreamSeparated =
         service.getLineage(
-            primarySiblingUrn, LineageDirection.UPSTREAM, 0, 100, 1, true, Set.of(), null, null);
+            primarySiblingUrn, LineageDirection.UPSTREAM, 0, 100, 1, true, Set.of(), null);
     EntityLineageResult expectedResultPrimaryUpstreamSeparated = new EntityLineageResult();
     expectedResultPrimaryUpstreamSeparated.setCount(2);
     expectedResultPrimaryUpstreamSeparated.setStart(0);
@@ -965,15 +953,7 @@ public class SiblingGraphServiceTest {
     // Test for separateSiblings = true, secondary sibling
     EntityLineageResult secondarySiblingSeparated =
         service.getLineage(
-            alternateSiblingUrn,
-            LineageDirection.DOWNSTREAM,
-            0,
-            100,
-            1,
-            true,
-            Set.of(),
-            null,
-            null);
+            alternateSiblingUrn, LineageDirection.DOWNSTREAM, 0, 100, 1, true, Set.of(), null);
 
     EntityLineageResult expectedResultSecondarySeparated = new EntityLineageResult();
     expectedResultSecondarySeparated.setCount(numDownstreams);
@@ -986,7 +966,7 @@ public class SiblingGraphServiceTest {
 
     EntityLineageResult secondaryUpstreamSeparated =
         service.getLineage(
-            alternateSiblingUrn, LineageDirection.UPSTREAM, 0, 100, 1, true, Set.of(), null, null);
+            alternateSiblingUrn, LineageDirection.UPSTREAM, 0, 100, 1, true, Set.of(), null);
     EntityLineageResult expectedResultSecondaryUpstreamSeparated = new EntityLineageResult();
     expectedResultSecondaryUpstreamSeparated.setCount(3);
     expectedResultSecondaryUpstreamSeparated.setStart(0);
@@ -1006,7 +986,6 @@ public class SiblingGraphServiceTest {
             1,
             false,
             new HashSet<>(),
-            null,
             null);
     EntityLineageResult expectedResultPrimaryNonSeparated = new EntityLineageResult();
     expectedResultPrimaryNonSeparated.setCount(numDownstreams);
@@ -1018,15 +997,7 @@ public class SiblingGraphServiceTest {
 
     EntityLineageResult primarySiblingNonSeparatedUpstream =
         service.getLineage(
-            primarySiblingUrn,
-            LineageDirection.UPSTREAM,
-            0,
-            100,
-            1,
-            false,
-            new HashSet<>(),
-            null,
-            null);
+            primarySiblingUrn, LineageDirection.UPSTREAM, 0, 100, 1, false, new HashSet<>(), null);
     EntityLineageResult expectedResultPrimaryUpstreamNonSeparated = new EntityLineageResult();
     expectedResultPrimaryUpstreamNonSeparated.setCount(2);
     expectedResultPrimaryUpstreamNonSeparated.setStart(0);
@@ -1045,7 +1016,6 @@ public class SiblingGraphServiceTest {
             1,
             false,
             new HashSet<>(),
-            null,
             null);
     assertEquals(secondarySiblingNonSeparated, expectedResultPrimaryNonSeparated);
 
@@ -1058,7 +1028,6 @@ public class SiblingGraphServiceTest {
             1,
             false,
             new HashSet<>(),
-            null,
             null);
     assertEquals(secondarySiblingNonSeparatedUpstream, expectedResultPrimaryUpstreamNonSeparated);
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchResultCacheKeyTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/LineageSearchResultCacheKeyTest.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.search;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotSame;
 
-import java.time.temporal.ChronoUnit;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
 import org.testng.annotations.Test;
 
@@ -13,22 +12,18 @@ public class LineageSearchResultCacheKeyTest extends AbstractTestNGSpringContext
   public void testNulls() {
     // ensure no NPE
     assertEquals(
-        new EntityLineageResultCacheKey("", null, null, null, null, null, ChronoUnit.DAYS),
-        new EntityLineageResultCacheKey("", null, null, null, null, null, ChronoUnit.DAYS));
+        new EntityLineageResultCacheKey("", null, null, null, null),
+        new EntityLineageResultCacheKey("", null, null, null, null));
   }
 
   @Test
   public void testDateTruncation() {
     // expect start of day milli
     assertEquals(
-        new EntityLineageResultCacheKey(
-            "", null, null, 1679529600000L, 1679615999999L, null, ChronoUnit.DAYS),
-        new EntityLineageResultCacheKey(
-            "", null, null, 1679530293000L, 1679530293001L, null, ChronoUnit.DAYS));
+        new EntityLineageResultCacheKey("", null, null, null, null),
+        new EntityLineageResultCacheKey("", null, null, null, null));
     assertNotSame(
-        new EntityLineageResultCacheKey(
-            "", null, null, 1679529600000L, 1679616000000L, null, ChronoUnit.DAYS),
-        new EntityLineageResultCacheKey(
-            "", null, null, 1679530293000L, 1679530293001L, null, ChronoUnit.DAYS));
+        new EntityLineageResultCacheKey("", null, null, null, null),
+        new EntityLineageResultCacheKey("", null, null, null, null));
   }
 }

--- a/metadata-io/src/test/java/io/datahubproject/test/search/SearchTestUtils.java
+++ b/metadata-io/src/test/java/io/datahubproject/test/search/SearchTestUtils.java
@@ -173,7 +173,9 @@ public class SearchTestUtils {
                 .build());
 
     return lineageSearchService.searchAcrossLineage(
-        opContext.withSearchFlags(flags -> flags.setSkipCache(true)),
+        opContext
+            .withSearchFlags(flags -> flags.setSkipCache(true))
+            .withLineageFlags(flags -> flags),
         root,
         LineageDirection.DOWNSTREAM,
         SEARCHABLE_ENTITY_TYPES.stream()
@@ -184,9 +186,7 @@ public class SearchTestUtils {
         ResolverUtils.buildFilter(filters, List.of()),
         null,
         0,
-        100,
-        null,
-        null);
+        100);
   }
 
   public static AutoCompleteResults autocomplete(

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
@@ -67,6 +67,7 @@ public class MetadataChangeEventsProcessor {
               + Topics.METADATA_CHANGE_EVENT
               + "}}",
       containerFactory = "kafkaEventConsumer")
+  @Deprecated
   public void consume(final ConsumerRecord<String, GenericRecord> consumerRecord) {
     try (Timer.Context i = MetricUtils.timer(this.getClass(), "consume").time()) {
       kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
@@ -116,6 +117,7 @@ public class MetadataChangeEventsProcessor {
     return fmce;
   }
 
+  @Deprecated
   private void processProposedSnapshot(@Nonnull MetadataChangeEvent metadataChangeEvent)
       throws RemoteInvocationException {
     final Snapshot snapshotUnion = metadataChangeEvent.getProposedSnapshot();

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/LineageFlags.pdl
@@ -1,0 +1,29 @@
+namespace com.linkedin.metadata.query
+
+import com.linkedin.common.Urn
+
+/**
+ * Set of flags to control lineage search behavior
+ */
+record LineageFlags {
+   /**
+    * Limits number of entities explored per hop
+    */
+    entitiesExploredPerHopLimit: optional int
+
+    /**
+     * Start time for lineage edges to filter
+     */
+     startTimeMillis: optional long
+
+    /**
+     * End time for lineage edges to filter
+     */
+     endTimeMillis: optional long
+
+     /**
+      * Map of entity type to list of platform urns to ignore as hops during graph walk. Note: this can potentially cause
+      * a large amount of additional hops to occur and should be used with caution.
+      */
+      ignoreAsHops: optional map[string, array[Urn]]
+}

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -7,6 +7,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
@@ -85,6 +86,22 @@ public class OperationContext {
   }
 
   /**
+   * Apply a set of default flags on top of any existing lineage flags
+   *
+   * @param opContext
+   * @param flagDefaults
+   * @return
+   */
+  public static OperationContext withLineageFlags(
+      OperationContext opContext, Function<LineageFlags, LineageFlags> flagDefaults) {
+
+    return opContext.toBuilder()
+        // update lineage flags for the request's session
+        .searchContext(opContext.getSearchContext().withLineageFlagDefaults(flagDefaults))
+        .build(opContext.getSessionAuthentication());
+  }
+
+  /**
    * Set the system authentication object AND allow escalation of privilege for the session. This
    * OperationContext typically serves the default.
    *
@@ -137,6 +154,11 @@ public class OperationContext {
   public OperationContext withSearchFlags(
       @Nonnull Function<SearchFlags, SearchFlags> flagDefaults) {
     return OperationContext.withSearchFlags(this, flagDefaults);
+  }
+
+  public OperationContext withLineageFlags(
+      @Nonnull Function<LineageFlags, LineageFlags> flagDefaults) {
+    return OperationContext.withLineageFlags(this, flagDefaults);
   }
 
   public OperationContext asSession(

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SearchContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/SearchContext.java
@@ -1,10 +1,15 @@
 package io.datahubproject.metadata.context;
 
+import com.linkedin.common.UrnArray;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.SearchFlags;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
+import com.linkedin.util.Pair;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -31,8 +36,22 @@ public class SearchContext implements ContextInterface {
     }
   }
 
+  public static SearchContext withLineageFlagDefaults(
+      @Nonnull SearchContext searchContext,
+      @Nonnull Function<LineageFlags, LineageFlags> flagDefaults) {
+    try {
+      return searchContext.toBuilder()
+          .lineageFlags(flagDefaults.apply(searchContext.getLineageFlags().copy()))
+          .build();
+    } catch (CloneNotSupportedException e) {
+      throw new IllegalStateException(
+          "Unable to clone RecordTemplate: " + searchContext.getLineageFlags(), e);
+    }
+  }
+
   @Nonnull private final IndexConvention indexConvention;
   @Nonnull private final SearchFlags searchFlags;
+  @Nonnull private final LineageFlags lineageFlags;
 
   public boolean isRestrictedSearch() {
     return Optional.ofNullable(searchFlags.isIncludeRestricted()).orElse(false);
@@ -40,6 +59,10 @@ public class SearchContext implements ContextInterface {
 
   public SearchContext withFlagDefaults(Function<SearchFlags, SearchFlags> flagDefaults) {
     return SearchContext.withFlagDefaults(this, flagDefaults);
+  }
+
+  public SearchContext withLineageFlagDefaults(Function<LineageFlags, LineageFlags> flagDefaults) {
+    return SearchContext.withLineageFlagDefaults(this, flagDefaults);
   }
 
   /**
@@ -50,7 +73,10 @@ public class SearchContext implements ContextInterface {
   @Override
   public Optional<Integer> getCacheKeyComponent() {
     return Optional.of(
-        Stream.of(indexConvention.getPrefix().orElse(""), keySearchFlags().toString())
+        Stream.of(
+                indexConvention.getPrefix().orElse(""),
+                keySearchFlags().toString(),
+                keyLineageFlags())
             .mapToInt(String::hashCode)
             .sum());
   }
@@ -69,6 +95,48 @@ public class SearchContext implements ContextInterface {
     }
   }
 
+  // Converts LineageFlags into a consistent string for usage in the context key
+  private String keyLineageFlags() {
+    String startTime =
+        lineageFlags.getStartTimeMillis() != null
+            ? lineageFlags.getStartTimeMillis().toString()
+            : "";
+    String endTime =
+        lineageFlags.getEndTimeMillis() != null ? lineageFlags.getEndTimeMillis().toString() : "";
+    String perHopLimit =
+        lineageFlags.getEntitiesExploredPerHopLimit() != null
+            ? lineageFlags.getEntitiesExploredPerHopLimit().toString()
+            : "";
+
+    // Map's iterator does not result in a consistent string so we need to convert to something that
+    // will be consistent
+    // based on a sort order
+    String ignoreAsHops;
+    if (lineageFlags.getIgnoreAsHops() != null) {
+      ignoreAsHops =
+          lineageFlags.getIgnoreAsHops().entrySet().stream()
+              .map(entry -> new Pair<>(entry.getKey(), entry.getValue()))
+              .sorted(
+                  Comparator.comparing((Pair<String, UrnArray> pair) -> pair.getFirst())
+                      .thenComparing(pair -> Optional.ofNullable(pair.getSecond()).toString()))
+              .collect(Collectors.toList())
+              .toString();
+
+    } else {
+      ignoreAsHops = "";
+    }
+
+    return "{startTime="
+        + startTime
+        + ",endTime="
+        + endTime
+        + "perHopLimit="
+        + perHopLimit
+        + "ignoreAsHops="
+        + ignoreAsHops
+        + "}";
+  }
+
   public static class SearchContextBuilder {
 
     public SearchContextBuilder searchFlags(@Nullable SearchFlags searchFlags) {
@@ -76,15 +144,27 @@ public class SearchContext implements ContextInterface {
       return this;
     }
 
+    public SearchContextBuilder lineageFlags(@Nullable LineageFlags lineageFlags) {
+      this.lineageFlags = lineageFlags != null ? lineageFlags : buildDefaultLineageFlags();
+      return this;
+    }
+
     public SearchContext build() {
       if (this.searchFlags == null) {
         searchFlags(buildDefaultSearchFlags());
       }
-      return new SearchContext(this.indexConvention, this.searchFlags);
+      if (this.lineageFlags == null) {
+        lineageFlags(buildDefaultLineageFlags());
+      }
+      return new SearchContext(this.indexConvention, this.searchFlags, this.lineageFlags);
     }
   }
 
   private static SearchFlags buildDefaultSearchFlags() {
     return new SearchFlags().setSkipCache(false);
+  }
+
+  private static LineageFlags buildDefaultLineageFlags() {
+    return new LineageFlags();
   }
 }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/CacheTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/search/CacheTest.java
@@ -33,7 +33,6 @@ import com.linkedin.metadata.search.cache.CacheableSearcher;
 import com.linkedin.metadata.search.cache.CachedEntityLineageResult;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.javatuples.Quintet;
 import org.javatuples.Sextet;
@@ -185,8 +184,7 @@ public class CacheTest extends JetTestSupport {
     Cache cache2 = cacheManager2.getCache("relationshipSearchService");
 
     EntityLineageResultCacheKey key =
-        new EntityLineageResultCacheKey(
-            "", corpuserUrn, LineageDirection.DOWNSTREAM, 0L, 1L, 1, ChronoUnit.DAYS);
+        new EntityLineageResultCacheKey("", corpuserUrn, LineageDirection.DOWNSTREAM, 1, null);
 
     cache1.put(key, cachedEntityLineageResult);
 

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -90,7 +90,7 @@ public interface EntityClient {
    * @param field field of the dataset
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   AutoCompleteResult autoComplete(
@@ -98,7 +98,7 @@ public interface EntityClient {
       @Nonnull String entityType,
       @Nonnull String query,
       @Nullable Filter requestFilters,
-      @Nonnull int limit,
+      int limit,
       @Nullable String field)
       throws RemoteInvocationException;
 
@@ -108,7 +108,7 @@ public interface EntityClient {
    * @param query search query
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   AutoCompleteResult autoComplete(
@@ -116,7 +116,7 @@ public interface EntityClient {
       @Nonnull String entityType,
       @Nonnull String query,
       @Nullable Filter requestFilters,
-      @Nonnull int limit)
+      int limit)
       throws RemoteInvocationException;
 
   /**
@@ -127,9 +127,8 @@ public interface EntityClient {
    * @param requestFilters browse filters
    * @param start start offset of first dataset
    * @param limit max number of datasets
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   BrowseResult browse(
       @Nonnull OperationContext opContext,
       @Nonnull String entityType,
@@ -148,7 +147,7 @@ public interface EntityClient {
    * @param input search query
    * @param start start offset of first group
    * @param count max number of results requested
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   BrowseResultV2 browseV2(
@@ -170,7 +169,7 @@ public interface EntityClient {
    * @param input search query
    * @param start start offset of first group
    * @param count max number of results requested
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   BrowseResultV2 browseV2(
@@ -207,9 +206,8 @@ public interface EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of search results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   SearchResult search(
       @Nonnull OperationContext opContext,
       @Nonnull String entity,
@@ -228,9 +226,8 @@ public interface EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of list results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   ListResult list(
       @Nonnull OperationContext opContext,
       @Nonnull String entity,
@@ -248,9 +245,8 @@ public interface EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   SearchResult search(
       @Nonnull OperationContext opContext,
       @Nonnull String entity,
@@ -270,7 +266,7 @@ public interface EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   SearchResult searchAcrossEntities(
@@ -293,9 +289,8 @@ public interface EntityClient {
    * @param count max number of search results requested
    * @param facets list of facets we want aggregations for
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   SearchResult searchAcrossEntities(
       @Nonnull OperationContext opContext,
       @Nonnull List<String> entities,
@@ -317,7 +312,7 @@ public interface EntityClient {
    * @param keepAlive string representation of time to keep point in time alive, ex: 5m
    * @param count max number of search results requested
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   ScrollResult scrollAcrossEntities(
@@ -345,7 +340,6 @@ public interface EntityClient {
    * @return a {@link SearchResult} that contains a list of matched documents and related search
    *     result metadata
    */
-  @Nonnull
   LineageSearchResult searchAcrossLineage(
       @Nonnull OperationContext opContext,
       @Nonnull Urn sourceUrn,
@@ -369,44 +363,9 @@ public interface EntityClient {
    * @param maxHops the max number of hops away to search for. If null, searches all hops.
    * @param filter the request map with fields and values as filters to be applied to search hits
    * @param sortCriterion {@link SortCriterion} to be applied to search results
-   * @param start index to start the search from
-   * @param count the number of search hits to return
-   * @param endTimeMillis end time to filter to
-   * @param startTimeMillis start time to filter from
-   * @return a {@link SearchResult} that contains a list of matched documents and related search
-   *     result metadata
-   */
-  @Nonnull
-  LineageSearchResult searchAcrossLineage(
-      @Nonnull OperationContext opContext,
-      @Nonnull Urn sourceUrn,
-      @Nonnull LineageDirection direction,
-      @Nonnull List<String> entities,
-      @Nonnull String input,
-      @Nullable Integer maxHops,
-      @Nullable Filter filter,
-      @Nullable SortCriterion sortCriterion,
-      int start,
-      int count,
-      @Nullable final Long startTimeMillis,
-      @Nullable final Long endTimeMillis)
-      throws RemoteInvocationException;
-
-  /**
-   * Gets a list of documents that match given search request that is related to the input entity
-   *
-   * @param sourceUrn Urn of the source entity
-   * @param direction Direction of the relationship
-   * @param entities list of entities to search (If empty, searches across all entities)
-   * @param input the search input text
-   * @param maxHops the max number of hops away to search for. If null, searches all hops.
-   * @param filter the request map with fields and values as filters to be applied to search hits
-   * @param sortCriterion {@link SortCriterion} to be applied to search results
    * @param scrollId opaque scroll ID indicating offset
    * @param keepAlive string representation of time to keep point in time alive, ex: 5m
-   * @param endTimeMillis end time to filter to
-   * @param startTimeMillis start time to filter from
-   * @param count the number of search hits to return
+   * @param count the number of search hits to return of roundtrips for UI visualizations.
    * @return a {@link SearchResult} that contains a list of matched documents and related search
    *     result metadata
    */
@@ -422,9 +381,7 @@ public interface EntityClient {
       @Nullable SortCriterion sortCriterion,
       @Nullable String scrollId,
       @Nonnull String keepAlive,
-      int count,
-      @Nullable final Long startTimeMillis,
-      @Nullable final Long endTimeMillis)
+      int count)
       throws RemoteInvocationException;
 
   /**
@@ -432,7 +389,7 @@ public interface EntityClient {
    *
    * @param urn urn for the entity
    * @return list of paths given urn
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   StringArray getBrowsePaths(@Nonnull Urn urn, @Nonnull Authentication authentication)
@@ -471,9 +428,8 @@ public interface EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of {@link SearchResult}s
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   SearchResult filter(
       @Nonnull OperationContext opContext,
       @Nonnull String entity,
@@ -489,9 +445,8 @@ public interface EntityClient {
    * @param urn the urn of the entity
    * @return true if an entity exists, i.e. there are > 0 aspects in the DB for the entity. This
    *     means that the entity has not been hard-deleted.
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
-  @Nonnull
   boolean exists(@Nonnull Urn urn, @Nonnull Authentication authentication)
       throws RemoteInvocationException;
 
@@ -589,7 +544,6 @@ public interface EntityClient {
         .collect(Collectors.toList());
   }
 
-  @Nonnull
   @Deprecated
   <T extends RecordTemplate> Optional<T> getVersionedAspect(
       @Nonnull String urn,

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -51,6 +51,7 @@ import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.browse.BrowseResultV2;
 import com.linkedin.metadata.graph.LineageDirection;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.ListResult;
 import com.linkedin.metadata.query.ListUrnsResult;
 import com.linkedin.metadata.query.SearchFlags;
@@ -144,7 +145,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    *
    * @param urns the urns of the entities to batch get
    * @param authentication the authentication to include in the request to the Metadata Service
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -197,7 +198,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param urns the urns of the entities to batch get
    * @param aspectNames the aspect names to batch get
    * @param authentication the authentication to include in the request to the Metadata Service
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -240,7 +241,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param versionedUrns the urns of the entities to batch get
    * @param aspectNames the aspect names to batch get
    * @param authentication the authentication to include in the request to the Metadata Service
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -280,11 +281,10 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    *
    * @param entityType the entity type to autocomplete against, e.g. 'dataset'
    * @param query search query
-   * @param field field of the dataset
+   * @param field field of the dataset to autocomplete against, e.g. 'name'
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
-   * @param field the field to autocomplete against, e.g. 'name'
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -293,7 +293,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       @Nonnull String entityType,
       @Nonnull String query,
       @Nullable Filter requestFilters,
-      @Nonnull int limit,
+      int limit,
       @Nullable String field)
       throws RemoteInvocationException {
     EntitiesDoAutocompleteRequestBuilder requestBuilder =
@@ -314,7 +314,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param query search query
    * @param requestFilters autocomplete filters
    * @param limit max number of autocomplete results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -323,7 +323,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       @Nonnull String entityType,
       @Nonnull String query,
       @Nullable Filter requestFilters,
-      @Nonnull int limit)
+      int limit)
       throws RemoteInvocationException {
     EntitiesDoAutocompleteRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS
@@ -343,7 +343,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param requestFilters browse filters
    * @param start start offset of first dataset
    * @param limit max number of datasets
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -377,7 +377,6 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param input search query
    * @param start start offset of first group
    * @param count max number of results requested
-   * @throws RemoteInvocationException
    */
   @Override
   @Nonnull
@@ -452,7 +451,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of search results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   @Override
@@ -488,7 +487,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return a set of list results
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -519,7 +518,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param start start offset for search results
    * @param count max number of search results requested
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   @Override
@@ -585,7 +584,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    * @param count max number of search results requested
    * @param facets list of facets we want aggregations for
    * @return Snapshot key
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Override
   @Nonnull
@@ -689,55 +688,20 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     if (filter != null) {
       requestBuilder.filterParam(filter);
     }
+    LineageFlags lineageFlags = opContext.getSearchContext().getLineageFlags();
+    if (lineageFlags.getStartTimeMillis() != null) {
+      requestBuilder.startTimeMillisParam(lineageFlags.getStartTimeMillis());
+    }
+    if (lineageFlags.getEndTimeMillis() != null) {
+      requestBuilder.endTimeMillisParam(lineageFlags.getEndTimeMillis());
+    }
     requestBuilder.searchFlagsParam(opContext.getSearchContext().getSearchFlags());
 
     return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
   }
 
+  @Override
   @Nonnull
-  @Override
-  public LineageSearchResult searchAcrossLineage(
-      @Nonnull OperationContext opContext,
-      @Nonnull Urn sourceUrn,
-      @Nonnull LineageDirection direction,
-      @Nonnull List<String> entities,
-      @Nonnull String input,
-      @Nullable Integer maxHops,
-      @Nullable Filter filter,
-      @Nullable SortCriterion sortCriterion,
-      int start,
-      int count,
-      @Nullable final Long startTimeMillis,
-      @Nullable final Long endTimeMillis)
-      throws RemoteInvocationException {
-
-    final EntitiesDoSearchAcrossLineageRequestBuilder requestBuilder =
-        ENTITIES_REQUEST_BUILDERS
-            .actionSearchAcrossLineage()
-            .urnParam(sourceUrn.toString())
-            .directionParam(direction.name())
-            .inputParam(input)
-            .startParam(start)
-            .countParam(count);
-
-    if (entities != null) {
-      requestBuilder.entitiesParam(new StringArray(entities));
-    }
-    if (filter != null) {
-      requestBuilder.filterParam(filter);
-    }
-    if (startTimeMillis != null) {
-      requestBuilder.startTimeMillisParam(startTimeMillis);
-    }
-    if (endTimeMillis != null) {
-      requestBuilder.endTimeMillisParam(endTimeMillis);
-    }
-    requestBuilder.searchFlagsParam(opContext.getSearchContext().getSearchFlags());
-
-    return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
-  }
-
-  @Override
   public LineageScrollResult scrollAcrossLineage(
       @Nonnull OperationContext opContext,
       @Nonnull Urn sourceUrn,
@@ -749,9 +713,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
       @Nullable SortCriterion sortCriterion,
       @Nullable String scrollId,
       @Nonnull String keepAlive,
-      int count,
-      @Nullable final Long startTimeMillis,
-      @Nullable final Long endTimeMillis)
+      int count)
       throws RemoteInvocationException {
     final EntitiesDoScrollAcrossLineageRequestBuilder requestBuilder =
         ENTITIES_REQUEST_BUILDERS
@@ -771,11 +733,12 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     if (scrollId != null) {
       requestBuilder.scrollIdParam(scrollId);
     }
-    if (startTimeMillis != null) {
-      requestBuilder.startTimeMillisParam(startTimeMillis);
+    LineageFlags lineageFlags = opContext.getSearchContext().getLineageFlags();
+    if (lineageFlags.getStartTimeMillis() != null) {
+      requestBuilder.startTimeMillisParam(lineageFlags.getStartTimeMillis());
     }
-    if (endTimeMillis != null) {
-      requestBuilder.endTimeMillisParam(endTimeMillis);
+    if (lineageFlags.getEndTimeMillis() != null) {
+      requestBuilder.endTimeMillisParam(lineageFlags.getEndTimeMillis());
     }
     requestBuilder.searchFlagsParam(opContext.getSearchContext().getSearchFlags());
 
@@ -787,7 +750,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
    *
    * @param urn urn for the entity
    * @return list of paths given urn
-   * @throws RemoteInvocationException
+   * @throws RemoteInvocationException when unable to execute request
    */
   @Nonnull
   public StringArray getBrowsePaths(@Nonnull Urn urn, @Nonnull final Authentication authentication)
@@ -873,7 +836,6 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     return sendClientRequest(requestBuilder, opContext.getAuthentication()).getEntity();
   }
 
-  @Nonnull
   @Override
   public boolean exists(@Nonnull Urn urn, @Nonnull final Authentication authentication)
       throws RemoteInvocationException {
@@ -993,7 +955,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
   /**
    * Ingest a MetadataChangeProposal event.
    *
-   * @return
+   * @return the urn string ingested
    */
   @Override
   public String ingestProposal(

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/graph/GraphService.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.graph;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.models.registry.LineageRegistry;
+import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
@@ -140,20 +141,18 @@ public interface GraphService {
       int offset,
       int count,
       int maxHops,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis) {
+      @Nullable LineageFlags lineageFlags) {
     return getLineage(
         entityUrn,
         direction,
         new GraphFilters(
-            new ArrayList(
+            new ArrayList<>(
                 getLineageRegistry()
                     .getEntitiesWithLineageToEntityType(entityUrn.getEntityType()))),
         offset,
         count,
         maxHops,
-        startTimeMillis,
-        endTimeMillis);
+        lineageFlags);
   }
 
   /**
@@ -165,6 +164,7 @@ public interface GraphService {
    * them
    */
   @Nonnull
+  @Deprecated
   default EntityLineageResult getLineage(
       @Nonnull Urn entityUrn,
       @Nonnull LineageDirection direction,
@@ -172,7 +172,7 @@ public interface GraphService {
       int offset,
       int count,
       int maxHops) {
-    return getLineage(entityUrn, direction, graphFilters, offset, count, maxHops, null, null);
+    return getLineage(entityUrn, direction, graphFilters, offset, count, maxHops, null);
   }
 
   /**
@@ -191,8 +191,7 @@ public interface GraphService {
       int offset,
       int count,
       int maxHops,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis) {
+      @Nullable LineageFlags lineageFlags) {
     if (maxHops > 1) {
       maxHops = 1;
     }


### PR DESCRIPTION
Allows the UI to filter which nodes get traversed in cases where graphs are excessively large and only partial lineage is desired.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
