### PR TITLE
fix(FieldNameAliases): make sure to process aliases when generating type mapping

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/models/EntitySpec.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/EntitySpec.java
@@ -58,6 +58,13 @@ public interface EntitySpec {
         fieldSet.add(SearchableAnnotation.FieldType.BOOLEAN);
         fieldSpecMap.put(fieldName, fieldSet);
       }
+      if (searchableAnnotation.getFieldNameAliases() != null && !searchableAnnotation.getFieldNameAliases().isEmpty()) {
+        for (String fieldName : searchableAnnotation.getFieldNameAliases()) {
+          Set<SearchableAnnotation.FieldType> fieldSet = new HashSet<>();
+          fieldSet.add(searchableAnnotation.getFieldType());
+          fieldSpecMap.put(fieldName, fieldSet);
+        }
+      }
     }
     fieldSpecMap.putAll(
         getSearchableFieldSpecs().stream()


### PR DESCRIPTION
We support Aliases but they were never loaded into the type mapping. this presented a challenge when using aliases for filtering- the filter would not be produced correctly. This PR fixes things.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
