### PR TITLE
fix(metadata-service): consider missing entities in form assignment hook

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/form/FormAssignmentHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/form/FormAssignmentHook.java
@@ -38,9 +38,6 @@ import org.springframework.stereotype.Component;
  * <p>3. When a form is hard deleted, any automations used for assigning the form, or validating
  * prompts, are automatically deleted.
  *
- * <p>Note that currently, Datasets, Dashboards, Charts, Data Jobs, Data Flows, Containers, are the
- * only asset types supported for this hook.
- *
  * <p>TODO: In the future, let's decide whether we want to support automations to auto-mark form
  * prompts as "completed" when they do in fact have the correct metadata. (Without user needing to
  * explicitly fill out a form prompt response)

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/util/SearchBasedFormAssignmentManager.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/util/SearchBasedFormAssignmentManager.java
@@ -18,7 +18,25 @@ import lombok.extern.slf4j.Slf4j;
 public class SearchBasedFormAssignmentManager {
 
   private static final ImmutableList<String> ENTITY_TYPES =
-      ImmutableList.of(Constants.DATASET_ENTITY_NAME);
+      ImmutableList.of(
+          Constants.DATASET_ENTITY_NAME,
+          Constants.DATA_JOB_ENTITY_NAME,
+          Constants.DATA_FLOW_ENTITY_NAME,
+          Constants.CHART_ENTITY_NAME,
+          Constants.DASHBOARD_ENTITY_NAME,
+          Constants.CORP_USER_ENTITY_NAME,
+          Constants.CORP_GROUP_ENTITY_NAME,
+          Constants.DOMAIN_ENTITY_NAME,
+          Constants.CONTAINER_ENTITY_NAME,
+          Constants.GLOSSARY_TERM_ENTITY_NAME,
+          Constants.GLOSSARY_NODE_ENTITY_NAME,
+          Constants.ML_MODEL_ENTITY_NAME,
+          Constants.ML_MODEL_GROUP_ENTITY_NAME,
+          Constants.ML_FEATURE_TABLE_ENTITY_NAME,
+          Constants.ML_FEATURE_ENTITY_NAME,
+          Constants.ML_PRIMARY_KEY_ENTITY_NAME,
+          Constants.DATA_PRODUCT_ENTITY_NAME,
+          Constants.SCHEMA_FIELD_ENTITY_NAME);
 
   public static void apply(
       OperationContext opContext,


### PR DESCRIPTION
This PR adds the missing entities, which are currently not affected by the FormAssignmentHook. Technically all entities added here should support form assigments, because this was added in this [PR](https://github.com/datahub-project/datahub/pull/9801). Also the comment in the FormAssignmentHook itself was wrong, because technically only datasets are currently supported - as all entities with forms are supported by the hook now, I have also removed the corresponding comment.

Although (and I hope someone knows this) it seems there is missing a bit more "logic" around forms: It seems there is currently no hook (or other logic) which would assign forms to newly created entities (e.g., data products created via UI, but also in general e.g. during ingestion), once a form was assigned to an entity it will not be (automatically) removed again, in case the filter changes (however such a logic could also interfere with the urn list within the datahub forms upsert -f [...] command...probably to have an automatic removal of forms, the list with the urns has also to be saved within the aspect with the filter)...are there any plans to improve these things? :-)


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
