### PR TITLE
fix(ingest/looker): fix looker browse paths v2

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_common.py
@@ -1137,16 +1137,9 @@ class LookerExplore:
         ]
 
         # Add tags
-        explore_tag_urns: List[TagAssociationClass] = []
-        for tag in self.tags:
-            tag_urn = TagUrn(tag)
-            explore_tag_urns.append(TagAssociationClass(tag_urn.urn()))
-            proposals.append(
-                MetadataChangeProposalWrapper(
-                    entityUrn=tag_urn.urn(),
-                    aspect=tag_urn.to_key_aspect(),
-                )
-            )
+        explore_tag_urns: List[TagAssociationClass] = [
+            TagAssociationClass(tag=TagUrn(tag).urn()) for tag in self.tags
+        ]
         if explore_tag_urns:
             dataset_snapshot.aspects.append(GlobalTagsClass(explore_tag_urns))
 


### PR DESCRIPTION
Fixes a regression from https://github.com/datahub-project/datahub/pull/10547

The tag key urns would previously interrupt the looker entity batches, which would cause the browse path v2 helper to generate bad browse paths. By relying on the tag materialization helper instead, we can avoid this problem.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
