### PR TITLE
feat(SDK) Add java SDK for structuredProperty entity PATCH + CRUD examples

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilder.java
@@ -1,0 +1,146 @@
+package com.linkedin.metadata.aspect.patch.builder;
+
+import static com.fasterxml.jackson.databind.node.JsonNodeFactory.instance;
+import static com.linkedin.metadata.Constants.*;
+
+import com.datahub.util.RecordUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.data.template.StringArrayMap;
+import com.linkedin.metadata.aspect.patch.PatchOperationType;
+import com.linkedin.structured.PropertyCardinality;
+import com.linkedin.structured.PropertyValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+
+public class StructuredPropertyDefinitionPatchBuilder
+    extends AbstractMultiFieldPatchBuilder<StructuredPropertyDefinitionPatchBuilder> {
+
+  public static final String PATH_DELIM = "/";
+  public static final String QUALIFIED_NAME_FIELD = "qualifiedName";
+  public static final String DISPLAY_NAME_FIELD = "displayName";
+  public static final String VALUE_TYPE_FIELD = "valueType";
+  public static final String TYPE_QUALIFIER_FIELD = "typeQualifier";
+  public static final String ALLOWED_VALUES_FIELD = "allowedValues";
+  public static final String CARDINALITY_FIELD = "cardinality";
+  public static final String ENTITY_TYPES_FIELD = "entityTypes";
+  public static final String DESCRIPTION_FIELD = "description";
+  public static final String IMMUTABLE_FIELD = "immutable";
+
+  // can only be used when creating a new structured property
+  public StructuredPropertyDefinitionPatchBuilder setQualifiedName(@Nonnull String name) {
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(),
+            PATH_DELIM + QUALIFIED_NAME_FIELD,
+            instance.textNode(name)));
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setDisplayName(@Nonnull String displayName) {
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(),
+            PATH_DELIM + DISPLAY_NAME_FIELD,
+            instance.textNode(displayName)));
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setValueType(@Nonnull String valueTypeUrn) {
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(),
+            PATH_DELIM + VALUE_TYPE_FIELD,
+            instance.textNode(valueTypeUrn)));
+    return this;
+  }
+
+  // can only be used when creating a new structured property
+  public StructuredPropertyDefinitionPatchBuilder setTypeQualifier(
+      @Nonnull StringArrayMap typeQualifier) {
+    ObjectNode value = instance.objectNode();
+    typeQualifier.forEach(
+        (key, values) -> {
+          ArrayNode valuesNode = instance.arrayNode();
+          values.forEach(valuesNode::add);
+          value.set(key, valuesNode);
+        });
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(), PATH_DELIM + TYPE_QUALIFIER_FIELD, value));
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder addAllowedValue(
+      @Nonnull PropertyValue propertyValue) {
+    try {
+      ObjectNode valueNode =
+          (ObjectNode) new ObjectMapper().readTree(RecordUtils.toJsonString(propertyValue));
+      this.pathValues.add(
+          ImmutableTriple.of(
+              PatchOperationType.ADD.getValue(),
+              PATH_DELIM + ALLOWED_VALUES_FIELD + PATH_DELIM + propertyValue.getValue(),
+              valueNode));
+      return this;
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(
+          "Failed to add allowed value, failed to parse provided aspect json.", e);
+    }
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setCardinality(
+      @Nonnull PropertyCardinality cardinality) {
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(),
+            PATH_DELIM + CARDINALITY_FIELD,
+            instance.textNode(cardinality.toString())));
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder addEntityType(@Nonnull String entityTypeUrn) {
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(),
+            PATH_DELIM + ENTITY_TYPES_FIELD + PATH_DELIM + entityTypeUrn,
+            instance.textNode(entityTypeUrn)));
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setDescription(@Nullable String description) {
+    if (description == null) {
+      this.pathValues.add(
+          ImmutableTriple.of(
+              PatchOperationType.REMOVE.getValue(), PATH_DELIM + DESCRIPTION_FIELD, null));
+    } else {
+      this.pathValues.add(
+          ImmutableTriple.of(
+              PatchOperationType.ADD.getValue(),
+              PATH_DELIM + DESCRIPTION_FIELD,
+              instance.textNode(description)));
+    }
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setImmutable(boolean immutable) {
+    this.pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(),
+            PATH_DELIM + IMMUTABLE_FIELD,
+            instance.booleanNode(immutable)));
+    return this;
+  }
+
+  @Override
+  protected String getAspectName() {
+    return STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
+  }
+
+  @Override
+  protected String getEntityType() {
+    return STRUCTURED_PROPERTY_ENTITY_NAME;
+  }
+}

