### PR TITLE
chore(ingest): update acryl-datahub-classify version

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -103,7 +103,7 @@ sqlglot_lib = {
 }
 
 classification_lib = {
-    "acryl-datahub-classify==0.0.10",
+    "acryl-datahub-classify==0.0.11",
     # This is a bit of a hack. Because we download the SpaCy model at runtime in the classify plugin,
     # we need pip to be available.
     "pip",


### PR DESCRIPTION
Most notably this transitively widens the `spacy` version requirements https://github.com/acryldata/datahub-classify/pull/22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `acryl-datahub-classify` library version from `0.0.10` to `0.0.11` for improved stability and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->