### PR TITLE
feat(ingestion/SageMaker): Remove deprecated apis and add stateful ingestion capability

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/common.py
@@ -1,13 +1,22 @@
-from dataclasses import dataclass
-from typing import Dict, Optional, Union
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
 
 from pydantic.fields import Field
 
-from datahub.ingestion.api.source import SourceReport
+from datahub.configuration.source_common import PlatformInstanceConfigMixin
 from datahub.ingestion.source.aws.aws_common import AwsSourceConfig
+from datahub.ingestion.source.state.stale_entity_removal_handler import (
+    StaleEntityRemovalSourceReport,
+    StatefulIngestionConfigBase,
+    StatefulStaleMetadataRemovalConfig,
+)
 
 
-class SagemakerSourceConfig(AwsSourceConfig):
+class SagemakerSourceConfig(
+    AwsSourceConfig,
+    PlatformInstanceConfigMixin,
+    StatefulIngestionConfigBase,
+):
     extract_feature_groups: Optional[bool] = Field(
         default=True, description="Whether to extract feature groups."
     )
@@ -17,6 +26,8 @@ class SagemakerSourceConfig(AwsSourceConfig):
     extract_jobs: Optional[Union[Dict[str, str], bool]] = Field(
         default=True, description="Whether to extract AutoML jobs."
     )
+    # Custom Stateful Ingestion settings
+    stateful_ingestion: Optional[StatefulStaleMetadataRemovalConfig] = None
 
     @property
     def sagemaker_client(self):
@@ -24,7 +35,7 @@ class SagemakerSourceConfig(AwsSourceConfig):
 
 
 @dataclass
-class SagemakerSourceReport(SourceReport):
+class SagemakerSourceReport(StaleEntityRemovalSourceReport):
     feature_groups_scanned = 0
     features_scanned = 0
     endpoints_scanned = 0
@@ -32,6 +43,7 @@ class SagemakerSourceReport(SourceReport):
     models_scanned = 0
     jobs_scanned = 0
     datasets_scanned = 0
+    filtered: List[str] = field(default_factory=list)
 
     def report_feature_group_scanned(self) -> None:
         self.feature_groups_scanned += 1
@@ -53,3 +65,6 @@ class SagemakerSourceReport(SourceReport):
 
     def report_dataset_scanned(self) -> None:
         self.datasets_scanned += 1
+
+    def report_dropped(self, name: str) -> None:
+        self.filtered.append(name)

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/job_classes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/job_classes.py
@@ -1,4 +1,6 @@
-from typing import Dict, Final
+from typing import Dict
+
+from typing_extensions import Final
 
 from datahub.metadata.schema_classes import JobStatusClass
 
@@ -63,8 +65,9 @@ class AutoMlJobInfo(SageMakerJobInfo):
     list_key: Final = "AutoMLJobSummaries"
     list_name_key: Final = "AutoMLJobName"
     list_arn_key: Final = "AutoMLJobArn"
-    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.describe_auto_ml_job
-    describe_command: Final = "describe_auto_ml_job"
+    # DescribeAutoMLJobV2 are new versions of CreateAutoMLJob and DescribeAutoMLJob which offer backward compatibility.
+    # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeAutoMLJobV2.html
+    describe_command: Final = "describe_auto_ml_job_v2"
     describe_name_key: Final = "AutoMLJobName"
     describe_arn_key: Final = "AutoMLJobArn"
     describe_status_key: Final = "AutoMLJobStatus"
@@ -99,28 +102,6 @@ class CompilationJobInfo(SageMakerJobInfo):
         "STOPPED": JobStatusClass.STOPPED,
     }
     processor = "process_compilation_job"
