### PR TITLE
Batch get entity endpoints

### DIFF
--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/client/OpenApiClient.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/client/OpenApiClient.java
@@ -2,8 +2,8 @@ package io.datahubproject.openapi.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.openapi.v2.models.BatchGetUrnRequest;
-import io.datahubproject.openapi.v2.models.BatchGetUrnResponse;
+import io.datahubproject.openapi.models.BatchGetUrnRequest;
+import io.datahubproject.openapi.models.BatchGetUrnResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/models/BatchGetUrnRequest.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/models/BatchGetUrnRequest.java
@@ -1,4 +1,4 @@
-package io.datahubproject.openapi.v2.models;
+package io.datahubproject.openapi.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/models/BatchGetUrnResponse.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/models/BatchGetUrnResponse.java
@@ -1,4 +1,4 @@
-package io.datahubproject.openapi.v2.models;
+package io.datahubproject.openapi.models;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,8 +13,8 @@ import lombok.Value;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(builder = BatchGetUrnResponse.BatchGetUrnResponseBuilder.class)
-public class BatchGetUrnResponse implements Serializable {
+public class BatchGetUrnResponse<T extends GenericEntity> implements Serializable {
   @JsonProperty("entities")
   @Schema(description = "List of entity responses")
-  List<GenericEntityV2> entities;
+  List<T> entities;
 }

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/EntityController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/v2/controller/EntityController.java
@@ -1,15 +1,9 @@
 package io.datahubproject.openapi.v2.controller;
 
-import static com.linkedin.metadata.authorization.ApiOperation.READ;
-
 import com.datahub.authentication.Actor;
-import com.datahub.authentication.Authentication;
-import com.datahub.authentication.AuthenticationContext;
-import com.datahub.authorization.AuthUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.ByteString;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.EnvelopedAspect;
@@ -28,37 +22,23 @@ import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.util.Pair;
 import io.datahubproject.metadata.context.OperationContext;
-import io.datahubproject.metadata.context.RequestContext;
 import io.datahubproject.openapi.controller.GenericEntitiesController;
 import io.datahubproject.openapi.exception.InvalidUrnException;
-import io.datahubproject.openapi.exception.UnauthorizedException;
-import io.datahubproject.openapi.v2.models.BatchGetUrnRequest;
-import io.datahubproject.openapi.v2.models.BatchGetUrnResponse;
 import io.datahubproject.openapi.v2.models.GenericEntityScrollResultV2;
 import io.datahubproject.openapi.v2.models.GenericEntityV2;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -82,48 +62,6 @@ public class EntityController
         .results(toRecordTemplates(opContext, searchEntities, aspectNames, withSystemMetadata))
         .scrollId(scrollId)
         .build();
-  }
-
-  @Tag(name = "Generic Entities")
-  @PostMapping(value = "/batch/{entityName}", produces = MediaType.APPLICATION_JSON_VALUE)
-  @Operation(summary = "Get a batch of entities")
-  public ResponseEntity<BatchGetUrnResponse> getEntityBatch(
-      HttpServletRequest httpServletRequest,
-      @PathVariable("entityName") String entityName,
-      @RequestBody BatchGetUrnRequest request)
-      throws URISyntaxException {
-
-    List<Urn> urns = request.getUrns().stream().map(UrnUtils::getUrn).collect(Collectors.toList());
-
-    Authentication authentication = AuthenticationContext.getAuthentication();
-    if (!AuthUtil.isAPIAuthorizedEntityUrns(authentication, authorizationChain, READ, urns)) {
-      throw new UnauthorizedException(
-          authentication.getActor().toUrnStr() + " is unauthorized to " + READ + "  entities.");
-    }
-    OperationContext opContext =
-        OperationContext.asSession(
-            systemOperationContext,
-            RequestContext.builder()
-                .buildOpenapi(
-                    authentication.getActor().toUrnStr(),
-                    httpServletRequest,
-                    "getEntityBatch",
-                    entityName),
-            authorizationChain,
-            authentication,
-            true);
-
-    return ResponseEntity.of(
-        Optional.of(
-            BatchGetUrnResponse.builder()
-                .entities(
-                    new ArrayList<>(
-                        buildEntityList(
-                            opContext,
-                            urns,
-                            new HashSet<>(request.getAspectNames()),
-                            request.isWithSystemMetadata())))
-                .build()));
   }
 
   @Override


### PR DESCRIPTION
- Move batch get entity endpoints to GenericEntityController
- Register typed batch get endpoints in v3 open api

```
/v3/entity/batch/dataset:
    post:
      tags:
      - dataset Entity
      summary: Batch Get Dataset entities.
      requestBody:
        description: Batch Get dataset entities.
        content:
          application/json:
            schema:
              properties:
                aspectNames:
                  type: array
                  description: List of aspect names to get
                  items:
                    type: string
                    default: container
                    enum:
                    - container
                    - testResults
                    - editableSchemaMetadata
                    - siblings
                    - access
                    - datasetUpstreamLineage
                    - viewProperties
                    - datasetProperties
                    - globalTags
                    - browsePathsV2
                    - embed
                    - schemaMetadata
                    - datasetKey
                    - domains
                    - subTypes
                    - datasetProfile
                    - deprecation
                    - browsePaths
                    - incidentsSummary
                    - datasetUsageStatistics
                    - structuredProperties
                    - ownership
                    - dataPlatformInstance
                    - datasetDeprecation
                    - editableDatasetProperties
                    - glossaryTerms
                    - institutionalMemory
                    - operation
                    - upstreamLineage
                    - forms
                    - status
                withSystemMetadata:
                  type: boolean
                  default: true
                urns:
                  type: array
                  items:
                    type: string
                    description: List of urns to get
        required: true
      responses:
        "200":
          description: Create a batch of dataset entities.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/BatchGetDatasetEntityResponse_v3'

BatchGetDatasetEntityResponse_v3:
      required:
      - entities
      type: object
      properties:
        entities:
          properties:
            urn:
              type: string
              description: Entity key urn
            aspects:
              $ref: '#/components/schemas/DatasetEntityResponse_v3'
      description: Batch get Dataset objects.
```


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented batch entity retrieval functionality, improving efficiency for bulk data requests.
  - Enhanced API to support batch GET requests for entities.

- **Refactor**
  - Updated package structure for `BatchGetUrnRequest` and `BatchGetUrnResponse` to streamline model organization.
  - Removed redundant authentication and authorization imports to clean up codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->