### PR TITLE
fix(changeEvents): add description-parameter to the change-event of a schemaField-description

### DIFF
--- a/docs/managed-datahub/datahub-api/entity-events-api.md
+++ b/docs/managed-datahub/datahub-api/entity-events-api.md
@@ -352,7 +352,7 @@ This event is emitted when a description has been added to an entity on DataHub.
 
 #### Header
 
-<table><thead><tr><th>Category</th><th>Operation</th><th>Entity Types</th><th data-hidden></th></tr></thead><tbody><tr><td>DOCUMENTATION</td><td>ADD</td><td><code>dataset</code>, <code>dashboard</code>, <code>chart</code>, <code>dataJob</code>, <code>dataFlow</code> , <code>container</code>, <code>glossaryTerm</code>, <code>domain</code>, <code>tag</code></td><td></td></tr></tbody></table>
+<table><thead><tr><th>Category</th><th>Operation</th><th>Entity Types</th><th data-hidden></th></tr></thead><tbody><tr><td>DOCUMENTATION</td><td>ADD</td><td><code>dataset</code>, <code>dashboard</code>, <code>chart</code>, <code>dataJob</code>, <code>dataFlow</code> , <code>container</code>, <code>glossaryTerm</code>, <code>domain</code>, <code>tag</code>, <code>schemaField</code></td><td></td></tr></tbody></table>
 
 #### Parameters
 
@@ -378,13 +378,45 @@ This event is emitted when a description has been added to an entity on DataHub.
 }
 ```
 
+### Modify Description Event
+
+This event is emitted when an existing description of an entity has been modified on DataHub.
+
+#### Header
+
+<table><thead><tr><th>Category</th><th>Operation</th><th>Entity Types</th><th data-hidden></th></tr></thead><tbody><tr><td>DOCUMENTATION</td><td>MODIFY</td><td><code>dataset</code>, <code>dashboard</code>, <code>chart</code>, <code>dataJob</code>, <code>dataFlow</code> , <code>container</code>, <code>glossaryTerm</code>, <code>domain</code>, <code>tag</code>, <code>schemaField</code></td><td></td></tr></tbody></table>
+
+#### Parameters
+
+| Name        | Type   | Description                        | Optional |
+|-------------| ------ |------------------------------------| -------- |
+| description | String | The new description of the entity. | False    |
+
+#### Sample Event
+
+```
+{
+  "entityUrn": "urn:li:dataset:abc",
+  "entityType": "dataset",
+  "category": "DOCUMENTATION",
+  "operation": "MODIFY",
+  "parameters": {
+    "description": "This is a new description"
+  },
+  "auditStamp": {
+    "actor": "urn:li:corpuser:jdoe",
+    "time": 1706646452982
+  }
+}
+```
+
 ### Remove Description Event
 
 This event is emitted when an existing description has been removed from an entity on DataHub.
 
 #### Header
 
-<table><thead><tr><th>Category</th><th>Operation</th><th>Entity Types</th><th data-hidden></th></tr></thead><tbody><tr><td>DOCUMENTATION</td><td>REMOVE</td><td><code>dataset</code>, <code>dashboard</code>, <code>chart</code>, <code>dataJob</code>, <code>container</code> ,<code>dataFlow</code> , <code>glossaryTerm</code>, <code>domain</code>, <code>tag</code></td><td></td></tr></tbody></table>
+<table><thead><tr><th>Category</th><th>Operation</th><th>Entity Types</th><th data-hidden></th></tr></thead><tbody><tr><td>DOCUMENTATION</td><td>REMOVE</td><td><code>dataset</code>, <code>dashboard</code>, <code>chart</code>, <code>dataJob</code>, <code>container</code> ,<code>dataFlow</code> , <code>glossaryTerm</code>, <code>domain</code>, <code>tag</code>, <code>schemaField</code></td><td></td></tr></tbody></table>
 
 #### Parameters
 

--- a/docs/managed-datahub/datahub-api/entity-events-api.md
+++ b/docs/managed-datahub/datahub-api/entity-events-api.md
@@ -378,38 +378,6 @@ This event is emitted when a description has been added to an entity on DataHub.
 }
 ```
 
