### PR TITLE
feat(ingest/bigquery): Respect dataset and table patterns when ingesting lineage via catalog api

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -533,11 +533,8 @@ class BigqueryLineageExtractor:
                     continue
 
                 # Convert project table to <project_id>.<dataset_id>.<table_id> format
-                table = "{}.{}.{}".format(
-                    project_table.project,
-                    project_table.dataset_id,
-                    project_table.table_id,
-                )
+                table = f"{project_table.project}.{project_table.dataset_id}.{project_table.table_id}"
+
                 logger.info("Creating lineage map for table %s", table)
                 upstreams = set()
                 downstream_table = lineage_v1.EntityReference()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -517,19 +517,23 @@ class BigqueryLineageExtractor:
                     ]
                 )
 
-            # Convert project tables to <project_id>.<dataset_id>.<table_id> format
-            project_table_names = list(
-                map(
-                    lambda table: "{}.{}.{}".format(
-                        table.project, table.dataset_id, table.table_id
-                    ),
-                    project_tables,
-                )
-            )
-
             lineage_map: Dict[str, Set[LineageEdge]] = {}
             curr_date = datetime.now()
-            for table in project_table_names:
+            for project_table in project_tables:
+
+                if not is_schema_allowed(
+                        self.config.dataset_pattern,
+                        schema_name=project_table.dataset_id,
+                        db_name=project_table.project,
+                        match_fully_qualified_schema_name=self.config.match_fully_qualified_names,
+                ) or not self.config.table_pattern.allowed(
+                    project_table.table_id
+                ):
+                    self.report.num_skipped_lineage_entries_not_allowed[project_table.project] += 1
+                    continue
+
+                # Convert project table to <project_id>.<dataset_id>.<table_id> format
+                table = "{}.{}.{}".format(project_table.project, project_table.dataset_id, project_table.table_id)
                 logger.info("Creating lineage map for table %s", table)
                 upstreams = set()
                 downstream_table = lineage_v1.EntityReference()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -522,18 +522,22 @@ class BigqueryLineageExtractor:
             for project_table in project_tables:
 
                 if not is_schema_allowed(
-                        self.config.dataset_pattern,
-                        schema_name=project_table.dataset_id,
-                        db_name=project_table.project,
-                        match_fully_qualified_schema_name=self.config.match_fully_qualified_names,
-                ) or not self.config.table_pattern.allowed(
-                    project_table.table_id
-                ):
-                    self.report.num_skipped_lineage_entries_not_allowed[project_table.project] += 1
+                    self.config.dataset_pattern,
+                    schema_name=project_table.dataset_id,
+                    db_name=project_table.project,
+                    match_fully_qualified_schema_name=self.config.match_fully_qualified_names,
+                ) or not self.config.table_pattern.allowed(project_table.table_id):
+                    self.report.num_skipped_lineage_entries_not_allowed[
+                        project_table.project
+                    ] += 1
                     continue
 
                 # Convert project table to <project_id>.<dataset_id>.<table_id> format
-                table = "{}.{}.{}".format(project_table.project, project_table.dataset_id, project_table.table_id)
+                table = "{}.{}.{}".format(
+                    project_table.project,
+                    project_table.dataset_id,
+                    project_table.table_id,
+                )
                 logger.info("Creating lineage map for table %s", table)
                 upstreams = set()
                 downstream_table = lineage_v1.EntityReference()

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py
@@ -520,20 +520,19 @@ class BigqueryLineageExtractor:
             lineage_map: Dict[str, Set[LineageEdge]] = {}
             curr_date = datetime.now()
             for project_table in project_tables:
+                # Convert project table to <project_id>.<dataset_id>.<table_id> format
+                table = f"{project_table.project}.{project_table.dataset_id}.{project_table.table_id}"
 
                 if not is_schema_allowed(
                     self.config.dataset_pattern,
                     schema_name=project_table.dataset_id,
                     db_name=project_table.project,
                     match_fully_qualified_schema_name=self.config.match_fully_qualified_names,
-                ) or not self.config.table_pattern.allowed(project_table.table_id):
+                ) or not self.config.table_pattern.allowed(table):
                     self.report.num_skipped_lineage_entries_not_allowed[
                         project_table.project
                     ] += 1
                     continue
-
-                # Convert project table to <project_id>.<dataset_id>.<table_id> format
-                table = f"{project_table.project}.{project_table.dataset_id}.{project_table.table_id}"
 
                 logger.info("Creating lineage map for table %s", table)
                 upstreams = set()


### PR DESCRIPTION
Similar to when ingesting lineage via GCP audit logs: 

https://github.com/datahub-project/datahub/blob/06ef2ad5def7eb1de5d0b19ca2154ddbf96e1692/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/lineage.py#L733-L742 

Currently, when using `extract_lineage_from_catalog=True` a request is issued for every table in the project. 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
