### PR TITLE
fix(ingestion/bigquery-gcs-lineage): Add lineage extraction for BigQuery with GCS source

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery.py
@@ -73,7 +73,6 @@ from datahub.ingestion.source.common.subtypes import (
     DatasetContainerSubTypes,
     DatasetSubTypes,
 )
-from datahub.ingestion.source.gcs import gcs_utils
 from datahub.ingestion.source.sql.sql_utils import (
     add_table_to_schema_container,
     gen_database_container,
@@ -1146,15 +1145,10 @@ class BigqueryV2Source(StatefulIngestionSourceBase, TestableSource):
             uris_match = re.search(r"uris=\[([^\]]+)\]", table.ddl)
             if uris_match:
                 uris_str = uris_match.group(1)
-                uris_list = json.loads(f"[{uris_str}]")
-                storage_location = str(uris_list[0])
-                # Check that storage_location have the gs:// prefix.
-                if gcs_utils.is_gcs_uri(storage_location):
-                    yield from self.lineage_extractor.gen_lineage_workunits_with_gcs(
-                        self.gcs_parser_schema_resolver,
-                        dataset_urn,
-                        gcs_utils.strip_gcs_prefix(storage_location),
-                    )
+                source_uris = json.loads(f"[{uris_str}]")
+                yield from self.lineage_extractor.gen_lineage_workunits_with_gcs(
+                    self.gcs_parser_schema_resolver, dataset_urn, source_uris
+                )
 
         status = Status(removed=False)
         yield MetadataChangeProposalWrapper(

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -100,6 +100,7 @@ class BigqueryTable(BaseTable):
     long_term_billable_bytes: Optional[int] = None
     partition_info: Optional[PartitionInfo] = None
     columns_ignore_from_profiling: List[str] = field(default_factory=list)
+    table_type: Optional[str] = None
 
 
 @dataclass
@@ -301,6 +302,7 @@ class BigQuerySchemaApi:
         return BigqueryTable(
             name=table.table_name,
             created=table.created,
+            table_type=table.table_type,
             last_altered=(
                 datetime.fromtimestamp(
                     table.get("last_altered") / 1000, tz=timezone.utc

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -14,6 +14,7 @@ from datahub.ingestion.source.bigquery_v2.lineage import (
     BigqueryLineageExtractor,
     LineageEdge,
 )
+from datahub.metadata.schema_classes import UpstreamLineageClass
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 
 
@@ -131,3 +132,182 @@ def test_column_level_lineage(lineage_entries: List[QueryEvent]) -> None:
         upstream_lineage.fineGrainedLineages
         and len(upstream_lineage.fineGrainedLineages) == 2
     )
+
+
+class MockSchemaResolver(SchemaResolver):
+    def __init__(self, urns: Set[str]):
+        self._urns = urns
+
+    def get_urns(self) -> Set[str]:
+        return self._urns
+
+
+@pytest.fixture
+def mock_schema_resolver() -> MockSchemaResolver:
+    urns = {
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table3/file2.csv,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table2/part1/file1.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/sample1.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table3/file1.txt,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file2.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file1.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table2/part2/file2.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/bar.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/sample2.parquet,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept1/tests/table4/file1.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept1/tests/table4/file2.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=06/file1.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=07/file2.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/29/file1.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file1.txt,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file2.csv,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/table8/2023/06/29/file1.txt,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/table8/2023/06/29/file2.csv,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/level2/table9/2023/06/29/file1.txt,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/level2/table9/2023/06/29/file2.csv,PROD)",
+    }
+    return MockSchemaResolver(urns)
+
+
+@pytest.fixture
+def gcs_patterns() -> List[str]:
+    return [
+        "my-bucket/foo/tests/bar.avro",
+        "my-bucket/foo/tests/*.*",
+        "my-bucket/foo/tests/{table}/*.avro",
+        "my-bucket/foo/tests/{table}/*/*.avro",
+        "my-bucket/foo/tests/{table}/*.*",
+        "my-bucket/{dept}/tests/{table}/*.avro",
+        "my-bucket/{dept}/tests/{table}/{partition_key[0]}={partition[0]}/{partition_key[1]}={partition[1]}/*.avro",
+        "my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.avro",
+        "my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+        "my-bucket/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+        "my-bucket/*/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+    ]
+
+
+def validate_workunits(workunits, expected_upstreams):
+    assert len(workunits) == 1
+    assert workunits[0].get_aspect_of_type(UpstreamLineageClass)
+    upstream_lineage = workunits[0].get_aspect_of_type(UpstreamLineageClass)
+    assert len(upstream_lineage.upstreams) == len(expected_upstreams)
+    upstream_urns = {upstream.dataset for upstream in upstream_lineage.upstreams}
+    for expected_upstream in expected_upstreams:
+        assert expected_upstream in upstream_urns
+
+
+@pytest.mark.parametrize(
+    "gcs_pattern, expected_upstreams",
+    [
+        (
+            "my-bucket/foo/tests/bar.avro",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/bar.avro,PROD)"
+            ],
+        ),
+        (
+            "my-bucket/foo/tests/*.*",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/sample2.parquet,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/bar.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/sample1.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/foo/tests/{table}/*.avro",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file1.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/foo/tests/{table}/*/*.avro",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table2/part1/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table2/part2/file2.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/foo/tests/{table}/*.*",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table3/file2.csv,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table3/file1.txt,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file1.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/{dept}/tests/{table}/*.avro",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept1/tests/table4/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept1/tests/table4/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file2.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/{dept}/tests/{table}/{partition_key[0]}={partition[0]}/{partition_key[1]}={partition[1]}/*.avro",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=06/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=07/file2.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.avro",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/29/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file2.csv,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/29/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file1.txt,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=07/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/table8/2023/06/29/file1.txt,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=06/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/table8/2023/06/29/file2.csv,PROD)",
+            ],
+        ),
+        (
+            "my-bucket/*/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/29/file1.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/level2/table9/2023/06/29/file2.csv,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file1.txt,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file2.csv,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/level2/table9/2023/06/29/file1.txt,PROD)",
+            ],
+        ),
+    ],
+)
+def test_gen_lineage_workunits_with_gcs(
+    mock_schema_resolver: MockSchemaResolver,
+    gcs_pattern: str,
+    expected_upstreams: List[str],
+) -> None:
+    config = BigQueryV2Config()
+    report = BigQueryV2Report()
+    extractor = BigqueryLineageExtractor(
+        config, report, lambda x: builder.make_dataset_urn("bigquery", str(x))
+    )
+
+    dataset_urn = "urn:li:dataset:(urn:li:dataPlatform:bigquery,my_project.my_dataset.my_table,PROD)"
+
+    workunits = list(
+        extractor.gen_lineage_workunits_with_gcs(
+            mock_schema_resolver, dataset_urn, gcs_pattern
+        )
+    )
+
+    validate_workunits(workunits, expected_upstreams)

