### PR TITLE
fix/ added click to perticular result and dynamic wait

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/auto_complete/auto_complete.js
+++ b/smoke-test/tests/cypress/cypress/e2e/auto_complete/auto_complete.js
@@ -26,12 +26,14 @@ describe("auto-complete", () => {
     cy.login();
     cy.visit("/");
     cy.get("input[data-testid=search-input]").type("SampleCypressHiveDataset");
-    cy.get('[data-testid^="auto-complete-option"]').first().click();
+    cy.get('[data-testid^="auto-complete-option"]')
+      .contains("SampleCypressHiveDataset")
+      .click();
+    cy.get(".ant-table-row").should("be.visible");
     cy.url().should(
       "include",
       "dataset/urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD)",
     );
-    cy.wait(2000);
   });
 
   it("should filter auto-complete results when clicking on a quick filter", () => {


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved auto-complete selection accuracy by ensuring text content check before option selection.
  - Removed unnecessary wait operation for faster auto-complete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->