### PR TITLE
Use type: string for enum schemas

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
@@ -440,29 +440,28 @@ public class OpenAPIV3Generator {
                   // Set enums to "string".
                   if (s.getEnum() != null && !s.getEnum().isEmpty()) {
                     s.setType("string");
-                    return;
+                  } else {
+                    Set<String> requiredNames =
+                            Optional.ofNullable(s.getRequired())
+                                    .map(names -> Set.copyOf(names))
+                                    .orElse(new HashSet());
+                    Map<String, Schema> properties =
+                            Optional.ofNullable(s.getProperties()).orElse(new HashMap<>());
+                    properties.forEach(
+                            (name, schema) -> {
+                              String $ref = schema.get$ref();
+                              boolean isNameRequired = requiredNames.contains(name);
+                              if ($ref != null && !isNameRequired) {
+                                // A non-required $ref property must be wrapped in a { allOf: [ $ref ] }
+                                // object to allow the
+                                // property to be marked as nullable
+                                schema.setType(TYPE_OBJECT);
+                                schema.set$ref(null);
+                                schema.setAllOf(List.of(new Schema().$ref($ref)));
+                              }
+                              schema.setNullable(!isNameRequired);
+                            });
                   }
-                  Set<String> requiredNames =
-                      Optional.ofNullable(s.getRequired())
-                          .map(names -> Set.copyOf(names))
-                          .orElse(new HashSet());
-                  Map<String, Schema> properties =
-                      Optional.ofNullable(s.getProperties()).orElse(new HashMap<>());
-                  properties.forEach(
-                      (name, schema) -> {
-                        String $ref = schema.get$ref();
-                        boolean isNameRequired = requiredNames.contains(name);
-                        if ($ref != null && !isNameRequired) {
-                          // A non-required $ref property must be wrapped in a { allOf: [ $ref ] }
-                          // object to allow the
-                          // property to be marked as nullable
-                          schema.setType(TYPE_OBJECT);
-                          schema.set$ref(null);
-                          schema.setAllOf(List.of(new Schema().$ref($ref)));
-                        }
-                        schema.setNullable(!isNameRequired);
-                      });
-
                   components.addSchemas(n, s);
                 } catch (Exception e) {
                   throw new RuntimeException(e);

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
@@ -442,25 +442,25 @@ public class OpenAPIV3Generator {
                     s.setType("string");
                   } else {
                     Set<String> requiredNames =
-                            Optional.ofNullable(s.getRequired())
-                                    .map(names -> Set.copyOf(names))
-                                    .orElse(new HashSet());
+                        Optional.ofNullable(s.getRequired())
+                            .map(names -> Set.copyOf(names))
+                            .orElse(new HashSet());
                     Map<String, Schema> properties =
-                            Optional.ofNullable(s.getProperties()).orElse(new HashMap<>());
+                        Optional.ofNullable(s.getProperties()).orElse(new HashMap<>());
                     properties.forEach(
-                            (name, schema) -> {
-                              String $ref = schema.get$ref();
-                              boolean isNameRequired = requiredNames.contains(name);
-                              if ($ref != null && !isNameRequired) {
-                                // A non-required $ref property must be wrapped in a { allOf: [ $ref ] }
-                                // object to allow the
-                                // property to be marked as nullable
-                                schema.setType(TYPE_OBJECT);
-                                schema.set$ref(null);
-                                schema.setAllOf(List.of(new Schema().$ref($ref)));
-                              }
-                              schema.setNullable(!isNameRequired);
-                            });
+                        (name, schema) -> {
+                          String $ref = schema.get$ref();
+                          boolean isNameRequired = requiredNames.contains(name);
+                          if ($ref != null && !isNameRequired) {
+                            // A non-required $ref property must be wrapped in a { allOf: [ $ref ] }
+                            // object to allow the
+                            // property to be marked as nullable
+                            schema.setType(TYPE_OBJECT);
+                            schema.set$ref(null);
+                            schema.setAllOf(List.of(new Schema().$ref($ref)));
+                          }
+                          schema.setNullable(!isNameRequired);
+                        });
                   }
                   components.addSchemas(n, s);
                 } catch (Exception e) {

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v3/OpenAPIV3Generator.java
@@ -437,6 +437,11 @@ public class OpenAPIV3Generator {
                   final String newDefinition =
                       definition.replaceAll("definitions", "components/schemas");
                   Schema s = Json.mapper().readValue(newDefinition, Schema.class);
+                  // Set enums to "string".
+                  if (s.getEnum() != null && !s.getEnum().isEmpty()) {
+                    s.setType("string");
+                    return;
+                  }
                   Set<String> requiredNames =
                       Optional.ofNullable(s.getRequired())
                           .map(names -> Set.copyOf(names))

--- a/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/OpenAPIV3GeneratorTest.java
+++ b/metadata-service/openapi-servlet/src/test/java/io/datahubproject/openapi/v3/OpenAPIV3GeneratorTest.java
@@ -83,5 +83,10 @@ public class OpenAPIV3GeneratorTest {
         List.of(new Schema().$ref("#/components/schemas/SystemMetadata")),
         systemMetadata.getAllOf());
     assertTrue(systemMetadata.getNullable());
+
+    // Assert enum property is string.
+    Schema fabricType = openAPI.getComponents().getSchemas().get("FabricType");
+    assertEquals("string", fabricType.getType());
+    assertFalse(fabricType.getEnum().isEmpty());
   }
 }


### PR DESCRIPTION
Enum in `openapi` should be modeled as `type: "string"`, not "object"

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