--- a/metadata-ingestion/tests/unit/test_bigquery_lineage.py
+++ b/metadata-ingestion/tests/unit/test_bigquery_lineage.py
@@ -201,13 +201,13 @@ def validate_workunits(workunits, expected_upstreams):
     "gcs_pattern, expected_upstreams",
     [
         (
-            "my-bucket/foo/tests/bar.avro",
+            ["gs://my-bucket/foo/tests/bar.avro"],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/bar.avro,PROD)"
             ],
         ),
         (
-            "my-bucket/foo/tests/*.*",
+            ["gs://my-bucket/foo/tests/*.*"],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/sample2.parquet,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/bar.avro,PROD)",
@@ -215,21 +215,21 @@ def validate_workunits(workunits, expected_upstreams):
             ],
         ),
         (
-            "my-bucket/foo/tests/{table}/*.avro",
+            ["gs://my-bucket/foo/tests/{table}/*.avro"],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file2.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file1.avro,PROD)",
             ],
         ),
         (
-            "my-bucket/foo/tests/{table}/*/*.avro",
+            ["gs://my-bucket/foo/tests/{table}/*/*.avro"],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table2/part1/file1.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table2/part2/file2.avro,PROD)",
             ],
         ),
         (
-            "my-bucket/foo/tests/{table}/*.*",
+            ["gs://my-bucket/foo/tests/{table}/*.*"],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table3/file2.csv,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table3/file1.txt,PROD)",
@@ -238,7 +238,7 @@ def validate_workunits(workunits, expected_upstreams):
             ],
         ),
         (
-            "my-bucket/{dept}/tests/{table}/*.avro",
+            ["gs://my-bucket/{dept}/tests/{table}/*.avro"],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept1/tests/table4/file1.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept1/tests/table4/file2.avro,PROD)",
@@ -247,21 +247,27 @@ def validate_workunits(workunits, expected_upstreams):
             ],
         ),
         (
-            "my-bucket/{dept}/tests/{table}/{partition_key[0]}={partition[0]}/{partition_key[1]}={partition[1]}/*.avro",
+            [
+                "gs://my-bucket/{dept}/tests/{table}/{partition_key[0]}={partition[0]}/{partition_key[1]}={partition[1]}/*.avro"
+            ],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=06/file1.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=07/file2.avro,PROD)",
             ],
         ),
         (
-            "my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.avro",
+            [
+                "gs://my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.avro"
+            ],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/29/file1.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
             ],
         ),
         (
-            "my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+            [
+                "gs://my-bucket/{dept}/tests/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*"
+            ],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept4/tests/table7/2023/06/29/file2.csv,PROD)",
@@ -270,7 +276,9 @@ def validate_workunits(workunits, expected_upstreams):
             ],
         ),
         (
-            "my-bucket/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+            [
+                "gs://my-bucket/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*"
+            ],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept2/tests/table5/year=2023/month=07/file2.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/table8/2023/06/29/file1.txt,PROD)",
@@ -279,7 +287,9 @@ def validate_workunits(workunits, expected_upstreams):
             ],
         ),
         (
-            "my-bucket/*/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*",
+            [
+                "gs://my-bucket/*/*/{table}/{partition[0]}/{partition[1]}/{partition[2]}/*.*"
+            ],
             [
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/30/file2.avro,PROD)",
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/dept3/tests/table6/2023/06/29/file1.avro,PROD)",
@@ -289,11 +299,22 @@ def validate_workunits(workunits, expected_upstreams):
                 "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/level1/level2/table9/2023/06/29/file1.txt,PROD)",
             ],
         ),
