### PR TITLE
fix(search): fixes issue where exact match exclusive flag broke quoted structured search

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchQueryBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchQueryBuilder.java
@@ -455,7 +455,7 @@ public class SearchQueryBuilder {
     if (customQueryConfig != null) {
       executeStructuredQuery = customQueryConfig.isStructuredQuery();
     } else {
-      executeStructuredQuery = !(isQuoted(sanitizedQuery) && exactMatchConfiguration.isExclusive());
+      executeStructuredQuery = true;
     }
 
     if (executeStructuredQuery) {


### PR DESCRIPTION
Related to this issue: https://github.com/datahub-project/datahub/issues/10505
We found that enabling the flag `ELASTICSEARCH_QUERY_EXACT_MATCH_EXCLUSIVE` resolved the problem where quoted search with `_` or `-` had no effect. However, enabling this flag broke structured queries tat had quotes (which are needed if the search string contains a space) due to the check that has been removed by this PR.

It seems that this logic isn't intended and was just an artifact of modeling the function `getStructuredQuery` after the `getSimpleQuery` function: https://github.com/datahub-project/datahub/blob/3a72d924936c60116740901c7b14406ab0050c9a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchQueryBuilder.java#L321

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
