### PR TITLE
feat(custom-plugins): improve plugin factory merge

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginFactory.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -48,17 +49,72 @@ public class PluginFactory {
       PluginFactory b,
       @Nullable
           BiFunction<PluginConfiguration, List<ClassLoader>, PluginFactory> pluginFactoryProvider) {
+
+    if (b.isEmpty()) {
+      return a;
+    }
+    if (a.isEmpty()) {
+      return b;
+    }
+
     PluginConfiguration mergedPluginConfig =
         PluginConfiguration.merge(a.pluginConfiguration, b.pluginConfiguration);
     List<ClassLoader> mergedClassLoaders =
         Stream.concat(a.getClassLoaders().stream(), b.getClassLoaders().stream())
             .collect(Collectors.toList());
 
-    if (pluginFactoryProvider != null) {
-      return pluginFactoryProvider.apply(mergedPluginConfig, mergedClassLoaders);
-    } else {
-      return PluginFactory.withCustomClasspath(mergedPluginConfig, mergedClassLoaders);
+    if (!a.hasLoadedPlugins() && !b.hasLoadedPlugins()) {
+      if (pluginFactoryProvider != null) {
+        return pluginFactoryProvider.apply(mergedPluginConfig, mergedClassLoaders);
+      } else {
+        if (mergedPluginConfig
+            .streamAll()
+            .anyMatch(config -> config.getSpring() != null && config.getSpring().isEnabled())) {
+          throw new IllegalStateException(
+              "Unexpected Spring configuration found without a provided Spring Plugin Factory");
+        }
+        return PluginFactory.withCustomClasspath(mergedPluginConfig, mergedClassLoaders);
+      }
     }
+
+    PluginFactory loadedA = a.hasLoadedPlugins() ? a : a.loadPlugins();
+    PluginFactory loadedB = b.hasLoadedPlugins() ? b : b.loadPlugins();
+
+    return new PluginFactory(
+        mergedPluginConfig,
+        mergedClassLoaders,
+        Stream.concat(
+                loadedA.aspectPayloadValidators.stream()
+                    .filter(
+                        aPlugin ->
+                            loadedB.pluginConfiguration.getAspectPayloadValidators().stream()
+                                .noneMatch(bConfig -> aPlugin.getConfig().isDisabledBy(bConfig))),
+                loadedB.aspectPayloadValidators.stream())
+            .collect(Collectors.toList()),
+        Stream.concat(
+                loadedA.mutationHooks.stream()
+                    .filter(
+                        aPlugin ->
+                            loadedB.pluginConfiguration.getMutationHooks().stream()
+                                .noneMatch(bConfig -> aPlugin.getConfig().isDisabledBy(bConfig))),
+                loadedB.mutationHooks.stream())
+            .collect(Collectors.toList()),
+        Stream.concat(
+                loadedA.mclSideEffects.stream()
+                    .filter(
+                        aPlugin ->
+                            loadedB.pluginConfiguration.getMclSideEffects().stream()
+                                .noneMatch(bConfig -> aPlugin.getConfig().isDisabledBy(bConfig))),
+                loadedB.mclSideEffects.stream())
+            .collect(Collectors.toList()),
+        Stream.concat(
+                loadedA.mcpSideEffects.stream()
+                    .filter(
+                        aPlugin ->
+                            loadedB.pluginConfiguration.getMcpSideEffects().stream()
+                                .noneMatch(bConfig -> aPlugin.getConfig().isDisabledBy(bConfig))),
+                loadedB.mcpSideEffects.stream())
+            .collect(Collectors.toList()));
   }
 
   @Getter private final PluginConfiguration pluginConfiguration;
@@ -77,20 +133,60 @@ public class PluginFactory {
         pluginConfiguration == null ? PluginConfiguration.EMPTY : pluginConfiguration;
   }
 
+  public PluginFactory(
+      @Nullable PluginConfiguration pluginConfiguration,
+      @Nonnull List<ClassLoader> classLoaders,
+      @Nonnull List<AspectPayloadValidator> aspectPayloadValidators,
+      @Nonnull List<MutationHook> mutationHooks,
+      @Nonnull List<MCLSideEffect> mclSideEffects,
+      @Nonnull List<MCPSideEffect> mcpSideEffects) {
+    this.classLoaders = classLoaders;
+    this.pluginConfiguration =
+        pluginConfiguration == null ? PluginConfiguration.EMPTY : pluginConfiguration;
+    this.aspectPayloadValidators = applyDisable(aspectPayloadValidators);
+    this.mutationHooks = applyDisable(mutationHooks);
+    this.mclSideEffects = applyDisable(mclSideEffects);
+    this.mcpSideEffects = applyDisable(mcpSideEffects);
+  }
+
   public PluginFactory loadPlugins() {
-    this.aspectPayloadValidators = buildAspectPayloadValidators(this.pluginConfiguration);
-    this.mutationHooks = buildMutationHooks(this.pluginConfiguration);
-    this.mclSideEffects = buildMCLSideEffects(this.pluginConfiguration);
-    this.mcpSideEffects = buildMCPSideEffects(this.pluginConfiguration);
-    logSummary(
-        Stream.of(
-                this.aspectPayloadValidators,
-                this.mutationHooks,
-                this.mclSideEffects,
-                this.mcpSideEffects)
-            .flatMap(List::stream)
-            .collect(Collectors.toList()));
+    if (this.aspectPayloadValidators != null
+        || this.mutationHooks != null
+        || this.mclSideEffects != null
+        || this.mcpSideEffects != null) {
+      log.error("Plugins are already loaded. Re-building plugins will be skipped.");
+    } else {
+      this.aspectPayloadValidators = buildAspectPayloadValidators(this.pluginConfiguration);
+      this.mutationHooks = buildMutationHooks(this.pluginConfiguration);
+      this.mclSideEffects = buildMCLSideEffects(this.pluginConfiguration);
+      this.mcpSideEffects = buildMCPSideEffects(this.pluginConfiguration);
+      logSummary(
+          Stream.of(
+                  this.aspectPayloadValidators,
+                  this.mutationHooks,
+                  this.mclSideEffects,
+                  this.mcpSideEffects)
+              .flatMap(List::stream)
+              .collect(Collectors.toList()));
+    }
     return this;
+  }
+
+  public boolean isEmpty() {
+    return this.pluginConfiguration.isEmpty()
+        && Optional.ofNullable(this.aspectPayloadValidators).map(List::isEmpty).orElse(true)
+        && Optional.ofNullable(this.mutationHooks).map(List::isEmpty).orElse(true)
+        && Optional.ofNullable(this.mclSideEffects).map(List::isEmpty).orElse(true)
+        && Optional.ofNullable(this.mcpSideEffects).map(List::isEmpty).orElse(true);
+  }
+
+  public boolean hasLoadedPlugins() {
+    return Stream.of(
+            this.aspectPayloadValidators,
+            this.mutationHooks,
+            this.mcpSideEffects,
+            this.mcpSideEffects)
+        .anyMatch(Objects::nonNull);
   }
 
   private void logSummary(List<PluginSpec> pluginSpecs) {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/config/PluginConfiguration.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/config/PluginConfiguration.java
@@ -27,6 +27,13 @@ public class PluginConfiguration {
 
   public static PluginConfiguration EMPTY = new PluginConfiguration();
 
+  public boolean isEmpty() {
+    return aspectPayloadValidators.isEmpty()
+        && mutationHooks.isEmpty()
+        && mclSideEffects.isEmpty()
+        && mcpSideEffects.isEmpty();
+  }
+
   public static PluginConfiguration merge(PluginConfiguration a, PluginConfiguration b) {
     return new PluginConfiguration(
         Stream.concat(

--- a/metadata-service/plugin/build.gradle
+++ b/metadata-service/plugin/build.gradle
@@ -13,14 +13,18 @@ dependencies {
   implementation externalDependency.jacksonDataFormatYaml
   implementation externalDependency.jacksonJDK8
   implementation externalDependency.jacksonDataPropertyFormat
-  implementation externalDependency.logbackClassic;
+  implementation externalDependency.logbackClassic
   implementation externalDependency.slf4jApi
   
   compileOnly externalDependency.lombok
+  annotationProcessor externalDependency.lombok
 
+  testImplementation project(':test-models')
+  testImplementation project(path: ':test-models', configuration: 'testDataTemplate')
   testImplementation externalDependency.mockito
   testImplementation externalDependency.testng
-  annotationProcessor externalDependency.lombok
+  testCompileOnly externalDependency.lombok
+  testAnnotationProcessor externalDependency.lombok
 }
 
 test {

--- a/metadata-service/plugin/src/main/java/com/datahub/plugins/metadata/aspect/SpringPluginFactory.java
+++ b/metadata-service/plugin/src/main/java/com/datahub/plugins/metadata/aspect/SpringPluginFactory.java
@@ -106,16 +106,27 @@ public class SpringPluginFactory extends PluginFactory {
         try {
           Class<?> clazz = classLoader.loadClass(config.getClassName());
 
-          final T plugin;
+          final List<T> plugins;
           if (config.getSpring().getName() == null) {
-            plugin = (T) springApplicationContext.getBean(clazz);
+            plugins =
+                springApplicationContext.getBeansOfType(clazz).values().stream()
+                    .map(plugin -> (T) plugin)
+                    .collect(Collectors.toList());
           } else {
-            plugin = (T) springApplicationContext.getBean(config.getSpring().getName(), clazz);
+            plugins =
+                List.of((T) springApplicationContext.getBean(config.getSpring().getName(), clazz));
           }
 
-          if (plugin.enabled()) {
-            result.add((T) plugin.setConfig(config));
-          }
+          plugins.stream()
+              .filter(plugin -> plugin.enabled())
+              .forEach(
+                  plugin -> {
+                    if (plugin.getConfig() != null) {
+                      result.add(plugin);
+                    } else {
+                      result.add((T) plugin.setConfig(config));
+                    }
+                  });
 
           loaded = true;
           break;

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginFactoryTest.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/SpringPluginFactoryTest.java
@@ -1,0 +1,188 @@
+package com.datahub.plugins.metadata.aspect;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.datahub.test.TestEntityProfile;
+import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.batch.MCLItem;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MCLSideEffect;
+import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.EventSpec;
+import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
+import com.linkedin.metadata.models.registry.EntityRegistryException;
+import com.linkedin.metadata.models.registry.MergedEntityRegistry;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.springframework.context.annotation.Configuration;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+@Configuration
+public class SpringPluginFactoryTest {
+
+  public static String REGISTRY_FILE_1 = "test-entity-registry-plugins-1.yml";
+  public static String REGISTRY_SPRING_FILE_1 = "test-entity-registry-spring-plugins-1.yml";
+
+  @BeforeTest
+  public void disableAssert() {
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+  }
+
+  @Test
+  public void testMergedEntityRegistryWithSpringPluginFactory() throws EntityRegistryException {
+    ConfigEntityRegistry configEntityRegistry1 =
+        new ConfigEntityRegistry(
+            TestEntityProfile.class.getClassLoader().getResourceAsStream(REGISTRY_FILE_1));
+    ConfigEntityRegistry configEntityRegistry2 =
+        new ConfigEntityRegistry(
+            TestEntityProfile.class.getClassLoader().getResourceAsStream(REGISTRY_SPRING_FILE_1),
+            (config, classLoaders) ->
+                new SpringPluginFactory(
+                    null, config, List.of(SpringPluginFactoryTest.class.getClassLoader())));
+
+    MergedEntityRegistry mergedEntityRegistry = new MergedEntityRegistry(configEntityRegistry1);
+    mergedEntityRegistry.apply(configEntityRegistry2);
+
+    Map<String, EntitySpec> entitySpecs = mergedEntityRegistry.getEntitySpecs();
+    Map<String, EventSpec> eventSpecs = mergedEntityRegistry.getEventSpecs();
+    assertEquals(entitySpecs.values().size(), 2);
+    assertEquals(eventSpecs.values().size(), 1);
+
+    EntitySpec entitySpec = mergedEntityRegistry.getEntitySpec("dataset");
+    assertEquals(entitySpec.getName(), "dataset");
+    assertEquals(entitySpec.getKeyAspectSpec().getName(), "datasetKey");
+    assertEquals(entitySpec.getAspectSpecs().size(), 4);
+    assertNotNull(entitySpec.getAspectSpec("datasetKey"));
+    assertNotNull(entitySpec.getAspectSpec("datasetProperties"));
+    assertNotNull(entitySpec.getAspectSpec("schemaMetadata"));
+    assertNotNull(entitySpec.getAspectSpec("status"));
+
+    entitySpec = mergedEntityRegistry.getEntitySpec("chart");
+    assertEquals(entitySpec.getName(), "chart");
+    assertEquals(entitySpec.getKeyAspectSpec().getName(), "chartKey");
+    assertEquals(entitySpec.getAspectSpecs().size(), 3);
+    assertNotNull(entitySpec.getAspectSpec("chartKey"));
+    assertNotNull(entitySpec.getAspectSpec("chartInfo"));
+    assertNotNull(entitySpec.getAspectSpec("status"));
+
+    EventSpec eventSpec = mergedEntityRegistry.getEventSpec("testEvent");
+    assertEquals(eventSpec.getName(), "testEvent");
+    assertNotNull(eventSpec.getPegasusSchema());
+
+    assertEquals(
+        mergedEntityRegistry.getAllAspectPayloadValidators().stream()
+            .filter(validator -> validator.shouldApply(ChangeType.UPSERT, "chart", "status"))
+            .count(),
+        2);
+    assertEquals(
+        mergedEntityRegistry.getAllAspectPayloadValidators().stream()
+            .filter(validator -> validator.shouldApply(ChangeType.DELETE, "chart", "status"))
+            .count(),
+        1);
+
+    assertEquals(
+        mergedEntityRegistry.getAllMCPSideEffects().stream()
+            .filter(validator -> validator.shouldApply(ChangeType.UPSERT, "dataset", "datasetKey"))
+            .count(),
+        2);
+    assertEquals(
+        mergedEntityRegistry.getAllMCPSideEffects().stream()
+            .filter(validator -> validator.shouldApply(ChangeType.DELETE, "dataset", "datasetKey"))
+            .count(),
+        1);
+
+    assertEquals(
+        mergedEntityRegistry.getAllMutationHooks().stream()
+            .filter(validator -> validator.shouldApply(ChangeType.UPSERT, "*", "schemaMetadata"))
+            .count(),
+        2);
+    assertEquals(
+        mergedEntityRegistry.getAllMutationHooks().stream()
+            .filter(validator -> validator.shouldApply(ChangeType.DELETE, "*", "schemaMetadata"))
+            .count(),
+        1);
+  }
+
+  /*
+   * Various test plugins to be injected with Spring
+   */
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class TestValidator extends AspectPayloadValidator {
+
+    public AspectPluginConfig config;
+
+    @Override
+    protected Stream<AspectValidationException> validateProposedAspects(
+        @Nonnull Collection<? extends BatchItem> mcpItems,
+        @Nonnull RetrieverContext retrieverContext) {
+      return mcpItems.stream().map(i -> AspectValidationException.forItem(i, "test error"));
+    }
+
+    @Override
+    protected Stream<AspectValidationException> validatePreCommitAspects(
+        @Nonnull Collection<ChangeMCP> changeMCPs, @Nonnull RetrieverContext retrieverContext) {
+      return Stream.empty();
+    }
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class TestMutator extends MutationHook {
+    public AspectPluginConfig config;
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class TestMCPSideEffect extends MCPSideEffect {
+
+    public AspectPluginConfig config;
+
+    @Override
+    protected Stream<ChangeMCP> applyMCPSideEffect(
+        Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
+      return changeMCPS.stream();
+    }
+
+    @Override
+    protected Stream<MCPItem> postMCPSideEffect(
+        Collection<MCLItem> mclItems, @Nonnull RetrieverContext retrieverContext) {
+      return Stream.of();
+    }
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class TestMCLSideEffect extends MCLSideEffect {
+    public AspectPluginConfig config;
+
+    @Override
+    protected Stream<MCLItem> applyMCLSideEffect(
+        @Nonnull Collection<MCLItem> batchItems, @Nonnull RetrieverContext retrieverContext) {
+      return null;
+    }
+  }
+}

--- a/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/test/TestSpringPluginConfiguration.java
+++ b/metadata-service/plugin/src/test/java/com/datahub/plugins/metadata/aspect/test/TestSpringPluginConfiguration.java
@@ -1,0 +1,109 @@
+package com.datahub.plugins.metadata.aspect.test;
+
+import com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** This is the Spring class used for the test */
+@Configuration
+public class TestSpringPluginConfiguration {
+  @Bean
+  public SpringPluginFactoryTest.TestValidator springValidator1() {
+    SpringPluginFactoryTest.TestValidator testValidator =
+        new SpringPluginFactoryTest.TestValidator();
+    testValidator.setConfig(
+        AspectPluginConfig.builder()
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("dataset")
+                        .aspectName("status")
+                        .build()))
+            .className(SpringPluginFactoryTest.TestValidator.class.getName())
+            .enabled(true)
+            .supportedOperations(List.of(ChangeType.UPSERT.toString()))
+            .build());
+    return testValidator;
+  }
+
+  @Bean
+  public SpringPluginFactoryTest.TestValidator springValidator2() {
+    SpringPluginFactoryTest.TestValidator testValidator =
+        new SpringPluginFactoryTest.TestValidator();
+    testValidator.setConfig(
+        AspectPluginConfig.builder()
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("*")
+                        .aspectName("status")
+                        .build()))
+            .className(SpringPluginFactoryTest.TestValidator.class.getName())
+            .enabled(true)
+            .supportedOperations(List.of(ChangeType.DELETE.toString()))
+            .build());
+    return testValidator;
+  }
+
+  @Bean
+  public SpringPluginFactoryTest.TestMutator springMutator() {
+    SpringPluginFactoryTest.TestMutator testMutator = new SpringPluginFactoryTest.TestMutator();
+    testMutator.setConfig(
+        AspectPluginConfig.builder()
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("*")
+                        .aspectName("schemaMetadata")
+                        .build()))
+            .className(SpringPluginFactoryTest.TestMutator.class.getName())
+            .enabled(true)
+            .supportedOperations(
+                List.of(ChangeType.UPSERT.toString(), ChangeType.DELETE.toString()))
+            .build());
+    return testMutator;
+  }
+
+  @Bean
+  public SpringPluginFactoryTest.TestMCPSideEffect springMCPSideEffect() {
+    SpringPluginFactoryTest.TestMCPSideEffect testMCPSideEffect =
+        new SpringPluginFactoryTest.TestMCPSideEffect();
+    testMCPSideEffect.setConfig(
+        AspectPluginConfig.builder()
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("dataset")
+                        .aspectName("datasetKey")
+                        .build()))
+            .className(SpringPluginFactoryTest.TestMCPSideEffect.class.getName())
+            .enabled(true)
+            .supportedOperations(
+                List.of(ChangeType.UPSERT.toString(), ChangeType.DELETE.toString()))
+            .build());
+    return testMCPSideEffect;
+  }
+
+  @Bean
+  public SpringPluginFactoryTest.TestMCLSideEffect springMCLSideEffect() {
+    SpringPluginFactoryTest.TestMCLSideEffect testMCLSideEffect =
+        new SpringPluginFactoryTest.TestMCLSideEffect();
+    testMCLSideEffect.setConfig(
+        AspectPluginConfig.builder()
+            .supportedEntityAspectNames(
+                List.of(
+                    AspectPluginConfig.EntityAspectName.builder()
+                        .entityName("chart")
+                        .aspectName("ChartInfo")
+                        .build()))
+            .className(SpringPluginFactoryTest.TestMCLSideEffect.class.getName())
+            .enabled(true)
+            .supportedOperations(
+                List.of(ChangeType.UPSERT.toString(), ChangeType.DELETE.toString()))
+            .build());
+    return testMCLSideEffect;
+  }
+}

--- a/metadata-service/plugin/src/test/resources/test-entity-registry-plugins-1.yml
+++ b/metadata-service/plugin/src/test/resources/test-entity-registry-plugins-1.yml
@@ -1,0 +1,67 @@
+id: test-registry-1
+entities:
+  - name: dataset
+    keyAspect: datasetKey
+    category: core
+    aspects:
+      - datasetProperties
+      - schemaMetadata
+      - status
+  - name: chart
+    keyAspect: chartKey
+    aspects:
+      - chartInfo
+      - status
+events:
+  - name: testEvent
+
+plugins:
+  aspectPayloadValidators:
+    # All status aspects on any entity
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestValidator'
+      enabled: true
+      supportedOperations:
+        - UPSERT
+      supportedEntityAspectNames:
+        - entityName: '*'
+          aspectName: status
+    # Chart status only
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestValidator'
+      enabled: true
+      supportedOperations:
+        - UPSERT
+      supportedEntityAspectNames:
+        - entityName: chart
+          aspectName: status
+    # Disabled
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestValidator'
+      enabled: false
+      supportedOperations:
+        - DELETE
+      supportedEntityAspectNames:
+        - entityName: '*'
+          aspectName: status
+  mutationHooks:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestMutator'
+      enabled: true
+      supportedOperations:
+        - UPSERT
+      supportedEntityAspectNames:
+        - entityName: '*'
+          aspectName: schemaMetadata
+  mclSideEffects:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestMCLSideEffect'
+      enabled: true
+      supportedOperations:
+        - UPSERT
+      supportedEntityAspectNames:
+        - entityName: chart
+          aspectName: chartInfo
+  mcpSideEffects:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestMCPSideEffect'
+      enabled: true
+      supportedOperations:
+        - UPSERT
+      supportedEntityAspectNames:
+        - entityName: dataset
+          aspectName: datasetKey

--- a/metadata-service/plugin/src/test/resources/test-entity-registry-spring-plugins-1.yml
+++ b/metadata-service/plugin/src/test/resources/test-entity-registry-spring-plugins-1.yml
@@ -1,0 +1,52 @@
+id: test-registry-spring-1
+entities: []
+plugins:
+  aspectPayloadValidators:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestValidator'
+      packageScan:
+        - com.datahub.plugins.metadata.aspect.test
+      spring:
+        enabled: true
+      enabled: true
+      supportedOperations:
+        - UPSERT
+        - DELETE
+      supportedEntityAspectNames:
+        - entityName: '*'
+          aspectName: status
+  mutationHooks:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestMutator'
+      packageScan:
+        - com.datahub.plugins.metadata.aspect.test
+      spring:
+        enabled: true
+      supportedOperations:
+        - UPSERT
+        - DELETE
+      supportedEntityAspectNames:
+        - entityName: '*'
+          aspectName: schemaMetadata
+  mclSideEffects:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestMCLSideEffect'
+      packageScan:
+        - com.datahub.plugins.metadata.aspect.test
+      spring:
+        enabled: true
+      supportedOperations:
+        - UPSERT
+        - DELETE
+      supportedEntityAspectNames:
+        - entityName: chart
+          aspectName: chartInfo
+  mcpSideEffects:
+    - className: 'com.datahub.plugins.metadata.aspect.SpringPluginFactoryTest$TestMCPSideEffect'
+      packageScan:
+        - com.datahub.plugins.metadata.aspect.test
+      spring:
+        enabled: true
+      supportedOperations:
+        - UPSERT
+        - DELETE
+      supportedEntityAspectNames:
+        - entityName: dataset
+          aspectName: datasetKey


### PR DESCRIPTION
* added additional tests
* added the ability for Spring Plugin class to produce multiple plugin beans


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for plugin handling, including `isEmpty()` and `hasLoadedPlugins()`, enhancing the plugin management experience.

- **Bug Fixes**
  - Improved merging logic for plugins to handle loading and merging more efficiently.

- **Tests**
  - Added new test cases to ensure the proper functioning of empty and unloaded plugin merges.
  - Introduced comprehensive tests for Spring plugin factory configurations and entity registry with specific aspect configurations.

- **Chores**
  - Updated test dependencies for better testing coverage and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->