### PR TITLE
fix(ingestion): fix datajob patcher

### DIFF
--- a/metadata-ingestion/src/datahub/specific/datajob.py
+++ b/metadata-ingestion/src/datahub/specific/datajob.py
@@ -416,7 +416,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
             DataJobInputOutput.ASPECT_NAME,
             "add",
             path=f"/inputDatasetFields/{self.quote(input_urn)}",
-            value=input_edge,
+            value={},
         )
         return self
 
@@ -504,7 +504,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
             DataJobInputOutput.ASPECT_NAME,
             "add",
             path=f"/outputDatasetFields/{self.quote(output_urn)}",
-            value=output_edge,
+            value={},
         )
         return self
 

--- a/metadata-ingestion/src/datahub/specific/datajob.py
+++ b/metadata-ingestion/src/datahub/specific/datajob.py
@@ -378,9 +378,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         )
         return self
 
-    def add_input_dataset_field(
-        self, input: Union[Urn, str]
-    ) -> "DataJobPatchBuilder":
+    def add_input_dataset_field(self, input: Union[Urn, str]) -> "DataJobPatchBuilder":
         """
         Adds an input dataset field to the DataJobPatchBuilder.
 
@@ -396,9 +394,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         input_urn = str(input)
         urn = Urn.create_from_string(input_urn)
         if not urn.get_type() == "schemaField":
-            raise ValueError(
-                f"Input {input} is not a Schema Field urn"
-            )
+            raise ValueError(f"Input {input} is not a Schema Field urn")
 
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
@@ -472,9 +468,7 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         output_urn = str(output)
         urn = Urn.create_from_string(output_urn)
         if not urn.get_type() == "schemaField":
-            raise ValueError(
-                f"Input {output} is not a Schema Field urn"
-            )
+            raise ValueError(f"Input {output} is not a Schema Field urn")
 
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,

--- a/metadata-ingestion/src/datahub/specific/datajob.py
+++ b/metadata-ingestion/src/datahub/specific/datajob.py
@@ -379,39 +379,27 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         return self
 
     def add_input_dataset_field(
-        self, input: Union[Edge, Urn, str]
+        self, input: Union[Urn, str]
     ) -> "DataJobPatchBuilder":
         """
         Adds an input dataset field to the DataJobPatchBuilder.
 
         Args:
-            input: The input dataset field, which can be an Edge object, Urn object, or a string.
+            input: The input dataset field, which can be an Urn object, or a string.
 
         Returns:
             The DataJobPatchBuilder instance.
 
         Raises:
             ValueError: If the input is not a Schema Field urn.
-
-        Notes:
-            If `input` is an Edge object, it is used directly. If `input` is a Urn object or string,
-            it is converted to an Edge object and added with default audit stamps.
         """
-        if isinstance(input, Edge):
-            input_urn: str = input.destinationUrn
-            input_edge: Edge = input
-        elif isinstance(input, (Urn, str)):
-            input_urn = str(input)
-            if not input_urn.startswith("urn:li:schemaField:"):
-                raise ValueError(f"Input {input} is not a Schema Field urn")
-
-            input_edge = Edge(
-                destinationUrn=input_urn,
-                created=self._mint_auditstamp(),
-                lastModified=self._mint_auditstamp(),
+        input_urn = str(input)
+        urn = Urn.create_from_string(input_urn)
+        if not urn.get_type() == "schemaField":
+            raise ValueError(
+                f"Input {input} is not a Schema Field urn"
             )
 
-        self._ensure_urn_type("schemaField", [input_edge], "add_input_dataset_field")
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",
@@ -467,39 +455,27 @@ class DataJobPatchBuilder(MetadataPatchProposal):
         return self
 
     def add_output_dataset_field(
-        self, output: Union[Edge, Urn, str]
+        self, output: Union[Urn, str]
     ) -> "DataJobPatchBuilder":
         """
         Adds an output dataset field to the DataJobPatchBuilder.
 
         Args:
-            output: The output dataset field, which can be an Edge object, Urn object, or a string.
+            output: The output dataset field, which can be an Urn object, or a string.
 
         Returns:
             The DataJobPatchBuilder instance.
 
         Raises:
             ValueError: If the output is not a Schema Field urn.
-
-        Notes:
-            If `output` is an Edge object, it is used directly. If `output` is a Urn object or string,
-            it is converted to an Edge object and added with default audit stamps.
         """
-        if isinstance(output, Edge):
-            output_urn: str = output.destinationUrn
-            output_edge: Edge = output
-        elif isinstance(output, (Urn, str)):
-            output_urn = str(output)
-            if not output_urn.startswith("urn:li:schemaField:"):
-                raise ValueError(f"Input {input} is not a Schema Field urn")
-
-            output_edge = Edge(
-                destinationUrn=output_urn,
-                created=self._mint_auditstamp(),
-                lastModified=self._mint_auditstamp(),
+        output_urn = str(output)
+        urn = Urn.create_from_string(output_urn)
+        if not urn.get_type() == "schemaField":
+            raise ValueError(
+                f"Input {output} is not a Schema Field urn"
             )
 
-        self._ensure_urn_type("schemaField", [output_edge], "add_output_dataset_field")
         self._add_patch(
             DataJobInputOutput.ASPECT_NAME,
             "add",


### PR DESCRIPTION
A couple Urn arrays being treated as edges.
i.e. https://github.com/datahub-project/datahub/blob/master/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInputOutput.pdl#L180

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by standardizing the initialization of certain parameters, which previously could lead to inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->