### PR TITLE
fix(docker): use distinct empty env files

### DIFF
--- a/docker/profiles/docker-compose.actions.yml
+++ b/docker/profiles/docker-compose.actions.yml
@@ -5,7 +5,7 @@ x-datahub-actions-service: &datahub-actions-service
   env_file:
     - datahub-actions/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}
-    - ${DATAHUB_LOCAL_ACTIONS_ENV:-empty.env}
+    - ${DATAHUB_LOCAL_ACTIONS_ENV:-empty2.env}
   environment:
     ACTIONS_EXTRA_PACKAGES: ${ACTIONS_EXTRA_PACKAGES:-}
     ACTIONS_CONFIG: ${ACTIONS_CONFIG:-}

--- a/docker/profiles/docker-compose.frontend.yml
+++ b/docker/profiles/docker-compose.frontend.yml
@@ -7,7 +7,7 @@ x-datahub-frontend-service: &datahub-frontend-service
   env_file:
     - datahub-frontend/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}
-    - ${DATAHUB_LOCAL_FRONTEND_ENV:-empty.env}
+    - ${DATAHUB_LOCAL_FRONTEND_ENV:-empty2.env}
   environment: &datahub-frontend-service-env
     KAFKA_BOOTSTRAP_SERVER: broker:29092
   volumes:

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -61,7 +61,7 @@ x-datahub-system-update-service: &datahub-system-update-service
   env_file:
     - datahub-upgrade/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}
-    - ${DATAHUB_LOCAL_SYS_UPDATE_ENV:-empty.env}
+    - ${DATAHUB_LOCAL_SYS_UPDATE_ENV:-empty2.env}
   environment: &datahub-system-update-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *kafka-env]
     SCHEMA_REGISTRY_SYSTEM_UPDATE: ${SCHEMA_REGISTRY_SYSTEM_UPDATE:-true}
@@ -96,7 +96,7 @@ x-datahub-gms-service: &datahub-gms-service
   env_file:
     - datahub-gms/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}
-    - ${DATAHUB_LOCAL_GMS_ENV:-empty.env}
+    - ${DATAHUB_LOCAL_GMS_ENV:-empty2.env}
   environment: &datahub-gms-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env]
     ELASTICSEARCH_QUERY_CUSTOM_CONFIG_ENABLED: true
@@ -147,7 +147,7 @@ x-datahub-mae-consumer-service: &datahub-mae-consumer-service
   env_file:
     - datahub-mae-consumer/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}
-    - ${DATAHUB_LOCAL_MAE_ENV:-empty.env}
+    - ${DATAHUB_LOCAL_MAE_ENV:-empty2.env}
   environment: &datahub-mae-consumer-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *kafka-env]
 
@@ -173,7 +173,7 @@ x-datahub-mce-consumer-service: &datahub-mce-consumer-service
   env_file:
     - datahub-mce-consumer/env/docker.env
     - ${DATAHUB_LOCAL_COMMON_ENV:-empty.env}
-    - ${DATAHUB_LOCAL_MCE_ENV:-empty.env}
+    - ${DATAHUB_LOCAL_MCE_ENV:-empty2.env}
   environment: &datahub-mce-consumer-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env]
 

--- a/docker/profiles/empty.env
+++ b/docker/profiles/empty.env
@@ -1,4 +1,5 @@
-# Docker compose requires that all env_file entries exist.
+# Docker compose requires that all env_file entries exist and
+# are unique.
 # Because we have some optional env_file entries that can be set
 # as environment variables, we need a default file to point at
 # when those are not set.

--- a/docker/profiles/empty2.env
+++ b/docker/profiles/empty2.env
@@ -1,0 +1,1 @@
+# See empty.env.


### PR DESCRIPTION
Fixes support with newer versions of docker compose, which throw an error with our existing setup.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
