### PR TITLE
fix(lineage) Fix lineage source/dest filtering with explored per hop limit

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphQueryDAO.java
@@ -177,13 +177,18 @@ public class ESGraphQueryDAO {
     sourceFilterQuery.minimumShouldMatch(1);
     validEdges.stream()
         .filter(pair -> RelationshipDirection.OUTGOING.equals(pair.getValue().getDirection()))
-        .forEach(pair -> sourceFilterQuery.should(getAggregationFilter(pair)));
+        .forEach(
+            pair ->
+                sourceFilterQuery.should(
+                    getAggregationFilter(pair, RelationshipDirection.OUTGOING)));
 
     BoolQueryBuilder destFilterQuery = QueryBuilders.boolQuery();
     destFilterQuery.minimumShouldMatch(1);
     validEdges.stream()
         .filter(pair -> RelationshipDirection.INCOMING.equals(pair.getValue().getDirection()))
-        .forEach(pair -> destFilterQuery.should(getAggregationFilter(pair)));
+        .forEach(
+            pair ->
+                destFilterQuery.should(getAggregationFilter(pair, RelationshipDirection.INCOMING)));
 
     FilterAggregationBuilder sourceRelationshipTypeFilters =
         AggregationBuilders.filter(FILTER_BY_SOURCE_RELATIONSHIP, sourceFilterQuery);
@@ -226,17 +231,28 @@ public class ESGraphQueryDAO {
     }
   }
 
-  private BoolQueryBuilder getAggregationFilter(Pair<String, EdgeInfo> pair) {
+  private BoolQueryBuilder getAggregationFilter(
+      Pair<String, EdgeInfo> pair, RelationshipDirection direction) {
     BoolQueryBuilder subFilter = QueryBuilders.boolQuery();
     TermQueryBuilder relationshipTypeTerm =
-        QueryBuilders.termQuery(RELATIONSHIP_TYPE, pair.getValue().getType());
+        QueryBuilders.termQuery(RELATIONSHIP_TYPE, pair.getValue().getType()).caseInsensitive(true);
     subFilter.must(relationshipTypeTerm);
+
+    String sourceType;
+    String destinationType;
+    if (direction.equals(RelationshipDirection.OUTGOING)) {
+      sourceType = pair.getKey();
+      destinationType = pair.getValue().getOpposingEntityType();
+    } else {
+      sourceType = pair.getValue().getOpposingEntityType();
+      destinationType = pair.getKey();
+    }
+
     TermQueryBuilder sourceTypeTerm =
-        QueryBuilders.termQuery(SOURCE + ".entityType", pair.getKey());
+        QueryBuilders.termQuery(SOURCE + ".entityType", sourceType).caseInsensitive(true);
     subFilter.must(sourceTypeTerm);
     TermQueryBuilder destinationTypeTerm =
-        QueryBuilders.termQuery(
-            DESTINATION + ".entityType", pair.getValue().getOpposingEntityType());
+        QueryBuilders.termQuery(DESTINATION + ".entityType", destinationType).caseInsensitive(true);
     subFilter.must(destinationTypeTerm);
     return subFilter;
   }


### PR DESCRIPTION
There was a bug in how we were filtering when using the `entitiesExploredPerHopLimit` where we needed to reverse the `source` and `dest` filter depending on the lineage direction we were going. Without this fix we weren't matching on things like dataJobs in searchAcrossLineage down this path properly.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query filtering with direction-based relationship support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->