--- a/metadata-integration/java/datahub-client/src/test/java/datahub/client/patch/PatchTest.java
+++ b/metadata-integration/java/datahub-client/src/test/java/datahub/client/patch/PatchTest.java
@@ -758,7 +758,7 @@ public class PatchTest {
       String token = "";
       RestEmitter emitter = RestEmitter.create(b -> b.server("http://localhost:8080").token(token));
       Future<MetadataWriteResponse> response = emitter.emit(mcp, null);
-            System.out.println(response.get().getResponseContent());
+      System.out.println(response.get().getResponseContent());
 
     } catch (IOException | ExecutionException | InterruptedException e) {
       System.out.println(Arrays.asList(e.getStackTrace()));

--- a/metadata-integration/java/examples/src/main/java/io/datahubproject/examples/DatasetStructuredPropertiesUpdate.java
+++ b/metadata-integration/java/examples/src/main/java/io/datahubproject/examples/DatasetStructuredPropertiesUpdate.java
@@ -1,0 +1,79 @@
+package io.datahubproject.examples;
+
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.metadata.aspect.patch.builder.StructuredPropertiesPatchBuilder;
+import com.linkedin.mxe.MetadataChangeProposal;
+import datahub.client.MetadataWriteResponse;
+import datahub.client.rest.RestEmitter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class DatasetStructuredPropertiesUpdate {
+
+  private DatasetStructuredPropertiesUpdate() {}
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+
+    // Adding a structured property with a single string value
+    MetadataChangeProposal mcp1 =
+        new StructuredPropertiesPatchBuilder()
+            .urn(
+                UrnUtils.getUrn(
+                    "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)"))
+            .setStringProperty(
+                UrnUtils.getUrn("urn:li:structuredProperty:io.acryl.privacy.retentionTime"), "30")
+            .build();
+
+    String token = "";
+    RestEmitter emitter = RestEmitter.create(b -> b.server("http://localhost:8080").token(token));
+    Future<MetadataWriteResponse> response1 = emitter.emit(mcp1, null);
+    System.out.println(response1.get().getResponseContent());
+
+    // Adding a structured property with a list of string values
+    List<String> values = new ArrayList<>();
+    values.add("30");
+    values.add("90");
+    MetadataChangeProposal mcp2 =
+        new StructuredPropertiesPatchBuilder()
+            .urn(
+                UrnUtils.getUrn(
+                    "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)"))
+            .setStringProperty(
+                UrnUtils.getUrn("urn:li:structuredProperty:io.acryl.privacy.retentionTime"), values)
+            .build();
+
+    Future<MetadataWriteResponse> response2 = emitter.emit(mcp2, null);
+    System.out.println(response2.get().getResponseContent());
+
+    // Adding a structured property with a single number value
+    MetadataChangeProposal mcp3 =
+        new StructuredPropertiesPatchBuilder()
+            .urn(
+                UrnUtils.getUrn(
+                    "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)"))
+            .setNumberProperty(
+                UrnUtils.getUrn("urn:li:structuredProperty:io.acryl.dataManagement.replicationSLA"),
+                3456)
+            .build();
+
+    Future<MetadataWriteResponse> response3 = emitter.emit(mcp3, null);
+    System.out.println(response3.get().getResponseContent());
+
+    // Removing a structured property from a dataset
+    MetadataChangeProposal mcp4 =
+        new StructuredPropertiesPatchBuilder()
+            .urn(
+                UrnUtils.getUrn(
+                    "urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)"))
+            .removeProperty(
+                UrnUtils.getUrn("urn:li:structuredProperty:io.acryl.dataManagement.replicationSLA"))
+            .build();
+
+    Future<MetadataWriteResponse> response4 = emitter.emit(mcp4, null);
+    System.out.println(response4.get().getResponseContent());
+  }
+}

