### PR TITLE
fix(restoreIndices): batchSize vs limit

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -48,7 +48,7 @@ public class SendMAEStep implements UpgradeStep {
 
     @Override
     public RestoreIndicesResult call() {
-      return _entityService.restoreIndices(args, context.report()::addLine);
+      return _entityService.streamRestoreIndices(args, context.report()::addLine).findFirst().get();
     }
   }
 
@@ -85,7 +85,10 @@ public class SendMAEStep implements UpgradeStep {
   private RestoreIndicesArgs getArgs(UpgradeContext context) {
     RestoreIndicesArgs result = new RestoreIndicesArgs();
     result.batchSize = getBatchSize(context.parsedArgs());
+    // this class assumes batch size == limit
+    result.limit = getBatchSize(context.parsedArgs());
     context.report().addLine(String.format("batchSize is %d", result.batchSize));
+    context.report().addLine(String.format("limit is %d", result.limit));
     result.numThreads = getThreadCount(context.parsedArgs());
     context.report().addLine(String.format("numThreads is %d", result.numThreads));
     result.batchDelayMs = getBatchDelayMs(context.parsedArgs());

--- a/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNonBlockingTest.java
+++ b/datahub-upgrade/src/test/java/com/linkedin/datahub/upgrade/DatahubUpgradeNonBlockingTest.java
@@ -1,0 +1,64 @@
+package com.linkedin.datahub.upgrade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import com.linkedin.datahub.upgrade.impl.DefaultUpgradeManager;
+import com.linkedin.datahub.upgrade.system.SystemUpdateNonBlocking;
+import com.linkedin.datahub.upgrade.system.vianodes.ReindexDataJobViaNodesCLL;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
+import java.util.List;
+import javax.inject.Named;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.Test;
+
+@ActiveProfiles("test")
+@SpringBootTest(
+    classes = {UpgradeCliApplication.class, UpgradeCliApplicationTestConfiguration.class},
+    properties = {
+      "BOOTSTRAP_SYSTEM_UPDATE_DATA_JOB_NODE_CLL_ENABLED=true",
+      "kafka.schemaRegistry.type=INTERNAL",
+      "DATAHUB_UPGRADE_HISTORY_TOPIC_NAME=test_due_topic",
+      "METADATA_CHANGE_LOG_VERSIONED_TOPIC_NAME=test_mcl_versioned_topic"
+    },
+    args = {"-u", "SystemUpdateNonBlocking"})
+public class DatahubUpgradeNonBlockingTest extends AbstractTestNGSpringContextTests {
+
+  @Autowired(required = false)
+  @Named("systemUpdateNonBlocking")
+  private SystemUpdateNonBlocking systemUpdateNonBlocking;
+
+  @Autowired
+  @Test
+  public void testSystemUpdateNonBlockingInit() {
+    assertNotNull(systemUpdateNonBlocking);
+  }
+
+  @Test
+  public void testReindexDataJobViaNodesCLLPaging() {
+    EntityService<?> mockService = mock(EntityService.class);
+    ReindexDataJobViaNodesCLL cllUpgrade = new ReindexDataJobViaNodesCLL(mockService, true, 10);
+    SystemUpdateNonBlocking upgrade =
+        new SystemUpdateNonBlocking(List.of(), List.of(cllUpgrade), null);
+    DefaultUpgradeManager manager = new DefaultUpgradeManager();
+    manager.register(upgrade);
+    manager.execute("SystemUpdateNonBlocking", List.of());
+    verify(mockService, times(1))
+        .streamRestoreIndices(
+            eq(
+                new RestoreIndicesArgs()
+                    .batchSize(10)
+                    .limit(0)
+                    .aspectName("dataJobInputOutput")
+                    .urnLike("urn:li:dataJob:%")),
+            any());
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
@@ -5,7 +5,6 @@ import com.linkedin.metadata.aspect.batch.AspectsBatch;
 import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
-import io.ebean.PagedList;
 import io.ebean.Transaction;
 import java.sql.Timestamp;
 import java.util.List;
@@ -106,7 +105,7 @@ public interface AspectDao {
   Integer countAspect(@Nonnull final String aspectName, @Nullable String urnLike);
 
   @Nonnull
-  PagedList<EbeanAspectV2> getPagedAspects(final RestoreIndicesArgs args);
+  Stream<Stream<EbeanAspectV2>> streamAspectBatches(final RestoreIndicesArgs args);
 
   @Nonnull
   Stream<EntityAspect> streamAspects(String entityName, String aspectName);

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -49,7 +49,6 @@ import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
 import com.linkedin.metadata.aspect.utils.DefaultAspectsUtil;
 import com.linkedin.metadata.config.PreProcessHooks;
-import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
 import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
 import com.linkedin.metadata.entity.ebean.batch.DeleteItemImpl;
@@ -76,7 +75,6 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.util.Pair;
-import io.ebean.PagedList;
 import io.ebean.Transaction;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.net.URISyntaxException;
@@ -1177,38 +1175,38 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
 
   @Nonnull
   @Override
-  public RestoreIndicesResult restoreIndices(
+  public Stream<RestoreIndicesResult> streamRestoreIndices(
       @Nonnull RestoreIndicesArgs args, @Nonnull Consumer<String> logger) {
 
     logger.accept(String.format("Args are %s", args));
     logger.accept(
         String.format(
-            "Reading rows %s through %s from the aspects table started.",
-            args.start, args.start + args.batchSize));
+            "Reading rows %s through %s (0 == infinite) in batches of %s from the aspects table started.",
+            args.start, args.limit, args.batchSize));
+
     long startTime = System.currentTimeMillis();
-    PagedList<EbeanAspectV2> rows = aspectDao.getPagedAspects(args);
-    long timeSqlQueryMs = System.currentTimeMillis() - startTime;
+    return aspectDao
+        .streamAspectBatches(args)
+        .map(
+            batchStream -> {
+              long timeSqlQueryMs = System.currentTimeMillis() - startTime;
 
-    logger.accept(
-        String.format(
-            "Reading rows %s through %s from the aspects table completed.",
-            args.start, args.start + args.batchSize));
+              List<SystemAspect> systemAspects =
+                  EntityUtils.toSystemAspectFromEbeanAspects(
+                      batchStream.collect(Collectors.toList()), this);
 
-    List<SystemAspect> systemAspects =
-        EntityUtils.toSystemAspectFromEbeanAspects(
-            rows != null ? rows.getList() : List.<EbeanAspectV2>of(), this);
+              RestoreIndicesResult result = restoreIndices(systemAspects, logger);
+              result.timeSqlQueryMs = timeSqlQueryMs;
 
-    RestoreIndicesResult result = restoreIndices(systemAspects, logger);
-
-    try {
-      TimeUnit.MILLISECONDS.sleep(args.batchDelayMs);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(
-          "Thread interrupted while sleeping after successful batch migration.");
-    }
-
-    result.timeSqlQueryMs = timeSqlQueryMs;
-    return result;
+              logger.accept("Batch completed.");
+              try {
+                TimeUnit.MILLISECONDS.sleep(args.batchDelayMs);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(
+                    "Thread interrupted while sleeping after successful batch migration.");
+              }
+              return result;
+            });
   }
 
   @Nonnull

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/cassandra/CassandraAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/cassandra/CassandraAspectDao.java
@@ -34,7 +34,6 @@ import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
 import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.ExtraInfoArray;
 import com.linkedin.metadata.query.ListResultMetadata;
-import io.ebean.PagedList;
 import io.ebean.Transaction;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -492,7 +491,7 @@ public class CassandraAspectDao implements AspectDao, AspectMigrationsDao {
   }
 
   @Nonnull
-  public PagedList<EbeanAspectV2> getPagedAspects(final RestoreIndicesArgs args) {
+  public Stream<Stream<EbeanAspectV2>> streamAspectBatches(final RestoreIndicesArgs args) {
     // Not implemented
     return null;
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -8,6 +8,7 @@ import com.datahub.util.exception.RetryLimitReached;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Iterators;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.aspect.AspectRetriever;
@@ -47,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.persistence.PersistenceException;
@@ -495,7 +498,7 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
 
   @Nonnull
   @Override
-  public PagedList<EbeanAspectV2> getPagedAspects(final RestoreIndicesArgs args) {
+  public Stream<Stream<EbeanAspectV2>> streamAspectBatches(final RestoreIndicesArgs args) {
     ExpressionList<EbeanAspectV2> exp =
         _server
             .find(EbeanAspectV2.class)
@@ -531,13 +534,27 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
       }
     }
 
-    return exp.orderBy()
-        .asc(EbeanAspectV2.URN_COLUMN)
-        .orderBy()
-        .asc(EbeanAspectV2.ASPECT_COLUMN)
-        .setFirstRow(start)
-        .setMaxRows(args.batchSize)
-        .findPagedList();
+    if (args.limit > 0) {
+      exp = exp.setMaxRows(args.limit);
+    }
+
+    return partition(
+        exp.orderBy()
+            .asc(EbeanAspectV2.URN_COLUMN)
+            .orderBy()
+            .asc(EbeanAspectV2.ASPECT_COLUMN)
+            .setFirstRow(start)
+            .findStream(),
+        args.batchSize);
+  }
+
+  private static <T> Stream<Stream<T>> partition(Stream<T> source, int size) {
+    final Iterator<T> it = source.iterator();
+    final Iterator<Stream<T>> partIt =
+        Iterators.transform(Iterators.partition(it, size), List::stream);
+    final Iterable<Stream<T>> iterable = () -> partIt;
+
+    return StreamSupport.stream(iterable.spliterator(), false);
   }
 
   @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -44,6 +44,7 @@ import io.ebean.annotation.TxIsolation;
 import java.net.URISyntaxException;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -513,6 +514,15 @@ public class EbeanAspectDao implements AspectDao, AspectMigrationsDao {
     }
     if (args.urnLike != null) {
       exp = exp.like(EbeanAspectV2.URN_COLUMN, args.urnLike);
+    }
+    if (args.gePitEpochMs > 0) {
+      exp =
+          exp.ge(
+                  EbeanAspectV2.CREATED_ON_COLUMN,
+                  Timestamp.from(Instant.ofEpochMilli(args.gePitEpochMs)))
+              .le(
+                  EbeanAspectV2.CREATED_ON_COLUMN,
+                  Timestamp.from(Instant.ofEpochMilli(args.lePitEpochMs)));
     }
 
     int start = args.start;

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
@@ -1578,13 +1578,13 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
       clearInvocations(_mockProducer);
 
       RestoreIndicesArgs args = new RestoreIndicesArgs();
-      args.setAspectName(UPSTREAM_LINEAGE_ASPECT_NAME);
-      args.setBatchSize(1);
-      args.setStart(0);
-      args.setBatchDelayMs(1L);
-      args.setNumThreads(1);
-      args.setUrn(urnStr);
-      _entityServiceImpl.restoreIndices(args, obj -> {});
+      args.aspectName(UPSTREAM_LINEAGE_ASPECT_NAME);
+      args.batchSize(1);
+      args.start(0);
+      args.batchDelayMs(1L);
+      args.numThreads(1);
+      args.urn(urnStr);
+      _entityServiceImpl.streamRestoreIndices(args, obj -> {}).collect(Collectors.toList());
 
       ArgumentCaptor<MetadataChangeLog> mclCaptor =
           ArgumentCaptor.forClass(MetadataChangeLog.class);

--- a/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTest.java
+++ b/metadata-jobs/mce-consumer-job/src/test/java/com/linkedin/metadata/kafka/MceConsumerApplicationTest.java
@@ -7,6 +7,7 @@ import static org.testng.AssertJUnit.*;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesResult;
 import io.datahubproject.metadata.jobs.common.health.kafka.KafkaHealthIndicator;
+import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -30,7 +31,7 @@ public class MceConsumerApplicationTest extends AbstractTestNGSpringContextTests
   public void testRestliServletConfig() {
     RestoreIndicesResult mockResult = new RestoreIndicesResult();
     mockResult.setRowsMigrated(100);
-    when(_mockEntityService.restoreIndices(any(), any())).thenReturn(mockResult);
+    when(_mockEntityService.streamRestoreIndices(any(), any())).thenReturn(Stream.of(mockResult));
 
     String response =
         this.restTemplate.postForObject(

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/elastic/OperationsController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/operations/elastic/OperationsController.java
@@ -257,7 +257,10 @@ public class OperationsController {
       @RequestParam(required = false, name = "batchSize", defaultValue = "500") @Nullable
           Integer batchSize,
       @RequestParam(required = false, name = "start", defaultValue = "0") @Nullable Integer start,
-      @RequestParam(required = false, name = "limit", defaultValue = "0") @Nullable Integer limit) {
+      @RequestParam(required = false, name = "limit", defaultValue = "0") @Nullable Integer limit,
+      @RequestParam(required = false, name = "gePitEpochMs", defaultValue = "0") @Nullable
+          Long gePitEpochMs,
+      @RequestParam(required = false, name = "lePitEpochMs") @Nullable Long lePitEpochMs) {
 
     Authentication authentication = AuthenticationContext.getAuthentication();
     if (!AuthUtil.isAPIAuthorized(
@@ -275,7 +278,9 @@ public class OperationsController {
                     .orElse(null))
             .start(start)
             .batchSize(batchSize)
-            .limit(limit);
+            .limit(limit)
+            .gePitEpochMs(gePitEpochMs)
+            .lePitEpochMs(lePitEpochMs);
 
     return ResponseEntity.of(
         Optional.of(

--- a/metadata-service/restli-api/src/main/idl/com.linkedin.entity.aspects.restspec.json
+++ b/metadata-service/restli-api/src/main/idl/com.linkedin.entity.aspects.restspec.json
@@ -114,6 +114,14 @@
         "name" : "limit",
         "type" : "int",
         "optional" : true
+      }, {
+        "name" : "gePitEpochMs",
+        "type" : "long",
+        "optional" : true
+      }, {
+        "name" : "lePitEpochMs",
+        "type" : "long",
+        "optional" : true
       } ],
       "returns" : "string"
     } ],

--- a/metadata-service/restli-api/src/main/idl/com.linkedin.entity.aspects.restspec.json
+++ b/metadata-service/restli-api/src/main/idl/com.linkedin.entity.aspects.restspec.json
@@ -110,6 +110,10 @@
         "name" : "batchSize",
         "type" : "int",
         "optional" : true
+      }, {
+        "name" : "limit",
+        "type" : "int",
+        "optional" : true
       } ],
       "returns" : "string"
     } ],

--- a/metadata-service/restli-api/src/main/idl/com.linkedin.operations.operations.restspec.json
+++ b/metadata-service/restli-api/src/main/idl/com.linkedin.operations.operations.restspec.json
@@ -55,6 +55,10 @@
         "name" : "batchSize",
         "type" : "int",
         "optional" : true
+      }, {
+        "name" : "limit",
+        "type" : "int",
+        "optional" : true
       } ],
       "returns" : "string"
     }, {

--- a/metadata-service/restli-api/src/main/idl/com.linkedin.operations.operations.restspec.json
+++ b/metadata-service/restli-api/src/main/idl/com.linkedin.operations.operations.restspec.json
@@ -59,6 +59,14 @@
         "name" : "limit",
         "type" : "int",
         "optional" : true
+      }, {
+        "name" : "gePitEpochMs",
+        "type" : "long",
+        "optional" : true
+      }, {
+        "name" : "lePitEpochMs",
+        "type" : "long",
+        "optional" : true
       } ],
       "returns" : "string"
     }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -4136,6 +4136,10 @@
           "name" : "batchSize",
           "type" : "int",
           "optional" : true
