### PR TITLE
fix(ingest/iceberg): add support for nested dictionaries when configuring pyiceberg

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/iceberg/iceberg_common.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field, validator
 from pyiceberg.catalog import Catalog, load_catalog
@@ -59,7 +59,7 @@ class IcebergSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin)
         default=None, description="Iceberg Stateful Ingestion Config."
     )
     # The catalog configuration is using a dictionary to be open and flexible.  All the keys and values are handled by pyiceberg.  This will future-proof any configuration change done by pyiceberg.
-    catalog: Dict[str, Dict[str, str]] = Field(
+    catalog: Dict[str, Dict[str, Any]] = Field(
         description="Catalog configuration where to find Iceberg tables.  Only one catalog specification is supported.  The format is the same as [pyiceberg's catalog configuration](https://py.iceberg.apache.org/configuration/), where the catalog name is specified as the object name and attributes are set as key-value pairs.",
     )
     table_pattern: AllowDenyPattern = Field(

--- a/metadata-ingestion/tests/unit/test_iceberg.py
+++ b/metadata-ingestion/tests/unit/test_iceberg.py
@@ -1,6 +1,6 @@
 import uuid
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import pytest
 from pydantic import ValidationError
@@ -122,6 +122,16 @@ def test_config_for_tests():
     Test valid iceberg source that will be used in unit tests.
     """
     with_iceberg_source()
+
+
+def test_config_support_nested_dicts():
+    """
+    Test that Iceberg source supports nested dictionaries inside its configuration, as allowed by pyiceberg.
+    """
+    catalog = {"test": {"type": "rest", "nested_dict": {"nested_key": "nested_value"}}}
+    test_config = IcebergSourceConfig(catalog=catalog)
+    assert isinstance(test_config.catalog["test"]["nested_dict"], Dict)
+    assert test_config.catalog["test"]["nested_dict"]["nested_key"] == "nested_value"
 
 
 @pytest.mark.parametrize(

--- a/metadata-ingestion/tests/unit/test_iceberg.py
+++ b/metadata-ingestion/tests/unit/test_iceberg.py
@@ -128,10 +128,22 @@ def test_config_support_nested_dicts():
     """
     Test that Iceberg source supports nested dictionaries inside its configuration, as allowed by pyiceberg.
     """
-    catalog = {"test": {"type": "rest", "nested_dict": {"nested_key": "nested_value"}}}
+    catalog = {
+        "test": {
+            "type": "rest",
+            "nested_dict": {
+                "nested_key": "nested_value",
+                "subnested_dict": {"subnested_key": "subnested_value"},
+            },
+        }
+    }
     test_config = IcebergSourceConfig(catalog=catalog)
     assert isinstance(test_config.catalog["test"]["nested_dict"], Dict)
     assert test_config.catalog["test"]["nested_dict"]["nested_key"] == "nested_value"
+    assert (
+        test_config.catalog["test"]["nested_dict"]["subnested_dict"]["subnested_key"]
+        == "subnested_value"
+    )
 
 
 @pytest.mark.parametrize(

--- a/metadata-ingestion/tests/unit/test_iceberg.py
+++ b/metadata-ingestion/tests/unit/test_iceberg.py
@@ -1,6 +1,6 @@
 import uuid
 from decimal import Decimal
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 from pydantic import ValidationError
@@ -133,6 +133,7 @@ def test_config_support_nested_dicts():
             "type": "rest",
             "nested_dict": {
                 "nested_key": "nested_value",
+                "nested_array": ["a1", "a2"],
                 "subnested_dict": {"subnested_key": "subnested_value"},
             },
         }
@@ -140,6 +141,11 @@ def test_config_support_nested_dicts():
     test_config = IcebergSourceConfig(catalog=catalog)
     assert isinstance(test_config.catalog["test"]["nested_dict"], Dict)
     assert test_config.catalog["test"]["nested_dict"]["nested_key"] == "nested_value"
+    assert isinstance(test_config.catalog["test"]["nested_dict"]["nested_array"], List)
+    assert test_config.catalog["test"]["nested_dict"]["nested_array"][0] == "a1"
+    assert isinstance(
+        test_config.catalog["test"]["nested_dict"]["subnested_dict"], Dict
+    )
     assert (
         test_config.catalog["test"]["nested_dict"]["subnested_dict"]["subnested_key"]
         == "subnested_value"


### PR DESCRIPTION
In a previous PR (#10614), I added support for future pyiceberg releases.  Part of this PR was to delegate the configuration of the catalog to pyiceberg, but the contributed code only supported dictionaries of string values.  It turns out that some pyiceberg configuration requires more than just strings, so this PR is opening up the configuration options to any value types.

Here is an example of a config that requires something else than a string (as found in [pyiceberg's configuration](https://py.iceberg.apache.org/configuration/)):
<img width="860" alt="image" src="https://github.com/datahub-project/datahub/assets/56447460/72ad4f58-b569-4d98-a0b1-dcf61f6413bf">



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
