### PR TITLE
feat(cli): add actors field to forms subcommand

### DIFF
--- a/metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py
+++ b/metadata-ingestion/src/datahub/api/entities/structuredproperties/structuredproperties.py
@@ -89,7 +89,8 @@ class StructuredProperties(ConfigModel):
     @validator("urn", pre=True, always=True)
     def urn_must_be_present(cls, v, values):
         if not v:
-            assert "id" in values, "id must be present if urn is not"
+            if "id" not in values:
+                raise ValueError("id must be present if urn is not")
             return f"urn:li:structuredProperty:{values['id']}"
         return v
 
@@ -151,7 +152,10 @@ class StructuredProperties(ConfigModel):
         structured_property: Optional[
             StructuredPropertyDefinitionClass
         ] = graph.get_aspect(urn, StructuredPropertyDefinitionClass)
-        assert structured_property is not None
+        if structured_property is None:
+            raise Exception(
+                "StructuredPropertyDefinition aspect is None. Unable to create structured property."
+            )
         return StructuredProperties(
             urn=urn,
             qualified_name=structured_property.qualifiedName,


### PR DESCRIPTION
This PR adds the possibiliy to provide the actors field to the FormInfo aspect when creating forms via the CLI.

I have also changed some of the assertions in the corresponding forms and structured properties classes to throw exceptions instead of relying on the assert statement (see also here: #10219; one of the assert statements was only used for mypy, therefore the assert statement is still used there).

Regarding the format_owners and format_group_owners methods, I don't wanted to change the (public) interface of the Forms class, but of course we don't need them and could also directly use the format_users and format_groups methods in the add_owners method (as the Forms class is relatively new, I don't think it should be an issue to change the interface anyway, but someone else should decide this...).

There were also some changes caused by the linter, let's see whether the linter in the corresponding GitHub Action is accepting the changes or not (I am not sure whether is works correctly on my local environment)...🤷‍♂️

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
