### PR TITLE
feat: add GlossaryTerms to EditableSchemaFieldInfoUpdate(error)

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -4514,7 +4514,7 @@ input EditableSchemaFieldInfoUpdate {
     """
     The structured glossary terms associated with the notebook
     """
-    glossaryTerms: GlossaryTerms
+    glossaryTerms: CreateGlossaryEntityInput
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -4510,6 +4510,11 @@ input EditableSchemaFieldInfoUpdate {
     Tags associated with the field
     """
     globalTags: GlobalTagsUpdate
+
+    """
+    The structured glossary terms associated with the notebook
+    """
+    glossaryTerms: GlossaryTerms
 }
 
 """


### PR DESCRIPTION

***
Adding GlossaryTerms in the EditableSchemaFieldInfoUpdate it is showing me error that glossaryTerms are not of input type and if I add glossaryTerms as a new input type then I have to add all the related fields as input in the entity.graphql and there are a lot of subfields in GlossaryTerms which I have to add as input type.