### PR TITLE
docs(subscriptions): adding docs for assertion level subscriptions on managed DH

### DIFF
--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -93,17 +93,25 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-group-subscriptions.png"/>
 </p>
 
-### Subscribing to an assertion
+### Subscribing to specific assertions
 
 You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view or on the assertion's profile page.
-[screenshot]
+<img width="1149" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/52532e7c-3f48-4d69-af90-a317023eb101">
+<img width="604" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/17a04b48-42ad-481e-a6fb-e43d5b200b09">
+
 
 Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
+<img width="426" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/46d758c5-9a64-4f3b-8392-93794709c077">
+
 You must first remove your dataset-level subscription:
-[screenshot]
+<img width="883" alt="Screenshot 2024-05-14 at 5 49 32 PM" src="https://github.com/datahub-project/datahub/assets/159848059/4eeeab03-5cf6-4ee1-9c14-047a3115f9d7">
+<img width="623" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/42eec31a-061e-45e2-9e63-73708f5d84c7">
+<img width="603" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/8626bc28-21bd-4293-b5e9-8a0f0fe20022">
+
 
 Then select individual assertions you'd like to subscribe to:
-[screenshot]
+<img width="683" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/3bd47614-bbe9-4e76-b0bb-449532b62b0b">
+
 
 
 ## FAQ

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -96,21 +96,21 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
 ### Subscribing to specific assertions
 
 You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view or on the assertion's profile page.
-<img width="1149" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/52532e7c-3f48-4d69-af90-a317023eb101">
-<img width="604" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/17a04b48-42ad-481e-a6fb-e43d5b200b09">
+<img width="1149" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/52532e7c-3f48-4d69-af90-a317023eb101" />
+<img width="604" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/17a04b48-42ad-481e-a6fb-e43d5b200b09" />
 
 
 Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
-<img width="426" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/46d758c5-9a64-4f3b-8392-93794709c077">
+<img width="426" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/46d758c5-9a64-4f3b-8392-93794709c077" />
 
 You must first remove your dataset-level subscription:
-<img width="883" alt="Screenshot 2024-05-14 at 5 49 32 PM" src="https://github.com/datahub-project/datahub/assets/159848059/4eeeab03-5cf6-4ee1-9c14-047a3115f9d7">
-<img width="623" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/42eec31a-061e-45e2-9e63-73708f5d84c7">
-<img width="603" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/8626bc28-21bd-4293-b5e9-8a0f0fe20022">
+<img width="883" alt="Screenshot 2024-05-14 at 5 49 32 PM" src="https://github.com/datahub-project/datahub/assets/159848059/4eeeab03-5cf6-4ee1-9c14-047a3115f9d7" />
+<img width="623" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/42eec31a-061e-45e2-9e63-73708f5d84c7" />
+<img width="603" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/8626bc28-21bd-4293-b5e9-8a0f0fe20022" />
 
 
 Then select individual assertions you'd like to subscribe to:
-<img width="683" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/3bd47614-bbe9-4e76-b0bb-449532b62b0b">
+<img width="683" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/3bd47614-bbe9-4e76-b0bb-449532b62b0b" />
 
 
 

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -93,34 +93,35 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-group-subscriptions.png"/>
 </p>
 
-### Subscribing to individual assertions
+### Subscribing to Assertions
+You can always subscribe to *all* assertions on a table using the steps outlined in the earlier sections. However, in some cases you may want to only be notified about specific assertions on a table. For instance, a table may be used for different sorts of data, segmented by a category column - so there may be several different checks for each category. As a consumer, you may only care about the freshness check that runs on one specific category of this larger table.
 
 You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view:
 <p align="center">
-  <img width="70%" alt="1" src="https://github.com/datahub-project/datahub/assets/159848059/65eac334-66cc-46a1-b32c-9288077ffcce" />
+  <img width="70%" alt="1" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-1.jpg" />
 </p>
 
 Or on the assertion's profile page:
 <p align="center">
-  <img width="70%" alt="2" src="https://github.com/datahub-project/datahub/assets/159848059/d138f33f-08b6-4b25-b4c6-ba7c875d3501" />
+  <img width="70%" alt="2" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-2.jpg" />
 </p>
 
 
 Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
 <p align="center">
-  <img width="70%" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/9ea2715e-04dd-4c23-a894-8ab8ef11064c" />
+  <img width="70%" alt="3" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-unsub-1.jpg" />
 </p>
 
 You must first remove your dataset-level subscription:
 <p align="center">
-  <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/4485704e-bf76-4f68-a992-27a7654b04be" />
-  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/e323da02-9345-4842-b22c-a6be1323f2ac" />
+  <img width="70%" alt="4" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-unsub-2.jpg" />
+  <img width="70%" alt="5" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-unsub-3.jpg" />
 </p>
 
 
 Then select individual assertions you'd like to subscribe to:
 <p align="center">