-### Modify Description Event
-
-This event is emitted when an existing description of an entity has been modified on DataHub.
-
-#### Header
-
-<table><thead><tr><th>Category</th><th>Operation</th><th>Entity Types</th><th data-hidden></th></tr></thead><tbody><tr><td>DOCUMENTATION</td><td>MODIFY</td><td><code>dataset</code>, <code>dashboard</code>, <code>chart</code>, <code>dataJob</code>, <code>dataFlow</code> , <code>container</code>, <code>glossaryTerm</code>, <code>domain</code>, <code>tag</code>, <code>schemaField</code></td><td></td></tr></tbody></table>
-
-#### Parameters
-
-| Name        | Type   | Description                        | Optional |
-|-------------| ------ |------------------------------------| -------- |
-| description | String | The new description of the entity. | False    |
-
-#### Sample Event
-
-```
-{
-  "entityUrn": "urn:li:dataset:abc",
-  "entityType": "dataset",
-  "category": "DOCUMENTATION",
-  "operation": "MODIFY",
-  "parameters": {
-    "description": "This is a new description"
-  },
-  "auditStamp": {
-    "actor": "urn:li:corpuser:jdoe",
-    "time": 1706646452982
-  }
-}
-```
-
 ### Remove Description Event
 
 This event is emitted when an existing description has been removed from an entity on DataHub.

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/EditableSchemaMetadataChangeEventGenerator.java
@@ -5,6 +5,7 @@ import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGenerator
 
 import com.datahub.util.RecordUtils;
 import com.github.fge.jsonpatch.JsonPatch;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.GlossaryTerms;
@@ -166,6 +167,7 @@ public class EditableSchemaMetadataChangeEventGenerator
                   targetFieldInfo.getFieldPath(),
                   datasetFieldUrn,
                   targetFieldDescription))
+          .parameters(ImmutableMap.of("description", targetFieldDescription))
           .auditStamp(auditStamp)
           .build();
     }
@@ -183,6 +185,7 @@ public class EditableSchemaMetadataChangeEventGenerator
                   Optional.ofNullable(targetFieldInfo).map(EditableSchemaFieldInfo::getFieldPath),
                   datasetFieldUrn,
                   baseFieldDescription))
+          .parameters(ImmutableMap.of("description", baseFieldDescription))
           .auditStamp(auditStamp)
           .build();
     }
@@ -203,6 +206,7 @@ public class EditableSchemaMetadataChangeEventGenerator
                   datasetFieldUrn,
                   baseFieldDescription,
                   targetFieldDescription))
+          .parameters(ImmutableMap.of("description", targetFieldDescription))
           .auditStamp(auditStamp)
           .build();
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -4,6 +4,7 @@ import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGenerator
 
 import com.datahub.util.RecordUtils;
 import com.github.fge.jsonpatch.JsonPatch;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
@@ -62,6 +63,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
           .description(
               String.format(
                   FIELD_DESCRIPTION_ADDED_FORMAT, targetDescription, targetField.getFieldPath()))
+          .parameters(ImmutableMap.of("description", targetDescription))
           .auditStamp(auditStamp)
           .build();
     }
@@ -75,6 +77,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
           .description(
               String.format(
                   FIELD_DESCRIPTION_REMOVED_FORMAT, baseDescription, baseField.getFieldPath()))
+          .parameters(ImmutableMap.of("description", baseDescription))
           .auditStamp(auditStamp)
           .build();
     }
@@ -91,6 +94,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
                   baseField.getFieldPath(),
                   baseDescription,
                   targetDescription))
+          .parameters(ImmutableMap.of("description", targetDescription))
           .auditStamp(auditStamp)
           .build();
     }

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.kafka.hook.event;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGeneratorUtils.getSchemaFieldUrn;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -58,8 +59,7 @@ import com.linkedin.mxe.PlatformEvent;
 import com.linkedin.mxe.PlatformEventHeader;
 import com.linkedin.platform.event.v1.EntityChangeEvent;
 import com.linkedin.platform.event.v1.Parameters;
-import com.linkedin.schema.EditableSchemaMetadata;
-import com.linkedin.schema.SchemaMetadata;
+import com.linkedin.schema.*;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.net.URISyntaxException;
@@ -71,7 +71,7 @@ import org.testng.annotations.Test;
 /**
  * Tests the {@link EntityChangeEventGeneratorHook}.
  *
- * <p>TODO: Include Schema Field Tests, description update tests.
+ * <p>TODO: Include more Schema Field Tests for tags, terms and schema-changes.
  */
 public class EntityChangeEventGeneratorHookTest {
   private static final long EVENT_TIME = 123L;
@@ -677,23 +677,21 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
-    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.ADD,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            newDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.ADD,
+            null,
+            ImmutableMap.of("description", newDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
 
@@ -705,25 +703,23 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
-    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
     event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new DatasetProperties()));
 
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.ADD,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            newDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.ADD,
+            null,
+            ImmutableMap.of("description", newDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
 
@@ -735,25 +731,24 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
-    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
-    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription("Old desc")));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription("Old desc")));
 
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.MODIFY,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            newDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.MODIFY,
+            null,
+            ImmutableMap.of("description", newDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
 
@@ -765,28 +760,25 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
     event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties()));