+        (
+            [
+                "gs://my-bucket/foo/tests/bar.avro",
+                "gs://my-bucket/foo/tests/{table}/*.avro",
+            ],
+            [
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/bar.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file2.avro,PROD)",
+                "urn:li:dataset:(urn:li:dataPlatform:gcs,my-bucket/foo/tests/table1/file1.avro,PROD)",
+            ],
+        ),
     ],
 )
 def test_gen_lineage_workunits_with_gcs(
     mock_schema_resolver: MockSchemaResolver,
-    gcs_pattern: str,
+    gcs_pattern: List[str],
     expected_upstreams: List[str],
 ) -> None:
     config = BigQueryV2Config()
@@ -306,7 +327,7 @@ def test_gen_lineage_workunits_with_gcs(
 
     workunits = list(
         extractor.gen_lineage_workunits_with_gcs(
-            mock_schema_resolver, dataset_urn, gcs_pattern
+            mock_schema_resolver, dataset_urn, source_uris=gcs_pattern
         )
     )
 


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for schema resolution based on different platforms, including GCS.
  - Enhanced external table handling with GCS storage locations to generate lineage work units.

- **Enhancements**
  - Updated `BigqueryTable` class to include a `table_type` field for better table categorization.
  - Introduced new methods to support GCS pattern transformations and lineage work unit generation.

- **Tests**
  - Added unit tests to validate lineage work units generated from specific GCS patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->