### PR TITLE
feat(SDK) Add StructuredPropertyPatchBuilder in python sdk and provide sample CRUD files

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
@@ -12,6 +12,8 @@ import java.util.List;
 
 public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template<T> {
 
+  static final String UNIT_SEPARATOR_DELIMITER = "␟";
+
   /**
    * Takes an Array field on the {@link RecordTemplate} subtype along with a set of key fields to
    * transform into a map Avoids producing side effects by copying nodes, use resulting node and not
@@ -39,7 +41,15 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
                 JsonNode nodeClone = node.deepCopy();
                 if (!keyFields.isEmpty()) {
                   for (String keyField : keyFields) {
-                    String key = node.get(keyField).asText();
+                    String key;
+                    // if the keyField has a unit separator, we are working with a nested key
+                    if (keyField.contains(UNIT_SEPARATOR_DELIMITER)) {
+                      String[] keyParts = keyField.split(UNIT_SEPARATOR_DELIMITER);
+                      JsonNode keyObject = node.get(keyParts[0]);
+                      key = keyObject.get(keyParts[1]).asText();
+                    } else {
+                      key = node.get(keyField).asText();
+                    }
                     keyValue =
                         keyValue.get(key) == null
                             ? (ObjectNode) keyValue.set(key, instance.objectNode()).get(key)

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/AspectTemplateEngine.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/AspectTemplateEngine.java
@@ -12,6 +12,7 @@ import static com.linkedin.metadata.Constants.GLOBAL_TAGS_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.GLOSSARY_TERMS_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.OWNERSHIP_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTIES_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.UPSTREAM_LINEAGE_ASPECT_NAME;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -46,7 +47,8 @@ public class AspectTemplateEngine {
               DATA_JOB_INPUT_OUTPUT_ASPECT_NAME,
               CHART_INFO_ASPECT_NAME,
               DASHBOARD_INFO_ASPECT_NAME,
-              STRUCTURED_PROPERTIES_ASPECT_NAME)
+              STRUCTURED_PROPERTIES_ASPECT_NAME,
+              STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME)
           .collect(Collectors.toSet());
 
   private final Map<String, Template<? extends RecordTemplate>> _aspectTemplateMap;

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/structuredproperty/StructuredPropertyDefinitionTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/structuredproperty/StructuredPropertyDefinitionTemplate.java
@@ -1,0 +1,86 @@
+package com.linkedin.metadata.aspect.patch.template.structuredproperty;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.patch.template.CompoundKeyTemplate;
+import com.linkedin.structured.StructuredPropertyDefinition;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+
+public class StructuredPropertyDefinitionTemplate
+    extends CompoundKeyTemplate<StructuredPropertyDefinition> {
+
+  private static final String ENTITY_TYPES_FIELD_NAME = "entityTypes";
+  private static final String ALLOWED_VALUES_FIELD_NAME = "allowedValues";
+  private static final String VALUE_FIELD_NAME = "value";
+  private static final String UNIT_SEPARATOR_DELIMITER = "␟";
+
+  @Override
+  public StructuredPropertyDefinition getSubtype(RecordTemplate recordTemplate)
+      throws ClassCastException {
+    if (recordTemplate instanceof StructuredPropertyDefinition) {
+      return (StructuredPropertyDefinition) recordTemplate;
+    }
+    throw new ClassCastException("Unable to cast RecordTemplate to StructuredPropertyDefinition");
+  }
+
+  @Override
+  public Class<StructuredPropertyDefinition> getTemplateType() {
+    return StructuredPropertyDefinition.class;
+  }
+
+  @Nonnull
+  @Override
+  public StructuredPropertyDefinition getDefault() {
+    StructuredPropertyDefinition definition = new StructuredPropertyDefinition();
+    definition.setQualifiedName("");
+    definition.setValueType(UrnUtils.getUrn("urn:li:dataType:datahub.string"));
+    definition.setEntityTypes(new UrnArray());
+
+    return definition;
+  }
+
+  @Nonnull
+  @Override
+  public JsonNode transformFields(JsonNode baseNode) {
+    JsonNode transformedNode =
+        arrayFieldToMap(baseNode, ENTITY_TYPES_FIELD_NAME, Collections.emptyList());
+
+    if (transformedNode.get(ALLOWED_VALUES_FIELD_NAME) == null) {
+      return transformedNode;
+    }
+
+    // allowedValues has a nested key - value.string or value.number depending on type. Mapping
+    // needs this nested key
+    JsonNode allowedValues = transformedNode.get(ALLOWED_VALUES_FIELD_NAME);
+    if (((ArrayNode) allowedValues).size() > 0) {
+      JsonNode allowedValue = ((ArrayNode) allowedValues).get(0);
+      JsonNode value = allowedValue.get(VALUE_FIELD_NAME);
+      String secondaryKeyName = value.fieldNames().next();
+      return arrayFieldToMap(
+          transformedNode,
+          ALLOWED_VALUES_FIELD_NAME,
+          Collections.singletonList(
+              VALUE_FIELD_NAME + UNIT_SEPARATOR_DELIMITER + secondaryKeyName));
+    }
+
+    return arrayFieldToMap(
+        transformedNode, ALLOWED_VALUES_FIELD_NAME, Collections.singletonList(VALUE_FIELD_NAME));
+  }
+
+  @Nonnull
+  @Override
+  public JsonNode rebaseFields(JsonNode patched) {
+    JsonNode patchedNode =
+        transformedMapToArray(patched, ENTITY_TYPES_FIELD_NAME, Collections.emptyList());
+
+    if (patchedNode.get(ALLOWED_VALUES_FIELD_NAME) == null) {
+      return patchedNode;
+    }
+    return transformedMapToArray(
+        patchedNode, ALLOWED_VALUES_FIELD_NAME, Collections.singletonList(VALUE_FIELD_NAME));
+  }
+}

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
@@ -20,6 +20,7 @@ import com.linkedin.metadata.aspect.patch.template.dataproduct.DataProductProper
 import com.linkedin.metadata.aspect.patch.template.dataset.DatasetPropertiesTemplate;
 import com.linkedin.metadata.aspect.patch.template.dataset.EditableSchemaMetadataTemplate;
 import com.linkedin.metadata.aspect.patch.template.dataset.UpstreamLineageTemplate;
+import com.linkedin.metadata.aspect.patch.template.structuredproperty.StructuredPropertyDefinitionTemplate;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.DefaultEntitySpec;
 import com.linkedin.metadata.models.EntitySpec;
@@ -87,6 +88,8 @@ public class SnapshotEntityRegistry implements EntityRegistry {
     aspectSpecTemplateMap.put(DATA_JOB_INPUT_OUTPUT_ASPECT_NAME, new DataJobInputOutputTemplate());
     aspectSpecTemplateMap.put(
         STRUCTURED_PROPERTIES_ASPECT_NAME, new StructuredPropertiesTemplate());
+    aspectSpecTemplateMap.put(
+        STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME, new StructuredPropertyDefinitionTemplate());
     return new AspectTemplateEngine(aspectSpecTemplateMap);
   }
 

--- a/metadata-ingestion/examples/library/dataset_add_structured_properties.py
+++ b/metadata-ingestion/examples/library/dataset_add_structured_properties.py
@@ -1,0 +1,24 @@
+import logging
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.rest_emitter import DataHubRestEmitter
+from datahub.specific.dataset import DatasetPatchBuilder
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Create rest emitter
+rest_emitter = DataHubRestEmitter(gms_server="http://localhost:8080")
+
+dataset_urn = make_dataset_urn(platform="hive", name="fct_users_created", env="PROD")
+
+
+for patch_mcp in (
+    DatasetPatchBuilder(dataset_urn)
+    .add_structured_property("io.acryl.dataManagement.replicationSLA", 12)
+    .build()
+):
+    rest_emitter.emit(patch_mcp)
+
+
+log.info(f"Added cluster_name, retention_time properties to dataset {dataset_urn}")

--- a/metadata-ingestion/examples/library/dataset_remove_structured_properties.py
+++ b/metadata-ingestion/examples/library/dataset_remove_structured_properties.py
@@ -1,0 +1,24 @@
+import logging
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.rest_emitter import DataHubRestEmitter
+from datahub.specific.dataset import DatasetPatchBuilder
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Create rest emitter
+rest_emitter = DataHubRestEmitter(gms_server="http://localhost:8080")
+
+dataset_urn = make_dataset_urn(platform="hive", name="fct_users_created", env="PROD")
+
+
+for patch_mcp in (
+    DatasetPatchBuilder(dataset_urn)
+    .remove_structured_property("io.acryl.dataManagement.replicationSLA")
+    .build()
+):
+    rest_emitter.emit(patch_mcp)
+
+
+log.info(f"Added cluster_name, retention_time properties to dataset {dataset_urn}")

--- a/metadata-ingestion/examples/library/dataset_update_structured_properties.py
+++ b/metadata-ingestion/examples/library/dataset_update_structured_properties.py
@@ -1,0 +1,24 @@
+import logging
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.rest_emitter import DataHubRestEmitter
+from datahub.specific.dataset import DatasetPatchBuilder
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Create rest emitter
+rest_emitter = DataHubRestEmitter(gms_server="http://localhost:8080")
+
+dataset_urn = make_dataset_urn(platform="hive", name="fct_users_created", env="PROD")
+
+
+for patch_mcp in (
+    DatasetPatchBuilder(dataset_urn)
+    .set_structured_property("io.acryl.dataManagement.replicationSLA", 120)
+    .build()
+):
+    rest_emitter.emit(patch_mcp)
+
+
+log.info(f"Added cluster_name, retention_time properties to dataset {dataset_urn}")

--- a/metadata-ingestion/examples/structured_properties/create_structured_property.py
+++ b/metadata-ingestion/examples/structured_properties/create_structured_property.py
@@ -1,0 +1,98 @@
+import logging
+
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.rest_emitter import DatahubRestEmitter
+
+# Imports for metadata model classes
+from datahub.metadata.schema_classes import (
+    PropertyValueClass,
+    StructuredPropertyDefinitionClass,
+)
+from datahub.metadata.urns import StructuredPropertyUrn
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# Create rest emitter
+rest_emitter = DatahubRestEmitter(gms_server="http://localhost:8080")
+
+# first, let's make an open ended structured property that allows one text value
+text_property_urn = StructuredPropertyUrn("openTextProperty")
+text_property_definition = StructuredPropertyDefinitionClass(
+    qualifiedName="io.acryl.openTextProperty",
+    displayName="Open Text Property",
+    valueType="urn:li:dataType:datahub.string",
+    cardinality="SINGLE",
+    entityTypes=[
+        "urn:li:entityType:datahub.dataset",
+        "urn:li:entityType:datahub.container",
+    ],
+    description="This structured property allows a signle open ended response as a value",
+    immutable=False,
+)
+
+event_prop_1: MetadataChangeProposalWrapper = MetadataChangeProposalWrapper(
+    entityUrn=str(text_property_urn),
+    aspect=text_property_definition,
+)
+rest_emitter.emit(event_prop_1)
+
+# next, let's make a property that allows for multiple datahub entity urns as values
+# This example property could be used to reference other users or groups in datahub
+urn_property_urn = StructuredPropertyUrn("dataSteward")
+urn_property_definition = StructuredPropertyDefinitionClass(
+    qualifiedName="io.acryl.dataManagement.dataSteward",
+    displayName="Data Steward",
+    valueType="urn:li:dataType:datahub.urn",
+    cardinality="MULTIPLE",
+    entityTypes=["urn:li:entityType:datahub.dataset"],
+    description="The data stewards of this asset are in charge of ensuring data cleanliness and governance",
+    immutable=True,
+    typeQualifier={
+        "allowedTypes": [
+            "urn:li:entityType:datahub.corpuser",
+            "urn:li:entityType:datahub.corpGroup",
+        ]
+    },  # this line ensures only user or group urns can be assigned as values
+)
+
+event_prop_2: MetadataChangeProposalWrapper = MetadataChangeProposalWrapper(
+    entityUrn=str(urn_property_urn),
+    aspect=urn_property_definition,
+)
+rest_emitter.emit(event_prop_2)
+
+# finally, let's make a single select number property with a few allowed options
+number_property_urn = StructuredPropertyUrn("replicationSLA")
+number_property_definition = StructuredPropertyDefinitionClass(
+    qualifiedName="io.acryl.dataManagement.replicationSLA",
+    displayName="Retention Time",
+    valueType="urn:li:dataType:datahub.number",
+    cardinality="SINGLE",
+    entityTypes=[
+        "urn:li:entityType:datahub.dataset",
+        "urn:li:entityType:datahub.dataFlow",
+    ],
+    description="SLA for how long data can be delayed before replicating to the destination cluster",
+    immutable=False,
+    allowedValues=[
+        PropertyValueClass(
+            value=30,
+            description="30 days, usually reserved for datasets that are ephemeral and contain pii",
+        ),
+        PropertyValueClass(
+            value=90,
+            description="Use this for datasets that drive monthly reporting but contain pii",
+        ),
+        PropertyValueClass(
+            value=365,
+            description="Use this for non-sensitive data that can be retained for longer",
+        ),
+    ],
+)
+
+event_prop_3: MetadataChangeProposalWrapper = MetadataChangeProposalWrapper(
+    entityUrn=str(number_property_urn),
+    aspect=number_property_definition,
+)
+rest_emitter.emit(event_prop_3)

--- a/metadata-ingestion/examples/structured_properties/update_structured_property.py
+++ b/metadata-ingestion/examples/structured_properties/update_structured_property.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Union
+
+from datahub.configuration.kafka import KafkaProducerConnectionConfig
+from datahub.emitter.kafka_emitter import DatahubKafkaEmitter, KafkaEmitterConfig
+from datahub.emitter.rest_emitter import DataHubRestEmitter
+from datahub.metadata.urns import StructuredPropertyUrn
+from datahub.specific.structured_property import StructuredPropertyPatchBuilder
+
+log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+# Get an emitter, either REST or Kafka, this example shows you both
+def get_emitter() -> Union[DataHubRestEmitter, DatahubKafkaEmitter]:
+    USE_REST_EMITTER = True
+    if USE_REST_EMITTER:
+        gms_endpoint = "http://localhost:8080"
+        return DataHubRestEmitter(gms_server=gms_endpoint)
+    else:
+        kafka_server = "localhost:9092"
+        schema_registry_url = "http://localhost:8081"
+        return DatahubKafkaEmitter(
+            config=KafkaEmitterConfig(
+                connection=KafkaProducerConnectionConfig(
+                    bootstrap=kafka_server, schema_registry_url=schema_registry_url
+                )
+            )
+        )
+
+
+# input your unique structured property ID
+property_urn = StructuredPropertyUrn("dataSteward")
+
+with get_emitter() as emitter:
+    for patch_mcp in (
+        StructuredPropertyPatchBuilder(str(property_urn))
+        .set_display_name("test display name")
+        .set_cardinality("MULTIPLE")
+        .add_entity_type("urn:li:entityType:datahub.dataJob")
+        .build()
+    ):
+        emitter.emit(patch_mcp)

--- a/metadata-ingestion/src/datahub/specific/structured_property.py
+++ b/metadata-ingestion/src/datahub/specific/structured_property.py
@@ -1,0 +1,125 @@
+from typing import Dict, List, Optional, Union
+
+from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
+from datahub.metadata.schema_classes import (
+    KafkaAuditHeaderClass,
+    PropertyValueClass,
+    StructuredPropertyDefinitionClass as StructuredPropertyDefinition,
+    SystemMetadataClass,
+)
+from datahub.utilities.urns.urn import Urn
+
+
+# This patch builder is for structured property entities. Not for the aspect on assets.
+class StructuredPropertyPatchBuilder(MetadataPatchProposal):
+    def __init__(
+        self,
+        urn: str,
+        system_metadata: Optional[SystemMetadataClass] = None,
+        audit_header: Optional[KafkaAuditHeaderClass] = None,
+    ) -> None:
+        super().__init__(
+            urn, system_metadata=system_metadata, audit_header=audit_header
+        )
+
+    # can only be used when creating a new structured property
+    def set_qualified_name(
+        self, qualified_name: str
+    ) -> "StructuredPropertyPatchBuilder":
+        self._add_patch(
+            StructuredPropertyDefinition.ASPECT_NAME,
+            "add",
+            path="/qualifiedName",
+            value=qualified_name,
+        )
+        return self
+
+    def set_display_name(
+        self, display_name: Optional[str] = None
+    ) -> "StructuredPropertyPatchBuilder":
+        if display_name is not None:
+            self._add_patch(
+                StructuredPropertyDefinition.ASPECT_NAME,
+                "add",
+                path="/displayName",
+                value=display_name,
+            )
+        return self
+
+    # can only be used when creating a new structured property
+    def set_value_type(
+        self, value_type: Union[str, Urn]
+    ) -> "StructuredPropertyPatchBuilder":
+        self._add_patch(
+            StructuredPropertyDefinition.ASPECT_NAME,
+            "add",
+            path="/valueType",
+            value=value_type,
+        )
+        return self
+
+    # can only be used when creating a new structured property
+    def set_type_qualifier(
+        self, type_qualifier: Optional[Dict[str, List[str]]] = None
+    ) -> "StructuredPropertyPatchBuilder":
+        if type_qualifier is not None:
+            self._add_patch(
+                StructuredPropertyDefinition.ASPECT_NAME,
+                "add",
+                path="/typeQualifier",
+                value=type_qualifier,
+            )
+        return self
+
+    # can only be used when creating a new structured property
+    def add_allowed_value(
+        self, allowed_value: PropertyValueClass
+    ) -> "StructuredPropertyPatchBuilder":
+        self._add_patch(
+            StructuredPropertyDefinition.ASPECT_NAME,
+            "add",
+            path=f"/allowedValues/{str(allowed_value.get('value'))}",
+            value=allowed_value,
+        )
+        return self
+
+    def set_cardinality(self, cardinality: str) -> "StructuredPropertyPatchBuilder":
+        self._add_patch(
+            StructuredPropertyDefinition.ASPECT_NAME,
+            "add",
+            path="/cardinality",
+            value=cardinality,
+        )
+        return self
+
+    def add_entity_type(
+        self, entity_type: Union[str, Urn]
+    ) -> "StructuredPropertyPatchBuilder":
+        self._add_patch(
+            StructuredPropertyDefinition.ASPECT_NAME,
+            "add",
+            path=f"/entityTypes/{self.quote(str(entity_type))}",
+            value=entity_type,
+        )
+        return self
+
+    def set_description(
+        self, description: Optional[str] = None
+    ) -> "StructuredPropertyPatchBuilder":
+        if description is not None:
+            self._add_patch(
+                StructuredPropertyDefinition.ASPECT_NAME,
+                "add",
+                path="/description",
+                value=description,
+            )
+        return self
+
+    def set_immutable(self, immutable: bool) -> "StructuredPropertyPatchBuilder":
+        self._add_patch(
+            StructuredPropertyDefinition.ASPECT_NAME,
+            "add",
+            path="/immutable",
+            value=immutable,
+        )
+        return self


### PR DESCRIPTION

This PR extends out the python SDK to include a patch builder for structured property entities as well as some sample files for CRUDing these entities.

On top of that, I added some basic sample files for adding, updating, and removing structured properties onto datasets as well.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced structured property management for datasets. Users can now add, update, and remove structured properties with dedicated scripts.
  - Added support for structured property definitions, enhancing data categorization and management capabilities.
- **Documentation**
  - Example scripts added to showcase how to create, update, and emit structured property changes using DataHub's REST and Kafka interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->