### PR TITLE
fix(assertions): minor changes in custom assertion api

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/ReportAssertionResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/assertion/ReportAssertionResultResolver.java
@@ -72,9 +72,10 @@ public class ReportAssertionResultResolver implements DataFetcher<CompletableFut
                 context.getOperationContext(),
                 assertionUrn,
                 asserteeUrn,
-                input.getTimestampMillis(),
-                assertionResult,
-                mapContextParameters(input.getProperties()));
+                input.getTimestampMillis() != null
+                    ? input.getTimestampMillis()
+                    : System.currentTimeMillis(),
+                assertionResult);
             return true;
           }
           throw new AuthorizationException(
@@ -98,6 +99,9 @@ public class ReportAssertionResultResolver implements DataFetcher<CompletableFut
     assertionResult.setExternalUrl(input.getExternalUrl(), SetMode.IGNORE_NULL);
     if (assertionResult.getType() == AssertionResultType.ERROR && input.getError() != null) {
       assertionResult.setError(mapAssertionResultError(input));
+    }
+    if (input.getProperties() != null) {
+      assertionResult.setNativeResults(mapContextParameters(input.getProperties()));
     }
     return assertionResult;
   }

--- a/datahub-graphql-core/src/main/resources/assertions.graphql
+++ b/datahub-graphql-core/src/main/resources/assertions.graphql
@@ -87,7 +87,9 @@ input AssertionResultInput {
   type: AssertionResultType!
 
   """
-  Additional key-value pairs representing runtime context
+  Additional metadata representing about the native results of the assertion.
+  These will be displayed alongside the result.
+  It should be used to capture additional context that is useful for the user.
   """
   properties: [StringMapEntryInput!]
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/ReportAssertionResultResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/ReportAssertionResultResolverTest.java
@@ -61,8 +61,8 @@ public class ReportAssertionResultResolverTest {
                           .setType(com.linkedin.assertion.AssertionResultErrorType.UNKNOWN_ERROR)
                           .setProperties(
                               new StringMap(Map.of("message", "an unknown error occurred"))))
-                  .setExternalUrl(customAssertionUrl))
-          .setRuntimeContext(new StringMap(Map.of("prop1", "value1")));
+                  .setExternalUrl(customAssertionUrl)
+                  .setNativeResults(new StringMap(Map.of("prop1", "value1"))));
 
   @Test
   public void testGetSuccessReportAssertionRunEvent() throws Exception {
@@ -91,8 +91,7 @@ public class ReportAssertionResultResolverTest {
             Mockito.eq(TEST_ASSERTION_URN),
             Mockito.eq(TEST_DATASET_URN),
             Mockito.eq(TEST_ASSERTION_RUN_EVENT.getTimestampMillis()),
-            Mockito.eq(TEST_ASSERTION_RUN_EVENT.getResult()),
-            Mockito.eq(TEST_ASSERTION_RUN_EVENT.getRuntimeContext()));
+            Mockito.eq(TEST_ASSERTION_RUN_EVENT.getResult()));
   }
 
   @Test
@@ -126,7 +125,6 @@ public class ReportAssertionResultResolverTest {
             Mockito.any(),
             Mockito.any(),
             Mockito.any(),
-            Mockito.any(),
             Mockito.any());
   }
 