-  <img width="70%" alt="7" src="https://github.com/datahub-project/datahub/assets/159848059/1b8b855b-62a7-49f0-b544-aad28ae47197" />
+  <img width="70%" alt="7" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-resub-1.jpg" />
 </p>
 
 

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -94,7 +94,7 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
 </p>
 
 ### Subscribing to Assertions
-You can always subscribe to *all* assertions on a table using the steps outlined in the earlier sections. However, in some cases you may want to only be notified about specific assertions on a table. For instance, a table may be used for different sorts of data, segmented by a category column - so there may be several different checks for each category. As a consumer, you may only care about the freshness check that runs on one specific category of this larger table.
+You can always subscribe to _all assertion status changes_ on a table using the steps outlined in the earlier sections. However, in some cases you may want to only be notified about specific assertions on a table. For instance, a table may contain several subsets of information, segmented by a category column - so there may be several different checks for each category. As a consumer, you may only care about the freshness check that runs on one specific category of this larger table.
 
 You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view:
 <p align="center">
@@ -107,7 +107,7 @@ Or on the assertion's profile page:
 </p>
 
 
-Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
+Note: if you are subscribed to all assertions at the dataset level, then you will not be able to **Unsubscribe** from an individual assertion.
 <p align="center">
   <img width="70%" alt="3" src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-assertion-sub-unsub-1.jpg" />
 </p>

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -113,8 +113,8 @@ Note: if you are subscribed to all assertions at the dataset level, then you wil
 
 You must first remove your dataset-level subscription:
 <p align="center">
-  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/7803abb9-e33d-4ac1-a11c-059296cd06a4" />
   <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/74df6d58-fa37-4373-91b2-b73cb7b98172" />
+  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/7803abb9-e33d-4ac1-a11c-059296cd06a4" />
 </p>
 
 

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -1,4 +1,4 @@
-import FeatureAvailability from '@site/src/components/FeatureAvailability';
+<img width="1098" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/222d94f5-ae01-4f55-9ce6-51d67ab2f59f">import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 # Subscriptions & Notifications
 
@@ -93,24 +93,35 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-group-subscriptions.png"/>
 </p>
 
-### Subscribing to specific assertions
+### Subscribing to individual assertions
 
-You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view or on the assertion's profile page.
-<img width="1149" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/52532e7c-3f48-4d69-af90-a317023eb101" />
-<img width="604" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/17a04b48-42ad-481e-a6fb-e43d5b200b09" />
+You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view:
+<p align="center">
+  <img width="70%" alt="1" src="https://github.com/datahub-project/datahub/assets/159848059/195300df-b2b5-4863-972d-dc4b6764f3bc">
+</p>
+
+...or on the assertion's profile page:
+<p align="center">
+  <img width="70%" alt="2" src="https://github.com/datahub-project/datahub/assets/159848059/b2e2446c-18b6-45c7-851b-3d49aabeacae">
+</p>
 
 
 Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
-<img width="426" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/46d758c5-9a64-4f3b-8392-93794709c077" />
+<p align="center">
+  <img width="70%" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/2092928a-ea9c-464a-b691-06e706cdeed0">
+</p>
 
 You must first remove your dataset-level subscription:
-<img width="883" alt="Screenshot 2024-05-14 at 5 49 32 PM" src="https://github.com/datahub-project/datahub/assets/159848059/4eeeab03-5cf6-4ee1-9c14-047a3115f9d7" />
-<img width="623" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/42eec31a-061e-45e2-9e63-73708f5d84c7" />
-<img width="603" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/8626bc28-21bd-4293-b5e9-8a0f0fe20022" />
+<p align="center">
+  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/7803abb9-e33d-4ac1-a11c-059296cd06a4">
+  <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/74df6d58-fa37-4373-91b2-b73cb7b98172">
+</p>
 
 
 Then select individual assertions you'd like to subscribe to:
-<img width="683" alt="image" src="https://github.com/datahub-project/datahub/assets/159848059/3bd47614-bbe9-4e76-b0bb-449532b62b0b" />
+<p align="center">
+  <img width="70%" alt="7" src="https://github.com/datahub-project/datahub/assets/159848059/15c428af-5f9d-4a9d-a178-c2d58835b051">
+</p>
 
 
 

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -93,6 +93,19 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
   <img width="70%"  src="https://raw.githubusercontent.com/datahub-project/static-assets/main/imgs/saas/subscription-and-notification/s_n-group-subscriptions.png"/>
 </p>
 
+### Subscribing to an assertion
+
+You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view or on the assertion's profile page.
+[screenshot]
+
+Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
+You must first remove your dataset-level subscription:
+[screenshot]
+
+Then select individual assertions you'd like to subscribe to:
+[screenshot]
+
+
 ## FAQ
 
 <details>

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -97,30 +97,30 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
 
 You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view:
 <p align="center">
