### PR TITLE
test(ingest/mssql): use non-ephemeral mapping port

### DIFF
--- a/metadata-ingestion/tests/integration/sql_server/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/sql_server/docker-compose.yml
@@ -8,6 +8,6 @@ services:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: "test!Password"
     ports:
-      - 51433:1433
+      - 21433:1433
     volumes:
       - ./setup:/setup

--- a/metadata-ingestion/tests/integration/sql_server/source_files/mssql_no_db_to_file.yml
+++ b/metadata-ingestion/tests/integration/sql_server/source_files/mssql_no_db_to_file.yml
@@ -5,7 +5,7 @@ source:
   config:
     username: sa
     password: test!Password
-    host_port: localhost:51433
+    host_port: localhost:21433
 
 sink:
   type: file

--- a/metadata-ingestion/tests/integration/sql_server/source_files/mssql_no_db_with_filter.yml
+++ b/metadata-ingestion/tests/integration/sql_server/source_files/mssql_no_db_with_filter.yml
@@ -5,7 +5,7 @@ source:
   config:
     username: sa
     password: test!Password
-    host_port: localhost:51433
+    host_port: localhost:21433
     database_pattern:
       deny:
         - NewData

--- a/metadata-ingestion/tests/integration/sql_server/source_files/mssql_to_file.yml
+++ b/metadata-ingestion/tests/integration/sql_server/source_files/mssql_to_file.yml
@@ -6,7 +6,7 @@ source:
     username: sa
     password: test!Password
     database: DemoData
-    host_port: localhost:51433
+    host_port: localhost:21433
     # use_odbc: True
     # uri_args:
     #   driver: "ODBC Driver 17 for SQL Server"

--- a/metadata-ingestion/tests/integration/sql_server/source_files/mssql_with_lower_case_urn.yml
+++ b/metadata-ingestion/tests/integration/sql_server/source_files/mssql_with_lower_case_urn.yml
@@ -6,7 +6,7 @@ source:
     username: sa
     password: test!Password
     database: DemoData
-    host_port: localhost:51433
+    host_port: localhost:21433
     convert_urns_to_lowercase: true
     # use_odbc: True
     # uri_args:


### PR DESCRIPTION
This currently causes test flakes. Example: https://github.com/datahub-project/datahub/actions/runs/8380098358/job/22948505013?pr=10101

```
E           Error response from daemon: driver failed programming external connectivity on endpoint testsqlserver (1d5c212229e8c26777f660620d74d31851808daa2de92df89e510eb0584f124e): Error starting userland proxy: listen tcp4 0.0.0.0:51433: bind: address already in use
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
