### PR TITLE
fix(build): upgrade vercel builds to Node 20.x

### DIFF
--- a/docs-website/vercel-setup.sh
+++ b/docs-website/vercel-setup.sh
@@ -11,7 +11,6 @@ set -euxo pipefail
 # for reuse.
 
 yum groupinstall "Development Tools" -y
-yum erase openssl-devel -y
 yum install openssl openssl-devel libffi-devel bzip2-devel wget nodejs -y
 
 wget https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tgz

--- a/docs-website/vercel-setup.sh
+++ b/docs-website/vercel-setup.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 ./metadata-ingestion/scripts/install_deps.sh
 
 # Set up java version for gradle
-yum install java-17-amazon-corretto
+yum install java-17-amazon-corretto -y
 java --version
 
 # Build python from source.

--- a/docs-website/vercel-setup.sh
+++ b/docs-website/vercel-setup.sh
@@ -12,7 +12,7 @@ set -euxo pipefail
 
 yum groupinstall "Development Tools" -y
 yum erase openssl-devel -y
-yum install openssl11 openssl11-devel libffi-devel bzip2-devel wget nodejs -y
+yum install openssl openssl-devel libffi-devel bzip2-devel wget nodejs -y
 
 wget https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tgz
 tar -xf Python-3.10.11.tgz

--- a/docs-website/vercel-setup.sh
+++ b/docs-website/vercel-setup.sh
@@ -4,6 +4,10 @@ set -euxo pipefail
 
 ./metadata-ingestion/scripts/install_deps.sh
 
+# Set up java version for gradle
+yum install java-17-amazon-corretto
+java --version
+
 # Build python from source.
 # Amazon Linux 2 has Python 3.8, but it's version of OpenSSL is super old and hence it
 # doesn't work with the packages we use. As such, we have to build Python from source.
@@ -28,6 +32,3 @@ rm "$py3"
 ln "$(which python3.10)" "$py3"
 python3 --version
 
-# Set up java version for gradle
-yum install java-17-amazon-corretto
-java --version

--- a/metadata-ingestion/scripts/install_deps.sh
+++ b/metadata-ingestion/scripts/install_deps.sh
@@ -18,7 +18,8 @@ else
             sqlite-devel \
             xz-devel \
             libxml2-devel \
-            libxslt-devel
+            libxslt-devel \
+	    krb5-devel
     else
         $sudo_cmd apt-get update && $sudo_cmd apt-get install -y \
             python3-ldap \


### PR DESCRIPTION
Upgrades from legacy build image to the new one (https://vercel.com/docs/deployments/build-image/build-image#build-image)

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated OpenSSL package installation command from `openssl11` to `openssl` in setup scripts.
  - Added a new step to set up the Java version for Gradle in setup scripts.
  - Included `krb5-devel` package in the dependency list for specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->