### PR TITLE
fix: update use of autocomplete query instead of search query

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/DomainParentSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/DomainParentSelect.tsx
@@ -56,7 +56,7 @@ export default function DomainParentSelect({ selectedParentUrn, setSelectedParen
     });
     const domainSearchResultsFiltered =
         isMoving && domainUrn
-            ? searchResults.filter((r) => filterResultsForMove(r.entity as Domain, domainUrn))
+            ? searchResults.filter((r) => filterResultsForMove(r as Domain, domainUrn))
             : searchResults;
 
     function selectDomain(domain: Domain) {
@@ -89,10 +89,10 @@ export default function DomainParentSelect({ selectedParentUrn, setSelectedParen
                 dropdownStyle={isShowingDomainNavigator || !searchQuery ? { display: 'none' } : {}}
             >
                 {domainSearchResultsFiltered.map((result) => (
-                    <Select.Option key={result?.entity?.urn} value={result.entity.urn}>
+                    <Select.Option key={result?.urn} value={result.urn}>
                         <SearchResultContainer>
-                            <ParentEntities parentEntities={getParentDomains(result.entity, entityRegistry)} />
-                            {entityRegistry.getDisplayName(result.entity.type, result.entity)}
+                            <ParentEntities parentEntities={getParentDomains(result, entityRegistry)} />
+                            {entityRegistry.getDisplayName(result.type, result)}
                         </SearchResultContainer>
                     </Select.Option>
                 ))}

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/NodeParentSelect.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/NodeParentSelect.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Select } from 'antd';
 import styled from 'styled-components';
-import { EntityType, GlossaryNode, SearchResult } from '../../../../types.generated';
+import { EntityType, GlossaryNode } from '../../../../types.generated';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { useEntityData } from '../EntityContext';
 import ClickOutside from '../../../shared/ClickOutside';
@@ -55,9 +55,9 @@ function NodeParentSelect(props: Props) {
         setSelectedParentUrn,
     });
 
-    const nodeSearchResults: SearchResult[] = searchResults.filter((r) =>
-        filterResultsForMove(r.entity as GlossaryNode, entityDataUrn),
-    );
+    const nodeSearchResults = isMoving
+        ? searchResults.filter((r) => filterResultsForMove(r as GlossaryNode, entityDataUrn))
+        : searchResults;
 
     const isShowingGlossaryBrowser = !searchQuery && isFocusedOnInput;
     const shouldHideSelf = isMoving && entityType === EntityType.GlossaryNode;
@@ -77,12 +77,9 @@ function NodeParentSelect(props: Props) {
                 autoFocus={props.autofocus}
             >
                 {nodeSearchResults?.map((result) => (
-                    <Select.Option key={result?.entity?.urn} value={result.entity.urn}>
-                        <SearchResultContainer>
-                            <ParentEntities parentEntities={getParentGlossary(result.entity, entityRegistry)} />
-                            {entityRegistry.getDisplayName(result.entity.type, result.entity)}
-                        </SearchResultContainer>
-                    </Select.Option>
+                    <Select.Option key={result?.urn} value={result.urn}>
+                    {entityRegistry.getDisplayName(result.type, result)}
+                </Select.Option>
                 ))}
             </Select>
             <BrowserWrapper isHidden={!isShowingGlossaryBrowser}>

--- a/datahub-web-react/src/app/entity/shared/EntityDropdown/useParentSelector.ts
+++ b/datahub-web-react/src/app/entity/shared/EntityDropdown/useParentSelector.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useGetSearchResultsLazyQuery } from '../../../../graphql/search.generated';
+import { useGetAutoCompleteResultsLazyQuery } from '../../../../graphql/search.generated';
 import { EntityType } from '../../../../types.generated';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import { GenericEntityProperties } from '../types';
@@ -17,8 +17,8 @@ export default function useParentSelector({ entityType, entityData, selectedPare
     const [searchQuery, setSearchQuery] = useState('');
     const entityRegistry = useEntityRegistry();
 
-    const [search, { data }] = useGetSearchResultsLazyQuery();
-    const searchResults = data?.search?.searchResults || [];
+    const [getAutoCompleteResults, { data: autoCompleteResultsValue }] = useGetAutoCompleteResultsLazyQuery();
+    const searchResults = autoCompleteResultsValue?.autoComplete?.entities || [];
 
     useEffect(() => {
         if (entityData && selectedParentUrn === entityData.urn) {
@@ -29,23 +29,24 @@ export default function useParentSelector({ entityType, entityData, selectedPare
 
     function handleSearch(text: string) {
         setSearchQuery(text);
-        search({
-            variables: {
-                input: {
-                    type: entityType,
-                    query: text,
-                    start: 0,
-                    count: 5,
+        if (text) {
+            getAutoCompleteResults({
+                variables: {
+                    input: {
+                        type: entityType,
+                        query: text,
+                        limit: 5,
+                    },
                 },
-            },
-        });
+            });
+        };
     }
 
     function onSelectParent(parentUrn: string) {
-        const selectedParent = searchResults.find((result) => result.entity.urn === parentUrn);
+        const selectedParent = searchResults.find((result) => result.urn === parentUrn);
         if (selectedParent) {
             setSelectedParentUrn(parentUrn);
-            const displayName = entityRegistry.getDisplayName(selectedParent.entity.type, selectedParent.entity);
+            const displayName = entityRegistry.getDisplayName(selectedParent.type, selectedParent);
             setSelectedParentName(displayName);
         }
     }


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
https://linear.app/acryl-data/issue/APPT-44/modal-autocomplete-use-autocomplete-query-over-search-query-[domain
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

Related PR
https://github.com/acryldata/datahub-fork/pull/3278
