### PR TITLE
fix(views): Add relationship annotation to GlobalViewsSettings urn

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/settings/global/GlobalViewsSettings.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/settings/global/GlobalViewsSettings.pdl
@@ -9,5 +9,9 @@ record GlobalViewsSettings {
   /**
    * The default View for the instance, or organization.
    */
+   @Relationship = {
+      "name": "viewedWith",
+      "entityTypes": [ "dataHubView" ]
+   }
    defaultView: optional Urn
 }

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/ViewService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/ViewService.java
@@ -11,12 +11,14 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.entity.AspectUtils;
 import com.linkedin.metadata.key.DataHubViewKey;
 import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.view.DataHubViewDefinition;
 import com.linkedin.view.DataHubViewInfo;
 import com.linkedin.view.DataHubViewType;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -177,7 +179,7 @@ public class ViewService extends BaseService {
     try {
       this.entityClient.deleteEntity(
           opContext, Objects.requireNonNull(viewUrn, "viewUrn must not be null"));
-      
+
       // Asynchronously delete all references to the entity (to return quickly)
       CompletableFuture.runAsync(
           () -> {

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/ViewService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/ViewService.java
@@ -177,6 +177,20 @@ public class ViewService extends BaseService {
     try {
       this.entityClient.deleteEntity(
           opContext, Objects.requireNonNull(viewUrn, "viewUrn must not be null"));
+      
+      // Asynchronously delete all references to the entity (to return quickly)
+      CompletableFuture.runAsync(
+          () -> {
+            try {
+              this.entityClient.deleteEntityReferences(opContext, viewUrn);
+            } catch (RemoteInvocationException e) {
+              log.error(
+                  String.format(
+                      "Caught exception while attempting to clear all entity references for view with urn %s",
+                      viewUrn),
+                  e);
+            }
+          });
     } catch (Exception e) {
       throw new RuntimeException(String.format("Failed to delete View with urn %s", viewUrn), e);
     }


### PR DESCRIPTION
Adds relationship annotation to `GlobalViewsSettings`'s `defaultView` property & executes referential delete in `ViewService`. 

This is to delete by reference modification when deleting Views that were assigned as the default.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
