### PR TITLE
feat(ingest): make query formatting more robust

### DIFF
--- a/metadata-ingestion/src/datahub/sql_parsing/sqlglot_utils.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/sqlglot_utils.py
@@ -315,8 +315,8 @@ def try_format_query(
 
     try:
         dialect = get_dialect(platform)
-        expression = parse_statement(expression, dialect=dialect)
-        return expression.sql(dialect=dialect, pretty=True)
+        parsed_expression = parse_statement(expression, dialect=dialect)
+        return parsed_expression.sql(dialect=dialect, pretty=True)
     except Exception as e:
         if raises:
             raise


### PR DESCRIPTION
If expression.sql() throws a recursion error and we're given a string to begin with, we should return that string as-is instead of throwing an error.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
