### PR TITLE
feat(graphql): Support tagging incidents and assertions via GraphQL API 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionMapper.java
@@ -1,7 +1,10 @@
 package com.linkedin.datahub.graphql.types.assertion;
 
+import static com.linkedin.metadata.Constants.GLOBAL_TAGS_ASPECT_NAME;
+
 import com.linkedin.assertion.AssertionInfo;
 import com.linkedin.common.DataPlatformInstance;
+import com.linkedin.common.GlobalTags;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
@@ -20,6 +23,7 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.SchemaFieldRef;
 import com.linkedin.datahub.graphql.types.common.mappers.DataPlatformInstanceAspectMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
@@ -60,6 +64,13 @@ public class AssertionMapper {
     final EnvelopedAspect envelopedStatus = aspects.get(Constants.STATUS_ASPECT_NAME);
     if (envelopedStatus != null) {
       result.setStatus(mapStatus(new Status(envelopedStatus.getValue().data())));
+    }
+
+    final EnvelopedAspect envelopedTags = aspects.get(GLOBAL_TAGS_ASPECT_NAME);
+    if (envelopedTags != null) {
+      result.setTags(
+          GlobalTagsMapper.map(
+              context, new GlobalTags(envelopedTags.getValue().data()), entityUrn));
     }
 
     return result;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/assertion/AssertionType.java
@@ -27,7 +27,9 @@ public class AssertionType
       ImmutableSet.of(
           Constants.ASSERTION_KEY_ASPECT_NAME,
           Constants.ASSERTION_INFO_ASPECT_NAME,
-          Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME);
+          Constants.DATA_PLATFORM_INSTANCE_ASPECT_NAME,
+          Constants.GLOBAL_TAGS_ASPECT_NAME);
+
   private final EntityClient _entityClient;
 
   public AssertionType(final EntityClient entityClient) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/incident/IncidentMapper.java
@@ -1,5 +1,8 @@
 package com.linkedin.datahub.graphql.types.incident;
 
+import static com.linkedin.metadata.Constants.GLOBAL_TAGS_ASPECT_NAME;
+
+import com.linkedin.common.GlobalTags;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.GetMode;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -12,6 +15,7 @@ import com.linkedin.datahub.graphql.generated.IncidentStatus;
 import com.linkedin.datahub.graphql.generated.IncidentType;
 import com.linkedin.datahub.graphql.types.common.mappers.AuditStampMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
+import com.linkedin.datahub.graphql.types.tag.mappers.GlobalTagsMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.entity.EnvelopedAspectMap;
@@ -50,6 +54,14 @@ public class IncidentMapper {
     } else {
       throw new RuntimeException(String.format("Incident does not exist!. urn: %s", entityUrn));
     }
