### PR TITLE
Cc  fix broken cll impact analysis

### DIFF
--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -967,10 +967,6 @@ fragment searchResults on SearchResults {
 fragment entityField on SchemaFieldEntity {
   urn
   type
-  parent {
-    urn
-    type
-  }
   fieldPath
   structuredProperties {
     properties {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -383,7 +383,7 @@ fragment nonSiblingsDatasetSearchFields on Dataset {
     ...datasetStatsFields
 }
 
-fragment searchResultFields on Entity {
+fragment searchResultsWithoutSchemaField on Entity {
     urn
     type
     ... on Dataset {
@@ -854,6 +854,10 @@ fragment searchResultFields on Entity {
     ... on BusinessAttribute {
         ...businessAttributeFields
     }
+}
+
+fragment searchResultFields on Entity {
+    ...searchResultsWithoutSchemaField
     ... on SchemaFieldEntity {
           ...entityField
     }
@@ -967,6 +971,10 @@ fragment searchResults on SearchResults {
 fragment entityField on SchemaFieldEntity {
   urn
   type
+  parent {
+    urn
+    type
+  }
   fieldPath
   structuredProperties {
     properties {
@@ -985,7 +993,7 @@ fragment schemaFieldEntityFields on SchemaFieldEntity {
     type
     fieldPath
     parent {
-        ...searchResultFields
+        ...searchResultsWithoutSchemaField
     }
 }
 
@@ -1018,7 +1026,7 @@ fragment searchAcrossRelationshipResults on SearchAcrossLineageResults {
         }
         paths {
             path {
-                ...searchResultFields
+                ...searchResultsWithoutSchemaField
                 ... on SchemaFieldEntity {
                     ...schemaFieldEntityFields
                 }


### PR DESCRIPTION
We recently had some changes into what we're querying that caused clashing in a query where we were querying `parent` on schema fields twice in search results. I updated the queries to remove this clashing, so now everything should work as expected.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
