### PR TITLE
docs(domains): dataset_add_domain_execute_graphql.py with example

### DIFF
--- a/metadata-ingestion/examples/library/dataset_add_domain_execute_graphql.py
+++ b/metadata-ingestion/examples/library/dataset_add_domain_execute_graphql.py
@@ -1,15 +1,31 @@
 # read-modify-write requires access to the DataHubGraph (RestEmitter is not enough)
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.emitter.mce_builder import make_dataset_urn, make_domain_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.rest_emitter import DatahubRestEmitter
+from datahub.metadata.schema_classes import DomainsClass, ChangeTypeClass
+
+# Define the dataset URN
+dataset_urn = make_dataset_urn(platform="hive", name="realestate_db.sales", env="PROD")
 
 gms_endpoint = "http://localhost:8080"
-graph = DataHubGraph(DatahubClientConfig(server=gms_endpoint))
+rest_emitter = DatahubRestEmitter(gms_server=gms_endpoint)
 
-# Query multiple aspects from entity
-query = """
-mutation setDomain {
-    setDomain(domainUrn: "urn:li:domain:marketing", entityUrn: "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)")
-}
-"""
-result = graph.execute_graphql(query=query)
+# Define the domain URN
+domain_urn = make_domain_urn("marketing")
 
-print(result)
+# Create the Domains aspect
+domains_aspect = DomainsClass(domains=[domain_urn])
+
+# Create the MetadataChangeProposalWrapper event
+event = MetadataChangeProposalWrapper(
+    entityUrn=dataset_urn,
+    aspect=domains_aspect,
+    changeType=ChangeTypeClass.UPSERT
+)
+
+# Create the REST emitter
+rest_emitter = DatahubRestEmitter(gms_server="http://localhost:8080")
+
+# Emit the event
+rest_emitter.emit(event)


### PR DESCRIPTION
Previously, our python example just ran GQL. This runs using the python SDK.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
