### PR TITLE
feat(graphql): log query name if operation name is not provided

### DIFF
--- a/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/SpringQueryContext.java
+++ b/metadata-service/graphql-servlet-impl/src/main/java/com/datahub/graphql/SpringQueryContext.java
@@ -17,6 +17,7 @@ public class SpringQueryContext implements QueryContext {
   private final boolean isAuthenticated;
   private final Authentication authentication;
   private final Authorizer authorizer;
+  @Getter private final String queryName;
   @Nonnull private final OperationContext operationContext;
 
   public SpringQueryContext(
@@ -30,7 +31,7 @@ public class SpringQueryContext implements QueryContext {
     this.authentication = authentication;
     this.authorizer = authorizer;
 
-    String queryName =
+    this.queryName =
         new Parser()
             .parseDocument(jsonQuery).getDefinitions().stream()
                 .filter(def -> def instanceof OperationDefinition)


### PR DESCRIPTION
GraphQL operation name is an optional field only required if multiple operations are present. If not present, use query name for logging.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
