### PR TITLE
fix(elasticsearch logging): log how long bulk execution took

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/BulkListener.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/BulkListener.java
@@ -39,12 +39,19 @@ public class BulkListener implements BulkProcessor.Listener {
 
   @Override
   public void afterBulk(long executionId, BulkRequest request, BulkResponse response) {
+    String ingestTook = "";
+    long ingestTookInMillis = response.getIngestTookInMillis();
+    if (ingestTookInMillis != BulkResponse.NO_INGEST_TOOK) {
+      ingestTook = " Bulk ingest preprocessing took time ms: " + ingestTookInMillis;
+    }
+
     if (response.hasFailures()) {
       log.error(
           "Failed to feed bulk request. Number of events: "
               + response.getItems().length
               + " Took time ms: "
-              + response.getIngestTookInMillis()
+              + response.getTook().getMillis()
+              + ingestTook
               + " Message: "
               + response.buildFailureMessage());
     } else {
@@ -52,7 +59,8 @@ public class BulkListener implements BulkProcessor.Listener {
           "Successfully fed bulk request. Number of events: "
               + response.getItems().length
               + " Took time ms: "
-              + response.getIngestTookInMillis());
+              + response.getTook().getMillis()
+              + ingestTook);
     }
     incrementMetrics(response);
   }


### PR DESCRIPTION
Elasticsearch bulk execution logs currently always print `Took time ms` as `-1`:

```
INFO  c.l.m.s.e.update.BulkListener:51 - Successfully fed bulk request. Number of events: 5 Took time ms: -1
```

The problem is that the printed time is actually the bulk ingest preprocessing time, which is -1 if ingest is not enabled.

This change now logs how long bulk execution took. The bulk ingest preprocessing time is only logged if available.

```
INFO  c.l.m.s.e.update.BulkListener - Successfully fed bulk request. Number of events: 12 Took time ms: 542
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