-    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(oldDescription)));
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(oldDescription)));
 
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.REMOVE,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            oldDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.REMOVE,
+            null,
+            ImmutableMap.of("description", oldDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
-
 
   @Test
   public void testEditableDatasetPropertiesAdd() throws Exception {
@@ -796,23 +788,22 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
-    event.setAspect(GenericRecordUtils.serializeAspect(new EditableDatasetProperties().setDescription(newDescription)));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(
+            new EditableDatasetProperties().setDescription(newDescription)));
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.ADD,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            newDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.ADD,
+            null,
+            ImmutableMap.of("description", newDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
 
@@ -824,25 +815,25 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
-    event.setAspect(GenericRecordUtils.serializeAspect(new EditableDatasetProperties().setDescription(newDescription)));
-    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new EditableDatasetProperties()));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(
+            new EditableDatasetProperties().setDescription(newDescription)));
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(new EditableDatasetProperties()));
 
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.ADD,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            newDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.ADD,
+            null,
+            ImmutableMap.of("description", newDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
 
@@ -854,25 +845,26 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
-    event.setAspect(GenericRecordUtils.serializeAspect(new EditableDatasetProperties().setDescription(newDescription)));
-    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new EditableDatasetProperties().setDescription("Old desc")));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(
+            new EditableDatasetProperties().setDescription(newDescription)));
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(
+            new EditableDatasetProperties().setDescription("Old desc")));
 
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.MODIFY,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            newDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.MODIFY,
+            null,
+            ImmutableMap.of("description", newDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
   }
 
@@ -884,26 +876,172 @@ public class EntityChangeEventGeneratorHookTest {
     event.setAspectName(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME);
     event.setChangeType(ChangeType.UPSERT);
     event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
-    event.setEntityType(DATASET_ENTITY_NAME);
     event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
 
     event.setAspect(GenericRecordUtils.serializeAspect(new EditableDatasetProperties()));
-    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new EditableDatasetProperties().setDescription(oldDescription)));
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(
+            new EditableDatasetProperties().setDescription(oldDescription)));
 
     _entityChangeEventHook.invoke(event);
 
     PlatformEvent platformEvent =
-            createChangeEvent(
-                    DATASET_ENTITY_NAME,
-                    Urn.createFromString(TEST_DATASET_URN),
-                    ChangeCategory.DOCUMENTATION,
-                    ChangeOperation.REMOVE,
-                    null,
-                    ImmutableMap.of(
-                            "description",
-                            oldDescription),
-                    actorUrn);
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.REMOVE,
+            null,
+            ImmutableMap.of("description", oldDescription),
+            actorUrn);
     verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
