### PR TITLE
fix(oidc settings): use correct path for preferredJwsAlgorithm

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcConfigs.java
@@ -226,8 +226,8 @@ public class OidcConfigs extends SsoConfigs {
         extractJwtAccessTokenClaims =
             Optional.of(jsonNode.get(EXTRACT_JWT_ACCESS_TOKEN_CLAIMS).asBoolean());
       }
-      if (jsonNode.has(PREFERRED_JWS_ALGORITHM_2)) {
-        preferredJwsAlgorithm = Optional.of(jsonNode.get(PREFERRED_JWS_ALGORITHM_2).asText());
+      if (jsonNode.has(PREFERRED_JWS_ALGORITHM)) {
+        preferredJwsAlgorithm = Optional.of(jsonNode.get(PREFERRED_JWS_ALGORITHM).asText());
       } else {
         preferredJwsAlgorithm =
             Optional.ofNullable(getOptional(configs, OIDC_PREFERRED_JWS_ALGORITHM, null));

--- a/datahub-frontend/test/security/OidcConfigurationTest.java
+++ b/datahub-frontend/test/security/OidcConfigurationTest.java
@@ -322,7 +322,7 @@ public class OidcConfigurationTest {
 
   @Test
   public void readPreferredJwsAlgorithmPropagationFromConfig() {
-    final String SSO_SETTINGS_JSON_STR = new JSONObject().put(PREFERRED_JWS_ALGORITHM, "HS256").toString();
+    final String SSO_SETTINGS_JSON_STR = new JSONObject().toString();
     CONFIG.withValue(OIDC_PREFERRED_JWS_ALGORITHM, ConfigValueFactory.fromAnyRef("RS256"));
     OidcConfigs.Builder oidcConfigsBuilder = new OidcConfigs.Builder();
     oidcConfigsBuilder.from(CONFIG, SSO_SETTINGS_JSON_STR);
@@ -333,7 +333,7 @@ public class OidcConfigurationTest {
 
   @Test
   public void readPreferredJwsAlgorithmPropagationFromJSON() {
-    final String SSO_SETTINGS_JSON_STR = new JSONObject().put(PREFERRED_JWS_ALGORITHM, "Unused").put(PREFERRED_JWS_ALGORITHM_2, "HS256").toString();
+    final String SSO_SETTINGS_JSON_STR = new JSONObject().put(PREFERRED_JWS_ALGORITHM, "HS256").toString();
     CONFIG.withValue(OIDC_PREFERRED_JWS_ALGORITHM, ConfigValueFactory.fromAnyRef("RS256"));
     OidcConfigs.Builder oidcConfigsBuilder = new OidcConfigs.Builder();
     oidcConfigsBuilder.from(CONFIG, SSO_SETTINGS_JSON_STR);


### PR DESCRIPTION
The response from the `auth/getSsoSettings` endpoint uses the `preferredJwsAlgorithm` path.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
