### PR TITLE
fix(assertions) aligned graphql AssertionType definition with the AssertionType defined in metadata-models

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -7766,10 +7766,33 @@ enum DatasetAssertionScope {
 }
 
 """
-The top-level assertion type. Currently single Dataset assertions are the only type supported.
+The top-level assertion type.
 """
 enum AssertionType {
+    """
+    A single-dataset assertion.
+    """
     DATASET
+    """
+    An assertion which indicates when a particular operation should occur to an asset.
+    """
+    FRESHNESS
+    """
+    An assertion which indicates how much data should be available for a particular asset.
+    """
+    VOLUME
+    """
+    A raw SQL-statement based assertion.
+    """
+    SQL
+    """
+    A structured assertion targeting a specific column or field of the Dataset.
+    """
+    FIELD
+    """
+    A schema or structural assertion.
+    """
+    DATA_SCHEMA
 }
 
 """

--- a/metadata-models/src/main/pegasus/com/linkedin/assertion/AssertionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/assertion/AssertionInfo.pdl
@@ -38,6 +38,11 @@ record AssertionInfo includes CustomProperties, ExternalReference {
       SQL
 
       /**
+       * A structured assertion targeting a specific column or field of the Dataset.
+       */
+      FIELD
+
+      /**
        * A schema or structural assertion.
        *
        * Would have named this SCHEMA but the codegen for PDL does not allow this (reserved word).


### PR DESCRIPTION
Fixes: https://github.com/datahub-project/datahub/issues/10456

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