+  @Test
+  public void testColumnDescriptionChanges() throws Exception {
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(SCHEMA_METADATA_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    SchemaField field1 = new SchemaField().setNativeDataType("string").setFieldPath("c1");
+    SchemaField field2 = new SchemaField().setNativeDataType("string").setFieldPath("c2");
+    SchemaField field3 = new SchemaField().setNativeDataType("string").setFieldPath("c3");
+    SchemaField field4 = new SchemaField().setNativeDataType("string").setFieldPath("c4");
+
+    SchemaFieldArray oldFields = new SchemaFieldArray();
+    SchemaFieldArray newFields = new SchemaFieldArray();
+
+    oldFields.add(field1.clone());
+    newFields.add(field1.clone().setDescription("c1Desc"));
+
+    oldFields.add(field2.clone().setDescription("oldC2Desc"));
+    newFields.add(field2.clone().setDescription("newC2Desc"));
+
+    oldFields.add(field3.clone().setDescription("c3Desc"));
+    newFields.add(field3.clone());
+
+    oldFields.add(field4.clone().setDescription("c4Desc"));
+    newFields.add(field4.clone().setDescription("c4Desc"));
+
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(new SchemaMetadata().setFields(oldFields)));
+    event.setAspect(GenericRecordUtils.serializeAspect(new SchemaMetadata().setFields(newFields)));
+
+    _entityChangeEventHook.invoke(event);
+
+    verifyProducePlatformEvent(
+        _mockClient,
+        createChangeEvent(
+            SCHEMA_FIELD_ENTITY_NAME,
+            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c1"),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.ADD,
+            null,
+            ImmutableMap.of("description", "c1Desc"),
+            actorUrn),
+        false);
+
+    verifyProducePlatformEvent(
+        _mockClient,
+        createChangeEvent(
+            SCHEMA_FIELD_ENTITY_NAME,
+            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c2"),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.MODIFY,
+            null,
+            ImmutableMap.of("description", "newC2Desc"),
+            actorUrn),
+        false);
+
+    verifyProducePlatformEvent(
+        _mockClient,
+        createChangeEvent(
+            SCHEMA_FIELD_ENTITY_NAME,
+            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c3"),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.REMOVE,
+            null,
+            ImmutableMap.of("description", "c3Desc"),
+            actorUrn),
+        true);
+  }
+
+  @Test
+  public void testEditableColumnDescriptionChanges() throws Exception {
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(EDITABLE_SCHEMA_METADATA_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    EditableSchemaFieldInfo field1 = new EditableSchemaFieldInfo().setFieldPath("c1");
+    EditableSchemaFieldInfo field2 = new EditableSchemaFieldInfo().setFieldPath("c2");
+    EditableSchemaFieldInfo field3 = new EditableSchemaFieldInfo().setFieldPath("c3");
+    EditableSchemaFieldInfo field4 = new EditableSchemaFieldInfo().setFieldPath("c4");
+
+    EditableSchemaFieldInfoArray oldFields = new EditableSchemaFieldInfoArray();
+    EditableSchemaFieldInfoArray newFields = new EditableSchemaFieldInfoArray();
+
+    oldFields.add(field1.clone());
+    newFields.add(field1.clone().setDescription("c1Desc"));
+
+    oldFields.add(field2.clone().setDescription("oldC2Desc"));
+    newFields.add(field2.clone().setDescription("newC2Desc"));
+
+    oldFields.add(field3.clone().setDescription("c3Desc"));
+    newFields.add(field3.clone());
+
+    oldFields.add(field4.clone().setDescription("c4Desc"));
+    newFields.add(field4.clone().setDescription("c4Desc"));
+
+    event.setPreviousAspectValue(
+        GenericRecordUtils.serializeAspect(
+            new EditableSchemaMetadata().setEditableSchemaFieldInfo(oldFields)));
+    event.setAspect(
+        GenericRecordUtils.serializeAspect(
+            new EditableSchemaMetadata().setEditableSchemaFieldInfo(newFields)));
+
+    _entityChangeEventHook.invoke(event);
+
+    verifyProducePlatformEvent(
+        _mockClient,
+        createChangeEvent(
+            SCHEMA_FIELD_ENTITY_NAME,
+            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c1"),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.ADD,
+            null,
+            ImmutableMap.of("description", "c1Desc"),
+            actorUrn),
+        false);
+
+    verifyProducePlatformEvent(
+        _mockClient,
+        createChangeEvent(
+            SCHEMA_FIELD_ENTITY_NAME,
+            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c2"),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.MODIFY,
+            null,
+            ImmutableMap.of("description", "newC2Desc"),
+            actorUrn),
+        false);
+
+    verifyProducePlatformEvent(
+        _mockClient,
+        createChangeEvent(
+            SCHEMA_FIELD_ENTITY_NAME,
+            getSchemaFieldUrn(Urn.createFromString(TEST_DATASET_URN), "c3"),
+            ChangeCategory.DOCUMENTATION,
+            ChangeOperation.REMOVE,
+            null,
+            ImmutableMap.of("description", "c3Desc"),
+            actorUrn),
+        true);
   }
 
   private PlatformEvent createChangeEvent(
@@ -946,9 +1084,12 @@ public class EntityChangeEventGeneratorHookTest {
     registry.register(STATUS_ASPECT_NAME, new StatusChangeEventGenerator());
     registry.register(DEPRECATION_ASPECT_NAME, new DeprecationChangeEventGenerator());
     registry.register(DATASET_PROPERTIES_ASPECT_NAME, new DatasetPropertiesChangeEventGenerator());
-    registry.register(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME, new EditableDatasetPropertiesChangeEventGenerator());
+    registry.register(
+        EDITABLE_DATASET_PROPERTIES_ASPECT_NAME,
+        new EditableDatasetPropertiesChangeEventGenerator());
     registry.register(SCHEMA_METADATA_ASPECT_NAME, new SchemaMetadataChangeEventGenerator());
-    registry.register(EDITABLE_SCHEMA_METADATA_ASPECT_NAME, new EditableSchemaMetadataChangeEventGenerator());
+    registry.register(
+        EDITABLE_SCHEMA_METADATA_ASPECT_NAME, new EditableSchemaMetadataChangeEventGenerator());
 
     // Entity Lifecycle change event generators
     registry.register(DATASET_KEY_ASPECT_NAME, new EntityKeyChangeEventGenerator<>());
@@ -993,17 +1134,18 @@ public class EntityChangeEventGeneratorHookTest {
     Mockito.when(datasetSpec.getAspectSpec(eq(DATASET_PROPERTIES_ASPECT_NAME)))
         .thenReturn(mockDatasetProperties);
 
-    AspectSpec mockEditableDatasetProperties = createMockAspectSpec(EditableDatasetProperties.class);
+    AspectSpec mockEditableDatasetProperties =
+        createMockAspectSpec(EditableDatasetProperties.class);
     Mockito.when(datasetSpec.getAspectSpec(eq(EDITABLE_DATASET_PROPERTIES_ASPECT_NAME)))
-            .thenReturn(mockEditableDatasetProperties);
+        .thenReturn(mockEditableDatasetProperties);
 
     AspectSpec mockSchemaMetadata = createMockAspectSpec(SchemaMetadata.class);
     Mockito.when(datasetSpec.getAspectSpec(eq(SCHEMA_METADATA_ASPECT_NAME)))
-            .thenReturn(mockSchemaMetadata);
+        .thenReturn(mockSchemaMetadata);
 
     AspectSpec mockEditableSchemaMetadata = createMockAspectSpec(EditableSchemaMetadata.class);
     Mockito.when(datasetSpec.getAspectSpec(eq(EDITABLE_SCHEMA_METADATA_ASPECT_NAME)))
-            .thenReturn(mockEditableSchemaMetadata);
+        .thenReturn(mockEditableSchemaMetadata);
 
     Mockito.when(registry.getEntitySpec(eq(DATASET_ENTITY_NAME))).thenReturn(datasetSpec);
 

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -898,7 +898,7 @@ public class EntityChangeEventGeneratorHookTest {
   }
 
   @Test
-  public void testColumnDescriptionChanges() throws Exception {
+  public void testSchemaFieldDescriptionChanges() throws Exception {
     MetadataChangeLog event = new MetadataChangeLog();
     event.setEntityType(DATASET_ENTITY_NAME);
     event.setAspectName(SCHEMA_METADATA_ASPECT_NAME);
@@ -970,7 +970,7 @@ public class EntityChangeEventGeneratorHookTest {
   }
 
   @Test
-  public void testEditableColumnDescriptionChanges() throws Exception {
+  public void testEditableSchemaFieldDescriptionChanges() throws Exception {
     MetadataChangeLog event = new MetadataChangeLog();
     event.setEntityType(DATASET_ENTITY_NAME);
     event.setAspectName(EDITABLE_SCHEMA_METADATA_ASPECT_NAME);

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -1168,8 +1168,6 @@ public class EntityChangeEventGeneratorHookTest {
     Mockito.when(registry.getEntitySpec(DATA_PROCESS_INSTANCE_ENTITY_NAME))
         .thenReturn(dataProcessInstanceSpec);
 
-    // Build SchemaField Entity Spec
-
     return TestOperationContexts.systemContextNoSearchAuthorization(registry);
   }
 

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -50,16 +50,7 @@ import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeOperation;
-import com.linkedin.metadata.timeline.eventgenerator.AssertionRunEventChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.DataProcessInstanceRunEventChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.DeprecationChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.EntityChangeEventGeneratorRegistry;
-import com.linkedin.metadata.timeline.eventgenerator.EntityKeyChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.GlobalTagsChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.GlossaryTermsChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.OwnershipChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.SingleDomainChangeEventGenerator;
-import com.linkedin.metadata.timeline.eventgenerator.StatusChangeEventGenerator;
+import com.linkedin.metadata.timeline.eventgenerator.*;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.PlatformEvent;
@@ -675,6 +666,124 @@ public class EntityChangeEventGeneratorHookTest {
     Mockito.verifyNoMoreInteractions(_mockClient);
   }
 
+  @Test
+  public void testDatasetPropertiesAdd() throws Exception {
+    final String newDescription = "New desc";
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
+    _entityChangeEventHook.invoke(event);
+
+    PlatformEvent platformEvent =
+            createChangeEvent(
+                    DATASET_ENTITY_NAME,
+                    Urn.createFromString(TEST_DATASET_URN),
+                    ChangeCategory.DOCUMENTATION,
+                    ChangeOperation.ADD,
+                    null,
+                    ImmutableMap.of(
+                            "description",
+                            newDescription),
+                    actorUrn);
+    verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
+  @Test
+  public void testDatasetDescriptionAdd() throws Exception {
+    final String newDescription = "New desc";
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
+    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new DatasetProperties()));
+
+    _entityChangeEventHook.invoke(event);
+
+    PlatformEvent platformEvent =
+            createChangeEvent(
+                    DATASET_ENTITY_NAME,
+                    Urn.createFromString(TEST_DATASET_URN),
+                    ChangeCategory.DOCUMENTATION,
+                    ChangeOperation.ADD,
+                    null,
+                    ImmutableMap.of(
+                            "description",
+                            newDescription),
+                    actorUrn);
+    verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
+  @Test
+  public void testDatasetDescriptionModify() throws Exception {
+    final String newDescription = "New desc";
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(newDescription)));
+    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription("Old desc")));
+
+    _entityChangeEventHook.invoke(event);
+
+    PlatformEvent platformEvent =
+            createChangeEvent(
+                    DATASET_ENTITY_NAME,
+                    Urn.createFromString(TEST_DATASET_URN),
+                    ChangeCategory.DOCUMENTATION,
+                    ChangeOperation.MODIFY,
+                    null,
+                    ImmutableMap.of(
+                            "description",
+                            newDescription),
+                    actorUrn);
+    verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
+  @Test
+  public void testDatasetDescriptionRemove() throws Exception {
+    final String oldDescription = "Old desc";
+    MetadataChangeLog event = new MetadataChangeLog();
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
+    event.setChangeType(ChangeType.UPSERT);
+    event.setEntityUrn(Urn.createFromString(TEST_DATASET_URN));
+    event.setEntityType(DATASET_ENTITY_NAME);
+    event.setCreated(new AuditStamp().setActor(actorUrn).setTime(EVENT_TIME));
+
+    event.setAspect(GenericRecordUtils.serializeAspect(new DatasetProperties()));
+    event.setPreviousAspectValue(GenericRecordUtils.serializeAspect(new DatasetProperties().setDescription(oldDescription)));
+
+    _entityChangeEventHook.invoke(event);
+
+    PlatformEvent platformEvent =
+            createChangeEvent(
+                    DATASET_ENTITY_NAME,
+                    Urn.createFromString(TEST_DATASET_URN),
+                    ChangeCategory.DOCUMENTATION,
+                    ChangeOperation.REMOVE,
+                    null,
+                    ImmutableMap.of(
+                            "description",
+                            oldDescription),
+                    actorUrn);
+    verifyProducePlatformEvent(_mockClient, platformEvent);
+  }
+
   private PlatformEvent createChangeEvent(
       String entityType,
       Urn entityUrn,
@@ -714,6 +823,7 @@ public class EntityChangeEventGeneratorHookTest {
     registry.register(OWNERSHIP_ASPECT_NAME, new OwnershipChangeEventGenerator());
     registry.register(STATUS_ASPECT_NAME, new StatusChangeEventGenerator());
     registry.register(DEPRECATION_ASPECT_NAME, new DeprecationChangeEventGenerator());
+    registry.register(DATASET_PROPERTIES_ASPECT_NAME, new DatasetPropertiesChangeEventGenerator());
 
     // TODO Add Dataset Schema Field related change generators.
 
@@ -755,6 +865,10 @@ public class EntityChangeEventGeneratorHookTest {
 
     AspectSpec mockDatasetKey = createMockAspectSpec(DatasetKey.class);
     Mockito.when(datasetSpec.getAspectSpec(eq(DATASET_KEY_ASPECT_NAME))).thenReturn(mockDatasetKey);
+
+    AspectSpec mockDatasetProperties = createMockAspectSpec(DatasetProperties.class);
+    Mockito.when(datasetSpec.getAspectSpec(eq(DATASET_PROPERTIES_ASPECT_NAME)))
+        .thenReturn(mockDatasetProperties);
 
     Mockito.when(registry.getEntitySpec(eq(DATASET_ENTITY_NAME))).thenReturn(datasetSpec);
 


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
