### PR TITLE
fix(ingestion/glue): Add support for missing config options for profiling in Glue

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -55,6 +55,19 @@ New (optional fields `systemMetadata` and `headers`):
   "headers": {}
 }
 ```
+- #10858 Profiling configuration for Glue source has been updated.
+
+Previously, the configuration was:
+```yaml
+profiling: {}
+```
+
+Now, it needs to be:
+
+```yaml
+profiling:
+  enabled: true
+```
 
 ### Potential Downtime
 

--- a/metadata-ingestion/src/datahub/ingestion/source/glue_profiling_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue_profiling_config.py
@@ -1,4 +1,3 @@
-import os
 from typing import Optional
 
 from pydantic.fields import Field
@@ -15,14 +14,6 @@ class GlueProfilingConfig(ConfigModel):
     profile_table_level_only: bool = Field(
         default=False,
         description="Whether to perform profiling at table-level only, or include column-level profiling as well.",
-    )
-    # The default of (5 * cpu_count) is adopted from the default max_workers
-    # parameter of ThreadPoolExecutor. Given that profiling is often an I/O-bound
-    # task, it may make sense to increase this default value in the future.
-    # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
-    max_workers: int = Field(
-        default=5 * (os.cpu_count() or 4),
-        description="Number of worker threads to use for profiling. Set to 1 to disable.",
     )
     row_count: Optional[str] = Field(
         default=None,

--- a/metadata-ingestion/src/datahub/ingestion/source/glue_profiling_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue_profiling_config.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 from pydantic.fields import Field
@@ -7,6 +8,22 @@ from datahub.ingestion.source_config.operation_config import OperationConfig
 
 
 class GlueProfilingConfig(ConfigModel):
+    enabled: bool = Field(
+        default=False,
+        description="Whether profiling should be done.",
+    )
+    profile_table_level_only: bool = Field(
+        default=False,
+        description="Whether to perform profiling at table-level only, or include column-level profiling as well.",
+    )
+    # The default of (5 * cpu_count) is adopted from the default max_workers
+    # parameter of ThreadPoolExecutor. Given that profiling is often an I/O-bound
+    # task, it may make sense to increase this default value in the future.
+    # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
+    max_workers: int = Field(
+        default=5 * (os.cpu_count() or 4),
+        description="Number of worker threads to use for profiling. Set to 1 to disable.",
+    )
     row_count: Optional[str] = Field(
         default=None,
         description="The parameter name for row count in glue table.",

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -1,1342 +1,1342 @@
 [
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "platform": "glue",
-                "env": "PROD",
-                "database": "flights-database",
-                "param1": "value1",
-                "param2": "value2",
-                "LocationUri": "s3://test-bucket/test-prefix",
-                "CreateTime": "June 09, 2021 at 14:14:19"
-            },
-            "name": "flights-database",
-            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/flights-database"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:glue"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Database"
-            ]
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "platform": "glue",
-                "env": "PROD",
-                "database": "test-database",
-                "CreateTime": "June 01, 2021 at 14:55:02"
-            },
-            "name": "test-database",
-            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/test-database"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:glue"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Database"
-            ]
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
-    "changeType": "UPSERT",
-    "aspectName": "containerProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "platform": "glue",
-                "env": "PROD",
-                "database": "empty-database",
-                "CreateTime": "June 01, 2021 at 14:55:13"
-            },
-            "name": "empty-database",
-            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/empty-database"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:glue"
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Database"
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
+        "changeType": "UPSERT",
+        "aspectName": "containerProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "platform": "glue",
+                    "env": "PROD",
+                    "database": "flights-database",
+                    "param1": "value1",
+                    "param2": "value2",
+                    "LocationUri": "s3://test-bucket/test-prefix",
+                    "CreateTime": "June 09, 2021 at 14:14:19"
                 },
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "CrawlerSchemaDeserializerVersion": "1.0",
-                            "CrawlerSchemaSerializerVersion": "1.0",
-                            "UPDATED_BY_CRAWLER": "flights-crawler",
-                            "averageRecordSize": "55",
-                            "avro.schema.literal": "{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
-                            "classification": "avro",
-                            "compressionType": "none",
-                            "objectCount": "30",
-                            "recordCount": "169222196",
-                            "sizeKey": "9503351413",
-                            "typeOfData": "file",
-                            "Location": "s3://crawler-public-us-west-2/flight/avro/",
-                            "InputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
-                            "OutputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
-                            "Compressed": "False",
-                            "NumberOfBuckets": "-1",
-                            "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
-                            "BucketColumns": "[]",
-                            "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
-                        },
-                        "name": "avro",
-                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
-                        "tags": []
-                    }
+                "name": "flights-database",
+                "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/flights-database"
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:glue"
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Database"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+        "changeType": "UPSERT",
+        "aspectName": "containerProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "platform": "glue",
+                    "env": "PROD",
+                    "database": "test-database",
+                    "CreateTime": "June 01, 2021 at 14:55:02"
                 },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "flights-database.avro",
-                        "platform": "urn:li:dataPlatform:glue",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "[version=2.0].[type=int].yr",
-                                "nullable": true,
-                                "description": "test comment",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].flightdate",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].uniquecarrier",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=int].airlineid",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
-                                },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].carrier",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].flightnum",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].origin",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].year",
-                                "nullable": true,
-                                "description": "partition test comment",
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            }
-                        ]
-                    }
+                "name": "test-database",
+                "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/test-database"
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:glue"
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Database"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
+        "changeType": "UPSERT",
+        "aspectName": "containerProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "platform": "glue",
+                    "env": "PROD",
+                    "database": "empty-database",
+                    "CreateTime": "June 01, 2021 at 14:55:13"
                 },
-                {
-                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
-                        "platform": "urn:li:dataPlatform:glue"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:owner",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                "name": "empty-database",
+                "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/empty-database"
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
+        "changeType": "UPSERT",
+        "aspectName": "dataPlatformInstance",
+        "aspect": {
+            "json": {
+                "platform": "urn:li:dataPlatform:glue"
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:110bc08849d1c1bde5fc345dab5c3ae7",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Database"
+                ]
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
                         }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:baz:bob"
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "CrawlerSchemaDeserializerVersion": "1.0",
+                                "CrawlerSchemaSerializerVersion": "1.0",
+                                "UPDATED_BY_CRAWLER": "flights-crawler",
+                                "averageRecordSize": "55",
+                                "avro.schema.literal": "{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+                                "classification": "avro",
+                                "compressionType": "none",
+                                "objectCount": "30",
+                                "recordCount": "169222196",
+                                "sizeKey": "9503351413",
+                                "typeOfData": "file",
+                                "Location": "s3://crawler-public-us-west-2/flight/avro/",
+                                "InputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
+                                "OutputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
+                                "Compressed": "False",
+                                "NumberOfBuckets": "-1",
+                                "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
+                                "BucketColumns": "[]",
+                                "SortColumns": "[]",
+                                "StoredAsSubDirectories": "False"
                             },
-                            {
-                                "tag": "urn:li:tag:foo:bar"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba"
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_jsons_markers,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "CrawlerSchemaDeserializerVersion": "1.0",
-                            "CrawlerSchemaSerializerVersion": "1.0",
-                            "UPDATED_BY_CRAWLER": "test-jsons",
-                            "averageRecordSize": "273",
-                            "classification": "json",
-                            "compressionType": "none",
-                            "objectCount": "1",
-                            "recordCount": "1",
-                            "sizeKey": "273",
-                            "typeOfData": "file",
-                            "Location": "s3://test-glue-jsons/markers/",
-                            "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
-                            "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-                            "Compressed": "False",
-                            "NumberOfBuckets": "-1",
-                            "SerdeInfo": "{'SerializationLibrary': 'org.openx.data.jsonserde.JsonSerDe', 'Parameters': {'paths': 'markers'}}",
-                            "BucketColumns": "[]",
-                            "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
-                        },
-                        "name": "test_jsons_markers",
-                        "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_jsons_markers",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "test-database.test_jsons_markers",
-                        "platform": "urn:li:dataPlatform:glue",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers",
-                                "nullable": true,
-                                "type": {
+                            "name": "avro",
+                            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database/avro",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "flights-database.avro",
+                            "platform": "urn:li:dataPlatform:glue",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "[version=2.0].[type=int].yr",
+                                    "nullable": true,
+                                    "description": "test comment",
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.ArrayType": {
-                                            "nestedType": [
-                                                "record"
-                                            ]
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
                                         }
-                                    }
+                                    },
+                                    "nativeDataType": "int",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "array<struct<name:string,position:array<double>,location:array<double>>>",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<struct<name:string,position:array<double>,location:array<double>>>\"}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=string].name",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].flightdate",
+                                    "nullable": true,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].position",
-                                "nullable": true,
-                                "type": {
-                                    "type": {
-                                        "com.linkedin.pegasus2avro.schema.ArrayType": {
-                                            "nestedType": [
-                                                "double"
-                                            ]
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
                                         }
-                                    }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "array<double>",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].location",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].uniquecarrier",
+                                    "nullable": true,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.ArrayType": {
-                                            "nestedType": [
-                                                "double"
-                                            ]
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
                                         }
-                                    }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "array<double>",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"array<double>\"}"
-                            }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
-                        "platform": "urn:li:dataPlatform:glue"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:owner",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        }
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:baz:bob"
-                            },
-                            {
-                                "tag": "urn:li:tag:foo:bar"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_jsons_markers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_jsons_markers,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7"
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "CrawlerSchemaDeserializerVersion": "1.0",
-                            "CrawlerSchemaSerializerVersion": "1.0",
-                            "UPDATED_BY_CRAWLER": "test",
-                            "averageRecordSize": "19",
-                            "classification": "parquet",
-                            "compressionType": "none",
-                            "objectCount": "60",
-                            "recordCount": "167497743",
-                            "sizeKey": "4463574900",
-                            "typeOfData": "file",
-                            "Location": "s3://crawler-public-us-west-2/flight/parquet/",
-                            "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
-                            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
-                            "Compressed": "False",
-                            "NumberOfBuckets": "-1",
-                            "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
-                            "BucketColumns": "[]",
-                            "SortColumns": "[]",
-                            "StoredAsSubDirectories": "False"
-                        },
-                        "name": "test_parquet",
-                        "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
-                        "tags": []
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "test-database.test_parquet",
-                        "platform": "urn:li:dataPlatform:glue",
-                        "version": 0,
-                        "created": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
-                        },
-                        "hash": "",
-                        "platformSchema": {
-                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                                "tableSchema": ""
-                            }
-                        },
-                        "fields": [
-                            {
-                                "fieldPath": "[version=2.0].[type=int].yr",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=int].airlineid",
+                                    "nullable": true,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "int",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=int].quarter",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].carrier",
+                                    "nullable": true,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=int].month",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].flightnum",
+                                    "nullable": true,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=int].dayofmonth",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].origin",
+                                    "nullable": true,
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
-                                    }
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
                                 },
-                                "nativeDataType": "int",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
-                            },
-                            {
-                                "fieldPath": "[version=2.0].[type=string].year",
-                                "nullable": true,
-                                "type": {
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].year",
+                                    "nullable": true,
+                                    "description": "partition test comment",
                                     "type": {
-                                        "com.linkedin.pegasus2avro.schema.StringType": {}
-                                    }
-                                },
-                                "nativeDataType": "string",
-                                "recursive": false,
-                                "isPartOfKey": false,
-                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                            "platform": "urn:li:dataPlatform:glue"
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:owner",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        ]
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
-                        "platform": "urn:li:dataPlatform:glue"
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.Ownership": {
-                        "owners": [
-                            {
-                                "owner": "urn:li:corpuser:owner",
-                                "type": "DATAOWNER"
-                            }
-                        ],
-                        "ownerTypes": {},
-                        "lastModified": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:baz:bob"
+                                },
+                                {
+                                    "tag": "urn:li:tag:foo:bar"
+                                }
+                            ]
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.common.GlobalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:baz:bob"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Table"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "container",
+        "aspect": {
+            "json": {
+                "container": "urn:li:container:0b9f1f731ecf6743be6207fec3dc9cba"
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_jsons_markers,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "CrawlerSchemaDeserializerVersion": "1.0",
+                                "CrawlerSchemaSerializerVersion": "1.0",
+                                "UPDATED_BY_CRAWLER": "test-jsons",
+                                "averageRecordSize": "273",
+                                "classification": "json",
+                                "compressionType": "none",
+                                "objectCount": "1",
+                                "recordCount": "1",
+                                "sizeKey": "273",
+                                "typeOfData": "file",
+                                "Location": "s3://test-glue-jsons/markers/",
+                                "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+                                "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                                "Compressed": "False",
+                                "NumberOfBuckets": "-1",
+                                "SerdeInfo": "{'SerializationLibrary': 'org.openx.data.jsonserde.JsonSerDe', 'Parameters': {'paths': 'markers'}}",
+                                "BucketColumns": "[]",
+                                "SortColumns": "[]",
+                                "StoredAsSubDirectories": "False"
                             },
-                            {
-                                "tag": "urn:li:tag:foo:bar"
+                            "name": "test_jsons_markers",
+                            "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_jsons_markers",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "test-database.test_jsons_markers",
+                            "platform": "urn:li:dataPlatform:glue",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.ArrayType": {
+                                                "nestedType": [
+                                                    "record"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "nativeDataType": "array<struct<name:string,position:array<double>,location:array<double>>>",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"array<struct<name:string,position:array<double>,location:array<double>>>\"}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=string].name",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].position",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.ArrayType": {
+                                                "nestedType": [
+                                                    "double"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "nativeDataType": "array<double>",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=struct].[type=array].[type=struct].markers.[type=array].[type=double].location",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.ArrayType": {
+                                                "nestedType": [
+                                                    "double"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "nativeDataType": "array<double>",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"array<double>\"}"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                            "platform": "urn:li:dataPlatform:glue"
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:owner",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
                             }
-                        ]
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7"
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-            "urn": "urn:li:dataFlow:(glue,test-job-1,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-                        "customProperties": {
-                            "role": "arn:aws:iam::123412341234:role/service-role/AWSGlueServiceRole-glue-crawler",
-                            "created": "2021-06-10 16:51:25.690000",
-                            "modified": "2021-06-10 16:55:35.307000",
-                            "command": "s3://aws-glue-assets-123412341234-us-west-2/scripts/job-1.py"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1",
-                        "description": "The first test job"
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
-            "urn": "urn:li:dataFlow:(glue,test-job-2,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
-                        "customProperties": {
-                            "role": "arn:aws:iam::123412341234:role/service-role/AWSGlueServiceRole-glue-crawler",
-                            "created": "2021-06-10 16:58:32.469000",
-                            "modified": "2021-06-10 16:58:32.469000",
-                            "command": "s3://aws-glue-assets-123412341234-us-west-2/scripts/job-2.py"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
-                        "name": "test-job-2",
-                        "description": "The second test job"
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Filter-Transform0_job1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "f": "lambda row : ()",
-                            "transformation_ctx": "\"Transform0\"",
-                            "transformType": "Filter",
-                            "nodeId": "Transform0_job1"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1:Filter-Transform0_job1",
-                        "type": {
-                            "string": "GLUE"
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:baz:bob"
+                                },
+                                {
+                                    "tag": "urn:li:tag:foo:bar"
+                                }
+                            ]
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform2_job1)"
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform1_job1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\"), (\"flightnum\", \"string\", \"flightnum\", \"string\"), (\"origin\", \"string\", \"origin\", \"string\"), (\"dest\", \"string\", \"dest\", \"string\"), (\"depdelay\", \"int\", \"depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"weatherdelay\", \"int\"), (\"year\", \"string\", \"year\", \"string\")]",
-                            "transformation_ctx": "\"Transform1\"",
-                            "transformType": "ApplyMapping",
-                            "nodeId": "Transform1_job1"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1:ApplyMapping-Transform1_job1",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_jsons_markers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Table"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_jsons_markers,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "container",
+        "aspect": {
+            "json": {
+                "container": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7"
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "CrawlerSchemaDeserializerVersion": "1.0",
+                                "CrawlerSchemaSerializerVersion": "1.0",
+                                "UPDATED_BY_CRAWLER": "test",
+                                "averageRecordSize": "19",
+                                "classification": "parquet",
+                                "compressionType": "none",
+                                "objectCount": "60",
+                                "recordCount": "167497743",
+                                "sizeKey": "4463574900",
+                                "typeOfData": "file",
+                                "Location": "s3://crawler-public-us-west-2/flight/parquet/",
+                                "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+                                "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+                                "Compressed": "False",
+                                "NumberOfBuckets": "-1",
+                                "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe', 'Parameters': {'serialization.format': '1'}}",
+                                "BucketColumns": "[]",
+                                "SortColumns": "[]",
+                                "StoredAsSubDirectories": "False"
+                            },
+                            "name": "test_parquet",
+                            "qualifiedName": "arn:aws:glue:us-west-2:795586375822:table/test-database/test_parquet",
+                            "tags": []
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                            "schemaName": "test-database.test_parquet",
+                            "platform": "urn:li:dataPlatform:glue",
+                            "version": 0,
+                            "created": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            },
+                            "hash": "",
+                            "platformSchema": {
+                                "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                    "tableSchema": ""
+                                }
+                            },
+                            "fields": [
+                                {
+                                    "fieldPath": "[version=2.0].[type=int].yr",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "int",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=int].quarter",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "int",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=int].month",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "int",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=int].dayofmonth",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "int",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                                },
+                                {
+                                    "fieldPath": "[version=2.0].[type=string].year",
+                                    "nullable": true,
+                                    "type": {
+                                        "type": {
+                                            "com.linkedin.pegasus2avro.schema.StringType": {}
+                                        }
+                                    },
+                                    "nativeDataType": "string",
+                                    "recursive": false,
+                                    "isPartOfKey": false,
+                                    "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                            "platform": "urn:li:dataPlatform:glue"
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:owner",
+                                    "type": "DATAOWNER"
+                                }
+                            ],
+                            "ownerTypes": {},
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.common.GlobalTags": {
+                            "tags": [
+                                {
+                                    "tag": "urn:li:tag:baz:bob"
+                                },
+                                {
+                                    "tag": "urn:li:tag:foo:bar"
+                                }
+                            ]
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Filter-Transform0_job1)"
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform2_job1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\"), (\"flightnum\", \"string\", \"flightnum\", \"string\"), (\"origin\", \"string\", \"origin\", \"string\"), (\"dest\", \"string\", \"dest\", \"string\"), (\"depdelay\", \"int\", \"depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"weatherdelay\", \"int\"), (\"year\", \"string\", \"year\", \"string\")]",
-                            "transformation_ctx": "\"Transform2\"",
-                            "transformType": "ApplyMapping",
-                            "nodeId": "Transform2_job1"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1:ApplyMapping-Transform2_job1",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "subTypes",
+        "aspect": {
+            "json": {
+                "typeNames": [
+                    "Table"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataset",
+        "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "container",
+        "aspect": {
+            "json": {
+                "container": "urn:li:container:bdf4342ea6899d162eae685bfe9074a7"
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+                "urn": "urn:li:dataFlow:(glue,test-job-1,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                            "customProperties": {
+                                "role": "arn:aws:iam::123412341234:role/service-role/AWSGlueServiceRole-glue-crawler",
+                                "created": "2021-06-10 16:51:25.690000",
+                                "modified": "2021-06-10 16:55:35.307000",
+                                "command": "s3://aws-glue-assets-123412341234-us-west-2/scripts/job-1.py"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1",
+                            "description": "The first test job"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [
-                            "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)"
-                        ],
-                        "outputDatasets": [],
-                        "inputDatajobs": []
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Join-Transform3_job1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "keys2": "[\"(right) flightdate\"]",
-                            "transformation_ctx": "\"Transform3\"",
-                            "keys1": "[\"yr\"]",
-                            "transformType": "Join",
-                            "nodeId": "Transform3_job1"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1:Join-Transform3_job1",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataFlowSnapshot": {
+                "urn": "urn:li:dataFlow:(glue,test-job-2,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataFlowInfo": {
+                            "customProperties": {
+                                "role": "arn:aws:iam::123412341234:role/service-role/AWSGlueServiceRole-glue-crawler",
+                                "created": "2021-06-10 16:58:32.469000",
+                                "modified": "2021-06-10 16:58:32.469000",
+                                "command": "s3://aws-glue-assets-123412341234-us-west-2/scripts/job-2.py"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
+                            "name": "test-job-2",
+                            "description": "The second test job"
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform4_job1)"
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform4_job1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\"), (\"flightnum\", \"string\", \"flightnum\", \"string\"), (\"origin\", \"string\", \"origin\", \"string\"), (\"dest\", \"string\", \"dest\", \"string\"), (\"depdelay\", \"int\", \"depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"weatherdelay\", \"int\"), (\"year\", \"string\", \"year\", \"string\")]",
-                            "transformation_ctx": "\"Transform4\"",
-                            "transformType": "ApplyMapping",
-                            "nodeId": "Transform4_job1"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1:ApplyMapping-Transform4_job1",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Filter-Transform0_job1)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "f": "lambda row : ()",
+                                "transformation_ctx": "\"Transform0\"",
+                                "transformType": "Filter",
+                                "nodeId": "Transform0_job1"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1:Filter-Transform0_job1",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": [
+                                "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform2_job1)"
+                            ]
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": []
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform5_job1)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "mappings": "[(\"yr\", \"int\", \"(right) yr\", \"int\"), (\"flightdate\", \"string\", \"(right) flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"(right) uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"(right) airlineid\", \"int\"), (\"carrier\", \"string\", \"(right) carrier\", \"string\"), (\"flightnum\", \"string\", \"(right) flightnum\", \"string\"), (\"origin\", \"string\", \"(right) origin\", \"string\"), (\"dest\", \"string\", \"(right) dest\", \"string\"), (\"depdelay\", \"int\", \"(right) depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"(right) carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"(right) weatherdelay\", \"int\"), (\"year\", \"string\", \"(right) year\", \"string\")]",
-                            "transformation_ctx": "\"Transform5\"",
-                            "transformType": "ApplyMapping",
-                            "nodeId": "Transform5_job1"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
-                        "name": "test-job-1:ApplyMapping-Transform5_job1",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform1_job1)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\"), (\"flightnum\", \"string\", \"flightnum\", \"string\"), (\"origin\", \"string\", \"origin\", \"string\"), (\"dest\", \"string\", \"dest\", \"string\"), (\"depdelay\", \"int\", \"depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"weatherdelay\", \"int\"), (\"year\", \"string\", \"year\", \"string\")]",
+                                "transformation_ctx": "\"Transform1\"",
+                                "transformType": "ApplyMapping",
+                                "nodeId": "Transform1_job1"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1:ApplyMapping-Transform1_job1",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": [
+                                "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Filter-Transform0_job1)"
+                            ]
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": []
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,test-glue-jsons,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
-                    }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "connection_type": "s3",
-                            "format": "json",
-                            "connection_options": "{'path': 's3://test-glue-jsons/', 'partitionKeys': []}",
-                            "transformation_ctx": "DataSink1"
-                        },
-                        "tags": []
-                    }
-                }
-            ]
-        }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SplitFields-Transform0_job2)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "paths": "[\"yr\", \"quarter\", \"month\", \"dayofmonth\", \"dayofweek\", \"flightdate\", \"uniquecarrier\"]",
-                            "name2": "\"Transform0Output1\"",
-                            "name1": "\"Transform0Output0\"",
-                            "transformation_ctx": "\"Transform0\"",
-                            "transformType": "SplitFields",
-                            "nodeId": "Transform0_job2"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
-                        "name": "test-job-2:SplitFields-Transform0_job2",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform2_job1)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\"), (\"flightnum\", \"string\", \"flightnum\", \"string\"), (\"origin\", \"string\", \"origin\", \"string\"), (\"dest\", \"string\", \"dest\", \"string\"), (\"depdelay\", \"int\", \"depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"weatherdelay\", \"int\"), (\"year\", \"string\", \"year\", \"string\")]",
+                                "transformation_ctx": "\"Transform2\"",
+                                "transformType": "ApplyMapping",
+                                "nodeId": "Transform2_job1"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1:ApplyMapping-Transform2_job1",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [
+                                "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database.avro,PROD)"
+                            ],
+                            "outputDatasets": [],
+                            "inputDatajobs": []
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)"
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"quarter\", \"int\", \"quarter\", \"int\"), (\"month\", \"int\", \"month\", \"int\"), (\"dayofmonth\", \"int\", \"dayofmonth\", \"int\"), (\"dayofweek\", \"int\", \"dayofweek\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\")]",
-                            "transformation_ctx": "\"Transform1\"",
-                            "transformType": "ApplyMapping",
-                            "nodeId": "Transform1_job2"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
-                        "name": "test-job-2:ApplyMapping-Transform1_job2",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Join-Transform3_job1)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "keys2": "[\"(right) flightdate\"]",
+                                "transformation_ctx": "\"Transform3\"",
+                                "keys1": "[\"yr\"]",
+                                "transformType": "Join",
+                                "nodeId": "Transform3_job1"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1:Join-Transform3_job1",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": [
+                                "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform4_job1)"
+                            ]
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [
-                            "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)"
-                        ],
-                        "outputDatasets": [],
-                        "inputDatajobs": []
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),FillMissingValues-Transform2_job2)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "missing_values_column": "\"dayofmonth\"",
-                            "transformation_ctx": "\"Transform2\"",
-                            "transformType": "FillMissingValues",
-                            "nodeId": "Transform2_job2"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
-                        "name": "test-job-2:FillMissingValues-Transform2_job2",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform4_job1)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\"), (\"flightnum\", \"string\", \"flightnum\", \"string\"), (\"origin\", \"string\", \"origin\", \"string\"), (\"dest\", \"string\", \"dest\", \"string\"), (\"depdelay\", \"int\", \"depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"weatherdelay\", \"int\"), (\"year\", \"string\", \"year\", \"string\")]",
+                                "transformation_ctx": "\"Transform4\"",
+                                "transformType": "ApplyMapping",
+                                "nodeId": "Transform4_job1"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1:ApplyMapping-Transform4_job1",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": []
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)"
-                        ]
-                    }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
-            "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SelectFields-Transform3_job2)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
-                        "customProperties": {
-                            "paths": "[]",
-                            "transformation_ctx": "\"Transform3\"",
-                            "transformType": "SelectFields",
-                            "nodeId": "Transform3_job2"
-                        },
-                        "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
-                        "name": "test-job-2:SelectFields-Transform3_job2",
-                        "type": {
-                            "string": "GLUE"
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform5_job1)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "mappings": "[(\"yr\", \"int\", \"(right) yr\", \"int\"), (\"flightdate\", \"string\", \"(right) flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"(right) uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"(right) airlineid\", \"int\"), (\"carrier\", \"string\", \"(right) carrier\", \"string\"), (\"flightnum\", \"string\", \"(right) flightnum\", \"string\"), (\"origin\", \"string\", \"(right) origin\", \"string\"), (\"dest\", \"string\", \"(right) dest\", \"string\"), (\"depdelay\", \"int\", \"(right) depdelay\", \"int\"), (\"carrierdelay\", \"int\", \"(right) carrierdelay\", \"int\"), (\"weatherdelay\", \"int\", \"(right) weatherdelay\", \"int\"), (\"year\", \"string\", \"(right) year\", \"string\")]",
+                                "transformation_ctx": "\"Transform5\"",
+                                "transformType": "ApplyMapping",
+                                "nodeId": "Transform5_job1"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-1/graph",
+                            "name": "test-job-1:ApplyMapping-Transform5_job1",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": []
                         }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
-                        "inputDatasets": [],
-                        "outputDatasets": [
-                            "urn:li:dataset:(urn:li:dataPlatform:s3,test-glue-jsons,PROD)"
-                        ],
-                        "inputDatajobs": [
-                            "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),FillMissingValues-Transform2_job2)"
-                        ]
+                ]
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,test-glue-jsons,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "connection_type": "s3",
+                                "format": "json",
+                                "connection_options": "{'path': 's3://test-glue-jsons/', 'partitionKeys': []}",
+                                "transformation_ctx": "DataSink1"
+                            },
+                            "tags": []
+                        }
                     }
-                }
-            ]
+                ]
+            }
         }
-    }
-},
-{
-    "proposedSnapshot": {
-        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,test-glue-jsons,PROD)",
-            "aspects": [
-                {
-                    "com.linkedin.pegasus2avro.common.Status": {
-                        "removed": false
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SplitFields-Transform0_job2)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "paths": "[\"yr\", \"quarter\", \"month\", \"dayofmonth\", \"dayofweek\", \"flightdate\", \"uniquecarrier\"]",
+                                "name2": "\"Transform0Output1\"",
+                                "name1": "\"Transform0Output0\"",
+                                "transformation_ctx": "\"Transform0\"",
+                                "transformType": "SplitFields",
+                                "nodeId": "Transform0_job2"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
+                            "name": "test-job-2:SplitFields-Transform0_job2",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": [
+                                "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)"
+                            ]
+                        }
                     }
-                },
-                {
-                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-                        "customProperties": {
-                            "connection_type": "s3",
-                            "format": "json",
-                            "connection_options": "{'path': 's3://test-glue-jsons/', 'partitionKeys': []}",
-                            "transformation_ctx": "DataSink0"
-                        },
-                        "tags": []
+                ]
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "mappings": "[(\"yr\", \"int\", \"yr\", \"int\"), (\"quarter\", \"int\", \"quarter\", \"int\"), (\"month\", \"int\", \"month\", \"int\"), (\"dayofmonth\", \"int\", \"dayofmonth\", \"int\"), (\"dayofweek\", \"int\", \"dayofweek\", \"int\"), (\"flightdate\", \"string\", \"flightdate\", \"string\"), (\"uniquecarrier\", \"string\", \"uniquecarrier\", \"string\"), (\"airlineid\", \"int\", \"airlineid\", \"int\"), (\"carrier\", \"string\", \"carrier\", \"string\")]",
+                                "transformation_ctx": "\"Transform1\"",
+                                "transformType": "ApplyMapping",
+                                "nodeId": "Transform1_job2"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
+                            "name": "test-job-2:ApplyMapping-Transform1_job2",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [
+                                "urn:li:dataset:(urn:li:dataPlatform:glue,test-database.test_parquet,PROD)"
+                            ],
+                            "outputDatasets": [],
+                            "inputDatajobs": []
+                        }
                     }
-                }
-            ]
+                ]
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),FillMissingValues-Transform2_job2)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "missing_values_column": "\"dayofmonth\"",
+                                "transformation_ctx": "\"Transform2\"",
+                                "transformType": "FillMissingValues",
+                                "nodeId": "Transform2_job2"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
+                            "name": "test-job-2:FillMissingValues-Transform2_job2",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [],
+                            "inputDatajobs": [
+                                "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)"
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DataJobSnapshot": {
+                "urn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SelectFields-Transform3_job2)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInfo": {
+                            "customProperties": {
+                                "paths": "[]",
+                                "transformation_ctx": "\"Transform3\"",
+                                "transformType": "SelectFields",
+                                "nodeId": "Transform3_job2"
+                            },
+                            "externalUrl": "https://us-west-2.console.aws.amazon.com/gluestudio/home?region=us-west-2#/editor/job/test-job-2/graph",
+                            "name": "test-job-2:SelectFields-Transform3_job2",
+                            "type": {
+                                "string": "GLUE"
+                            }
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.datajob.DataJobInputOutput": {
+                            "inputDatasets": [],
+                            "outputDatasets": [
+                                "urn:li:dataset:(urn:li:dataPlatform:s3,test-glue-jsons,PROD)"
+                            ],
+                            "inputDatajobs": [
+                                "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),FillMissingValues-Transform2_job2)"
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:s3,test-glue-jsons,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.common.Status": {
+                            "removed": false
+                        }
+                    },
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "customProperties": {
+                                "connection_type": "s3",
+                                "format": "json",
+                                "connection_options": "{'path': 's3://test-glue-jsons/', 'partitionKeys': []}",
+                                "transformation_ctx": "DataSink0"
+                            },
+                            "tags": []
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "dataFlow",
+        "entityUrn": "urn:li:dataFlow:(glue,test-job-1,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataFlow",
+        "entityUrn": "urn:li:dataFlow:(glue,test-job-2,PROD)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform1_job1)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform2_job1)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform4_job1)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform5_job1)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Filter-Transform0_job1)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Join-Transform3_job1)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),FillMissingValues-Transform2_job2)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SelectFields-Transform3_job2)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "dataJob",
+        "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SplitFields-Transform0_job2)",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:baz:bob",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "baz:bob"
+            }
+        }
+    },
+    {
+        "entityType": "tag",
+        "entityUrn": "urn:li:tag:foo:bar",
+        "changeType": "UPSERT",
+        "aspectName": "tagKey",
+        "aspect": {
+            "json": {
+                "name": "foo:bar"
+            }
         }
     }
-},
-{
-    "entityType": "dataFlow",
-    "entityUrn": "urn:li:dataFlow:(glue,test-job-1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataFlow",
-    "entityUrn": "urn:li:dataFlow:(glue,test-job-2,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform1_job1)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform2_job1)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform4_job1)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),ApplyMapping-Transform5_job1)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Filter-Transform0_job1)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-1,PROD),Join-Transform3_job1)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),ApplyMapping-Transform1_job2)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),FillMissingValues-Transform2_job2)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SelectFields-Transform3_job2)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "dataJob",
-    "entityUrn": "urn:li:dataJob:(urn:li:dataFlow:(glue,test-job-2,PROD),SplitFields-Transform0_job2)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:baz:bob",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "baz:bob"
-        }
-    }
-},
-{
-    "entityType": "tag",
-    "entityUrn": "urn:li:tag:foo:bar",
-    "changeType": "UPSERT",
-    "aspectName": "tagKey",
-    "aspect": {
-        "json": {
-            "name": "foo:bar"
-        }
-    }
-}
-]
+    ]

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden_profiling.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden_profiling.json
@@ -1,0 +1,289 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:77f8f4c39b47069d3a71191de1333b0e",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "glue",
+                "env": "PROD",
+                "database": "flights-database-profiling",
+                "param1": "value1",
+                "param2": "value2",
+                "LocationUri": "s3://test-bucket/test-prefix",
+                "CreateTime": "June 09, 2021 at 14:14:19"
+            },
+            "name": "flights-database-profiling",
+            "qualifiedName": "arn:aws:glue:us-west-2:123412341234:database/flights-database-profiling"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:77f8f4c39b47069d3a71191de1333b0e",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:77f8f4c39b47069d3a71191de1333b0e",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:glue"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:77f8f4c39b47069d3a71191de1333b0e",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Database"
+            ]
+        }
+    }
+},
+{
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database-profiling.avro-profiling,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "CrawlerSchemaDeserializerVersion": "1.0",
+                            "CrawlerSchemaSerializerVersion": "1.0",
+                            "UPDATED_BY_CRAWLER": "flights-crawler",
+                            "averageRecordSize": "55",
+                            "avro.schema.literal": "{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}",
+                            "classification": "avro",
+                            "compressionType": "none",
+                            "objectCount": "30",
+                            "recordCount": "169222196",
+                            "sizeKey": "9503351413",
+                            "typeOfData": "file",
+                            "Location": "s3://crawler-public-us-west-2/flight/avro/",
+                            "InputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
+                            "OutputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
+                            "Compressed": "False",
+                            "NumberOfBuckets": "-1",
+                            "SerdeInfo": "{'SerializationLibrary': 'org.apache.hadoop.hive.serde2.avro.AvroSerDe', 'Parameters': {'avro.schema.literal': '{\"type\":\"record\",\"name\":\"flights_avro_subset\",\"namespace\":\"default\",\"fields\":[{\"name\":\"yr\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"flightdate\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"uniquecarrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"airlineid\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrier\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"flightnum\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"origin\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"dest\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"depdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"carrierdelay\",\"type\":[\"null\",\"int\"],\"default\":null},{\"name\":\"weatherdelay\",\"type\":[\"null\",\"int\"],\"default\":null}]}', 'serialization.format': '1'}}",
+                            "BucketColumns": "[]",
+                            "SortColumns": "[]",
+                            "StoredAsSubDirectories": "False"
+                        },
+                        "name": "avro-profiling",
+                        "qualifiedName": "arn:aws:glue:us-west-2:123412341234:table/flights-database-profiling/avro-profiling",
+                        "tags": []
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "flights-database-profiling.avro-profiling",
+                        "platform": "urn:li:dataPlatform:glue",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        },
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "[version=2.0].[type=int].yr",
+                                "nullable": true,
+                                "description": "test comment",
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].flightdate",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].uniquecarrier",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=int].airlineid",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"int\", \"_nullable\": true}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].carrier",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].flightnum",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                            },
+                            {
+                                "fieldPath": "[version=2.0].[type=string].origin",
+                                "nullable": true,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "isPartOfKey": false,
+                                "jsonProps": "{\"native_data_type\": \"string\", \"_nullable\": true}"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.DataPlatformInstance": {
+                        "platform": "urn:li:dataPlatform:glue"
+                    }
+                },
+                {
+                    "com.linkedin.pegasus2avro.common.Ownership": {
+                        "owners": [
+                            {
+                                "owner": "urn:li:corpuser:owner",
+                                "type": "DATAOWNER"
+                            }
+                        ],
+                        "ownerTypes": {},
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database-profiling.avro-profiling,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database-profiling.avro-profiling,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:77f8f4c39b47069d3a71191de1333b0e"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,flights-database-profiling.avro-profiling,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProfile",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1586847600000,
+            "partitionSpec": {
+                "type": "FULL_TABLE",
+                "partition": "FULL_TABLE_SNAPSHOT"
+            },
+            "fieldProfiles": [
+                {
+                    "fieldPath": "yr",
+                    "uniqueCount": 1,
+                    "uniqueProportion": 2.0,
+                    "nullCount": 0,
+                    "nullProportion": 11.0,
+                    "min": "1",
+                    "max": "10",
+                    "mean": "1",
+                    "median": "2",
+                    "stdev": "3"
+                }
+            ]
+        }
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -686,24 +686,14 @@ def test_glue_ingest_include_column_lineage(
     )
 
 
-@pytest.mark.parametrize(
-    "platform_instance, mce_file, mce_golden_file",
-    [
-        (None, "glue_mces.json", "glue_mces_golden_profiling.json"),
-    ],
-)
 @freeze_time(FROZEN_TIME)
 def test_glue_ingest_with_profiling(
     tmp_path: Path,
     pytestconfig: PytestConfig,
-    platform_instance: str,
-    mce_file: str,
-    mce_golden_file: str,
 ) -> None:
-    glue_source_instance = glue_source_with_profiling(
-        platform_instance=platform_instance
-    )
-
+    glue_source_instance = glue_source_with_profiling()
+    mce_file = "glue_mces.json"
+    mce_golden_file = "glue_mces_golden_profiling.json"
     with Stubber(glue_source_instance.glue_client) as glue_stubber:
         glue_stubber.add_response("get_databases", get_databases_response_profiling, {})
 

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -13,7 +13,11 @@ from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.extractor.schema_util import avro_schema_to_mce_fields
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
 from datahub.ingestion.sink.file import write_metadata_file
-from datahub.ingestion.source.aws.glue import GlueSource, GlueSourceConfig
+from datahub.ingestion.source.aws.glue import (
+    GlueProfilingConfig,
+    GlueSource,
+    GlueSourceConfig,
+)
 from datahub.ingestion.source.state.sql_common_state import (
     BaseSQLAlchemyCheckpointState,
 )
@@ -38,6 +42,7 @@ from tests.unit.test_glue_source_stubs import (
     get_databases_delta_response,
     get_databases_response,
     get_databases_response_for_lineage,
+    get_databases_response_profiling,
     get_databases_response_with_resource_link,
     get_dataflow_graph_response_1,
     get_dataflow_graph_response_2,
@@ -54,9 +59,11 @@ from tests.unit.test_glue_source_stubs import (
     get_tables_response_1,
     get_tables_response_2,
     get_tables_response_for_target_database,
+    get_tables_response_profiling_1,
     resource_link_database,
     tables_1,
     tables_2,
+    tables_profiling_1,
     target_database_tables,
 )
 
@@ -89,6 +96,42 @@ def glue_source(
             extract_delta_schema_from_parameters=extract_delta_schema_from_parameters,
             emit_s3_lineage=emit_s3_lineage,
             include_column_lineage=include_column_lineage,
+        ),
+    )
+
+
+def glue_source_with_profiling(
+    platform_instance: Optional[str] = None,
+    use_s3_bucket_tags: bool = False,
+    use_s3_object_tags: bool = False,
+    extract_delta_schema_from_parameters: bool = False,
+) -> GlueSource:
+    profiling_config = GlueProfilingConfig(
+        enabled=True,
+        profile_table_level_only=False,
+        row_count="row_count",
+        column_count="column_count",
+        unique_count="unique_count",
+        unique_proportion="unique_proportion",
+        null_count="null_count",
+        null_proportion="null_proportion",
+        min="min",
+        max="max",
+        mean="mean",
+        median="median",
+        stdev="stdev",
+    )
+
+    return GlueSource(
+        ctx=PipelineContext(run_id="glue-source-test"),
+        config=GlueSourceConfig(
+            aws_region="us-west-2",
+            extract_transforms=False,
+            platform_instance=platform_instance,
+            use_s3_bucket_tags=use_s3_bucket_tags,
+            use_s3_object_tags=use_s3_object_tags,
+            extract_delta_schema_from_parameters=extract_delta_schema_from_parameters,
+            profiling=profiling_config,
         ),
     )
 
@@ -630,6 +673,54 @@ def test_glue_ingest_include_column_lineage(
         )
 
         mce_objects = [wu.metadata for wu in glue_source_instance.get_workunits()]
+        glue_stubber.assert_no_pending_responses()
+
+        write_metadata_file(tmp_path / mce_file, mce_objects)
+
+    # Verify the output.
+    test_resources_dir = pytestconfig.rootpath / "tests/unit/glue"
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=tmp_path / mce_file,
+        golden_path=test_resources_dir / mce_golden_file,
+    )
+
+
+@pytest.mark.parametrize(
+    "platform_instance, mce_file, mce_golden_file",
+    [
+        (None, "glue_mces.json", "glue_mces_golden_profiling.json"),
+    ],
+)
+@freeze_time(FROZEN_TIME)
+def test_glue_ingest_with_profiling(
+    tmp_path: Path,
+    pytestconfig: PytestConfig,
+    platform_instance: str,
+    mce_file: str,
+    mce_golden_file: str,
+) -> None:
+    glue_source_instance = glue_source_with_profiling(
+        platform_instance=platform_instance
+    )
+
+    with Stubber(glue_source_instance.glue_client) as glue_stubber:
+        glue_stubber.add_response("get_databases", get_databases_response_profiling, {})
+
+        glue_stubber.add_response(
+            "get_tables",
+            get_tables_response_profiling_1,
+            {"DatabaseName": "flights-database-profiling"},
+        )
+
+        glue_stubber.add_response(
+            "get_table",
+            {"Table": tables_profiling_1[0]},
+            {"DatabaseName": "flights-database-profiling", "Name": "avro-profiling"},
+        )
+
+        mce_objects = [wu.metadata for wu in glue_source_instance.get_workunits()]
+
         glue_stubber.assert_no_pending_responses()
 
         write_metadata_file(tmp_path / mce_file, mce_objects)

--- a/metadata-ingestion/tests/unit/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/test_glue_source_stubs.py
@@ -973,6 +973,112 @@ tables_lineage_1 = [
 get_tables_lineage_response_1 = {"TableList": tables_lineage_1}
 
 
+get_databases_response_profiling = {
+    "DatabaseList": [
+        {
+            "Name": "flights-database-profiling",
+            "CreateTime": datetime.datetime(2021, 6, 9, 14, 14, 19),
+            "CreateTableDefaultPermissions": [
+                {
+                    "Principal": {
+                        "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+                    },
+                    "Permissions": ["ALL"],
+                }
+            ],
+            "CatalogId": "123412341234",
+            "LocationUri": "s3://test-bucket/test-prefix",
+            "Parameters": {"param1": "value1", "param2": "value2"},
+        },
+    ]
+}
+
+tables_profiling_1 = [
+    {
+        "Name": "avro-profiling",
+        "DatabaseName": "flights-database-profiling",
+        "Owner": "owner",
+        "CreateTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "UpdateTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "LastAccessTime": datetime.datetime(2021, 6, 9, 14, 17, 35),
+        "Retention": 0,
+        "StorageDescriptor": {
+            "Columns": [
+                {
+                    "Name": "yr",
+                    "Type": "int",
+                    "Comment": "test comment",
+                    "Parameters": {
+                        "unique_proportion": "2",
+                        "min": "1",
+                        "median": "2",
+                        "max": "10",
+                        "mean": "1",
+                        "null_proportion": "11",
+                        "unique_count": "1",
+                        "stdev": "3",
+                        "null_count": "0",
+                    },
+                },
+                {"Name": "flightdate", "Type": "string"},
+                {"Name": "uniquecarrier", "Type": "string"},
+                {"Name": "airlineid", "Type": "int"},
+                {"Name": "carrier", "Type": "string"},
+                {"Name": "flightnum", "Type": "string"},
+                {"Name": "origin", "Type": "string"},
+            ],
+            "Location": "s3://crawler-public-us-west-2/flight/avro/",
+            "InputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat",
+            "Compressed": False,
+            "NumberOfBuckets": -1,
+            "SerdeInfo": {
+                "SerializationLibrary": "org.apache.hadoop.hive.serde2.avro.AvroSerDe",
+                "Parameters": {
+                    "avro.schema.literal": '{"type":"record","name":"flights_avro_subset","namespace":"default","fields":[{"name":"yr","type":["null","int"],"default":null},{"name":"flightdate","type":["null","string"],"default":null},{"name":"uniquecarrier","type":["null","string"],"default":null},{"name":"airlineid","type":["null","int"],"default":null},{"name":"carrier","type":["null","string"],"default":null},{"name":"flightnum","type":["null","string"],"default":null},{"name":"origin","type":["null","string"],"default":null},{"name":"dest","type":["null","string"],"default":null},{"name":"depdelay","type":["null","int"],"default":null},{"name":"carrierdelay","type":["null","int"],"default":null},{"name":"weatherdelay","type":["null","int"],"default":null}]}',
+                    "serialization.format": "1",
+                },
+            },
+            "BucketColumns": [],
+            "SortColumns": [],
+            "Parameters": {
+                "CrawlerSchemaDeserializerVersion": "1.0",
+                "CrawlerSchemaSerializerVersion": "1.0",
+                "UPDATED_BY_CRAWLER": "flights-crawler",
+                "averageRecordSize": "55",
+                "avro.schema.literal": '{"type":"record","name":"flights_avro_subset","namespace":"default","fields":[{"name":"yr","type":["null","int"],"default":null},{"name":"flightdate","type":["null","string"],"default":null},{"name":"uniquecarrier","type":["null","string"],"default":null},{"name":"airlineid","type":["null","int"],"default":null},{"name":"carrier","type":["null","string"],"default":null},{"name":"flightnum","type":["null","string"],"default":null},{"name":"origin","type":["null","string"],"default":null},{"name":"dest","type":["null","string"],"default":null},{"name":"depdelay","type":["null","int"],"default":null},{"name":"carrierdelay","type":["null","int"],"default":null},{"name":"weatherdelay","type":["null","int"],"default":null}]}',
+                "classification": "avro",
+                "compressionType": "none",
+                "objectCount": "30",
+                "recordCount": "169222196",
+                "sizeKey": "9503351413",
+                "typeOfData": "file",
+            },
+            "StoredAsSubDirectories": False,
+        },
+        "PartitionKeys": [],
+        "TableType": "EXTERNAL_TABLE",
+        "Parameters": {
+            "CrawlerSchemaDeserializerVersion": "1.0",
+            "CrawlerSchemaSerializerVersion": "1.0",
+            "UPDATED_BY_CRAWLER": "flights-crawler",
+            "averageRecordSize": "55",
+            "avro.schema.literal": '{"type":"record","name":"flights_avro_subset","namespace":"default","fields":[{"name":"yr","type":["null","int"],"default":null},{"name":"flightdate","type":["null","string"],"default":null},{"name":"uniquecarrier","type":["null","string"],"default":null},{"name":"airlineid","type":["null","int"],"default":null},{"name":"carrier","type":["null","string"],"default":null},{"name":"flightnum","type":["null","string"],"default":null},{"name":"origin","type":["null","string"],"default":null},{"name":"dest","type":["null","string"],"default":null},{"name":"depdelay","type":["null","int"],"default":null},{"name":"carrierdelay","type":["null","int"],"default":null},{"name":"weatherdelay","type":["null","int"],"default":null}]}',
+            "classification": "avro",
+            "compressionType": "none",
+            "objectCount": "30",
+            "recordCount": "169222196",
+            "sizeKey": "9503351413",
+            "typeOfData": "file",
+        },
+        "CreatedBy": "arn:aws:sts::123412341234:assumed-role/AWSGlueServiceRole-flights-crawler/AWS-Crawler",
+        "IsRegisteredWithLakeFormation": False,
+        "CatalogId": "123412341234",
+    }
+]
+get_tables_response_profiling_1 = {"TableList": tables_profiling_1}
+
+
 def mock_get_object_response(raw_body: str) -> Dict[str, Any]:
     """
     Mock s3 client get_object() response object.


### PR DESCRIPTION
**Summary:**

1. **Glue Source Profiling Configuration:**
   - Configuration parameters include:
     - `enabled`: Flag to enable or disable profiling (default: `false`).
     - `profile_table_level_only`: Flag to enable profiling at the table level only, excluding column-level profiling (default: `false`).
     - `max_workers`: Number of worker threads to use for profiling, defaulting to 5 times the CPU count.

2. **Test Cases:**
   - Added new test cases for Glue source to verify the new profiling configuration.
   - Ensured that existing Glue source test cases are compatible with the new configuration.

3. **Documentation Update:**
   - Updated the `updating-datahub.md` file to document the breaking change related to the profiling configuration for Glue source under the "Breaking Changes" section.

**QA:**
- Validated the change locally to ensure its working as expected

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced profiling support for AWS Glue data ingestion, including options to enable profiling and restrict it to table-level only.

- **Improvements**
  - Simplified profiling logic for enhanced readability and efficiency.

- **Tests**
  - Added comprehensive test cases to validate profiling functionalities within the AWS Glue data ingestion module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->