### PR TITLE
feat(deprecation) Return actor entity with deprecation aspect

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -59,6 +59,7 @@ import com.linkedin.datahub.graphql.generated.DataPlatformInstance;
 import com.linkedin.datahub.graphql.generated.DataQualityContract;
 import com.linkedin.datahub.graphql.generated.Dataset;
 import com.linkedin.datahub.graphql.generated.DatasetStatsSummary;
+import com.linkedin.datahub.graphql.generated.Deprecation;
 import com.linkedin.datahub.graphql.generated.Domain;
 import com.linkedin.datahub.graphql.generated.ERModelRelationship;
 import com.linkedin.datahub.graphql.generated.ERModelRelationshipProperties;
@@ -785,6 +786,7 @@ public class GmsGraphQLEngine {
     configureBusinessAttributeResolver(builder);
     configureBusinessAttributeAssociationResolver(builder);
     configureConnectionResolvers(builder);
+    configureDeprecationResolvers(builder);
   }
 
   private void configureOrganisationRoleResolvers(RuntimeWiring.Builder builder) {
@@ -3149,5 +3151,15 @@ public class GmsGraphQLEngine {
                           ? connection.getPlatform().getUrn()
                           : null;
                     })));
+  }
+
+  private void configureDeprecationResolvers(final RuntimeWiring.Builder builder) {
+    builder.type(
+        "Deprecation",
+        typeWiring ->
+            typeWiring.dataFetcher(
+                "actorEntity",
+                new EntityTypeResolver(
+                    entityTypes, (env) -> ((Deprecation) env.getSource()).getActorEntity())));
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/DeprecationMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/DeprecationMapper.java
@@ -20,6 +20,7 @@ public class DeprecationMapper
       @Nullable QueryContext context, @Nonnull final com.linkedin.common.Deprecation input) {
     final Deprecation result = new Deprecation();
     result.setActor(input.getActor().toString());
+    result.setActorEntity(UrnToEntityMapper.map(context, input.getActor()));
     result.setDeprecated(input.isDeprecated());
     result.setDecommissionTime(input.getDecommissionTime());
     result.setNote(input.getNote());

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -8183,6 +8183,11 @@ type Deprecation {
     The user who will be credited for modifying this deprecation content
     """
     actor: String
+
+    """
+    The hydrated user who will be credited for modifying this deprecation content
+    """
+    actorEntity: Entity
 }
 
 """


### PR DESCRIPTION
Along with the current urn of the actor that we return with a `Deprecation` aspect to the graphql API, let's also return a hydrated `actorEntity`. This will be used in the UI later.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for handling `Deprecation` entities in GraphQL, enhancing the deprecation tracking capabilities.
  
- **Enhancements**
  - Updated `Deprecation` type in the GraphQL schema to include a new `actorEntity` field for more detailed information on who deprecated an item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->