### PR TITLE
fix(mae): fix mae standalone platform consumer

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/service/BusinessAttributeUpdateHookService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/service/BusinessAttributeUpdateHookService.java
@@ -6,27 +6,31 @@ import static com.linkedin.metadata.search.utils.QueryUtils.newRelationshipFilte
 
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.businessattribute.BusinessAttributes;
-import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.entity.Aspect;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.models.graph.Edge;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntity;
-import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.graph.GraphService;
-import com.linkedin.metadata.graph.RelatedEntitiesResult;
-import com.linkedin.metadata.models.AspectSpec;
-import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.PegasusUtils;
 import com.linkedin.mxe.PlatformEvent;
 import com.linkedin.platform.event.v1.EntityChangeEvent;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -34,25 +38,21 @@ import org.springframework.stereotype.Component;
 public class BusinessAttributeUpdateHookService {
   private static final String BUSINESS_ATTRIBUTE_OF = "BusinessAttributeOf";
 
-  private final GraphService graphService;
-  private final EntityService<?> entityService;
-  private final EntityRegistry entityRegistry;
-
+  private final UpdateIndicesService updateIndicesService;
   private final int relatedEntitiesCount;
+  private final int getRelatedEntitiesBatchSize;
 
   public static final String TAG = "TAG";
   public static final String GLOSSARY_TERM = "GLOSSARY_TERM";
   public static final String DOCUMENTATION = "DOCUMENTATION";
 
   public BusinessAttributeUpdateHookService(
-      GraphService graphService,
-      EntityService<?> entityService,
-      EntityRegistry entityRegistry,
-      @NonNull @Value("${businessAttribute.fetchRelatedEntitiesCount}") int relatedEntitiesCount) {
-    this.graphService = graphService;
-    this.entityService = entityService;
-    this.entityRegistry = entityRegistry;
+      @NonNull UpdateIndicesService updateIndicesService,
+      @NonNull @Value("${businessAttribute.fetchRelatedEntitiesCount}") int relatedEntitiesCount,
+      @NonNull @Value("${businessAttribute.fetchRelatedEntitiesBatchSize}") int relatedBatchSize) {
+    this.updateIndicesService = updateIndicesService;
     this.relatedEntitiesCount = relatedEntitiesCount;
+    this.getRelatedEntitiesBatchSize = relatedBatchSize;
   }
 
   public void handleChangeEvent(
@@ -76,58 +76,76 @@ public class BusinessAttributeUpdateHookService {
     Urn urn = entityChangeEvent.getEntityUrn();
     log.info("Business Attribute update hook invoked for urn :" + urn);
 
-    RelatedEntitiesResult entityAssociatedWithBusinessAttribute =
-        graphService.findRelatedEntities(
+    fetchRelatedEntities(opContext, urn, batch -> processBatch(opContext, batch), null, 0);
+  }
+
+  private void fetchRelatedEntities(
+      @NonNull final OperationContext opContext,
+      @NonNull final Urn urn,
+      @NonNull final Consumer<RelatedEntitiesScrollResult> resultConsumer,
+      @Nullable String scrollId,
+      int consumedEntityCount) {
+    GraphRetriever graph = opContext.getRetrieverContext().get().getGraphRetriever();
+
+    RelatedEntitiesScrollResult result =
+        graph.scrollRelatedEntities(
             null,
             newFilter("urn", urn.toString()),
             null,
             EMPTY_FILTER,
             Arrays.asList(BUSINESS_ATTRIBUTE_OF),
             newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-            0,
-            relatedEntitiesCount);
+            Edge.EDGE_SORT_CRITERION,
+            scrollId,
+            getRelatedEntitiesBatchSize,
+            null,
+            null);
+    resultConsumer.accept(result);
 
-    for (RelatedEntity relatedEntity : entityAssociatedWithBusinessAttribute.getEntities()) {
-      String entityUrnStr = relatedEntity.getUrn();
-      try {
-        Urn entityUrn = new Urn(entityUrnStr);
-        final AspectSpec aspectSpec =
-            entityRegistry
-                .getEntitySpec(Constants.SCHEMA_FIELD_ENTITY_NAME)
-                .getAspectSpec(Constants.BUSINESS_ATTRIBUTE_ASPECT);
-
-        EnvelopedAspect envelopedAspect =
-            entityService.getLatestEnvelopedAspect(
-                opContext,
-                Constants.SCHEMA_FIELD_ENTITY_NAME,
-                entityUrn,
-                Constants.BUSINESS_ATTRIBUTE_ASPECT);
-        BusinessAttributes businessAttributes =
-            new BusinessAttributes(envelopedAspect.getValue().data());
-
-        final AuditStamp auditStamp =
-            new AuditStamp()
-                .setActor(Urn.createFromString(Constants.SYSTEM_ACTOR))
-                .setTime(System.currentTimeMillis());
-
-        entityService
-            .alwaysProduceMCLAsync(
-                opContext,
-                entityUrn,
-                Constants.SCHEMA_FIELD_ENTITY_NAME,
-                Constants.BUSINESS_ATTRIBUTE_ASPECT,
-                aspectSpec,
-                null,
-                businessAttributes,
-                null,
-                null,
-                auditStamp,
-                ChangeType.UPSERT)
-            .getFirst();
-
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+    if (result.getScrollId() != null && consumedEntityCount < relatedEntitiesCount) {
+      fetchRelatedEntities(
+          opContext,
+          urn,
+          resultConsumer,
+          result.getScrollId(),
+          consumedEntityCount + result.getEntities().size());
     }
+  }
+
+  private void processBatch(
+      @NonNull OperationContext opContext, @NonNull RelatedEntitiesScrollResult batch) {
+    AspectRetriever aspectRetriever = opContext.getRetrieverContext().get().getAspectRetriever();
+
+    Set<Urn> entityUrns =
+        batch.getEntities().stream()
+            .map(RelatedEntity::getUrn)
+            .map(UrnUtils::getUrn)
+            .collect(Collectors.toSet());
+
+    Map<Urn, Map<String, Aspect>> entityAspectMap =
+        aspectRetriever.getLatestAspectObjects(
+            entityUrns, Set.of(Constants.BUSINESS_ATTRIBUTE_ASPECT));
+
+    entityAspectMap.entrySet().stream()
+        .filter(entry -> entry.getValue().containsKey(Constants.BUSINESS_ATTRIBUTE_ASPECT))
+        .forEach(
+            entry -> {
+              final Urn entityUrn = entry.getKey();
+              final Aspect aspect = entry.getValue().get(Constants.BUSINESS_ATTRIBUTE_ASPECT);
+
+              updateIndicesService.handleChangeEvent(
+                  opContext,
+                  PegasusUtils.constructMCL(
+                      null,
+                      Constants.SCHEMA_FIELD_ENTITY_NAME,
+                      entityUrn,
+                      ChangeType.UPSERT,
+                      Constants.BUSINESS_ATTRIBUTE_ASPECT,
+                      opContext.getAuditStamp(),
+                      new BusinessAttributes(aspect.data()),
+                      null,
+                      null,
+                      null));
+            });
   }
 }

--- a/metadata-jobs/pe-consumer/build.gradle
+++ b/metadata-jobs/pe-consumer/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   testRuntimeOnly externalDependency.logbackClassic
   testImplementation externalDependency.springBootTest
   testImplementation externalDependency.testng
+  testImplementation project(':metadata-operation-context')
 }
 
 task avroSchemaSources(type: Copy) {

--- a/metadata-jobs/pe-consumer/src/main/java/com/datahub/event/hook/BusinessAttributeUpdateHook.java
+++ b/metadata-jobs/pe-consumer/src/main/java/com/datahub/event/hook/BusinessAttributeUpdateHook.java
@@ -1,26 +1,38 @@
 package com.datahub.event.hook;
 
 import com.linkedin.gms.factory.common.GraphServiceFactory;
-import com.linkedin.gms.factory.entity.EntityServiceFactory;
-import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.metadata.service.BusinessAttributeUpdateHookService;
 import com.linkedin.mxe.PlatformEvent;
 import io.datahubproject.metadata.context.OperationContext;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@Import({EntityServiceFactory.class, EntityRegistryFactory.class, GraphServiceFactory.class})
+@Import(GraphServiceFactory.class)
 public class BusinessAttributeUpdateHook implements PlatformEventHook {
 
   protected final BusinessAttributeUpdateHookService businessAttributeUpdateHookService;
+  protected final boolean enabled;
 
   public BusinessAttributeUpdateHook(
-      BusinessAttributeUpdateHookService businessAttributeUpdateHookService) {
+      BusinessAttributeUpdateHookService businessAttributeUpdateHookService,
+      @Value("${featureFlags.businessAttributeEntityEnabled}") boolean enabled) {
     this.businessAttributeUpdateHookService = businessAttributeUpdateHookService;
+    this.enabled = enabled;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  @Override
+  public void init() {
+    log.info("Initialized PlatformEventHook: BusinessAttributeUpdateHook");
   }
 
   /**

--- a/metadata-jobs/pe-consumer/src/test/java/com/datahub/event/hook/BusinessAttributeUpdateHookTest.java
+++ b/metadata-jobs/pe-consumer/src/test/java/com/datahub/event/hook/BusinessAttributeUpdateHookTest.java
@@ -1,15 +1,14 @@
 package com.datahub.event.hook;
 
-import static com.datahub.event.hook.EntityRegistryTestUtil.ENTITY_REGISTRY;
 import static com.linkedin.metadata.Constants.BUSINESS_ATTRIBUTE_ASPECT;
-import static com.linkedin.metadata.Constants.SCHEMA_FIELD_ENTITY_NAME;
-import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
-import static com.linkedin.metadata.search.utils.QueryUtils.newFilter;
-import static com.linkedin.metadata.search.utils.QueryUtils.newRelationshipFilter;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
-import static org.testng.Assert.assertEquals;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -23,31 +22,36 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.DataMap;
 import com.linkedin.entity.Aspect;
-import com.linkedin.entity.EnvelopedAspect;
-import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.models.graph.Edge;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
+import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntity;
-import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.graph.GraphService;
-import com.linkedin.metadata.graph.RelatedEntitiesResult;
-import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
+import com.linkedin.metadata.query.filter.RelationshipFilter;
 import com.linkedin.metadata.service.BusinessAttributeUpdateHookService;
+import com.linkedin.metadata.service.UpdateIndicesService;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.PlatformEvent;
 import com.linkedin.mxe.PlatformEventHeader;
-import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.platform.event.v1.EntityChangeEvent;
 import com.linkedin.platform.event.v1.Parameters;
-import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.metadata.context.RetrieverContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Future;
+import java.util.Set;
 import org.mockito.Mockito;
+import org.mockito.stubbing.OngoingStubbing;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -63,118 +67,94 @@ public class BusinessAttributeUpdateHookTest {
   private static final long EVENT_TIME = 123L;
   private static final String TEST_ACTOR_URN = "urn:li:corpuser:test";
   private static Urn actorUrn;
-  private GraphService mockGraphService;
-  private EntityService mockEntityService;
+  private UpdateIndicesService mockUpdateIndicesService;
   private BusinessAttributeUpdateHook businessAttributeUpdateHook;
   private BusinessAttributeUpdateHookService businessAttributeServiceHook;
 
   @BeforeMethod
   public void setupTest() throws URISyntaxException {
-    mockGraphService = mock(GraphService.class);
-    mockEntityService = mock(EntityService.class);
+    mockUpdateIndicesService = mock(UpdateIndicesService.class);
     actorUrn = Urn.createFromString(TEST_ACTOR_URN);
     businessAttributeServiceHook =
-        new BusinessAttributeUpdateHookService(
-            mockGraphService, mockEntityService, ENTITY_REGISTRY, 100);
-    businessAttributeUpdateHook = new BusinessAttributeUpdateHook(businessAttributeServiceHook);
+        new BusinessAttributeUpdateHookService(mockUpdateIndicesService, 100, 1);
+    businessAttributeUpdateHook =
+        new BusinessAttributeUpdateHook(businessAttributeServiceHook, true);
   }
 
   @Test
   public void testMCLOnBusinessAttributeUpdate() throws Exception {
     PlatformEvent platformEvent = createPlatformEventBusinessAttribute();
-    final RelatedEntitiesResult mockRelatedEntities =
-        new RelatedEntitiesResult(
-            0,
-            1,
-            1,
+
+    // mock response
+    OperationContext opContext =
+        mockOperationContextWithGraph(
             ImmutableList.of(
+                new RelatedEntity(BUSINESS_ATTRIBUTE_OF, SCHEMA_FIELD_URN.toString()),
                 new RelatedEntity(BUSINESS_ATTRIBUTE_OF, SCHEMA_FIELD_URN.toString())));
-    // mock response
-    Mockito.when(
-            mockGraphService.findRelatedEntities(
-                null,
-                newFilter("urn", TEST_BUSINESS_ATTRIBUTE_URN),
-                null,
-                EMPTY_FILTER,
-                Arrays.asList(BUSINESS_ATTRIBUTE_OF),
-                newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-                0,
-                100))
-        .thenReturn(mockRelatedEntities);
-    assertEquals(mockRelatedEntities.getTotal(), 1);
 
-    Mockito.when(
-            mockEntityService.getLatestEnvelopedAspect(
-                any(OperationContext.class),
-                eq(SCHEMA_FIELD_ENTITY_NAME),
-                eq(SCHEMA_FIELD_URN),
-                eq(BUSINESS_ATTRIBUTE_ASPECT)))
-        .thenReturn(envelopedAspect());
-
-    // mock response
-    Mockito.when(
-            mockEntityService.alwaysProduceMCLAsync(
-                any(OperationContext.class),
-                any(Urn.class),
-                Mockito.anyString(),
-                Mockito.anyString(),
-                any(AspectSpec.class),
-                eq(null),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(ChangeType.class)))
-        .thenReturn(Pair.of(mock(Future.class), false));
+    when(opContext
+            .getRetrieverContext()
+            .get()
+            .getAspectRetriever()
+            .getLatestAspectObjects(
+                eq(Set.of(SCHEMA_FIELD_URN)), eq(Set.of(BUSINESS_ATTRIBUTE_ASPECT))))
+        .thenReturn(
+            Map.of(
+                SCHEMA_FIELD_URN,
+                Map.of(BUSINESS_ATTRIBUTE_ASPECT, new Aspect(new BusinessAttributes().data()))));
 
     // invoke
-    businessAttributeServiceHook.handleChangeEvent(mock(OperationContext.class), platformEvent);
+    businessAttributeServiceHook.handleChangeEvent(opContext, platformEvent);
 
     // verify
-    Mockito.verify(mockGraphService, Mockito.times(1))
-        .findRelatedEntities(
-            any(), any(), any(), any(), any(), any(), Mockito.anyInt(), Mockito.anyInt());
+    // page 1
+    Mockito.verify(opContext.getRetrieverContext().get().getGraphRetriever(), Mockito.times(1))
+        .scrollRelatedEntities(
+            isNull(),
+            any(Filter.class),
+            isNull(),
+            any(Filter.class),
+            any(),
+            any(RelationshipFilter.class),
+            eq(Edge.EDGE_SORT_CRITERION),
+            isNull(),
+            anyInt(),
+            isNull(),
+            isNull());
+    // page 2
+    Mockito.verify(opContext.getRetrieverContext().get().getGraphRetriever(), Mockito.times(1))
+        .scrollRelatedEntities(
+            isNull(),
+            any(Filter.class),
+            isNull(),
+            any(Filter.class),
+            any(),
+            any(RelationshipFilter.class),
+            eq(Edge.EDGE_SORT_CRITERION),
+            eq("1"),
+            anyInt(),
+            isNull(),
+            isNull());
 
-    Mockito.verify(mockEntityService, Mockito.times(1))
-        .alwaysProduceMCLAsync(
-            any(OperationContext.class),
-            any(Urn.class),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            any(AspectSpec.class),
-            eq(null),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(ChangeType.class));
+    Mockito.verifyNoMoreInteractions(opContext.getRetrieverContext().get().getGraphRetriever());
+
+    // 2 pages = 2 ingest proposals
+    Mockito.verify(mockUpdateIndicesService, Mockito.times(2))
+        .handleChangeEvent(any(OperationContext.class), any(MetadataChangeLog.class));
   }
 
   @Test
   private void testMCLOnInvalidCategory() throws Exception {
     PlatformEvent platformEvent = createPlatformEventInvalidCategory();
+    OperationContext opContext = mockOperationContextWithGraph(ImmutableList.of());
 
     // invoke
-    businessAttributeServiceHook.handleChangeEvent(mock(OperationContext.class), platformEvent);
+    businessAttributeServiceHook.handleChangeEvent(opContext, platformEvent);
 
     // verify
-    Mockito.verify(mockGraphService, Mockito.times(0))
-        .findRelatedEntities(
-            any(), any(), any(), any(), any(), any(), Mockito.anyInt(), Mockito.anyInt());
-
-    Mockito.verify(mockEntityService, Mockito.times(0))
-        .alwaysProduceMCLAsync(
-            any(OperationContext.class),
-            any(Urn.class),
-            Mockito.anyString(),
-            Mockito.anyString(),
-            any(AspectSpec.class),
-            eq(null),
-            any(),
-            any(),
-            any(),
-            any(),
-            any(ChangeType.class));
+    Mockito.verifyNoInteractions(opContext.getRetrieverContext().get().getGraphRetriever());
+    Mockito.verifyNoInteractions(opContext.getRetrieverContext().get().getAspectRetriever());
+    Mockito.verifyNoInteractions(mockUpdateIndicesService);
   }
 
   public static PlatformEvent createPlatformEventBusinessAttribute() throws Exception {
@@ -241,10 +221,62 @@ public class BusinessAttributeUpdateHookTest {
     return platformEvent;
   }
 
-  private EnvelopedAspect envelopedAspect() {
-    EnvelopedAspect envelopedAspect = new EnvelopedAspect();
-    envelopedAspect.setValue(new Aspect(new BusinessAttributes().data()));
-    envelopedAspect.setSystemMetadata(new SystemMetadata());
-    return envelopedAspect;
+  private OperationContext mockOperationContextWithGraph(List<RelatedEntity> graphEdges) {
+    GraphRetriever graphRetriever = mock(GraphRetriever.class);
+
+    RetrieverContext mockRetrieverContext = mock(RetrieverContext.class);
+    when(mockRetrieverContext.getAspectRetriever()).thenReturn(mock(AspectRetriever.class));
+    when(mockRetrieverContext.getGraphRetriever()).thenReturn(graphRetriever);
+
+    OperationContext opContext =
+        TestOperationContexts.systemContextNoSearchAuthorization(mockRetrieverContext);
+
+    // reset mock for test
+    reset(opContext.getRetrieverContext().get().getAspectRetriever());
+
+    if (!graphEdges.isEmpty()) {
+
+      int idx = 0;
+      OngoingStubbing<RelatedEntitiesScrollResult> multiStub =
+          when(
+              graphRetriever.scrollRelatedEntities(
+                  isNull(),
+                  any(Filter.class),
+                  isNull(),
+                  any(Filter.class),
+                  eq(Arrays.asList(BUSINESS_ATTRIBUTE_OF)),
+                  any(RelationshipFilter.class),
+                  eq(Edge.EDGE_SORT_CRITERION),
+                  nullable(String.class),
+                  eq(1),
+                  isNull(),
+                  isNull()));
+
+      for (RelatedEntity relatedEntity : graphEdges) {
+        final String scrollId;
+        if (idx < graphEdges.size() - 1) {
+          idx += 1;
+          scrollId = String.valueOf(idx);
+        } else {
+          scrollId = null;
+        }
+
+        multiStub =
+            multiStub.thenReturn(
+                new RelatedEntitiesScrollResult(
+                    graphEdges.size(),
+                    1,
+                    scrollId,
+                    List.of(
+                        new RelatedEntities(
+                            relatedEntity.getRelationshipType(),
+                            relatedEntity.getUrn(),
+                            TEST_BUSINESS_ATTRIBUTE_URN,
+                            RelationshipDirection.INCOMING,
+                            null))));
+      }
+    }
+
+    return opContext;
   }
 }

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -445,4 +445,5 @@ forms:
     enabled: { $FORMS_HOOK_ENABLED:true }
 
 businessAttribute:
-  fetchRelatedEntitiesCount: ${BUSINESS_ATTRIBUTE_RELATED_ENTITIES_COUNT:100000}
+  fetchRelatedEntitiesCount: ${BUSINESS_ATTRIBUTE_RELATED_ENTITIES_COUNT:20000}
+  fetchRelatedEntitiesBatchSize: ${BUSINESS_ATTRIBUTE_RELATED_ENTITIES_BATCH_SIZE:1000}


### PR DESCRIPTION
Fix the mae consumer when in standalone mode with platform event consumer enabled.

* Refactor BusinessAttributeService/Hook to use `UpdateIndicesService` instead of `EntityService` allowing execution in standalone consumer mode.
* Removed default configuration with 100,000 limit ES query to avoid performance issues
* Implemented pagination for ES query
* Converted to the GraphRetriever client. (Updated test for pagination test)
* Added page/batch size configuration option (`BUSINESS_ATTRIBUTE_RELATED_ENTITIES_BATCH_SIZE`)
* Converted MCL producer to write directly to Elasticsearch rather then emit additional MCLs

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
