### PR TITLE
fix(ingest): only populate audit stamps where accurate

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/metabase.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metabase.py
@@ -441,7 +441,7 @@ class MetabaseSource(StatefulIngestionSourceBase):
             f"{last_edit_by.get('timestamp')}"
         )
         last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=modified_ts, actor=modified_actor),
+            created=None,
             lastModified=AuditStamp(time=modified_ts, actor=modified_actor),
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redash.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redash.py
@@ -694,7 +694,7 @@ class RedashSource(Source):
         title = f"{query_data.get('name')} {viz_data.get('name', '')}"
 
         last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=modified_ts, actor=modified_actor),
+            created=None,
             lastModified=AuditStamp(time=modified_ts, actor=modified_actor),
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redash.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redash.py
@@ -555,7 +555,7 @@ class RedashSource(Source):
         title = dashboard_data.get("name", "")
 
         last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=modified_ts, actor=modified_actor),
+            created=None,
             lastModified=AuditStamp(time=modified_ts, actor=modified_actor),
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -800,11 +800,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
             lastModified=(
                 TimeStamp(time=int(table.last_altered.timestamp() * 1000))
                 if table.last_altered
-                else (
-                    TimeStamp(time=int(table.created.timestamp() * 1000))
-                    if table.created
-                    else None
-                )
+                else None
             ),
             description=table.comment,
             qualifiedName=str(datahub_dataset_name),

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -762,11 +762,7 @@ class SnowflakeSchemaGenerator(
             lastModified=(
                 TimeStamp(time=int(table.last_altered.timestamp() * 1000))
                 if table.last_altered is not None
-                else (
-                    TimeStamp(time=int(table.created.timestamp() * 1000))
-                    if table.created is not None
-                    else None
-                )
+                else None
             ),
             description=table.comment,
             qualifiedName=f"{db_name}.{schema_name}.{table.name}",

--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -273,11 +273,9 @@ class SupersetSource(StatefulIngestionSourceBase):
             dp.parse(dashboard_data.get("changed_on_utc", "now")).timestamp() * 1000
         )
         title = dashboard_data.get("dashboard_title", "")
-        # note: the API does not currently supply created_by usernames due to a bug, but we are required to
-        # provide a created AuditStamp to comply with ChangeAuditStamp model. For now, I sub in the last
-        # modified actor urn
+        # note: the API does not currently supply created_by usernames due to a bug
         last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=modified_ts, actor=modified_actor),
+            created=None,
             lastModified=AuditStamp(time=modified_ts, actor=modified_actor),
         )
         dashboard_url = f"{self.config.display_uri}{dashboard_data.get('url', '')}"
@@ -380,11 +378,9 @@ class SupersetSource(StatefulIngestionSourceBase):
         )
         title = chart_data.get("slice_name", "")
 
-        # note: the API does not currently supply created_by usernames due to a bug, but we are required to
-        # provide a created AuditStamp to comply with ChangeAuditStamp model. For now, I sub in the last
-        # modified actor urn
+        # note: the API does not currently supply created_by usernames due to a bug
         last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=modified_ts, actor=modified_actor),
+            created=None,
             lastModified=AuditStamp(time=modified_ts, actor=modified_actor),
         )
         chart_type = chart_type_from_viz_type.get(chart_data.get("viz_type", ""))

--- a/metadata-ingestion/tests/integration/metabase/metabase_mces_golden.json
+++ b/metadata-ingestion/tests/integration/metabase/metabase_mces_golden.json
@@ -15,8 +15,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1639417592792,
-                                "actor": "urn:li:corpuser:admin@metabase.com"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1639417592792,
@@ -82,8 +82,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1636614000000,
-                                "actor": "urn:li:corpuser:admin@metabase.com"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1636614000000,
@@ -140,8 +140,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1685628119636,
-                                "actor": "urn:li:corpuser:john.doe@example.com"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1685628119636,

