### PR TITLE
feat(observe) expose assertion runId and lastObservedMillis to graphql

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/AssertionRunEventMapper.java
@@ -38,6 +38,7 @@ public class AssertionRunEventMapper
     final com.linkedin.datahub.graphql.generated.AssertionRunEvent assertionRunEvent =
         new com.linkedin.datahub.graphql.generated.AssertionRunEvent();
 
+    assertionRunEvent.setLastObservedMillis(envelopedAspect.getSystemMetadata().getLastObserved());
     assertionRunEvent.setTimestampMillis(gmsAssertionRunEvent.getTimestampMillis());
     assertionRunEvent.setAssertionUrn(gmsAssertionRunEvent.getAssertionUrn().toString());
     assertionRunEvent.setAsserteeUrn(gmsAssertionRunEvent.getAsserteeUrn().toString());

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -7405,6 +7405,11 @@ type AssertionRunEvent implements TimeSeriesAspect {
   timestampMillis: Long!
 
   """
+  The time at which the run event was last observed by the DataHub system - ie, when it was reported by external systems
+  """
+  lastObservedMillis: Long
+
+  """
   Urn of assertion which is evaluated
   """
   assertionUrn: String!
@@ -7420,7 +7425,7 @@ type AssertionRunEvent implements TimeSeriesAspect {
   runId: String!
 
   """
-  The status of the assertion run as per this timeseries event.
+  The status of the assertion run as per this timeseries event
   """
   status: AssertionRunStatus!
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/AssertionRunEventResolverTest.java
@@ -18,6 +18,7 @@ import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.SystemMetadata;
 import graphql.schema.DataFetchingEnvironment;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
@@ -58,7 +59,9 @@ public class AssertionRunEventResolverTest {
                         null, AssertionRunStatus.COMPLETE.toString()))))
         .thenReturn(
             ImmutableList.of(
-                new EnvelopedAspect().setAspect(GenericRecordUtils.serializeAspect(gmsRunEvent))));
+                new EnvelopedAspect()
+                    .setAspect(GenericRecordUtils.serializeAspect(gmsRunEvent))
+                    .setSystemMetadata(new SystemMetadata().setLastObserved(12L))));
 
     AssertionRunEventResolver resolver = new AssertionRunEventResolver(mockClient);
 
@@ -108,6 +111,7 @@ public class AssertionRunEventResolverTest {
         graphqlRunEvent.getStatus(),
         com.linkedin.datahub.graphql.generated.AssertionRunStatus.COMPLETE);
     assertEquals((float) graphqlRunEvent.getTimestampMillis(), 12L);
+    assertEquals((float) graphqlRunEvent.getLastObservedMillis(), 12L);
     assertEquals((float) graphqlRunEvent.getResult().getActualAggValue(), 10);
     assertEquals((long) graphqlRunEvent.getResult().getMissingCount(), 0L);
     assertEquals((long) graphqlRunEvent.getResult().getRowCount(), 1L);

--- a/datahub-web-react/src/graphql/assertion.graphql
+++ b/datahub-web-react/src/graphql/assertion.graphql
@@ -55,8 +55,10 @@ fragment assertionDetails on Assertion {
 
 fragment assertionRunEventDetails on AssertionRunEvent {
     timestampMillis
+    lastObservedMillis
     assertionUrn
     status
+    runId
     runtimeContext {
         key
         value


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
