### PR TITLE
docs(apis): Update datahub-apis.md to add link to search example

### DIFF
--- a/docs/api/datahub-apis.md
+++ b/docs/api/datahub-apis.md
@@ -66,7 +66,7 @@ Here's an overview of what each API can do.
 | Create a Dataset                   | 🚫                                                                           | ✅ [[Guide]](/docs/api/tutorials/datasets.md)                                 | ✅       |
 | Delete a Dataset (Soft Delete)     | ✅ [[Guide]](/docs/api/tutorials/datasets.md#delete-dataset)                  | ✅ [[Guide]](/docs/api/tutorials/datasets.md#delete-dataset)                  | ✅       |
 | Delete a Dataset (Hard Delete)     | 🚫                                                                           | ✅ [[Guide]](/docs/api/tutorials/datasets.md#delete-dataset)                  | ✅       |
-| Search a Dataset                   | ✅                                                                            | ✅                                                                            | ✅       |
+| Search a Dataset                   | ✅ [[Guide]](/docs/how/search/#graphql)                                      | ✅                                                                            | ✅       |
 | Read a Dataset Deprecation         | ✅                                                                            | ✅                                                                            | ✅       |
 | Read Dataset Entities (V2)         | ✅                                                                            | ✅                                                                            | ✅       |
 | Create a Tag                       | ✅ [[Guide]](/docs/api/tutorials/tags.md#create-tags)                         | ✅ [[Guide]](/docs/api/tutorials/tags.md#create-tags)                         | ✅       |

--- a/docs/api/datahub-apis.md
+++ b/docs/api/datahub-apis.md
@@ -66,7 +66,7 @@ Here's an overview of what each API can do.
 | Create a Dataset                   | 🚫                                                                           | ✅ [[Guide]](/docs/api/tutorials/datasets.md)                                 | ✅       |
 | Delete a Dataset (Soft Delete)     | ✅ [[Guide]](/docs/api/tutorials/datasets.md#delete-dataset)                  | ✅ [[Guide]](/docs/api/tutorials/datasets.md#delete-dataset)                  | ✅       |
 | Delete a Dataset (Hard Delete)     | 🚫                                                                           | ✅ [[Guide]](/docs/api/tutorials/datasets.md#delete-dataset)                  | ✅       |
-| Search a Dataset                   | ✅ [[Guide]](/docs/how/search/#graphql)                                      | ✅                                                                            | ✅       |
+| Search a Dataset                   | ✅ [[Guide]](/docs/how/search.md#graphql)                                     | ✅                                                                            | ✅       |
 | Read a Dataset Deprecation         | ✅                                                                            | ✅                                                                            | ✅       |
 | Read Dataset Entities (V2)         | ✅                                                                            | ✅                                                                            | ✅       |
 | Create a Tag                       | ✅ [[Guide]](/docs/api/tutorials/tags.md#create-tags)                         | ✅ [[Guide]](/docs/api/tutorials/tags.md#create-tags)                         | ✅       |


### PR DESCRIPTION
We have a graphql example and should link it from this table.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