+        }, {
+          "name" : "limit",
+          "type" : "int",
+          "optional" : true
         } ],
         "returns" : "string"
       } ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -4140,6 +4140,14 @@
           "name" : "limit",
           "type" : "int",
           "optional" : true
+        }, {
+          "name" : "gePitEpochMs",
+          "type" : "long",
+          "optional" : true
+        }, {
+          "name" : "lePitEpochMs",
+          "type" : "long",
+          "optional" : true
         } ],
         "returns" : "string"
       } ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -3782,6 +3782,10 @@
           "name" : "batchSize",
           "type" : "int",
           "optional" : true
+        }, {
+          "name" : "limit",
+          "type" : "int",
+          "optional" : true
         } ],
         "returns" : "string"
       }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -3786,6 +3786,14 @@
           "name" : "limit",
           "type" : "int",
           "optional" : true
+        }, {
+          "name" : "gePitEpochMs",
+          "type" : "long",
+          "optional" : true
+        }, {
+          "name" : "lePitEpochMs",
+          "type" : "long",
+          "optional" : true
         } ],
         "returns" : "string"
       }, {

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -297,7 +297,8 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       @ActionParam(PARAM_URN) @Optional @Nullable String urn,
       @ActionParam(PARAM_URN_LIKE) @Optional @Nullable String urnLike,
       @ActionParam("start") @Optional @Nullable Integer start,
-      @ActionParam("batchSize") @Optional @Nullable Integer batchSize) {
+      @ActionParam("batchSize") @Optional @Nullable Integer batchSize,
+      @ActionParam("limit") @Optional @Nullable Integer limit) {
     return RestliUtil.toTask(
         () -> {
             if (!isAPIAuthorized(
@@ -308,7 +309,7 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
                         HttpStatus.S_403_FORBIDDEN, "User is unauthorized to update entities.");
             }
           return Utils.restoreIndices(
-              aspectName, urn, urnLike, start, batchSize, _authorizer, _entityService);
+              aspectName, urn, urnLike, start, batchSize, limit, _authorizer, _entityService);
         },
         MetricRegistry.name(this.getClass(), "restoreIndices"));
   }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -298,7 +298,9 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       @ActionParam(PARAM_URN_LIKE) @Optional @Nullable String urnLike,
       @ActionParam("start") @Optional @Nullable Integer start,
       @ActionParam("batchSize") @Optional @Nullable Integer batchSize,
