### PR TITLE
feat(cli): add more details to get cli

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -22,6 +22,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - Protobuf CLI will no longer create binary encoded protoc custom properties. Flag added `-protocProp` in case this 
   behavior is required.
+- `datahub get ...` CLI output format changed a bit. To use the older output format pass `datahub get -v 1 ...`
 
 ### Potential Downtime
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -22,7 +22,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - Protobuf CLI will no longer create binary encoded protoc custom properties. Flag added `-protocProp` in case this 
   behavior is required.
-- `datahub get ...` CLI output format changed a bit. To use the older output format pass `datahub get -v 1 ...`
+- `datahub get ...` CLI output format changed a bit. To use the older output format pass `datahub get --no-details ...`
 
 ### Potential Downtime
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -22,7 +22,6 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - Protobuf CLI will no longer create binary encoded protoc custom properties. Flag added `-protocProp` in case this 
   behavior is required.
-- `datahub get ...` CLI output format changed a bit. To use the older output format pass `datahub get --no-details ...`
 
 ### Potential Downtime
 

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -522,6 +522,7 @@ def get_aspects_for_entity(
     aspects: List[str],
     typed: bool = False,
     cached_session_host: Optional[Tuple[Session, str]] = None,
+    version: int = 1,
 ) -> Dict[str, Union[dict, _Aspect]]:
     # Process non-timeseries aspects
     non_timeseries_aspects = [a for a in aspects if a not in TIMESERIES_ASPECT_MAP]
@@ -553,7 +554,12 @@ def get_aspects_for_entity(
             aspect_name
         )
 
-        aspect_dict = a["value"]
+        if version == 2:
+            aspect_dict = a
+            for k in ["name", "version", "type"]:
+                del aspect_dict[k]
+        else:
+            aspect_dict = a["value"]
         if not typed:
             aspect_map[aspect_name] = aspect_dict
         elif aspect_py_class:

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -522,7 +522,7 @@ def get_aspects_for_entity(
     aspects: List[str],
     typed: bool = False,
     cached_session_host: Optional[Tuple[Session, str]] = None,
-    version: int = 1,
+    details: bool = False,
 ) -> Dict[str, Union[dict, _Aspect]]:
     # Process non-timeseries aspects
     non_timeseries_aspects = [a for a in aspects if a not in TIMESERIES_ASPECT_MAP]
@@ -554,7 +554,7 @@ def get_aspects_for_entity(
             aspect_name
         )
 
-        if version == 2:
+        if details:
             aspect_dict = a
             for k in ["name", "version", "type"]:
                 del aspect_dict[k]

--- a/metadata-ingestion/src/datahub/cli/get_cli.py
+++ b/metadata-ingestion/src/datahub/cli/get_cli.py
@@ -25,8 +25,8 @@ def get() -> None:
     "--details/--no-details",
     required=False,
     is_flag=True,
-    default=True,
-    help="Whether to .",
+    default=False,
+    help="Whether to print details from database which help in audit.",
 )
 @click.pass_context
 @upgrade.check_upgrade

--- a/metadata-ingestion/src/datahub/cli/get_cli.py
+++ b/metadata-ingestion/src/datahub/cli/get_cli.py
@@ -22,17 +22,16 @@ def get() -> None:
 @click.option("--urn", required=False, type=str)
 @click.option("-a", "--aspect", required=False, multiple=True, type=str)
 @click.option(
-    "-v",
-    "--version",
+    "--details/--no-details",
     required=False,
-    type=int,
-    default=2,
-    help="Version of get CLI to use.",
+    is_flag=True,
+    default=True,
+    help="Whether to .",
 )
 @click.pass_context
 @upgrade.check_upgrade
 @telemetry.with_telemetry()
-def urn(ctx: Any, urn: Optional[str], aspect: List[str], version: int) -> None:
+def urn(ctx: Any, urn: Optional[str], aspect: List[str], details: bool) -> None:
     """
     Get metadata for an entity with an optional list of aspects to project.
     This works for both versioned aspects and timeseries aspects. For timeseries aspects, it fetches the latest value.
@@ -48,7 +47,7 @@ def urn(ctx: Any, urn: Optional[str], aspect: List[str], version: int) -> None:
     click.echo(
         json.dumps(
             get_aspects_for_entity(
-                entity_urn=urn, aspects=aspect, typed=False, version=version
+                entity_urn=urn, aspects=aspect, typed=False, details=details
             ),
             sort_keys=True,
             indent=2,

--- a/metadata-ingestion/src/datahub/cli/get_cli.py
+++ b/metadata-ingestion/src/datahub/cli/get_cli.py
@@ -21,10 +21,18 @@ def get() -> None:
 @get.command()
 @click.option("--urn", required=False, type=str)
 @click.option("-a", "--aspect", required=False, multiple=True, type=str)
+@click.option(
+    "-v",
+    "--version",
+    required=False,
+    type=int,
+    default=2,
+    help="Version of get CLI to use.",
+)
 @click.pass_context
 @upgrade.check_upgrade
 @telemetry.with_telemetry()
-def urn(ctx: Any, urn: Optional[str], aspect: List[str]) -> None:
+def urn(ctx: Any, urn: Optional[str], aspect: List[str], version: int) -> None:
     """
     Get metadata for an entity with an optional list of aspects to project.
     This works for both versioned aspects and timeseries aspects. For timeseries aspects, it fetches the latest value.
@@ -39,7 +47,9 @@ def urn(ctx: Any, urn: Optional[str], aspect: List[str]) -> None:
         logger.debug(f"Using urn from args {urn}")
     click.echo(
         json.dumps(
-            get_aspects_for_entity(entity_urn=urn, aspects=aspect, typed=False),
+            get_aspects_for_entity(
+                entity_urn=urn, aspects=aspect, typed=False, version=version
+            ),
             sort_keys=True,
             indent=2,
         )


### PR DESCRIPTION
EDIT
- Instead of using version now using `--details/--no-details` with details to be true so screenshot args are out of date but output format is still valid.

Format changed from
![image](https://github.com/datahub-project/datahub/assets/4127841/99099546-f63f-4563-979f-fa70edff54a6)

to

![image](https://github.com/datahub-project/datahub/assets/4127841/334a3419-9a2d-409d-a840-b9a2f03e4807)

which shows a lot more auditing information. This is useful to debug issues in an easier manner.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `--details/--no-details` flag to the `get` CLI command, allowing users to toggle detailed output.
  
- **Documentation**
  - Updated instructions for using the DataHub CLI, specifically around fetching data with the new output format options.

- **Enhancements**
  - Enhanced the `get_aspects_for_entity` function to support detailed processing based on the new `details` parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->