### PR TITLE
fix(ingest/tableau): quote special characters in external URL

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -15,7 +15,7 @@ from typing import (
     Union,
     cast,
 )
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import dateutil.parser as dp
 import tableauserverclient as TSC
@@ -2327,7 +2327,7 @@ class TableauSource(StatefulIngestionSourceBase, TestableSource):
             # sheet contained in dashboard
             site_part = f"/t/{self.config.site}" if self.config.site else ""
             dashboard_path = sheet[c.CONTAINED_IN_DASHBOARDS][0][c.PATH]
-            sheet_external_url = f"{self.config.connect_uri}{site_part}/authoring/{dashboard_path}/{sheet.get(c.NAME, '')}"
+            sheet_external_url = f"{self.config.connect_uri}{site_part}/authoring/{dashboard_path}/{quote(sheet.get(c.NAME, ''))}"
         else:
             # hidden or viz-in-tooltip sheet
             sheet_external_url = None

--- a/metadata-ingestion/tests/integration/tableau/tableau_cll_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_cll_mces_golden.json
@@ -898,7 +898,7 @@
                         "customProperties": {
                             "luid": "f0779f9d-6765-47a9-a8f6-c740cfd27783"
                         },
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline - Sent",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline%20-%20Sent",
                         "title": "Timeline - Sent",
                         "description": "",
                         "lastModified": {
@@ -1180,7 +1180,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign List",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign%20List",
                         "title": "Campaign List",
                         "description": "",
                         "lastModified": {
@@ -2368,7 +2368,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile - Sent by Campaign",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile%20-%20Sent%20by%20Campaign",
                         "title": "Mobile - Sent by Campaign",
                         "description": "",
                         "lastModified": {
@@ -3560,7 +3560,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Requests",
                         "title": "Opened Requests",
                         "description": "",
                         "lastModified": {
@@ -4068,7 +4068,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top 10 Items by Requests and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top%2010%20Items%20by%20Requests%20and%20YoY%20Change",
                         "title": "Top 10 Items by Requests and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -4544,7 +4544,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Problems",
                         "title": "Opened Problems",
                         "description": "",
                         "lastModified": {
@@ -5441,7 +5441,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High and Critical Priority Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High%20and%20Critical%20Priority%20Problems",
                         "title": "High and Critical Priority Problems",
                         "description": "",
                         "lastModified": {
@@ -5810,7 +5810,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total Incidents by Category and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total%20Incidents%20by%20Category%20and%20YoY%20Change",
                         "title": "Total Incidents by Category and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -6202,7 +6202,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known Errors",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known%20Errors",
                         "title": "Known Errors",
                         "description": "",
                         "lastModified": {
@@ -6649,7 +6649,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Requests",
                         "title": "Overdue Requests",
                         "description": "",
                         "lastModified": {
@@ -7070,7 +7070,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG Time to Solve an Incident",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG%20Time%20to%20Solve%20an%20Incident",
                         "title": "AVG Time to Solve an Incident",
                         "description": "",
                         "lastModified": {
@@ -7407,7 +7407,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made SLA?",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made%20SLA%3F",
                         "title": "Made SLA?",
                         "description": "",
                         "lastModified": {
@@ -8035,7 +8035,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Problems",
                         "title": "Overdue Problems",
                         "description": "",
                         "lastModified": {
@@ -9194,7 +9194,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age of Active Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age%20of%20Active%20Problems",
                         "title": "Age of Active Problems",
                         "description": "",
                         "lastModified": {
@@ -9589,7 +9589,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Incidents",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Incidents",
                         "title": "Opened Incidents",
                         "description": "",
                         "lastModified": {

--- a/metadata-ingestion/tests/integration/tableau/tableau_extract_all_project_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_extract_all_project_mces_golden.json
@@ -1157,7 +1157,7 @@
                         "customProperties": {
                             "luid": "f0779f9d-6765-47a9-a8f6-c740cfd27783"
                         },
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline - Sent",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline%20-%20Sent",
                         "title": "Timeline - Sent",
                         "description": "",
                         "lastModified": {
@@ -1439,7 +1439,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign List",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign%20List",
                         "title": "Campaign List",
                         "description": "",
                         "lastModified": {
@@ -2627,7 +2627,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile - Sent by Campaign",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile%20-%20Sent%20by%20Campaign",
                         "title": "Mobile - Sent by Campaign",
                         "description": "",
                         "lastModified": {
@@ -3819,7 +3819,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Requests",
                         "title": "Opened Requests",
                         "description": "",
                         "lastModified": {
@@ -4327,7 +4327,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top 10 Items by Requests and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top%2010%20Items%20by%20Requests%20and%20YoY%20Change",
                         "title": "Top 10 Items by Requests and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -4803,7 +4803,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Problems",
                         "title": "Opened Problems",
                         "description": "",
                         "lastModified": {
@@ -5700,7 +5700,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High and Critical Priority Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High%20and%20Critical%20Priority%20Problems",
                         "title": "High and Critical Priority Problems",
                         "description": "",
                         "lastModified": {
@@ -6069,7 +6069,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total Incidents by Category and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total%20Incidents%20by%20Category%20and%20YoY%20Change",
                         "title": "Total Incidents by Category and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -6461,7 +6461,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known Errors",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known%20Errors",
                         "title": "Known Errors",
                         "description": "",
                         "lastModified": {
@@ -6908,7 +6908,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Requests",
                         "title": "Overdue Requests",
                         "description": "",
                         "lastModified": {
@@ -7329,7 +7329,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG Time to Solve an Incident",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG%20Time%20to%20Solve%20an%20Incident",
                         "title": "AVG Time to Solve an Incident",
                         "description": "",
                         "lastModified": {
@@ -7666,7 +7666,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made SLA?",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made%20SLA%3F",
                         "title": "Made SLA?",
                         "description": "",
                         "lastModified": {
@@ -8294,7 +8294,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Problems",
                         "title": "Overdue Problems",
                         "description": "",
                         "lastModified": {
@@ -9453,7 +9453,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age of Active Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age%20of%20Active%20Problems",
                         "title": "Age of Active Problems",
                         "description": "",
                         "lastModified": {
@@ -9848,7 +9848,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Incidents",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Incidents",
                         "title": "Opened Incidents",
                         "description": "",
                         "lastModified": {

--- a/metadata-ingestion/tests/integration/tableau/tableau_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_mces_golden.json
@@ -898,7 +898,7 @@
                         "customProperties": {
                             "luid": "f0779f9d-6765-47a9-a8f6-c740cfd27783"
                         },
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline - Sent",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline%20-%20Sent",
                         "title": "Timeline - Sent",
                         "description": "",
                         "lastModified": {
@@ -1180,7 +1180,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign List",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign%20List",
                         "title": "Campaign List",
                         "description": "",
                         "lastModified": {
@@ -2368,7 +2368,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile - Sent by Campaign",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile%20-%20Sent%20by%20Campaign",
                         "title": "Mobile - Sent by Campaign",
                         "description": "",
                         "lastModified": {
@@ -3560,7 +3560,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Requests",
                         "title": "Opened Requests",
                         "description": "",
                         "lastModified": {
@@ -4068,7 +4068,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top 10 Items by Requests and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top%2010%20Items%20by%20Requests%20and%20YoY%20Change",
                         "title": "Top 10 Items by Requests and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -4544,7 +4544,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Problems",
                         "title": "Opened Problems",
                         "description": "",
                         "lastModified": {
@@ -5441,7 +5441,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High and Critical Priority Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High%20and%20Critical%20Priority%20Problems",
                         "title": "High and Critical Priority Problems",
                         "description": "",
                         "lastModified": {
@@ -5810,7 +5810,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total Incidents by Category and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total%20Incidents%20by%20Category%20and%20YoY%20Change",
                         "title": "Total Incidents by Category and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -6202,7 +6202,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known Errors",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known%20Errors",
                         "title": "Known Errors",
                         "description": "",
                         "lastModified": {
@@ -6649,7 +6649,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Requests",
                         "title": "Overdue Requests",
                         "description": "",
                         "lastModified": {
@@ -7070,7 +7070,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG Time to Solve an Incident",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG%20Time%20to%20Solve%20an%20Incident",
                         "title": "AVG Time to Solve an Incident",
                         "description": "",
                         "lastModified": {
@@ -7407,7 +7407,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made SLA?",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made%20SLA%3F",
                         "title": "Made SLA?",
                         "description": "",
                         "lastModified": {
@@ -8035,7 +8035,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Problems",
                         "title": "Overdue Problems",
                         "description": "",
                         "lastModified": {
@@ -9194,7 +9194,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age of Active Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age%20of%20Active%20Problems",
                         "title": "Age of Active Problems",
                         "description": "",
                         "lastModified": {
@@ -9589,7 +9589,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Incidents",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Incidents",
                         "title": "Opened Incidents",
                         "description": "",
                         "lastModified": {

--- a/metadata-ingestion/tests/integration/tableau/tableau_nested_project_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_nested_project_mces_golden.json
@@ -1157,7 +1157,7 @@
                         "customProperties": {
                             "luid": "f0779f9d-6765-47a9-a8f6-c740cfd27783"
                         },
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline - Sent",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline%20-%20Sent",
                         "title": "Timeline - Sent",
                         "description": "",
                         "lastModified": {
@@ -1439,7 +1439,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign List",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign%20List",
                         "title": "Campaign List",
                         "description": "",
                         "lastModified": {
@@ -2627,7 +2627,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile - Sent by Campaign",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile%20-%20Sent%20by%20Campaign",
                         "title": "Mobile - Sent by Campaign",
                         "description": "",
                         "lastModified": {
@@ -3819,7 +3819,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Requests",
                         "title": "Opened Requests",
                         "description": "",
                         "lastModified": {
@@ -4327,7 +4327,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top 10 Items by Requests and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top%2010%20Items%20by%20Requests%20and%20YoY%20Change",
                         "title": "Top 10 Items by Requests and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -4803,7 +4803,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Problems",
                         "title": "Opened Problems",
                         "description": "",
                         "lastModified": {
@@ -5700,7 +5700,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High and Critical Priority Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High%20and%20Critical%20Priority%20Problems",
                         "title": "High and Critical Priority Problems",
                         "description": "",
                         "lastModified": {
@@ -6069,7 +6069,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total Incidents by Category and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total%20Incidents%20by%20Category%20and%20YoY%20Change",
                         "title": "Total Incidents by Category and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -6461,7 +6461,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known Errors",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known%20Errors",
                         "title": "Known Errors",
                         "description": "",
                         "lastModified": {
@@ -6908,7 +6908,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Requests",
                         "title": "Overdue Requests",
                         "description": "",
                         "lastModified": {
@@ -7329,7 +7329,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG Time to Solve an Incident",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG%20Time%20to%20Solve%20an%20Incident",
                         "title": "AVG Time to Solve an Incident",
                         "description": "",
                         "lastModified": {
@@ -7666,7 +7666,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made SLA?",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made%20SLA%3F",
                         "title": "Made SLA?",
                         "description": "",
                         "lastModified": {
@@ -8294,7 +8294,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Problems",
                         "title": "Overdue Problems",
                         "description": "",
                         "lastModified": {
@@ -9453,7 +9453,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age of Active Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age%20of%20Active%20Problems",
                         "title": "Age of Active Problems",
                         "description": "",
                         "lastModified": {
@@ -9848,7 +9848,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Incidents",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Incidents",
                         "title": "Opened Incidents",
                         "description": "",
                         "lastModified": {

--- a/metadata-ingestion/tests/integration/tableau/tableau_signout_timeout_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_signout_timeout_mces_golden.json
@@ -898,7 +898,7 @@
                         "customProperties": {
                             "luid": "f0779f9d-6765-47a9-a8f6-c740cfd27783"
                         },
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline - Sent",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline%20-%20Sent",
                         "title": "Timeline - Sent",
                         "description": "",
                         "lastModified": {
@@ -1180,7 +1180,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign List",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign%20List",
                         "title": "Campaign List",
                         "description": "",
                         "lastModified": {
@@ -2368,7 +2368,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile - Sent by Campaign",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile%20-%20Sent%20by%20Campaign",
                         "title": "Mobile - Sent by Campaign",
                         "description": "",
                         "lastModified": {
@@ -3560,7 +3560,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Requests",
                         "title": "Opened Requests",
                         "description": "",
                         "lastModified": {
@@ -4068,7 +4068,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top 10 Items by Requests and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top%2010%20Items%20by%20Requests%20and%20YoY%20Change",
                         "title": "Top 10 Items by Requests and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -4544,7 +4544,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Problems",
                         "title": "Opened Problems",
                         "description": "",
                         "lastModified": {
@@ -5441,7 +5441,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High and Critical Priority Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High%20and%20Critical%20Priority%20Problems",
                         "title": "High and Critical Priority Problems",
                         "description": "",
                         "lastModified": {
@@ -5810,7 +5810,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total Incidents by Category and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total%20Incidents%20by%20Category%20and%20YoY%20Change",
                         "title": "Total Incidents by Category and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -6202,7 +6202,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known Errors",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known%20Errors",
                         "title": "Known Errors",
                         "description": "",
                         "lastModified": {
@@ -6649,7 +6649,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Requests",
                         "title": "Overdue Requests",
                         "description": "",
                         "lastModified": {
@@ -7070,7 +7070,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG Time to Solve an Incident",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG%20Time%20to%20Solve%20an%20Incident",
                         "title": "AVG Time to Solve an Incident",
                         "description": "",
                         "lastModified": {
@@ -7407,7 +7407,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made SLA?",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made%20SLA%3F",
                         "title": "Made SLA?",
                         "description": "",
                         "lastModified": {
@@ -8035,7 +8035,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Problems",
                         "title": "Overdue Problems",
                         "description": "",
                         "lastModified": {
@@ -9194,7 +9194,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age of Active Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age%20of%20Active%20Problems",
                         "title": "Age of Active Problems",
                         "description": "",
                         "lastModified": {
@@ -9589,7 +9589,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Incidents",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Incidents",
                         "title": "Opened Incidents",
                         "description": "",
                         "lastModified": {

--- a/metadata-ingestion/tests/integration/tableau/tableau_with_platform_instance_mces_golden.json
+++ b/metadata-ingestion/tests/integration/tableau/tableau_with_platform_instance_mces_golden.json
@@ -846,7 +846,7 @@
                         "customProperties": {
                             "luid": "f0779f9d-6765-47a9-a8f6-c740cfd27783"
                         },
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline - Sent",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Timeline%20-%20Sent",
                         "title": "Timeline - Sent",
                         "description": "",
                         "lastModified": {
@@ -1133,7 +1133,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign List",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Campaign%20List",
                         "title": "Campaign List",
                         "description": "",
                         "lastModified": {
@@ -2331,7 +2331,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile - Sent by Campaign",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/EmailPerformancebyCampaign/EmailPerformancebyCampaign/Mobile%20-%20Sent%20by%20Campaign",
                         "title": "Mobile - Sent by Campaign",
                         "description": "",
                         "lastModified": {
@@ -3543,7 +3543,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Requests",
                         "title": "Opened Requests",
                         "description": "",
                         "lastModified": {
@@ -4056,7 +4056,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top 10 Items by Requests and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Top%2010%20Items%20by%20Requests%20and%20YoY%20Change",
                         "title": "Top 10 Items by Requests and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -4537,7 +4537,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Problems",
                         "title": "Opened Problems",
                         "description": "",
                         "lastModified": {
@@ -5444,7 +5444,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High and Critical Priority Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/High%20and%20Critical%20Priority%20Problems",
                         "title": "High and Critical Priority Problems",
                         "description": "",
                         "lastModified": {
@@ -5818,7 +5818,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total Incidents by Category and YoY Change",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Total%20Incidents%20by%20Category%20and%20YoY%20Change",
                         "title": "Total Incidents by Category and YoY Change",
                         "description": "",
                         "lastModified": {
@@ -6215,7 +6215,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known Errors",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Known%20Errors",
                         "title": "Known Errors",
                         "description": "",
                         "lastModified": {
@@ -6667,7 +6667,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Requests",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Requests",
                         "title": "Overdue Requests",
                         "description": "",
                         "lastModified": {
@@ -7093,7 +7093,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG Time to Solve an Incident",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/AVG%20Time%20to%20Solve%20an%20Incident",
                         "title": "AVG Time to Solve an Incident",
                         "description": "",
                         "lastModified": {
@@ -7435,7 +7435,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made SLA?",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Made%20SLA%3F",
                         "title": "Made SLA?",
                         "description": "",
                         "lastModified": {
@@ -8073,7 +8073,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Overdue%20Problems",
                         "title": "Overdue Problems",
                         "description": "",
                         "lastModified": {
@@ -9247,7 +9247,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age of Active Problems",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Age%20of%20Active%20Problems",
                         "title": "Age of Active Problems",
                         "description": "",
                         "lastModified": {
@@ -9647,7 +9647,7 @@
                 {
                     "com.linkedin.pegasus2avro.chart.ChartInfo": {
                         "customProperties": {},
-                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened Incidents",
+                        "externalUrl": "https://do-not-connect/t/acryl/authoring/ExecutiveDashboard/ExecutiveDashboard/Opened%20Incidents",
                         "title": "Opened Incidents",
                         "description": "",
                         "lastModified": {


### PR DESCRIPTION
There is an issue when ingestion Tableau metadata where special characters, most pernicious being `/`, in chart names lead to invalid URLs displaying in DataHub

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL formatting by replacing spaces with URL-encoded spaces (%20) for better consistency and functionality of external URLs in Tableau integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->