-  <img width="70%" alt="1" src="https://github.com/datahub-project/datahub/assets/159848059/195300df-b2b5-4863-972d-dc4b6764f3bc" />
+  <img width="70%" alt="1" src="https://github.com/datahub-project/datahub/assets/159848059/65eac334-66cc-46a1-b32c-9288077ffcce" />
 </p>
 
-...or on the assertion's profile page:
+Or on the assertion's profile page:
 <p align="center">
-  <img width="70%" alt="2" src="https://github.com/datahub-project/datahub/assets/159848059/b2e2446c-18b6-45c7-851b-3d49aabeacae" />
+  <img width="70%" alt="2" src="https://github.com/datahub-project/datahub/assets/159848059/d138f33f-08b6-4b25-b4c6-ba7c875d3501" />
 </p>
 
 
 Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
 <p align="center">
-  <img width="70%" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/2092928a-ea9c-464a-b691-06e706cdeed0" />
+  <img width="70%" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/9ea2715e-04dd-4c23-a894-8ab8ef11064c" />
 </p>
 
 You must first remove your dataset-level subscription:
 <p align="center">
-  <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/74df6d58-fa37-4373-91b2-b73cb7b98172" />
-  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/7803abb9-e33d-4ac1-a11c-059296cd06a4" />
+  <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/4485704e-bf76-4f68-a992-27a7654b04be" />
+  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/e323da02-9345-4842-b22c-a6be1323f2ac" />
 </p>
 
 
 Then select individual assertions you'd like to subscribe to:
 <p align="center">
-  <img width="70%" alt="7" src="https://github.com/datahub-project/datahub/assets/159848059/15c428af-5f9d-4a9d-a178-c2d58835b051" />
+  <img width="70%" alt="7" src="https://github.com/datahub-project/datahub/assets/159848059/1b8b855b-62a7-49f0-b544-aad28ae47197" />
 </p>
 
 

--- a/docs/managed-datahub/subscription-and-notification.md
+++ b/docs/managed-datahub/subscription-and-notification.md
@@ -1,4 +1,4 @@
-<img width="1098" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/222d94f5-ae01-4f55-9ce6-51d67ab2f59f">import FeatureAvailability from '@site/src/components/FeatureAvailability';
+import FeatureAvailability from '@site/src/components/FeatureAvailability';
 
 # Subscriptions & Notifications
 
@@ -97,30 +97,30 @@ You can view and manage the group’s subscriptions on the group’s page on Dat
 
 You can subscribe to individual assertions by clicking the bell button on the assertion itself - either in the list view:
 <p align="center">
-  <img width="70%" alt="1" src="https://github.com/datahub-project/datahub/assets/159848059/195300df-b2b5-4863-972d-dc4b6764f3bc">
+  <img width="70%" alt="1" src="https://github.com/datahub-project/datahub/assets/159848059/195300df-b2b5-4863-972d-dc4b6764f3bc" />
 </p>
 
 ...or on the assertion's profile page:
 <p align="center">
-  <img width="70%" alt="2" src="https://github.com/datahub-project/datahub/assets/159848059/b2e2446c-18b6-45c7-851b-3d49aabeacae">
+  <img width="70%" alt="2" src="https://github.com/datahub-project/datahub/assets/159848059/b2e2446c-18b6-45c7-851b-3d49aabeacae" />
 </p>
 
 
 Note: if you are subscribed to all assertions at the dataset level, then you will not be able to 'unsubscribe' from an individual assertion.
 <p align="center">
-  <img width="70%" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/2092928a-ea9c-464a-b691-06e706cdeed0">
+  <img width="70%" alt="3" src="https://github.com/datahub-project/datahub/assets/159848059/2092928a-ea9c-464a-b691-06e706cdeed0" />
 </p>
 
 You must first remove your dataset-level subscription:
 <p align="center">
-  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/7803abb9-e33d-4ac1-a11c-059296cd06a4">
-  <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/74df6d58-fa37-4373-91b2-b73cb7b98172">
+  <img width="70%" alt="5" src="https://github.com/datahub-project/datahub/assets/159848059/7803abb9-e33d-4ac1-a11c-059296cd06a4" />
+  <img width="70%" alt="4" src="https://github.com/datahub-project/datahub/assets/159848059/74df6d58-fa37-4373-91b2-b73cb7b98172" />
 </p>
 
 
 Then select individual assertions you'd like to subscribe to:
 <p align="center">
-  <img width="70%" alt="7" src="https://github.com/datahub-project/datahub/assets/159848059/15c428af-5f9d-4a9d-a178-c2d58835b051">
+  <img width="70%" alt="7" src="https://github.com/datahub-project/datahub/assets/159848059/15c428af-5f9d-4a9d-a178-c2d58835b051" />
 </p>
 
 


### PR DESCRIPTION
Preview here: https://docs-website-git-jp-assertion-subs-docs-acryldata.vercel.app/docs/managed-datahub/subscription-and-notification#subscribing-to-individual-assertions

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
