### PR TITLE
docs(ingest): remove trailing comma on athena permission

### DIFF
--- a/metadata-ingestion/docs/sources/athena/athena_pre.md
+++ b/metadata-ingestion/docs/sources/athena/athena_pre.md
@@ -35,7 +35,7 @@ In order to execute this source, you will need to create a policy with below per
         "glue:GetPartitions", 
         "s3:GetObject",
         "s3:ListBucket",
-        "s3:GetBucketLocation",
+        "s3:GetBucketLocation"
       ],
       "Resource": [
         "arn:aws:athena:${region-id}:${account-id}:datacatalog/*",

--- a/metadata-ingestion/docs/sources/athena/athena_pre.md
+++ b/metadata-ingestion/docs/sources/athena/athena_pre.md
@@ -64,7 +64,7 @@ In order to execute this source, you will need to create a policy with below per
         "arn:aws:s3:::${athena-query-result-bucket}/*",
         "arn:aws:s3:::${athena-query-result-bucket}"
       ]
-    },
+    }
   ]
 }
 ```


### PR DESCRIPTION
Policy copy-and-paste is not working properly because of the trailing comma in the example.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