--- a/metadata-ingestion/tests/integration/superset/golden_test_ingest.json
+++ b/metadata-ingestion/tests/integration/superset/golden_test_ingest.json
@@ -28,8 +28,8 @@
                         "datasets": [],
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_1"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -44,7 +44,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "superset-test"
+        "runId": "superset-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -74,8 +75,8 @@
                         "datasets": [],
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_2"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -90,7 +91,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "superset-test"
+        "runId": "superset-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -114,8 +116,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_1"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -136,7 +138,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "superset-test"
+        "runId": "superset-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -160,8 +163,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_1"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -182,7 +185,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "superset-test"
+        "runId": "superset-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -206,8 +210,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_2"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -228,7 +232,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "superset-test"
+        "runId": "superset-test",
+        "lastRunId": "no-run-id-provided"
     }
 },
 {
@@ -252,8 +257,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_2"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -274,7 +279,8 @@
     },
     "systemMetadata": {
         "lastObserved": 1586847600000,
-        "runId": "superset-test"
+        "runId": "superset-test",
+        "lastRunId": "no-run-id-provided"
     }
 }
 ]

--- a/metadata-ingestion/tests/integration/superset/golden_test_stateful_ingest.json
+++ b/metadata-ingestion/tests/integration/superset/golden_test_stateful_ingest.json
@@ -28,8 +28,8 @@
                         "datasets": [],
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_1"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -70,8 +70,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_1"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -118,8 +118,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_1"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -166,8 +166,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_2"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,
@@ -214,8 +214,8 @@
                         "description": "",
                         "lastModified": {
                             "created": {
-                                "time": 1586847600000,
-                                "actor": "urn:li:corpuser:test_username_2"
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             },
                             "lastModified": {
                                 "time": 1586847600000,

--- a/metadata-ingestion/tests/unit/test_redash_source.py
+++ b/metadata-ingestion/tests/unit/test_redash_source.py
@@ -489,9 +489,7 @@ def test_get_dashboard_snapshot_before_v10():
                 ],
                 datasets=[],
                 lastModified=ChangeAuditStamps(
-                    created=AuditStamp(
-                        time=1628882055288, actor="urn:li:corpuser:unknown"
-                    ),
+                    created=None,
                     lastModified=AuditStamp(
                         time=1628882055288, actor="urn:li:corpuser:unknown"
                     ),
@@ -521,9 +519,7 @@ def test_get_dashboard_snapshot_after_v10():
                 ],
                 datasets=[],
                 lastModified=ChangeAuditStamps(
-                    created=AuditStamp(
-                        time=1628882055288, actor="urn:li:corpuser:unknown"
-                    ),
+                    created=None,
                     lastModified=AuditStamp(
                         time=1628882055288, actor="urn:li:corpuser:unknown"
                     ),
@@ -551,9 +547,7 @@ def test_get_known_viz_chart_snapshot(mocked_data_source):
                 title="My Query Chart",
                 description="",
                 lastModified=ChangeAuditStamps(
-                    created=AuditStamp(
-                        time=1628882022544, actor="urn:li:corpuser:unknown"
-                    ),
+                    created=None,
                     lastModified=AuditStamp(
                         time=1628882022544, actor="urn:li:corpuser:unknown"
                     ),
@@ -584,9 +578,7 @@ def test_get_unknown_viz_chart_snapshot(mocked_data_source):
                 title="My Query Sankey",
                 description="",
                 lastModified=ChangeAuditStamps(
-                    created=AuditStamp(
-                        time=1628882009571, actor="urn:li:corpuser:unknown"
-                    ),
+                    created=None,
                     lastModified=AuditStamp(
                         time=1628882009571, actor="urn:li:corpuser:unknown"
                     ),
@@ -711,9 +703,7 @@ def test_get_chart_snapshot_parse_table_names_from_sql(mocked_data_source):
                 title="My Query Chart",
                 description="",
                 lastModified=ChangeAuditStamps(
-                    created=AuditStamp(
-                        time=1628882022544, actor="urn:li:corpuser:unknown"
-                    ),
+                    created=None,
                     lastModified=AuditStamp(
                         time=1628882022544, actor="urn:li:corpuser:unknown"
                     ),


### PR DESCRIPTION
We used to use created as a fallback for lastModified (or vice versa). This fixes that up across our warehouse and BI sources, so that we can actually trust the info in the model.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized the `created` field to `None` across multiple sources and schemas (Metabase, Redash, Redshift, Snowflake, Superset) for consistency and due to missing `created_by` data.

- **Tests**
  - Updated test data and logic to reflect the changes in `created` field handling, ensuring accuracy in test scenarios for Metabase, Superset, and Redash integration tests.

- **Chores**
  - Cleaned up conditional checks and simplified logic for setting `lastModified` properties in various ingestion sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->