-      @ActionParam("limit") @Optional @Nullable Integer limit) {
+      @ActionParam("limit") @Optional @Nullable Integer limit,
+      @ActionParam("gePitEpochMs") @Optional @Nullable Long gePitEpochMs,
+      @ActionParam("lePitEpochMs") @Optional @Nullable Long lePitEpochMs) {
     return RestliUtil.toTask(
         () -> {
             if (!isAPIAuthorized(
@@ -309,7 +311,7 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
                         HttpStatus.S_403_FORBIDDEN, "User is unauthorized to update entities.");
             }
           return Utils.restoreIndices(
-              aspectName, urn, urnLike, start, batchSize, limit, _authorizer, _entityService);
+              aspectName, urn, urnLike, start, batchSize, limit, gePitEpochMs, lePitEpochMs, _authorizer, _entityService);
         },
         MetricRegistry.name(this.getClass(), "restoreIndices"));
   }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/OperationsResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/OperationsResource.java
@@ -92,9 +92,11 @@ public class OperationsResource extends CollectionResourceTaskTemplate<String, V
       @ActionParam(PARAM_URN_LIKE) @Optional @Nullable String urnLike,
       @ActionParam("start") @Optional @Nullable Integer start,
       @ActionParam("batchSize") @Optional @Nullable Integer batchSize,
