### PR TITLE
fix(mae-consumer): fix UpdateIndicesHook ignoring events with forceIndexing property set to true

### DIFF
--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/hook/UpdateIndicesHook.java
@@ -60,7 +60,8 @@ public class UpdateIndicesHook implements MetadataChangeLogHook {
   public void invoke(@Nonnull final MetadataChangeLog event) {
     if (event.getSystemMetadata() != null) {
       if (event.getSystemMetadata().getProperties() != null) {
-        if (UI_SOURCE.equals(event.getSystemMetadata().getProperties().get(APP_SOURCE))
+        if (!Boolean.parseBoolean(event.getSystemMetadata().getProperties().get(FORCE_INDEXING_KEY))
+            && UI_SOURCE.equals(event.getSystemMetadata().getProperties().get(APP_SOURCE))
             && !reprocessUIEvents) {
           // If coming from the UI, we pre-process the Update Indices hook as a fast path to avoid
           // Kafka lag


### PR DESCRIPTION
When the forceIndexing property is set to true, the UpdateIndicesHook should never ignore an event...the current logic is causing missing entities in the search index when using the restore indices job...

See here on Slack for details: https://datahubspace.slack.com/archives/C029A3M079U/p1716563376088529?thread_ts=1715145976.054479&cid=C029A3M079U

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