@@ -143,7 +141,6 @@ public class ReportAssertionResultResolverTest {
         .when(mockService)
         .addAssertionRunEvent(
             any(OperationContext.class),
-            Mockito.any(),
             Mockito.any(),
             Mockito.any(),
             Mockito.any(),

--- a/metadata-io/src/test/java/com/linkedin/metadata/service/AssertionServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/service/AssertionServiceTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.service;
 
 import static com.linkedin.metadata.Constants.*;
-import static com.linkedin.metadata.service.AssertionService.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -221,8 +220,7 @@ public class AssertionServiceTest {
         TEST_ASSERTION_URN,
         TEST_DATASET_URN,
         eventtime,
-        new AssertionResult().setType(AssertionResultType.SUCCESS),
-        null);
+        new AssertionResult().setType(AssertionResultType.SUCCESS));
 
     Mockito.verify(mockedEntityClient, Mockito.times(1))
         .ingestProposal(any(OperationContext.class), Mockito.any(), Mockito.eq(false));
@@ -234,7 +232,7 @@ public class AssertionServiceTest {
     AssertionService assertionService =
         new AssertionService(mockedEntityClient, mock(GraphClient.class));
     Long eventtime = 1718619000000L;
-    StringMap customProps = new StringMap(Map.of("prop-1", "value-1"));
+    StringMap nativeResults = new StringMap(Map.of("prop-1", "value-1"));
     StringMap errorProps = new StringMap(Map.of("message", "errorMessage"));
     String externalUrlOfAssertion = "https://abc/xyz";
 
@@ -254,7 +252,7 @@ public class AssertionServiceTest {
               Assert.assertEquals(runEvent.getAsserteeUrn(), TEST_DATASET_URN);
               Assert.assertEquals(runEvent.getTimestampMillis(), eventtime);
               Assert.assertEquals(runEvent.getStatus(), AssertionRunStatus.COMPLETE);
-              Assert.assertEquals(runEvent.getRuntimeContext(), customProps);
+              Assert.assertEquals(runEvent.getResult().getNativeResults(), nativeResults);
 
               AssertionResult result = runEvent.getResult();
               Assert.assertEquals(result.getType(), AssertionResultType.ERROR);
@@ -276,11 +274,11 @@ public class AssertionServiceTest {
         new AssertionResult()
             .setType(AssertionResultType.ERROR)
             .setExternalUrl(externalUrlOfAssertion)
+            .setNativeResults(nativeResults)
             .setError(
                 new AssertionResultError()
                     .setType(AssertionResultErrorType.UNKNOWN_ERROR)
-                    .setProperties(errorProps)),
-        customProps);
+                    .setProperties(errorProps)));
 
     Mockito.verify(mockedEntityClient, Mockito.times(1))
         .ingestProposal(any(OperationContext.class), Mockito.any(), Mockito.eq(false));

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/service/AssertionService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/service/AssertionService.java
@@ -14,7 +14,6 @@ import com.linkedin.common.DataPlatformInstance;
 import com.linkedin.common.EntityRelationships;
 import com.linkedin.common.url.Url;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.data.template.StringMap;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.SystemEntityClient;
 import com.linkedin.metadata.Constants;
@@ -157,8 +156,7 @@ public class AssertionService extends BaseService {
       @Nonnull Urn assertionUrn,
       @Nonnull Urn asserteeUrn,
       @Nonnull Long timestampMillis,
-      @Nonnull AssertionResult assertionResult,
-      @Nullable StringMap contextParameters) {
+      @Nonnull AssertionResult assertionResult) {
     AssertionRunEvent assertionRunEvent = new AssertionRunEvent();
     assertionRunEvent.setTimestampMillis(timestampMillis);
     assertionRunEvent.setRunId(timestampMillis.toString());
@@ -166,9 +164,6 @@ public class AssertionService extends BaseService {
     assertionRunEvent.setAsserteeUrn(asserteeUrn);
     assertionRunEvent.setStatus(AssertionRunStatus.COMPLETE);
     assertionRunEvent.setResult(assertionResult);
-    if (contextParameters != null) {
-      assertionRunEvent.setRuntimeContext(contextParameters);
-    }
 
     try {
       this.entityClient.ingestProposal(


### PR DESCRIPTION
- handle custom assertion reported without timestamp correctly
- map properties with nativeResults


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Handled null timestamp input by setting the current timestamp if it is null.
  - Updated metadata display for native results in assertions.

- **Documentation**
  - Clarified the `properties` field purpose in `assertions.graphql`.

- **Tests**
  - Adjusted test cases to align with changes in handling custom properties and native results in assertion results.

- **Refactor**
  - Removed unused parameters and imports in test and service methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->