-      @ActionParam("limit") @Optional @Nullable Integer limit) {
+      @ActionParam("limit") @Optional @Nullable Integer limit,
+      @ActionParam("gePitEpochMs") @Optional @Nullable Long gePitEpochMs,
+      @ActionParam("lePitEpochMs") @Optional @Nullable Long lePitEpochMs) {
     return RestliUtil.toTask(
-        () -> Utils.restoreIndices(aspectName, urn, urnLike, start, batchSize, limit, _authorizer, _entityService),
+        () -> Utils.restoreIndices(aspectName, urn, urnLike, start, batchSize, limit, gePitEpochMs, lePitEpochMs, _authorizer, _entityService),
         MetricRegistry.name(this.getClass(), "restoreIndices"));
   }
 

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/OperationsResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/OperationsResource.java
@@ -91,12 +91,10 @@ public class OperationsResource extends CollectionResourceTaskTemplate<String, V
       @ActionParam(PARAM_URN) @Optional @Nullable String urn,
       @ActionParam(PARAM_URN_LIKE) @Optional @Nullable String urnLike,
       @ActionParam("start") @Optional @Nullable Integer start,
-      @ActionParam("batchSize") @Optional @Nullable Integer batchSize) {
+      @ActionParam("batchSize") @Optional @Nullable Integer batchSize,
+      @ActionParam("limit") @Optional @Nullable Integer limit) {
     return RestliUtil.toTask(
-        () -> {
-          return Utils.restoreIndices(
-              aspectName, urn, urnLike, start, batchSize, _authorizer, _entityService);
-        },
+        () -> Utils.restoreIndices(aspectName, urn, urnLike, start, batchSize, limit, _authorizer, _entityService),
         MetricRegistry.name(this.getClass(), "restoreIndices"));
   }
 

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/Utils.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/Utils.java
@@ -11,10 +11,12 @@ import com.linkedin.metadata.authorization.Disjunctive;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
+import com.linkedin.metadata.entity.restoreindices.RestoreIndicesResult;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.RestLiServiceException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +33,7 @@ public class Utils {
       @Nullable String urnLike,
       @Nullable Integer start,
       @Nullable Integer batchSize,
+      @Nullable Integer limit,
       @Nonnull Authorizer authorizer,
       @Nonnull EntityService<?> entityService) {
 
@@ -49,14 +52,18 @@ public class Utils {
     }
     RestoreIndicesArgs args =
         new RestoreIndicesArgs()
-            .setAspectName(aspectName)
-            .setUrnLike(urnLike)
-            .setUrn(urn)
-            .setStart(start)
-            .setBatchSize(batchSize);
+            .aspectName(aspectName)
+            .urnLike(urnLike)
+            .urn(urn)
+            .start(start)
+            .batchSize(batchSize)
+            .limit(limit);
     Map<String, Object> result = new HashMap<>();
     result.put("args", args);
-    result.put("result", entityService.restoreIndices(args, log::info));
+    result.put("result", entityService
+            .streamRestoreIndices(args, log::info)
+            .map(RestoreIndicesResult::toString)
+            .collect(Collectors.joining("\n")));
     return result.toString();
   }
 }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/Utils.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/operations/Utils.java
