### PR TITLE
feat(lineage): give via and paths in entity lineage response

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
@@ -4,7 +4,6 @@ import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
 import static com.linkedin.datahub.graphql.types.mappers.MapperUtils.*;
 
 import com.datahub.authorization.AuthorizationConfiguration;
-import com.linkedin.common.UrnArray;
 import com.linkedin.common.UrnArrayArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -24,9 +23,7 @@ import com.linkedin.metadata.query.LineageFlags;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.services.RestrictedService;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -163,19 +160,8 @@ public class EntityLineageResultResolver
     result.setIsManual(lineageRelationship.hasIsManual() && lineageRelationship.isIsManual());
     if (lineageRelationship.getPaths() != null) {
       UrnArrayArray paths = lineageRelationship.getPaths();
-      List<String> viaNodes = new ArrayList<>();
       result.setPaths(
           paths.stream().map(path -> mapPath(context, path)).collect(Collectors.toList()));
-      for (UrnArray path : paths) {
-        int pathLength = path.size();
-        if (pathLength > 2) {
-          for (int i = 1; i < pathLength - 1; i++) {
-            Urn via = path.get(i);
-            viaNodes.add(via.toString());
-          }
-        }
-      }
-      result.setVia(viaNodes);
     }
 
     return result;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/MapperUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/MapperUtils.java
@@ -3,9 +3,11 @@ package com.linkedin.datahub.graphql.types.mappers;
 import static com.linkedin.datahub.graphql.util.SearchInsightsUtil.*;
 import static com.linkedin.metadata.utils.SearchUtil.*;
 
+import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AggregationMetadata;
+import com.linkedin.datahub.graphql.generated.EntityPath;
 import com.linkedin.datahub.graphql.generated.FacetMetadata;
 import com.linkedin.datahub.graphql.generated.MatchedField;
 import com.linkedin.datahub.graphql.generated.SearchResult;
@@ -103,5 +105,12 @@ public class MapperUtils {
       com.linkedin.metadata.search.SearchSuggestion suggestion) {
     return new SearchSuggestion(
         suggestion.getText(), suggestion.getScore(), Math.toIntExact(suggestion.getFrequency()));
+  }
+
+  public static EntityPath mapPath(@Nullable final QueryContext context, UrnArray path) {
+    EntityPath entityPath = new EntityPath();
+    entityPath.setPath(
+        path.stream().map(p -> UrnToEntityMapper.map(context, p)).collect(Collectors.toList()));
+    return entityPath;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/UrnSearchAcrossLineageResultsMapper.java
@@ -3,11 +3,9 @@ package com.linkedin.datahub.graphql.types.mappers;
 import static com.linkedin.datahub.graphql.types.mappers.MapperUtils.*;
 import static com.linkedin.datahub.graphql.util.SearchInsightsUtil.*;
 
-import com.linkedin.common.UrnArray;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.Entity;
-import com.linkedin.datahub.graphql.generated.EntityPath;
 import com.linkedin.datahub.graphql.generated.FreshnessStats;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResult;
 import com.linkedin.datahub.graphql.generated.SearchAcrossLineageResults;
@@ -72,13 +70,7 @@ public class UrnSearchAcrossLineageResultsMapper<T extends RecordTemplate, E ext
         .setDegree(searchEntity.getDegree())
         .setDegrees(new ArrayList<>(searchEntity.getDegrees()))
         .setExplored(Boolean.TRUE.equals(searchEntity.isExplored()))
+        .setIgnoredAsHop(Boolean.TRUE.equals(searchEntity.isIgnoredAsHop()))
         .build();
-  }
-
-  private EntityPath mapPath(@Nullable final QueryContext context, UrnArray path) {
-    EntityPath entityPath = new EntityPath();
-    entityPath.setPath(
-        path.stream().map(p -> UrnToEntityMapper.map(context, p)).collect(Collectors.toList()));
-    return entityPath;
   }
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1335,11 +1335,6 @@ type LineageRelationship {
     The paths traversed for this relationship
     """
     paths: [EntityPath]
-
-    """
-    Any in-between via nodes for this relationship
-    """
-    via: [String]
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1331,6 +1331,15 @@ type LineageRelationship {
     """
     isManual: Boolean
 
+    """
+    The paths traversed for this relationship
+    """
+    paths: [EntityPath]
+
+    """
+    Any in-between via nodes for this relationship
+    """
+    via: [String]
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -747,6 +747,11 @@ type SearchAcrossLineageResult {
   """
   explored: Boolean!
 
+  """
+  Whether this relationship was ignored as a hop
+  """
+  ignoredAsHop: Boolean!
+
 }
 
 """

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -389,9 +389,11 @@ public class ESGraphQueryDAO {
                                         || platformMatches(
                                             lineageRelationship.getEntity(),
                                             ignoreAsHops.get(entityType)))))
-            .map(LineageRelationship::getEntity)
-            .forEach(additionalCurrentLevel::add);
-        ;
+            .forEach(
+                lineageRelationship -> {
+                  additionalCurrentLevel.add(lineageRelationship.getEntity());
+                  lineageRelationship.setIgnoredAsHop(true);
+                });
         if (!additionalCurrentLevel.isEmpty()) {
           Stream<Urn> ignoreAsHopUrns =
               processOneHopLineage(

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/LineageSearchService.java
@@ -739,6 +739,7 @@ public class LineageSearchService {
         entity.setDegrees(lineageRelationship.getDegrees());
       }
       entity.setExplored(Boolean.TRUE.equals(lineageRelationship.isExplored()));
+      entity.setIgnoredAsHop(Boolean.TRUE.equals(lineageRelationship.isIgnoredAsHop()));
     }
     return entity;
   }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/graph/LineageRelationship.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/graph/LineageRelationship.pdl
@@ -72,4 +72,9 @@ record LineageRelationship {
     * Marks this relationship as explored during the graph walk
     */
     explored: optional boolean
+
+   /**
+    * Whether this relationship was ignored as a hop while performing the graph walk
+    */
+    ignoredAsHop: optional boolean
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/LineageSearchEntity.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/LineageSearchEntity.pdl
@@ -34,4 +34,9 @@ record LineageSearchEntity includes SearchEntity {
    * Marks an entity as having been explored for as a part of the graph walk
    */
    explored: optional boolean
+
+  /**
+    * Whether this relationship was ignored as a hop while performing the graph walk
+    */
+  ignoredAsHop: optional boolean
 }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -6210,6 +6210,11 @@
             "type" : "boolean",
             "doc" : "Marks an entity as having been explored for as a part of the graph walk",
             "optional" : true
+          }, {
+            "name" : "ignoredAsHop",
+            "type" : "boolean",
+            "doc" : "Whether this relationship was ignored as a hop while performing the graph walk",
+            "optional" : true
           } ]
         }
       },

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.lineage.relationships.snapshot.json
@@ -182,6 +182,11 @@
             "type" : "boolean",
             "doc" : "Marks this relationship as explored during the graph walk",
             "optional" : true
+          }, {
+            "name" : "ignoredAsHop",
+            "type" : "boolean",
+            "doc" : "Whether this relationship was ignored as a hop while performing the graph walk",
+            "optional" : true
           } ]
         }
       },


### PR DESCRIPTION
Gives additional information in lineage responses, whether a node was ignored as a hop as well as returning paths for an alternative flow.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