--- a/metadata-integration/java/examples/src/main/java/io/datahubproject/examples/StructuredPropertyUpsert.java
+++ b/metadata-integration/java/examples/src/main/java/io/datahubproject/examples/StructuredPropertyUpsert.java
@@ -1,0 +1,102 @@
+package io.datahubproject.examples;
+
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringArrayMap;
+import com.linkedin.metadata.aspect.patch.builder.StructuredPropertyDefinitionPatchBuilder;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.structured.PrimitivePropertyValue;
+import com.linkedin.structured.PropertyCardinality;
+import com.linkedin.structured.PropertyValue;
+import datahub.client.MetadataWriteResponse;
+import datahub.client.rest.RestEmitter;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class StructuredPropertyUpsert {
+
+  private StructuredPropertyUpsert() {}
+
+  public static void main(String[] args)
+      throws IOException, ExecutionException, InterruptedException {
+    // open ended string structured property on datasets and dataFlows
+    MetadataChangeProposal mcp1 =
+        new StructuredPropertyDefinitionPatchBuilder()
+            .urn(
+                UrnUtils.getUrn(
+                    "urn:li:structuredProperty:testString")) // use existing urn for update, new urn
+            // for new property
+            .setQualifiedName("io.acryl.testString")
+            .setDisplayName("Open Ended String")
+            .setValueType("urn:li:dataType:datahub.string")
+            .setCardinality(PropertyCardinality.SINGLE)
+            .addEntityType("urn:li:entityType:datahub.dataset")
+            .addEntityType("urn:li:entityType:datahub.dataFlow")
+            .setDescription("test description for open ended string")
+            .setImmutable(true)
+            .build();
+
+    String token = "";
+    RestEmitter emitter = RestEmitter.create(b -> b.server("http://localhost:8080").token(token));
+    Future<MetadataWriteResponse> response1 = emitter.emit(mcp1, null);
+    System.out.println(response1.get().getResponseContent());
+
+    // Next, let's make a property that allows for multiple datahub entity urns as values
+    // This example property could be used to reference other users or groups in datahub
+    StringArrayMap typeQualifier = new StringArrayMap();
+    typeQualifier.put(
+        "allowedTypes",
+        new StringArray(
+            "urn:li:entityType:datahub.corpuser", "urn:li:entityType:datahub.corpGroup"));
+
+    MetadataChangeProposal mcp2 =
+        new StructuredPropertyDefinitionPatchBuilder()
+            .urn(UrnUtils.getUrn("urn:li:structuredProperty:dataSteward"))
+            .setQualifiedName("io.acryl.dataManagement.dataSteward")
+            .setDisplayName("Data Steward")
+            .setValueType("urn:li:dataType:datahub.urn")
+            .setTypeQualifier(typeQualifier)
+            .setCardinality(PropertyCardinality.MULTIPLE)
+            .addEntityType("urn:li:entityType:datahub.dataset")
+            .setDescription(
+                "The data stewards of this asset are in charge of ensuring data cleanliness and governance")
+            .setImmutable(true)
+            .build();
+
+    Future<MetadataWriteResponse> response2 = emitter.emit(mcp2, null);
+    System.out.println(response2.get().getResponseContent());
+
+    // Finally, let's make a single select number property with a few allowed options
+    PropertyValue propertyValue1 = new PropertyValue();
+    PrimitivePropertyValue value1 = new PrimitivePropertyValue();
+    value1.setDouble(30.0);
+    propertyValue1.setDescription(
+        "30 days, usually reserved for datasets that are ephemeral and contain pii");
+    propertyValue1.setValue(value1);
+    PropertyValue propertyValue2 = new PropertyValue();
+    PrimitivePropertyValue value2 = new PrimitivePropertyValue();
+    value2.setDouble(90.0);
+    propertyValue2.setDescription(
+        "Use this for datasets that drive monthly reporting but contain pii");
+    propertyValue2.setValue(value2);
+
+    MetadataChangeProposal mcp3 =
+        new StructuredPropertyDefinitionPatchBuilder()
+            .urn(UrnUtils.getUrn("urn:li:structuredProperty:replicationSLA"))
+            .setQualifiedName("io.acryl.dataManagement.replicationSLA")
+            .setDisplayName("Replication SLA")
+            .setValueType("urn:li:dataType:datahub.string")
+            .addAllowedValue(propertyValue1)
+            .addAllowedValue(propertyValue2)
+            .setCardinality(PropertyCardinality.SINGLE)
+            .addEntityType("urn:li:entityType:datahub.dataset")
+            .setDescription(
+                "SLA for how long data can be delayed before replicating to the destination cluster")
+            .setImmutable(false)
+            .build();
+
+    Future<MetadataWriteResponse> response3 = emitter.emit(mcp3, null);
+    System.out.println(response3.get().getResponseContent());
+  }
+}


### PR DESCRIPTION
This PR tackles two main pieces in the Java SDK around structured properties:
1. Adding a patch builder for the Structured Property entity as well as tests and examples
2. Fixing the broken patch builder for the structuredProperties aspect on assets and adds tests and examples

So now you should be able to create structured properties and then assign/patch them on assets using the java SDK.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new structured property update functionalities for datasets.
  - Added classes and methods to define and upsert structured properties in DataHub.

- **Tests**
  - Added new test methods to validate structured property definitions and updates.

These updates enhance the flexibility and capabilities of managing structured properties, providing users with robust options for handling complex data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->