### PR TITLE
fix(metadata-service): add PE processor to component scan

### DIFF
--- a/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
@@ -14,6 +14,8 @@ import org.springframework.context.annotation.PropertySource;
 @ComponentScan(
     basePackages = {
       "com.linkedin.metadata.boot",
+      "com.linkedin.metadata.service",
+      "com.datahub.event",
       "com.linkedin.gms.factory.config",
       "com.linkedin.gms.factory.entityregistry",
       "com.linkedin.gms.factory.common",
@@ -34,7 +36,7 @@ import org.springframework.context.annotation.PropertySource;
       "com.linkedin.gms.factory.auth",
       "com.linkedin.gms.factory.search",
       "com.linkedin.gms.factory.secret",
-      "com.linkedin.gms.factory.timeseries"
+      "com.linkedin.gms.factory.timeseries",
     })
 @PropertySource(value = "classpath:/application.yaml", factory = YamlPropertySourceFactory.class)
 @Configuration


### PR DESCRIPTION
datahub-project/datahub#10290 removed `com.linkedin.metadata.service` and `com.datahub.event` from GMS' component scan but these are required in order to instantiate `com.datahub.event.PlatformEventProcessor` when `PE_CONSUMER_ENABLED` is set to `true` for GMS.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
