### PR TITLE
fix(ingest): improve performance of get_allowed_list in AllowDenyPattern when dealing with large lists

### DIFF
--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -243,14 +243,20 @@ class AllowDenyPattern(ConfigModel):
         return AllowDenyPattern()
 
     def allowed(self, string: str) -> bool:
-        for deny_pattern in self.deny:
-            if re.match(deny_pattern, string, self.regex_flags):
-                return False
+        if self._denied(string):
+            return False
 
         return any(
             re.match(allow_pattern, string, self.regex_flags)
             for allow_pattern in self.allow
         )
+
+    def _denied(self, string: str) -> bool:
+        for deny_pattern in self.deny:
+            if re.match(deny_pattern, string, self.regex_flags):
+                return True
+
+        return False
 
     def is_fully_specified_allow_list(self) -> bool:
         """
@@ -265,8 +271,11 @@ class AllowDenyPattern(ConfigModel):
 
     def get_allowed_list(self) -> List[str]:
         """Return the list of allowed strings as a list, after taking into account deny patterns, if possible"""
-        assert self.is_fully_specified_allow_list()
-        return [a for a in self.allow if self.allowed(a)]
+        if not self.is_fully_specified_allow_list():
+            raise ValueError(
+                "allow list must be fully specified to get list of allowed strings"
+            )
+        return [a for a in self.allow if not self._denied(a)]
 
     def __eq__(self, other):  # type: ignore
         return isinstance(other, self.__class__) and self.__dict__ == other.__dict__


### PR DESCRIPTION
When dealing with large allow pattern lists get_allowed_list is extremely inefficient, because each allow pattern is validated against all other allow pattern - as we are already dealing with all allowed patterns in the list we don't have to validate them whether they are allowed, because they are...we only have to check whether they are denied or not.

Example: For a list of 2730 allow patterns up to 2730^2 resp. 7.452.900 unnecessary regular expression checks are performed.

This PR adds a new method "denied" to AllowDenyPattern which is used to filter the allow patterns in get_allowed_list.

Of course this logic only works in case the allow list is a fully specified allow list, but this is already checked/asserted* in get_allowed_list. It seems currently the get_allowed_list is not used anywhere by the acryl-datahub package, but for a custom source we have large list of allow patterns, which can currently not be used effectively because of these unneccessary checks.

*Side-note: Should the assert statement really be used in productive code? I don't think so because in case optimization is used the assert statements are ignored and strange things might happen then...but there are also other locations where the assert statement is used, therefore that's maybe something which should be addressed in general and not within this PR...

See also the Python docs regarding the assert statement:
https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement
https://docs.python.org/3/using/cmdline.html#cmdoption-O

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
