### PR TITLE
fix(graphql) Fix entity type filter clash with legacy filters

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossEntitiesResolver.java
@@ -75,14 +75,20 @@ public class SearchAcrossEntitiesResolver implements DataFetcher<CompletableFutu
                 start,
                 count);
 
+            List<String> finalEntities =
+                maybeResolvedView != null
+                    ? SearchUtils.intersectEntityTypes(
+                        entityNames, maybeResolvedView.getDefinition().getEntityTypes())
+                    : entityNames;
+            if (finalEntities.size() == 0) {
+              return SearchUtils.createEmptySearchResults(start, count);
+            }
+
             return UrnSearchResultsMapper.map(
                 context,
                 _entityClient.searchAcrossEntities(
                     context.getOperationContext().withSearchFlags(flags -> searchFlags),
-                    maybeResolvedView != null
-                        ? SearchUtils.intersectEntityTypes(
-                            entityNames, maybeResolvedView.getDefinition().getEntityTypes())
-                        : entityNames,
+                    finalEntities,
                     sanitizedQuery,
                     maybeResolvedView != null
                         ? SearchUtils.combineFilters(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -21,6 +21,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.SearchResults;
 import com.linkedin.datahub.graphql.types.common.mappers.SearchFlagsInputMapper;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.metadata.query.SearchFlags;
@@ -313,5 +314,16 @@ public class SearchUtils {
     final List<EntityType> entityTypes =
         (inputTypes == null || inputTypes.isEmpty()) ? SEARCHABLE_ENTITY_TYPES : inputTypes;
     return entityTypes.stream().map(EntityTypeMapper::getName).collect(Collectors.toList());
+  }
+
+  public static SearchResults createEmptySearchResults(final int start, final int count) {
+    final SearchResults result = new SearchResults();
+    result.setStart(start);
+    result.setCount(count);
+    result.setTotal(0);
+    result.setSearchResults(new ArrayList<>());
+    result.setSuggestions(new ArrayList<>());
+    result.setFacets(new ArrayList<>());
+    return result;
   }
 }


### PR DESCRIPTION
This PR fixes a problem that occurs with legacy views where they explicitly defined entity types in a different field and we intersected that with `types` provided by the user. This then determines which indexes we search through. If the intersection between these two is empty, we should return no results. We default add all SEARCHABLE_ENTITY_TYPES if `types` is empty from the API input, so if the intersection is empty, it truly should be an empty search.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
