### PR TITLE
feat(metadata-jobs): improve consumer logging

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -122,7 +122,8 @@ public class ElasticSearchService implements EntitySearchService, ElasticSearchI
       return;
     }
     final String docId = maybeDocId.get();
-    log.debug(String.format("Appending run id for entityName: %s, docId: %s", entityName, docId));
+    log.info(
+        "Appending run id for entity name: {}, doc id: {}, run id: {}", entityName, docId, runId);
     esWriteDAO.applyScriptUpdate(
         entityName,
         docId,

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/BulkListener.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/BulkListener.java
@@ -47,7 +47,10 @@ public class BulkListener implements BulkProcessor.Listener {
 
     if (response.hasFailures()) {
       log.error(
-          "Failed to feed bulk request. Number of events: "
+          "Failed to feed bulk request "
+              + executionId
+              + "."
+              + " Number of events: "
               + response.getItems().length
               + " Took time ms: "
               + response.getTook().getMillis()
@@ -56,7 +59,10 @@ public class BulkListener implements BulkProcessor.Listener {
               + response.buildFailureMessage());
     } else {
       log.info(
-          "Successfully fed bulk request. Number of events: "
+          "Successfully fed bulk request "
+              + executionId
+              + "."
+              + " Number of events: "
               + response.getItems().length
               + " Took time ms: "
               + response.getTook().getMillis()
@@ -69,7 +75,8 @@ public class BulkListener implements BulkProcessor.Listener {
   public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
     // Exception raised outside this method
     log.error(
-        "Error feeding bulk request. No retries left. Request: {}",
+        "Error feeding bulk request {}. No retries left. Request: {}",
+        executionId,
         buildBulkRequestSummary(request),
         failure);
     incrementMetrics(request, failure);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESBulkProcessor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESBulkProcessor.java
@@ -79,6 +79,11 @@ public class ESBulkProcessor implements Closeable {
   public ESBulkProcessor add(DocWriteRequest<?> request) {
     MetricUtils.counter(this.getClass(), ES_WRITES_METRIC).inc();
     bulkProcessor.add(request);
+    log.info(
+        "Added request id: {}, operation type: {}, index: {}",
+        request.id(),
+        request.opType(),
+        request.index());
     return this;
   }
 

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/DataHubUsageEventsProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/DataHubUsageEventsProcessor.java
@@ -54,7 +54,15 @@ public class DataHubUsageEventsProcessor {
     try (Timer.Context i = MetricUtils.timer(this.getClass(), "consume").time()) {
       kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
       final String record = consumerRecord.value();
-      log.debug("Got DHUE");
+
+      log.info(
+          "Got DHUE event key: {}, topic: {}, partition: {}, offset: {}, value size: {}, timestamp: {}",
+          consumerRecord.key(),
+          consumerRecord.topic(),
+          consumerRecord.partition(),
+          consumerRecord.offset(),
+          consumerRecord.serializedValueSize(),
+          consumerRecord.timestamp());
 
       Optional<DataHubUsageEventTransformer.TransformedDocument> eventDocument =
           dataHubUsageEventTransformer.transformDataHubUsageEvent(record);

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
@@ -72,6 +72,16 @@ public class MetadataChangeEventsProcessor {
     try (Timer.Context i = MetricUtils.timer(this.getClass(), "consume").time()) {
       kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
       final GenericRecord record = consumerRecord.value();
+
+      log.info(
+          "Got MCE event key: {}, topic: {}, partition: {}, offset: {}, value size: {}, timestamp: {}",
+          consumerRecord.key(),
+          consumerRecord.topic(),
+          consumerRecord.partition(),
+          consumerRecord.offset(),
+          consumerRecord.serializedValueSize(),
+          consumerRecord.timestamp());
+
       log.debug("Record {}", record);
 
       MetadataChangeEvent event = new MetadataChangeEvent();

--- a/metadata-jobs/pe-consumer/src/main/java/com/datahub/event/PlatformEventProcessor.java
+++ b/metadata-jobs/pe-consumer/src/main/java/com/datahub/event/PlatformEventProcessor.java
@@ -50,11 +50,14 @@ public class PlatformEventProcessor {
 
       kafkaLagStats.update(System.currentTimeMillis() - consumerRecord.timestamp());
       final GenericRecord record = consumerRecord.value();
-      log.debug(
-          "Got Generic PE on topic: {}, partition: {}, offset: {}",
+      log.info(
+          "Got PE event key: {}, topic: {}, partition: {}, offset: {}, value size: {}, timestamp: {}",
+          consumerRecord.key(),
           consumerRecord.topic(),
           consumerRecord.partition(),
-          consumerRecord.offset());
+          consumerRecord.offset(),
+          consumerRecord.serializedValueSize(),
+          consumerRecord.timestamp());
       MetricUtils.counter(this.getClass(), "received_pe_count").inc();
 
       PlatformEvent event;
@@ -68,9 +71,13 @@ public class PlatformEventProcessor {
         return;
       }
 
-      log.debug("Invoking PE hooks for event name {}", event.getName());
+      log.info("Invoking PE hooks for event name {}", event.getName());
 
       for (PlatformEventHook hook : this.hooks) {
+        log.info(
+            "Invoking PE hook {} for event name {}",
+            hook.getClass().getSimpleName(),
+            event.getName());
         try (Timer.Context ignored =
             MetricUtils.timer(this.getClass(), hook.getClass().getSimpleName() + "_latency")
                 .time()) {
@@ -83,7 +90,7 @@ public class PlatformEventProcessor {
         }
       }
       MetricUtils.counter(this.getClass(), "consumed_pe_count").inc();
-      log.debug("Successfully completed PE hooks for event with name {}", event.getName());
+      log.info("Successfully completed PE hooks for event with name {}", event.getName());
     }
   }
 }

--- a/metadata-service/restli-servlet-impl/src/test/java/com/linkedin/metadata/resources/entity/AspectResourceTest.java
+++ b/metadata-service/restli-servlet-impl/src/test/java/com/linkedin/metadata/resources/entity/AspectResourceTest.java
@@ -123,7 +123,7 @@ public class AspectResourceTest {
                     .request(req)
                     .build())));
     aspectResource.ingestProposal(mcp, "false");
-    verify(producer, times(10))
+    verify(producer, times(5))
         .produceMetadataChangeLog(eq(urn), any(AspectSpec.class), any(MetadataChangeLog.class));
     verifyNoMoreInteractions(producer);
   }


### PR DESCRIPTION
Currently consumer logs do not record any events processed, making it difficult to analyze, troubleshoot or gain insights from event processing. This change improves logging so that consumer logs record all events processed.

Additionally, the timer measuring how long `ingestAspectsToLocalDB` takes no longer includes time spent in `emitMCL`.

For reference, new log output for an MCL event:

```
INFO  c.l.m.k.MetadataChangeLogProcessor - Got MCL event key: urn:li:dataHubExecutionRequest:modeldoc-generated, topic: MetadataChangeLog_Versioned_v1, partition: 0, offset: 20613, value size: 64766, timestamp: 1711856258850
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hooks for urn: urn:li:dataHubExecutionRequest:modeldoc-generated, aspect name: dataHubExecutionRequestResult, entity type: dataHubExecutionRequest, change type: UPSERT
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hook FormAssignmentHook for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hook IngestionSchedulerHook for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hook UpdateIndicesHook for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.s.e.update.ESBulkProcessor - Added request id: WfsoJ2g66rUx73/uwkiemA==, operation type: UPDATE, index: system_metadata_service_v1
INFO  c.l.m.s.e.update.ESBulkProcessor - Added request id: urn%3Ali%3AdataHubExecutionRequest%3Amodeldoc-generated, operation type: UPDATE, index: datahubexecutionrequestindex_v2
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hook IncidentsSummaryHook for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hook EntityChangeEventGeneratorHook for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.k.MetadataChangeLogProcessor - Invoking MCL hook SiblingAssociationHook for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.k.MetadataChangeLogProcessor - Successfully completed MCL hooks for urn: urn:li:dataHubExecutionRequest:modeldoc-generated
INFO  c.l.m.s.e.update.BulkListener - Successfully fed bulk request 27. Number of events: 8 Took time ms: 1022
```

MCP event:

```
INFO  c.l.m.k.MetadataChangeProposalsProcessor - Got MCP event key: urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.analytics.worldclass_solutions,PROD), topic: MetadataChangeProposal_v1, partition: 0, offset: 1703, value size: 283, timestamp: 1711856256171
INFO  c.l.m.entity.EntityServiceImpl - Ingesting aspects batch to database, items: [ChangeItemImpl{changeType=UPSERT, urn=urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.analytics.worldclass_solutions,PROD), aspectName='siblings', recordTemplate={siblings=[urn:li:dataset:(urn:li:dataPlatform:dbt,long_tail_companions.analytics.worldclass_solutions,PROD)], primary=false}, systemMetadata={lastObserved=1711856256173, runId=no-run-id-provided}}]
INFO  c.l.m.entity.EntityServiceImpl - Ingesting aspect with name siblings, urn urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.analytics.worldclass_solutions,PROD)
INFO  c.l.m.entity.EntityServiceImpl - Ingestion of aspects batch to database took 2 ms
INFO  c.l.m.entity.EntityServiceImpl - Skipped producing MCL for ingested aspect siblings, urn urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.analytics.worldclass_solutions,PROD). Aspect has not changed.
INFO  c.l.m.k.MetadataChangeProposalsProcessor - Successfully processed MCP event urn: urn:li:dataset:(urn:li:dataPlatform:snowflake,long_tail_companions.analytics.worldclass_solutions,PROD)
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
