### PR TITLE
fix(ingestion/glue): ensure date formatting works on all platforms for aws glue

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -901,7 +901,7 @@ class GlueSource(StatefulIngestionSourceBase):
             parameters["LocationUri"] = database["LocationUri"]
         if database.get("CreateTime") is not None:
             create_time: datetime.datetime = database["CreateTime"]
-            parameters["CreateTime"] = create_time.strftime("%B %-d, %Y at %H:%M:%S")
+            parameters["CreateTime"] = create_time.strftime("%B %d, %Y at %H:%M:%S")
         yield from gen_containers(
             container_key=database_container_key,
             name=database["Name"],

--- a/metadata-ingestion/tests/unit/glue/glue_delta_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_delta_mces_golden.json
@@ -11,7 +11,7 @@
                 "instance": "delta_platform_instance",
                 "env": "PROD",
                 "database": "delta-database",
-                "CreateTime": "June 9, 2021 at 14:14:19"
+                "CreateTime": "June 09, 2021 at 14:14:19"
             },
             "name": "delta-database",
             "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/delta-database"

--- a/metadata-ingestion/tests/unit/glue/glue_malformed_delta_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_malformed_delta_mces_golden.json
@@ -11,7 +11,7 @@
                 "instance": "delta_platform_instance",
                 "env": "PROD",
                 "database": "delta-database",
-                "CreateTime": "June 9, 2021 at 14:14:19"
+                "CreateTime": "June 09, 2021 at 14:14:19"
             },
             "name": "delta-database",
             "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/delta-database"

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -13,7 +13,7 @@
                 "param1": "value1",
                 "param2": "value2",
                 "LocationUri": "s3://test-bucket/test-prefix",
-                "CreateTime": "June 9, 2021 at 14:14:19"
+                "CreateTime": "June 09, 2021 at 14:14:19"
             },
             "name": "flights-database",
             "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/flights-database"
@@ -57,6 +57,59 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "glue",
+                "env": "PROD",
+                "database": "test-database",
+                "CreateTime": "June 01, 2021 at 14:55:02"
+            },
+            "name": "test-database",
+            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/test-database"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Database"
+            ]
+        }
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -66,7 +119,7 @@
                 "platform": "glue",
                 "env": "PROD",
                 "database": "empty-database",
-                "CreateTime": "June 1, 2021 at 14:55:13"
+                "CreateTime": "June 01, 2021 at 14:55:13"
             },
             "name": "empty-database",
             "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/empty-database"
@@ -333,59 +386,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "platform": "glue",
-                "env": "PROD",
-                "database": "test-database",
-                "CreateTime": "June 1, 2021 at 14:55:02"
-            },
-            "name": "test-database",
-            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/test-database"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:glue"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Database"
-            ]
         }
     }
 },

--- a/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_platform_instance_golden.json
@@ -14,7 +14,7 @@
                 "param1": "value1",
                 "param2": "value2",
                 "LocationUri": "s3://test-bucket/test-prefix",
-                "CreateTime": "June 9, 2021 at 14:14:19"
+                "CreateTime": "June 09, 2021 at 14:14:19"
             },
             "name": "flights-database",
             "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/flights-database"
@@ -59,6 +59,61 @@
 },
 {
     "entityType": "container",
+    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "glue",
+                "instance": "some_instance_name",
+                "env": "PROD",
+                "database": "test-database",
+                "CreateTime": "June 01, 2021 at 14:55:02"
+            },
+            "name": "test-database",
+            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/test-database"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:glue,some_instance_name)"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Database"
+            ]
+        }
+    }
+},
+{
+    "entityType": "container",
     "entityUrn": "urn:li:container:ac4381240e82d55400c22e4392e744a4",
     "changeType": "UPSERT",
     "aspectName": "containerProperties",
@@ -69,7 +124,7 @@
                 "instance": "some_instance_name",
                 "env": "PROD",
                 "database": "empty-database",
-                "CreateTime": "June 1, 2021 at 14:55:13"
+                "CreateTime": "June 01, 2021 at 14:55:13"
             },
             "name": "empty-database",
             "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/empty-database"
@@ -338,61 +393,6 @@
     "aspect": {
         "json": {
             "container": "urn:li:container:7d53111f2c71396ea6f6d26c84770665"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "platform": "glue",
-                "instance": "some_instance_name",
-                "env": "PROD",
-                "database": "test-database",
-                "CreateTime": "June 1, 2021 at 14:55:02"
-            },
-            "name": "test-database",
-            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/test-database"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:glue",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:glue,some_instance_name)"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:9fb26491b2c92dde9e80791dbecca9ca",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Database"
-            ]
         }
     }
 },


### PR DESCRIPTION


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized date format for `CreateTime` to ensure consistency across the application.

- **New Features**
  - Added detailed properties to database entities, including platform, environment, database name, and status information.
  - Included data platform instance details and subtypes for containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->