+
+    final EnvelopedAspect envelopedTags = aspects.get(GLOBAL_TAGS_ASPECT_NAME);
+    if (envelopedTags != null) {
+      result.setTags(
+          GlobalTagsMapper.map(
+              context, new GlobalTags(envelopedTags.getValue().data()), entityUrn));
+    }
+
     return result;
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/incident/IncidentType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/incident/IncidentType.java
@@ -23,7 +23,8 @@ import javax.annotation.Nonnull;
 public class IncidentType
     implements com.linkedin.datahub.graphql.types.EntityType<Incident, String> {
 
-  static final Set<String> ASPECTS_TO_FETCH = ImmutableSet.of(Constants.INCIDENT_INFO_ASPECT_NAME);
+  static final Set<String> ASPECTS_TO_FETCH =
+      ImmutableSet.of(Constants.INCIDENT_INFO_ASPECT_NAME, Constants.GLOBAL_TAGS_ASPECT_NAME);
   private final EntityClient _entityClient;
 
   public IncidentType(final EntityClient entityClient) {

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -7294,6 +7294,11 @@ type Assertion implements EntityWithRelationships & Entity {
     status: Status
 
     """
+    The standard tags for the Assertion
+    """
+    tags: GlobalTags
+
+    """
     Experimental API.
     For fetching extra aspects that do not have custom UI code yet
     """

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -108,6 +108,11 @@ type Incident implements Entity {
   created: AuditStamp!
 
   """
+  The standard tags for the Incident
+  """
+  tags: GlobalTags
+
+  """
   List of relationships between the source Entity and some destination entities with a given types
   """
   relationships(input: RelationshipsInput!): EntityRelationshipsResult

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentMapperTest.java
@@ -3,8 +3,12 @@ package com.linkedin.datahub.graphql.types.incident;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociationArray;
 import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.SetMode;
 import com.linkedin.datahub.graphql.generated.EntityType;
@@ -64,9 +68,22 @@ public class IncidentMapperTest {
     incidentInfo.setCreated(created);
 
     envelopedIncidentInfo.setValue(new Aspect(incidentInfo.data()));
+
+    EnvelopedAspect envelopedTagsAspect = new EnvelopedAspect();
+    GlobalTags tags = new GlobalTags();
+    tags.setTags(
+        new TagAssociationArray(
+            new TagAssociationArray(
+                Collections.singletonList(
+                    new com.linkedin.common.TagAssociation()
+                        .setTag(TagUrn.createFromString("urn:li:tag:test"))))));
+    envelopedTagsAspect.setValue(new Aspect(tags.data()));
+
     entityResponse.setAspects(
         new EnvelopedAspectMap(
-            Collections.singletonMap(Constants.INCIDENT_INFO_ASPECT_NAME, envelopedIncidentInfo)));
+            ImmutableMap.of(
+                Constants.INCIDENT_INFO_ASPECT_NAME, envelopedIncidentInfo,
+                Constants.GLOBAL_TAGS_ASPECT_NAME, envelopedTagsAspect)));
 
     Incident incident = IncidentMapper.map(null, entityResponse);
 
@@ -92,5 +109,9 @@ public class IncidentMapperTest {
     assertEquals(incident.getStatus().getLastUpdated().getActor(), userUrn.toString());
     assertEquals(incident.getCreated().getTime().longValue(), 1000L);
     assertEquals(incident.getCreated().getActor(), userUrn.toString());
+
+    assertEquals(incident.getTags().getTags().size(), 1);
+    assertEquals(
+        incident.getTags().getTags().get(0).getTag().getUrn().toString(), "urn:li:tag:test");
   }
 }

--- a/datahub-web-react/src/graphql/assertion.graphql
+++ b/datahub-web-react/src/graphql/assertion.graphql
@@ -48,6 +48,67 @@ fragment assertionDetails on Assertion {
         }
         description
     }
+    tags {
+        ...globalTagsFields
+    }
+}
+
+fragment incrementingSegmentSpecDetails on IncrementingSegmentSpec {
+    field {
+        path
+        type
+        nativeType
+    }
+    transformer {
+        type
+        nativeType
+    }
+}
+
+fragment assertionStdParametersDetails on AssertionStdParameters {
+    value {
+        value
+        type
+    }
+    minValue {
+        value
+        type
+    }
+    maxValue {
+        value
+        type
+    }
+}
+
+fragment assertionResultDetails on AssertionResult {
+    type
+    actualAggValue
+    rowCount
+    missingCount
+    unexpectedCount
+    externalUrl
+    nativeResults {
+        key
+        value
+    }
+    error {
+        type
+        properties {
+            key
+            value
+        }
+    }
+    # acryl only
+    assertion {
+        ...assertionInfo
+    }
+    parameters {
+        ...assertionEvaluationParameters
+    }
+    assertionInferenceDetails {
+        generatedAt
+>>>>>>> 78454d13cd9 (Adding metadata models)
+    }
 }
 
 fragment assertionRunEventDetails on AssertionRunEvent {

--- a/datahub-web-react/src/graphql/assertion.graphql
+++ b/datahub-web-react/src/graphql/assertion.graphql
@@ -53,64 +53,6 @@ fragment assertionDetails on Assertion {
     }
 }
 
-fragment incrementingSegmentSpecDetails on IncrementingSegmentSpec {
-    field {
-        path
-        type
-        nativeType
-    }
-    transformer {
-        type
-        nativeType
-    }
-}
-
-fragment assertionStdParametersDetails on AssertionStdParameters {
-    value {
-        value
-        type
-    }
-    minValue {
-        value
-        type
-    }
-    maxValue {
-        value
-        type
-    }
-}
-
-fragment assertionResultDetails on AssertionResult {
-    type
-    actualAggValue
-    rowCount
-    missingCount
-    unexpectedCount
-    externalUrl
-    nativeResults {
-        key
-        value
-    }
-    error {
-        type
-        properties {
-            key
-            value
-        }
-    }
-    # acryl only
-    assertion {
-        ...assertionInfo
-    }
-    parameters {
-        ...assertionEvaluationParameters
-    }
-    assertionInferenceDetails {
-        generatedAt
->>>>>>> 78454d13cd9 (Adding metadata models)
-    }
-}
-
 fragment assertionRunEventDetails on AssertionRunEvent {
     timestampMillis
     assertionUrn

--- a/datahub-web-react/src/graphql/incident.graphql
+++ b/datahub-web-react/src/graphql/incident.graphql
@@ -25,7 +25,7 @@ fragment incidentsFields on EntityIncidentsResult {
             actor
         }
         tags {
-        ...globalTagsFields
+            ...globalTagsFields
         }
     }
 }

--- a/datahub-web-react/src/graphql/incident.graphql
+++ b/datahub-web-react/src/graphql/incident.graphql
@@ -24,6 +24,9 @@ fragment incidentsFields on EntityIncidentsResult {
             time
             actor
         }
+        tags {
+        ...globalTagsFields
+        }
     }
 }
 

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -295,6 +295,7 @@ entities:
       - assertionRunEvent
       - assertionActions
       - status
+      - globalTags
   - name: dataHubRetention
     category: internal
     keyAspect: dataHubRetentionKey
@@ -464,6 +465,7 @@ entities:
     keyAspect: incidentKey
     aspects:
       - incidentInfo
+      - globalTags
   - name: dataHubRole
     category: core
     keyAspect: dataHubRoleKey


### PR DESCRIPTION
This will enable us to find assertions and incidents by tags applied via API!

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
