### PR TITLE
fix(smoke-test): pin requests to 2.31.0

### DIFF
--- a/smoke-test/requirements.txt
+++ b/smoke-test/requirements.txt
@@ -16,3 +16,5 @@ ruff==0.0.287
 # stub version are copied from metadata-ingestion/setup.py and that should be the source of truth
 types-requests>=2.28.11.6,<=2.31.0.3
 types-PyYAML
+# https://github.com/docker/docker-py/issues/3256
+requests<=2.31.0


### PR DESCRIPTION
Requests version `2.32.0` breaks Docker client.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
