### PR TITLE
feat(schema-registry): enable config endpoint internal schema registry

### DIFF
--- a/metadata-service/schema-registry-servlet/src/main/java/io/datahubproject/openapi/schema/registry/SchemaRegistryController.java
+++ b/metadata-service/schema-registry-servlet/src/main/java/io/datahubproject/openapi/schema/registry/SchemaRegistryController.java
@@ -36,6 +36,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 /** DataHub Rest Controller implementation for Confluent's Schema Registry OpenAPI spec. */
@@ -249,14 +250,21 @@ public class SchemaRegistryController
 
   @Override
   public ResponseEntity<Config> getSubjectLevelConfig(String subject, Boolean defaultToGlobal) {
-    log.error("[ConfigApi] getSubjectLevelConfig method not implemented");
-    return ConfigApi.super.getSubjectLevelConfig(subject, defaultToGlobal);
+    return getTopLevelConfig();
   }
 
+  @RequestMapping(
+      value = {"/config", "/config/"},
+      produces = {
+        "application/vnd.schemaregistry.v1+json",
+        "application/vnd.schemaregistry+json; qs=0.9",
+        "application/json; qs=0.5"
+      },
+      method = RequestMethod.GET)
   @Override
   public ResponseEntity<Config> getTopLevelConfig() {
-    log.error("[ConfigApi] getTopLevelConfig method not implemented");
-    return ConfigApi.super.getTopLevelConfig();
+    return ResponseEntity.ok(
+        new Config().compatibilityLevel(Config.CompatibilityLevelEnum.BACKWARD));
   }
 
   @Override


### PR DESCRIPTION
Enables compatibility with monitoring tools like https://github.com/provectus/kafka-ui

![Screenshot 2024-06-25 at 12 56 22 PM](https://github.com/datahub-project/datahub/assets/114954101/84f53a66-c44b-456f-b87e-a0d1e08f736d)
![Screenshot 2024-06-25 at 12 56 51 PM](https://github.com/datahub-project/datahub/assets/114954101/d55bf4e4-e4d8-4ac4-a703-1356274e84c5)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
