### PR TITLE
consider all values of FabricType enum in DatasetUrn util

### DIFF
--- a/li-utils/src/main/javaPegasus/com/linkedin/common/urn/UrnUtils.java
+++ b/li-utils/src/main/javaPegasus/com/linkedin/common/urn/UrnUtils.java
@@ -23,7 +23,7 @@ public class UrnUtils {
   @Nonnull
   public static DatasetUrn toDatasetUrn(
       @Nonnull String platformName, @Nonnull String datasetName, @Nonnull String origin) {
-    return new DatasetUrn(new DataPlatformUrn(platformName), datasetName, toFabricType(origin));
+    return new DatasetUrn(new DataPlatformUrn(platformName), datasetName, FabricType.valueOf(origin.toUpperCase()));
   }
 
   /**


### PR DESCRIPTION
Instead of using a statically mapped string -> enum conversion, just use the `Enum.valueOf` when converting from String -> FabricType

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
