### PR TITLE
ci(ingest): pin dask dependency for feast

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -343,6 +343,7 @@ plugins: Dict[str, Set[str]] = {
     "feast": {
         "feast>=0.34.0,<1",
         "flask-openid>=1.3.0",
+        "dask[dataframe]<2024.7.0",
     },
     "glue": aws_common,
     # hdbcli is supported officially by SAP, sqlalchemy-hana is built on top but not officially supported


### PR DESCRIPTION
Try Pinning dask to dask[dataframe]<2024.7.0 in feast ingestion dependencies to fix CI error `ImportError: Dask requires version '2.0.0' or newer of 'pandas' (version '1.5.3' currently installed).`.

Passing `--no-strip-extras`  for `uv pip install` build scripts may fix this longer term.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a dependency on `dask[dataframe]<2024.7.0` for improved data handling capabilities within the `feast` section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->