-
-
-class EdgePackagingJobInfo(SageMakerJobInfo):
-    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.list_edge_packaging_jobs
-    list_command: Final = "list_edge_packaging_jobs"
-    list_key: Final = "EdgePackagingJobSummaries"
-    list_name_key: Final = "EdgePackagingJobName"
-    list_arn_key: Final = "EdgePackagingJobArn"
-    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.describe_edge_packaging_job
-    describe_command: Final = "describe_edge_packaging_job"
-    describe_name_key: Final = "EdgePackagingJobName"
-    describe_arn_key: Final = "EdgePackagingJobArn"
-    describe_status_key: Final = "EdgePackagingJobStatus"
-    status_map = {
-        "INPROGRESS": JobStatusClass.IN_PROGRESS,
-        "COMPLETED": JobStatusClass.COMPLETED,
-        "FAILED": JobStatusClass.FAILED,
-        "STARTING": JobStatusClass.STARTING,
-        "STOPPING": JobStatusClass.STOPPING,
-        "STOPPED": JobStatusClass.STOPPED,
-    }
-    processor = "process_edge_packaging_job"
 
 
 class HyperParameterTuningJobInfo(SageMakerJobInfo):

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/jobs.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/jobs.py
@@ -26,7 +26,6 @@ from datahub.ingestion.source.aws.sagemaker_processors.common import (
 from datahub.ingestion.source.aws.sagemaker_processors.job_classes import (
     AutoMlJobInfo,
     CompilationJobInfo,
-    EdgePackagingJobInfo,
     HyperParameterTuningJobInfo,
     LabelingJobInfo,
     ProcessingJobInfo,
@@ -53,7 +52,6 @@ JobInfo = TypeVar(
     "JobInfo",
     AutoMlJobInfo,
     CompilationJobInfo,
-    EdgePackagingJobInfo,
     HyperParameterTuningJobInfo,
     LabelingJobInfo,
     ProcessingJobInfo,
@@ -65,7 +63,6 @@ JobInfo = TypeVar(
 class JobType(Enum):
     AUTO_ML = "auto_ml"
     COMPILATION = "compilation"
-    EDGE_PACKAGING = "edge_packaging"
     HYPER_PARAMETER_TUNING = "hyper_parameter_tuning"
     LABELING = "labeling"
     PROCESSING = "processing"
@@ -78,7 +75,6 @@ job_types = sorted([x for x in JobType], key=lambda x: x.value)
 job_type_to_info: Mapping[JobType, Any] = {
     JobType.AUTO_ML: AutoMlJobInfo(),
     JobType.COMPILATION: CompilationJobInfo(),
-    JobType.EDGE_PACKAGING: EdgePackagingJobInfo(),
     JobType.HYPER_PARAMETER_TUNING: HyperParameterTuningJobInfo(),
     JobType.LABELING: LabelingJobInfo(),
     JobType.PROCESSING: ProcessingJobInfo(),
@@ -416,23 +412,20 @@ class JobProcessor:
         """
         Process outputs from Boto3 describe_auto_ml_job()
 
-        See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.describe_auto_ml_job
+        See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/describe_auto_ml_job_v2.html
         """
 
         JOB_TYPE = JobType.AUTO_ML
 
         input_datasets = {}
-
-        for input_config in job.get("InputDataConfig", []):
+        for input_config in job.get("AutoMLJobInputDataConfig", []):
             input_data = input_config.get("DataSource", {}).get("S3DataSource")
-
             if input_data is not None and "S3Uri" in input_data:
                 input_datasets[make_s3_urn(input_data["S3Uri"], self.env)] = {
                     "dataset_type": "s3",
                     "uri": input_data["S3Uri"],
                     "datatype": input_data.get("S3DataType"),
                 }
-
         output_datasets = {}
 
         output_s3_path = job.get("OutputDataConfig", {}).get("S3OutputPath")
@@ -448,6 +441,18 @@ class JobProcessor:
             JOB_TYPE,
         )
 
+        metrics: Dict[str, Any] = {}
+        # Get job metrics from CandidateMetrics
+        candidate_metrics = (
+            job.get("BestCandidate", {})
+            .get("CandidateProperties", {})
+            .get("CandidateMetrics", [])
+        )
+        if candidate_metrics:
+            metrics = {
+                metric["MetricName"]: metric["Value"] for metric in candidate_metrics
+            }
+
         model_containers = job.get("BestCandidate", {}).get("InferenceContainers", [])
 
         for model_container in model_containers:
@@ -456,7 +461,7 @@ class JobProcessor:
             if model_data_url is not None:
                 job_key = JobKey(job_snapshot.urn, JobDirection.TRAINING)
 
-                self.update_model_image_jobs(model_data_url, job_key)
+                self.update_model_image_jobs(model_data_url, job_key, metrics=metrics)
 
         return SageMakerJob(
             job_name=job_name,
@@ -513,83 +518,6 @@ class JobProcessor:
             job_snapshot=job_snapshot,
             input_datasets=input_datasets,
             output_datasets=output_datasets,
-        )
-
-    def process_edge_packaging_job(
-        self,
-        job: Dict[str, Any],
-    ) -> SageMakerJob:
-        """
-        Process outputs from Boto3 describe_edge_packaging_job()
-
-        See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker.html#SageMaker.Client.describe_edge_packaging_job
-        """
-
-        JOB_TYPE = JobType.EDGE_PACKAGING
-
-        name: str = job["EdgePackagingJobName"]
-        arn: str = job["EdgePackagingJobArn"]
-
-        output_datasets = {}
-
-        model_artifact_s3_uri: Optional[str] = job.get("ModelArtifact")
-        output_s3_uri: Optional[str] = job.get("OutputConfig", {}).get(
-            "S3OutputLocation"
-        )
-
-        if model_artifact_s3_uri is not None:
-            output_datasets[make_s3_urn(model_artifact_s3_uri, self.env)] = {
-                "dataset_type": "s3",
-                "uri": model_artifact_s3_uri,
-            }
-
-        if output_s3_uri is not None:
-            output_datasets[make_s3_urn(output_s3_uri, self.env)] = {
-                "dataset_type": "s3",
-                "uri": output_s3_uri,
-            }
-
-        # from docs: "The name of the SageMaker Neo compilation job that is used to locate model artifacts that are being packaged."
-        compilation_job_name: Optional[str] = job.get("CompilationJobName")
-
-        output_jobs = set()
-        if compilation_job_name is not None:
-            # globally unique job name
-            full_job_name = ("compilation", compilation_job_name)
-
-            if full_job_name in self.name_to_arn:
-                output_jobs.add(
-                    make_sagemaker_job_urn(
-                        "compilation",
-                        compilation_job_name,
-                        self.name_to_arn[full_job_name],
-                        self.env,
-                    )
-                )
-            else:
-                self.report.report_warning(
-                    name,
-                    f"Unable to find ARN for compilation job {compilation_job_name} produced by edge packaging job {arn}",
-                )
-
-        job_snapshot, job_name, job_arn = self.create_common_job_snapshot(
-            job,
-            JOB_TYPE,
-            f"https://{self.aws_region}.console.aws.amazon.com/sagemaker/home?region={self.aws_region}#/edge-packaging-jobs/{job['EdgePackagingJobName']}",
-        )
-
-        if job.get("ModelName") is not None:
-            job_key = JobKey(job_snapshot.urn, JobDirection.DOWNSTREAM)
-
-            self.update_model_name_jobs(job["ModelName"], job_key)
-
-        return SageMakerJob(
-            job_name=job_name,
-            job_arn=job_arn,
-            job_type=JOB_TYPE,
-            job_snapshot=job_snapshot,
-            output_datasets=output_datasets,
-            output_jobs=output_jobs,
         )
 
     def process_hyper_parameter_tuning_job(

--- a/metadata-ingestion/tests/unit/sagemaker/sagemaker_mces_golden.json
+++ b/metadata-ingestion/tests/unit/sagemaker/sagemaker_mces_golden.json
@@ -337,42 +337,6 @@
 {
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "dataset_type": "s3",
-                            "uri": "s3://edge-packaging-bucket/model-artifact.tar.gz"
-                        },
-                        "tags": []
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "dataset_type": "s3",
-                            "uri": "s3://edge-packaging-bucket/output-config.tar.gz"
-                        },
-                        "tags": []
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,labeling-job/data-source.tar_gz,PROD)",
             "aspects": [
                 {
@@ -677,12 +641,11 @@
                         "customProperties": {
                             "AutoMLJobName": "an-auto-ml-job",
                             "AutoMLJobArn": "arn:aws:sagemaker:us-west-2:123412341234:auto-ml-job/an-auto-ml-job",
-                            "InputDataConfig": "[{'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://auto-ml-job-input-bucket/file.txt'}}, 'CompressionType': 'None', 'TargetAttributeName': 'some-name'}]",
+                            "AutoMLJobInputDataConfig": "[{'DataSource': {'S3DataSource': {'S3DataType': 'ManifestFile', 'S3Uri': 's3://auto-ml-job-input-bucket/file.txt'}}, 'CompressionType': 'None'}]",
                             "OutputDataConfig": "{'KmsKeyId': 'some-key-id', 'S3OutputPath': 's3://auto-ml-job-output-bucket/file.txt'}",
                             "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                            "AutoMLJobObjective": "{'MetricName': 'Accuracy'}",
-                            "ProblemType": "BinaryClassification",
-                            "AutoMLJobConfig": "{'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}, 'SecurityConfig': {'VolumeKmsKeyId': 'string', 'EnableInterContainerTrafficEncryption': True, 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}}}",
+                            "ResolvedAttributes": "{'AutoMLJobObjective': {'MetricName': 'Accuracy'}, 'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}, 'AutoMLProblemTypeResolvedAttributes': {'TabularResolvedAttributes': {'ProblemType': 'BinaryClassification'}}}",
+                            "SecurityConfig": "{'VolumeKmsKeyId': 'string', 'EnableInterContainerTrafficEncryption': True, 'VpcConfig': {'SecurityGroupIds': ['string'], 'Subnets': ['string']}}",
                             "CreationTime": "2015-01-01 00:00:00+00:00",
                             "EndTime": "2015-01-01 00:00:00+00:00",
                             "LastModifiedTime": "2015-01-01 00:00:00+00:00",
@@ -691,9 +654,8 @@
                             "BestCandidate": "{'CandidateName': 'string', 'FinalAutoMLJobObjectiveMetric': {'Type': 'Maximize', 'MetricName': 'Accuracy', 'Value': 1.0}, 'ObjectiveStatus': 'Succeeded', 'CandidateSteps': [{'CandidateStepType': 'AWS::SageMaker::TrainingJob', 'CandidateStepArn': 'string', 'CandidateStepName': 'string'}], 'CandidateStatus': 'Completed', 'InferenceContainers': [{'Image': 'string', 'ModelDataUrl': 's3://auto-ml-job/model-artifact.tar.gz', 'Environment': {'string': 'string'}}], 'CreationTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'EndTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'LastModifiedTime': datetime.datetime(2015, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), 'FailureReason': 'string', 'CandidateProperties': {'CandidateArtifactLocations': {'Explainability': 'string'}}}",
                             "AutoMLJobStatus": "Completed",
                             "AutoMLJobSecondaryStatus": "Starting",
-                            "GenerateCandidateDefinitionsOnly": "True",
+                            "AutoMLProblemTypeConfig": "{'TabularJobConfig': {'CandidateGenerationConfig': {'AlgorithmsConfig': [{'AutoMLAlgorithms': ['xgboost']}]}, 'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}, 'FeatureSpecificationS3Uri': 'string', 'Mode': 'AUTO', 'GenerateCandidateDefinitionsOnly': True, 'ProblemType': 'BinaryClassification', 'TargetAttributeName': 'ChannelType', 'SampleWeightAttributeName': 'string'}}",
                             "AutoMLJobArtifacts": "{'CandidateDefinitionNotebookLocation': 'string', 'DataExplorationNotebookLocation': 'string'}",
-                            "ResolvedAttributes": "{'AutoMLJobObjective': {'MetricName': 'Accuracy'}, 'ProblemType': 'BinaryClassification', 'CompletionCriteria': {'MaxCandidates': 123, 'MaxRuntimePerTrainingJobInSeconds': 123, 'MaxAutoMLJobRuntimeInSeconds': 123}}",
                             "ModelDeployConfig": "{'AutoGenerateEndpointName': True, 'EndpointName': 'string'}",
                             "ModelDeployResult": "{'EndpointName': 'string'}",
                             "jobType": "auto_ml"
@@ -790,77 +752,6 @@
                         ],
                         "outputDatasets": [
                             "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)"
-                        ],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)"
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-            "urn": "urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-                        "customProperties": {},
-                        "name": "an-edge-packaging-job"
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "EdgePackagingJobArn": "arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job",
-                            "EdgePackagingJobName": "an-edge-packaging-job",
-                            "CompilationJobName": "a-compilation-job",
-                            "ModelName": "the-second-model",
-                            "ModelVersion": "string",
-                            "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-                            "OutputConfig": "{'S3OutputLocation': 's3://edge-packaging-bucket/output-config.tar.gz', 'KmsKeyId': 'string', 'PresetDeploymentType': 'GreengrassV2Component', 'PresetDeploymentConfig': 'string'}",
-                            "ResourceKey": "string",
-                            "EdgePackagingJobStatus": "STARTING",
-                            "EdgePackagingJobStatusMessage": "string",
-                            "CreationTime": "2015-01-01 00:00:00+00:00",
-                            "LastModifiedTime": "2015-01-01 00:00:00+00:00",
-                            "ModelArtifact": "s3://edge-packaging-bucket/model-artifact.tar.gz",
-                            "ModelSignature": "string",
-                            "PresetDeploymentOutput": "{'Type': 'GreengrassV2Component', 'Artifact': 'arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/some-artifact', 'Status': 'COMPLETED', 'StatusMessage': 'string'}",
-                            "jobType": "edge_packaging"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/edge-packaging-jobs/an-edge-packaging-job",
-                        "name": "an-edge-packaging-job",
-                        "type": {
-                            "string": "SAGEMAKER"
-                        },
-                        "status": "STARTING"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.BrowsePaths": {
-                        "paths": [
-                            "/edge_packaging"
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [
-                            "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
-                            "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)"
                         ],
                         "inputDatajobs": []
                     }
@@ -1343,6 +1234,7 @@
                                 "type": "DATAOWNER"
                             }
                         ],
+                        "ownerTypes": {},
                         "lastModified": {
                             "time": 0,
                             "actor": "urn:li:corpuser:unknown"
@@ -1468,7 +1360,6 @@
                             "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,training:a-training-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:training-job/a-training-job)"
                         ],
                         "downstreamJobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
                             "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,transform:a-transform-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:transform-job/a-transform-job)"
                         ],
                         "groups": [
@@ -1501,17 +1392,6 @@
 {
     "entityType": "dataFlow",
     "entityUrn": "urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataFlow",
-    "entityUrn": "urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -1589,17 +1469,6 @@
 {
     "entityType": "dataJob",
     "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,compilation:a-compilation-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:compilation-job/a-compilation-job)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(sagemaker,edge_packaging:an-edge-packaging-job,PROD),arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -1699,28 +1568,6 @@
 {
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,compilation-job-bucket/output-config.tar_gz,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/model-artifact.tar_gz,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:s3,edge-packaging-bucket/output-config.tar_gz,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/unit/test_sagemaker_source_stubs.py
+++ b/metadata-ingestion/tests/unit/test_sagemaker_source_stubs.py
@@ -116,7 +116,7 @@ list_auto_ml_jobs_response = {
 describe_auto_ml_job_response = {
     "AutoMLJobName": auto_ml_job_name,
     "AutoMLJobArn": auto_ml_job_arn,
-    "InputDataConfig": [
+    "AutoMLJobInputDataConfig": [
         {
             "DataSource": {
                 "S3DataSource": {
@@ -125,7 +125,6 @@ describe_auto_ml_job_response = {
                 }
             },
             "CompressionType": "None",  # 'None'|'Gzip'
-            "TargetAttributeName": "some-name",
         },
     ],
     "OutputDataConfig": {
@@ -133,27 +132,31 @@ describe_auto_ml_job_response = {
         "S3OutputPath": "s3://auto-ml-job-output-bucket/file.txt",
     },
     "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-    "AutoMLJobObjective": {
-        "MetricName": "Accuracy",  # 'Accuracy'|'MSE'|'F1'|'F1macro'|'AUC'
-    },
-    "ProblemType": "BinaryClassification",  # 'BinaryClassification'|'MulticlassClassification'|'Regression'
-    "AutoMLJobConfig": {
+    "ResolvedAttributes": {
+        "AutoMLJobObjective": {
+            "MetricName": "Accuracy",  # 'Accuracy'|'MSE'|'F1'|'F1macro'|'AUC'
+        },
         "CompletionCriteria": {
             "MaxCandidates": 123,
             "MaxRuntimePerTrainingJobInSeconds": 123,
             "MaxAutoMLJobRuntimeInSeconds": 123,
         },
-        "SecurityConfig": {
-            "VolumeKmsKeyId": "string",
-            "EnableInterContainerTrafficEncryption": True,  # True|False
-            "VpcConfig": {
-                "SecurityGroupIds": [
-                    "string",
-                ],
-                "Subnets": [
-                    "string",
-                ],
-            },
+        "AutoMLProblemTypeResolvedAttributes": {
+            "TabularResolvedAttributes": {
+                "ProblemType": "BinaryClassification",  # 'BinaryClassification'|'MulticlassClassification'|'Regression'
+            }
+        },
+    },
+    "SecurityConfig": {
+        "VolumeKmsKeyId": "string",
+        "EnableInterContainerTrafficEncryption": True,  # True|False
+        "VpcConfig": {
+            "SecurityGroupIds": [
+                "string",
+            ],
+            "Subnets": [
+                "string",
+            ],
         },
     },
     "CreationTime": datetime(2015, 1, 1, tzinfo=timezone.utc),
@@ -219,24 +222,36 @@ describe_auto_ml_job_response = {
     # | "ExplainabilityError"
     # | "DeployingModel"
     # | "ModelDeploymentError"
-    "GenerateCandidateDefinitionsOnly": True,  # True | False
+    "AutoMLProblemTypeConfig": {
+        "TabularJobConfig": {
+            "CandidateGenerationConfig": {
+                "AlgorithmsConfig": [
+                    {
+                        "AutoMLAlgorithms": [
+                            "xgboost",  # 'xgboost'|'linear-learner'|'mlp'|'lightgbm'|'catboost'|'randomforest'|'extra-trees'|'nn-torch'|'fastai'
+                        ]
+                    },
+                ]
+            },
+            "CompletionCriteria": {
+                "MaxCandidates": 123,
+                "MaxRuntimePerTrainingJobInSeconds": 123,
+                "MaxAutoMLJobRuntimeInSeconds": 123,
+            },
+            "FeatureSpecificationS3Uri": "string",
+            "Mode": "AUTO",  # "AUTO" | "ENSEMBLING" | "HYPERPARAMETER_TUNING",
+            "GenerateCandidateDefinitionsOnly": True,  # True | False,
+            "ProblemType": "BinaryClassification",
+            # "BinaryClassification"
+            # | "MulticlassClassification"
+            # | "Regression",
+            "TargetAttributeName": "ChannelType",  # ChannelType, ContentType, CompressionType, DataSource
+            "SampleWeightAttributeName": "string",
+        }
+    },
     "AutoMLJobArtifacts": {
         "CandidateDefinitionNotebookLocation": "string",
         "DataExplorationNotebookLocation": "string",
-    },
-    "ResolvedAttributes": {
-        "AutoMLJobObjective": {
-            "MetricName": "Accuracy",  # "Accuracy" | "MSE" | "F1" | "F1macro" | "AUC"
-        },
-        "ProblemType": "BinaryClassification",
-        # "BinaryClassification"
-        # | "MulticlassClassification"
-        # | "Regression",
-        "CompletionCriteria": {
-            "MaxCandidates": 123,
-            "MaxRuntimePerTrainingJobInSeconds": 123,
-            "MaxAutoMLJobRuntimeInSeconds": 123,
-        },
     },
     "ModelDeployConfig": {
         "AutoGenerateEndpointName": True,  # True | False
@@ -309,51 +324,6 @@ describe_compilation_job_response = {
     },
 }
 
-edge_packaging_job_name = "an-edge-packaging-job"
-edge_packaging_job_arn = (
-    "arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/an-edge-packaging-job"
-)
-list_edge_packaging_jobs_response = {
-    "EdgePackagingJobSummaries": [
-        {
-            "EdgePackagingJobName": edge_packaging_job_name,
-            "EdgePackagingJobArn": edge_packaging_job_arn,
-            "EdgePackagingJobStatus": "STARTING",
-            "CompilationJobName": "string",
-            "ModelName": "string",
-            "ModelVersion": "string",
-            "CreationTime": datetime(2015, 1, 1, tzinfo=timezone.utc),
-            "LastModifiedTime": datetime(2015, 1, 1, tzinfo=timezone.utc),
-        },
-    ],
-}
-describe_edge_packaging_job_response = {
-    "EdgePackagingJobArn": edge_packaging_job_arn,
-    "EdgePackagingJobName": edge_packaging_job_name,
-    "CompilationJobName": compilation_job_name,
-    "ModelName": "the-second-model",
-    "ModelVersion": "string",
-    "RoleArn": "arn:aws:iam::123412341234:role/service-role/AmazonSageMakerServiceCatalogProductsUseRole",
-    "OutputConfig": {
-        "S3OutputLocation": "s3://edge-packaging-bucket/output-config.tar.gz",
-        "KmsKeyId": "string",
-        "PresetDeploymentType": "GreengrassV2Component",
-        "PresetDeploymentConfig": "string",
-    },
-    "ResourceKey": "string",
-    "EdgePackagingJobStatus": "STARTING",  # 'STARTING'|'INPROGRESS'|'COMPLETED'|'FAILED'|'STOPPING'|'STOPPED'
-    "EdgePackagingJobStatusMessage": "string",
-    "CreationTime": datetime(2015, 1, 1, tzinfo=timezone.utc),
-    "LastModifiedTime": datetime(2015, 1, 1, tzinfo=timezone.utc),
-    "ModelArtifact": "s3://edge-packaging-bucket/model-artifact.tar.gz",
-    "ModelSignature": "string",
-    "PresetDeploymentOutput": {
-        "Type": "GreengrassV2Component",
-        "Artifact": "arn:aws:sagemaker:us-west-2:123412341234:edge-packaging-job/some-artifact",
-        "Status": "COMPLETED",  # 'COMPLETED'|'FAILED'
-        "StatusMessage": "string",
-    },
-}
 
 hyper_parameter_tuning_job_name = "a-hyper-parameter-tuning-job"
 hyper_parameter_tuning_job_arn = "arn:aws:sagemaker:us-west-2:123412341234:hyper-parameter-tuning-job/a-hyper-parameter-tuning-job"
@@ -1191,11 +1161,6 @@ job_stubs: Mapping[str, Mapping[str, Any]] = {
         "list": list_compilation_jobs_response,
         "describe": describe_compilation_job_response,
         "describe_name": compilation_job_name,
-    },
-    "edge_packaging": {
-        "list": list_edge_packaging_jobs_response,
-        "describe": describe_edge_packaging_job_response,
-        "describe_name": edge_packaging_job_name,
     },
     "hyper_parameter_tuning": {
         "list": list_hyper_parameter_tuning_jobs_response,


### PR DESCRIPTION
This PR has the following improvements:

1. remove deprecated APIs: Amazon Sagemaker Edge retired on April 26th, 2024, so the calls to any edge packaging-related jobs will fail with errors: https://docs.aws.amazon.com/sagemaker/latest/dg/edge-eol.html, we should clean up all edge packaging related code
2. according to https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_DescribeAutoMLJobV2.html, DescribeAutoMLJobV2 are the new versions of CreateAutoMLJob and DescribeAutoMLJob which offer backward compatibility, the PR updates this API call to use this newer API
3. adds stateful ingestion capability to SageMaker ingestion

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