@@ -7,7 +7,6 @@ import com.datahub.authorization.EntitySpec;
 import com.datahub.plugins.auth.authorization.Authorizer;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
-import com.linkedin.metadata.authorization.Disjunctive;
 import com.linkedin.metadata.authorization.PoliciesConfig;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
@@ -34,6 +33,8 @@ public class Utils {
       @Nullable Integer start,
       @Nullable Integer batchSize,
       @Nullable Integer limit,
+      @Nullable Long gePitEpochMs,
+      @Nullable Long lePitEpochMs,
       @Nonnull Authorizer authorizer,
       @Nonnull EntityService<?> entityService) {
 
@@ -57,7 +58,9 @@ public class Utils {
             .urn(urn)
             .start(start)
             .batchSize(batchSize)
-            .limit(limit);
+            .limit(limit)
+            .gePitEpochMs(gePitEpochMs)
+            .lePitEpochMs(lePitEpochMs);
     Map<String, Object> result = new HashMap<>();
     result.put("args", args);
     result.put("result", entityService

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -244,7 +245,7 @@ public interface EntityService<U extends ChangeMCP> extends AspectRetriever {
   Integer getCountAspect(@Nonnull String aspectName, @Nullable String urnLike);
 
   // TODO: Extract this to a different service, doesn't need to be here
-  RestoreIndicesResult restoreIndices(
+  Stream<RestoreIndicesResult> streamRestoreIndices(
       @Nonnull RestoreIndicesArgs args, @Nonnull Consumer<String> logger);
 
   // Restore indices from list using key lookups (no scans)

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/entity/restoreindices/RestoreIndicesArgs.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/entity/restoreindices/RestoreIndicesArgs.java
@@ -1,13 +1,20 @@
 package com.linkedin.metadata.entity.restoreindices;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 @Data
+@Accessors(fluent = true)
 public class RestoreIndicesArgs implements Cloneable {
+  public static final int DEFAULT_BATCH_SIZE = 500;
+  public static final int DEFAULT_NUM_THREADS = 1;
+  public static final int DEFAULT_BATCH_DELAY_MS = 1;
+
   public int start = 0;
-  public int batchSize = 10;
-  public int numThreads = 1;
-  public long batchDelayMs = 1;
+  public int batchSize = DEFAULT_BATCH_SIZE;
+  public int limit = 0;
+  public int numThreads = DEFAULT_NUM_THREADS;
+  public long batchDelayMs = DEFAULT_BATCH_DELAY_MS;
   public String aspectName;
   public String urn;
   public String urnLike;
@@ -26,37 +33,28 @@ public class RestoreIndicesArgs implements Cloneable {
     }
   }
 
-  public RestoreIndicesArgs setAspectName(String aspectName) {
-    this.aspectName = aspectName;
+  public RestoreIndicesArgs start(Integer start) {
+    this.start = start != null ? start : 0;
     return this;
   }
 
-  public RestoreIndicesArgs setUrnLike(String urnLike) {
-    this.urnLike = urnLike;
+  public RestoreIndicesArgs batchSize(Integer batchSize) {
+    this.batchSize = batchSize != null ? batchSize : DEFAULT_BATCH_SIZE;
     return this;
   }
 
-  public RestoreIndicesArgs setUrn(String urn) {
-    this.urn = urn;
+  public RestoreIndicesArgs limit(Integer limit) {
+    this.limit = limit != null ? limit : 0;
     return this;
   }
 
-  public RestoreIndicesArgs setStart(Integer start) {
-    if (start != null) {
-      this.start = start;
-    }
+  public RestoreIndicesArgs numThreads(Integer numThreads) {
+    this.numThreads = numThreads != null ? numThreads : DEFAULT_NUM_THREADS;
     return this;
   }
 
-  public RestoreIndicesArgs setBatchSize(Integer batchSize) {
-    if (batchSize != null) {
-      this.batchSize = batchSize;
-    }
-    return this;
-  }
-
-  public RestoreIndicesArgs setUrnBasedPagination(Boolean urnBasedPagination) {
-    this.urnBasedPagination = urnBasedPagination;
+  public RestoreIndicesArgs batchDelayMs(Long batchDelayMs) {
+    this.batchDelayMs = batchDelayMs != null ? batchDelayMs : DEFAULT_BATCH_DELAY_MS;
     return this;
   }
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/entity/restoreindices/RestoreIndicesArgs.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/entity/restoreindices/RestoreIndicesArgs.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.entity.restoreindices;
 
+import java.time.Instant;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,12 +10,15 @@ public class RestoreIndicesArgs implements Cloneable {
   public static final int DEFAULT_BATCH_SIZE = 500;
   public static final int DEFAULT_NUM_THREADS = 1;
   public static final int DEFAULT_BATCH_DELAY_MS = 1;
+  public static final long DEFAULT_GE_PIT_EPOCH_MS = 0;
 
   public int start = 0;
   public int batchSize = DEFAULT_BATCH_SIZE;
   public int limit = 0;
   public int numThreads = DEFAULT_NUM_THREADS;
   public long batchDelayMs = DEFAULT_BATCH_DELAY_MS;
+  public long gePitEpochMs = DEFAULT_GE_PIT_EPOCH_MS;
+  public long lePitEpochMs;
   public String aspectName;
   public String urn;
   public String urnLike;
@@ -55,6 +59,16 @@ public class RestoreIndicesArgs implements Cloneable {
 
   public RestoreIndicesArgs batchDelayMs(Long batchDelayMs) {
     this.batchDelayMs = batchDelayMs != null ? batchDelayMs : DEFAULT_BATCH_DELAY_MS;
+    return this;
+  }
+
+  public RestoreIndicesArgs gePitEpochMs(Long gePitEpochMs) {
+    this.gePitEpochMs = gePitEpochMs != null ? gePitEpochMs : DEFAULT_GE_PIT_EPOCH_MS;
+    return this;
+  }
+
+  public RestoreIndicesArgs lePitEpochMs(Long lePitEpochMs) {
+    this.lePitEpochMs = lePitEpochMs != null ? lePitEpochMs : Instant.now().toEpochMilli();
     return this;
   }
 }


### PR DESCRIPTION
restoreIndices batchSize was being used as a limit instead of batchSize
added timestamp filters based on createdOn


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
