### PR TITLE
fix(ingestion/glue): fix to ingest the comment for partition key as description

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -1168,6 +1168,7 @@ class GlueSource(StatefulIngestionSourceBase):
                 schema_fields = get_schema_fields_for_hive_column(
                     hive_column_name=partition_key["Name"],
                     hive_column_type=partition_key.get("Type", "unknown"),
+                    description=partition_key.get("Comment"),
                     default_nullable=False,
                 )
                 assert schema_fields

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -113,6 +113,7 @@
                             {
                                 "fieldPath": "[version=2.0].[type=int].yr",
                                 "nullable": true,
+                                "description": "test comment",
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -204,6 +205,7 @@
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
                                 "nullable": true,
+                                "description": "partition test comment",
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}

--- a/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
@@ -115,6 +115,7 @@
                             {
                                 "fieldPath": "[version=2.0].[type=int].yr",
                                 "nullable": true,
+                                "description": "test comment",
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.NumberType": {}
@@ -206,6 +207,7 @@
                             {
                                 "fieldPath": "[version=2.0].[type=string].year",
                                 "nullable": true,
+                                "description": "partition test comment",
                                 "type": {
                                     "type": {
                                         "com.linkedin.pegasus2avro.schema.StringType": {}

--- a/metadata-ingestion/tests/unit/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/test_glue_source_stubs.py
@@ -92,7 +92,7 @@ tables_1 = [
         "Retention": 0,
         "StorageDescriptor": {
             "Columns": [
-                {"Name": "yr", "Type": "int"},
+                {"Name": "yr", "Type": "int", "Comment": "test comment"},
                 {"Name": "flightdate", "Type": "string"},
                 {"Name": "uniquecarrier", "Type": "string"},
                 {"Name": "airlineid", "Type": "int"},
@@ -129,7 +129,9 @@ tables_1 = [
             },
             "StoredAsSubDirectories": False,
         },
-        "PartitionKeys": [{"Name": "year", "Type": "string"}],
+        "PartitionKeys": [
+            {"Name": "year", "Type": "string", "Comment": "partition test comment"}
+        ],
         "TableType": "EXTERNAL_TABLE",
         "Parameters": {
             "CrawlerSchemaDeserializerVersion": "1.0",


### PR DESCRIPTION
fix to ingest the comment for partition key as description


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
