### PR TITLE
fix(smoke-test): missing test for move domain

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
@@ -165,18 +165,18 @@ describe("Verify nested domains test functionalities", () => {
   });
 
   it("verify Move domain root level to parent level", () => {
-    cy.waitTextVisible(domainName)
+    cy.waitTextVisible(domainName);
     moveDomaintoRootLevel();
-    cy.waitTextVisible("Moved Domain!")
-    cy.ensureTextNotPresent('Moved Domain!')
+    cy.waitTextVisible("Moved Domain!");
+    cy.ensureTextNotPresent('Moved Domain!');
     cy.goToDomainList();
     cy.waitTextVisible("1 sub-domain");
-  })
-  
+  });
+
   it("Verify Move domain parent level to root level", () => {
     moveDomaintoParent();
     cy.waitTextVisible("Moved Domain!");
-    cy.ensureTextNotPresent('Moved Domain!')
+    cy.ensureTextNotPresent('Moved Domain!');
     cy.goToDomainList();
     cy.waitTextVisible(domainName);
   });

--- a/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
@@ -164,9 +164,19 @@ describe("Verify nested domains test functionalities", () => {
     clearAndDelete();
   });
 
+  it("verify Move domain root level to parent level", () => {
+    cy.waitTextVisible(domainName)
+    moveDomaintoRootLevel();
+    cy.waitTextVisible("Moved Domain!")
+    cy.ensureTextNotPresent('Moved Domain!')
+    cy.goToDomainList();
+    cy.waitTextVisible("1 sub-domain");
+  })
+  
   it("Verify Move domain parent level to root level", () => {
     moveDomaintoParent();
     cy.waitTextVisible("Moved Domain!");
+    cy.ensureTextNotPresent('Moved Domain!')
     cy.goToDomainList();
     cy.waitTextVisible(domainName);
   });

--- a/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
+++ b/smoke-test/tests/cypress/cypress/e2e/domains/nested_domains.js
@@ -168,7 +168,7 @@ describe("Verify nested domains test functionalities", () => {
     cy.waitTextVisible(domainName);
     moveDomaintoRootLevel();
     cy.waitTextVisible("Moved Domain!");
-    cy.ensureTextNotPresent('Moved Domain!');
+    cy.ensureTextNotPresent("Moved Domain!");
     cy.goToDomainList();
     cy.waitTextVisible("1 sub-domain");
   });
@@ -176,7 +176,7 @@ describe("Verify nested domains test functionalities", () => {
   it("Verify Move domain parent level to root level", () => {
     moveDomaintoParent();
     cy.waitTextVisible("Moved Domain!");
-    cy.ensureTextNotPresent('Moved Domain!');
+    cy.ensureTextNotPresent("Moved Domain!");
     cy.goToDomainList();
     cy.waitTextVisible(domainName);
   });


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test cases for moving domains between levels in a nested structure, verifying domain movement to root and parent levels, including checks for text visibility and presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->