### PR TITLE
fix(ui) Fix preventing users from deleting personal views

### DIFF
--- a/datahub-web-react/src/app/entity/view/menu/ViewDropdownMenu.tsx
+++ b/datahub-web-react/src/app/entity/view/menu/ViewDropdownMenu.tsx
@@ -63,7 +63,7 @@ type Props = {
 export const ViewDropdownMenu = ({
     view,
     visible,
-    isOwnedByUser,
+    isOwnedByUser = view.viewType === DataHubViewType.Personal,
     trigger = 'hover',
     onClickEdit,
     onClickPreview,


### PR DESCRIPTION
There was a bug where we weren't showing the option to delete a personal view from the manage views page in settings because we aren't passing in whether the user is an owner or not. Well, this is determined on whether or not this view is a personal view, so we can default set that value and the problem is solved.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
