### PR TITLE
docs(classification): correct the casing for full name infotype

### DIFF
--- a/metadata-ingestion/docs/dev_guides/classification.md
+++ b/metadata-ingestion/docs/dev_guides/classification.md
@@ -339,7 +339,7 @@ source:
                   regex: []
                   library:
                     - spacy
-              Full_name:
+              Full_Name:
                 prediction_factors_and_weights:
                   name: 0.3
                   description: 0


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated field name in YAML configuration from `Full_name` to `Full_Name` in classification guide.
  - Fixed URL formatting by removing trailing newline at the end of the classification guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->