### PR TITLE
fix(ingest): correct profile_day_of_week implementation

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source_config/operation_config.py
@@ -69,10 +69,10 @@ def is_profiling_enabled(operation_config: OperationConfig) -> bool:
     today = datetime.date.today()
     if (
         operation_config.profile_day_of_week is not None
-        and operation_config.profile_date_of_month != today.weekday()
+        and operation_config.profile_day_of_week != today.weekday()
     ):
         logger.info(
-            "Profiling won't be done because weekday does not match config profile_date_of_month.",
+            "Profiling won't be done because weekday does not match config profile_day_of_week.",
         )
         return False
     if (


### PR DESCRIPTION
Condition to check if profiling should run mixed profile_date_of_month
variable into the profile_day_of_week section

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the condition for enabling profiling to ensure it matches the configured day of the week accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->