### PR TITLE
fix(smoke-test): add suffix in temp file creation

### DIFF
--- a/smoke-test/tests/dataproduct/test_dataproduct.py
+++ b/smoke-test/tests/dataproduct/test_dataproduct.py
@@ -87,7 +87,7 @@ sleep_sec, sleep_times = get_sleep_info()
 
 @pytest.fixture(scope="module", autouse=False)
 def ingest_cleanup_data(request):
-    new_file, filename = tempfile.mkstemp()
+    new_file, filename = tempfile.mkstemp(suffix=".json")
     try:
         create_test_data(filename)
         print("ingesting data products test data")


### PR DESCRIPTION
Fixes a regression from https://github.com/datahub-project/datahub/pull/8415


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved temporary file handling in data product tests by ensuring files have a `.json` suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->