### PR TITLE
feat(ingest): grafana connector

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -345,6 +345,7 @@ plugins: Dict[str, Set[str]] = {
         "flask-openid>=1.3.0",
         "dask[dataframe]<2024.7.0",
     },
+    "grafana": {"requests"},
     "glue": aws_common,
     # hdbcli is supported officially by SAP, sqlalchemy-hana is built on top but not officially supported
     "hana": sql_common
@@ -634,6 +635,7 @@ entry_points = {
         "dynamodb = datahub.ingestion.source.dynamodb.dynamodb:DynamoDBSource",
         "elasticsearch = datahub.ingestion.source.elastic_search:ElasticsearchSource",
         "feast = datahub.ingestion.source.feast:FeastRepositorySource",
+        "grafana = datahub.ingestion.source.grafana.grafana_source:GrafanaSource",
         "glue = datahub.ingestion.source.aws.glue:GlueSource",
         "sagemaker = datahub.ingestion.source.aws.sagemaker:SagemakerSource",
         "hana = datahub.ingestion.source.sql.hana:HanaSource",

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -436,6 +436,8 @@ class Pipeline:
                     )
                 )
 
+            stack.enter_context(self.sink)
+
             self.final_status = PipelineStatus.UNKNOWN
             self._notify_reporters_on_ingestion_start()
             callback = None
@@ -460,7 +462,17 @@ class Pipeline:
                     if not self.dry_run:
                         self.sink.handle_work_unit_start(wu)
                     try:
-                        record_envelopes = self.extractor.get_records(wu)
+                        # Most of this code is meant to be fully stream-based instead of generating all records into memory.
+                        # However, the extractor in particular will never generate a particularly large list. We want the
+                        # exception reporting to be associated with the source, and not the transformer. As such, we
+                        # need to materialize the generator returned by get_records().
+                        record_envelopes = list(self.extractor.get_records(wu))
+                    except Exception as e:
+                        self.source.get_report().failure(
+                            "Source produced bad metadata", context=wu.id, exc=e
+                        )
+                        continue
+                    try:
                         for record_envelope in self.transform(record_envelopes):
                             if not self.dry_run:
                                 try:
@@ -482,9 +494,9 @@ class Pipeline:
                         )
                         # TODO: Transformer errors should cause the pipeline to fail.
 
-                    self.extractor.close()
                     if not self.dry_run:
                         self.sink.handle_work_unit_end(wu)
+                self.extractor.close()
                 self.source.close()
                 # no more data is coming, we need to let the transformers produce any additional records if they are holding on to state
                 for record_envelope in self.transform(
@@ -517,8 +529,6 @@ class Pipeline:
                     callback.close()  # type: ignore
 
                 self._notify_reporters_on_ingestion_completion()
-
-                self.sink.close()
 
     def transform(self, records: Iterable[RecordEnvelope]) -> Iterable[RecordEnvelope]:
         """

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -379,13 +379,19 @@ class Pipeline:
         for reporter in self.reporters:
             try:
                 reporter.on_completion(
-                    status="CANCELLED"
-                    if self.final_status == PipelineStatus.CANCELLED
-                    else "FAILURE"
-                    if self.has_failures()
-                    else "SUCCESS"
-                    if self.final_status == PipelineStatus.COMPLETED
-                    else "UNKNOWN",
+                    status=(
+                        "CANCELLED"
+                        if self.final_status == PipelineStatus.CANCELLED
+                        else (
+                            "FAILURE"
+                            if self.has_failures()
+                            else (
+                                "SUCCESS"
+                                if self.final_status == PipelineStatus.COMPLETED
+                                else "UNKNOWN"
+                            )
+                        )
+                    ),
                     report=self._get_structured_report(),
                     ctx=self.ctx,
                 )
@@ -425,7 +431,7 @@ class Pipeline:
             return True
         return False
 
-    def run(self) -> None:
+    def run(self) -> None:  # noqa: C901
         with contextlib.ExitStack() as stack:
             if self.config.flags.generate_memory_profiles:
                 import memray

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -379,19 +379,13 @@ class Pipeline:
         for reporter in self.reporters:
             try:
                 reporter.on_completion(
-                    status=(
-                        "CANCELLED"
-                        if self.final_status == PipelineStatus.CANCELLED
-                        else (
-                            "FAILURE"
-                            if self.has_failures()
-                            else (
-                                "SUCCESS"
-                                if self.final_status == PipelineStatus.COMPLETED
-                                else "UNKNOWN"
-                            )
-                        )
-                    ),
+                    status="CANCELLED"
+                    if self.final_status == PipelineStatus.CANCELLED
+                    else "FAILURE"
+                    if self.has_failures()
+                    else "SUCCESS"
+                    if self.final_status == PipelineStatus.COMPLETED
+                    else "UNKNOWN",
                     report=self._get_structured_report(),
                     ctx=self.ctx,
                 )
@@ -431,7 +425,7 @@ class Pipeline:
             return True
         return False
 
-    def run(self) -> None:  # noqa: C901
+    def run(self) -> None:
         with contextlib.ExitStack() as stack:
             if self.config.flags.generate_memory_profiles:
                 import memray
@@ -441,8 +435,6 @@ class Pipeline:
                         f"{self.config.flags.generate_memory_profiles}/{self.config.run_id}.bin"
                     )
                 )
-
-            stack.enter_context(self.sink)
 
             self.final_status = PipelineStatus.UNKNOWN
             self._notify_reporters_on_ingestion_start()
@@ -468,17 +460,7 @@ class Pipeline:
                     if not self.dry_run:
                         self.sink.handle_work_unit_start(wu)
                     try:
-                        # Most of this code is meant to be fully stream-based instead of generating all records into memory.
-                        # However, the extractor in particular will never generate a particularly large list. We want the
-                        # exception reporting to be associated with the source, and not the transformer. As such, we
-                        # need to materialize the generator returned by get_records().
-                        record_envelopes = list(self.extractor.get_records(wu))
-                    except Exception as e:
-                        self.source.get_report().failure(
-                            "Source produced bad metadata", context=wu.id, exc=e
-                        )
-                        continue
-                    try:
+                        record_envelopes = self.extractor.get_records(wu)
                         for record_envelope in self.transform(record_envelopes):
                             if not self.dry_run:
                                 try:
@@ -500,9 +482,9 @@ class Pipeline:
                         )
                         # TODO: Transformer errors should cause the pipeline to fail.
 
+                    self.extractor.close()
                     if not self.dry_run:
                         self.sink.handle_work_unit_end(wu)
-                self.extractor.close()
                 self.source.close()
                 # no more data is coming, we need to let the transformers produce any additional records if they are holding on to state
                 for record_envelope in self.transform(
@@ -535,6 +517,8 @@ class Pipeline:
                     callback.close()  # type: ignore
 
                 self._notify_reporters_on_ingestion_completion()
+
+                self.sink.close()
 
     def transform(self, records: Iterable[RecordEnvelope]) -> Iterable[RecordEnvelope]:
         """

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -14,6 +14,7 @@ from datahub.ingestion.api.decorators import (
     support_status,
 )
 from datahub.ingestion.api.source import MetadataWorkUnitProcessor
+from datahub.ingestion.api.source_helpers import auto_workunit
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.state.stale_entity_removal_handler import (
     StaleEntityRemovalHandler,
@@ -97,32 +98,30 @@ class GrafanaSource(StatefulIngestionSourceBase):
                 name=_uid,
                 platform_instance=self.source_config.platform_instance,
             )
-            for mcp in MetadataChangeProposalWrapper.construct_many(
-                entityUrn=dashboard_urn,
-                aspects=[
-                    DashboardInfoClass(
-                        description="",
-                        title=_title,
-                        charts=[],
-                        lastModified=ChangeAuditStamps(),
-                        dashboardUrl=full_url,
-                        customProperties={
-                            "displayName": _title,
-                            "id": str(item["id"]),
-                            "uid": _uid,
-                            "title": _title,
-                            "uri": item["uri"],
-                            "type": item["type"],
-                            "folderId": str(item.get("folderId", None)),
-                            "folderUid": item.get("folderUid", None),
-                            "folderTitle": str(item.get("folderTitle", None)),
-                        },
-                    ),
-                    StatusClass(removed=False),
-                ],
-            ):
-                breakpoint()
-                yield MetadataWorkUnit(
-                    id=dashboard_urn,
-                    mcp=mcp,
+
+            yield from auto_workunit(
+                MetadataChangeProposalWrapper.construct_many(
+                    entityUrn=dashboard_urn,
+                    aspects=[
+                        DashboardInfoClass(
+                            description="",
+                            title=_title,
+                            charts=[],
+                            lastModified=ChangeAuditStamps(),
+                            dashboardUrl=full_url,
+                            customProperties={
+                                "displayName": _title,
+                                "id": str(item["id"]),
+                                "uid": _uid,
+                                "title": _title,
+                                "uri": item["uri"],
+                                "type": item["type"],
+                                "folderId": str(item.get("folderId", None)),
+                                "folderUid": item.get("folderUid", None),
+                                "folderTitle": str(item.get("folderTitle", None)),
+                            },
+                        ),
+                        StatusClass(removed=False),
+                    ],
                 )
+            )

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -89,13 +89,13 @@ class GrafanaSource(StatefulIngestionSourceBase):
             return
         res_json = response.json()
         for item in res_json:
-            _uid = item["uid"]
-            _title = item["title"]
-            _url = item["url"]
-            full_url = f"{self.source_config.url}{_url}"
+            uid = item["uid"]
+            title = item["title"]
+            url_path = item["url"]
+            full_url = f"{self.source_config.url}{url_path}"
             dashboard_urn = builder.make_dashboard_urn(
                 platform=self.platform,
-                name=_uid,
+                name=uid,
                 platform_instance=self.source_config.platform_instance,
             )
 
@@ -105,20 +105,24 @@ class GrafanaSource(StatefulIngestionSourceBase):
                     aspects=[
                         DashboardInfoClass(
                             description="",
-                            title=_title,
+                            title=title,
                             charts=[],
                             lastModified=ChangeAuditStamps(),
-                            dashboardUrl=full_url,
+                            externalUrl=full_url,
                             customProperties={
-                                "displayName": _title,
-                                "id": str(item["id"]),
-                                "uid": _uid,
-                                "title": _title,
-                                "uri": item["uri"],
-                                "type": item["type"],
-                                "folderId": str(item.get("folderId", None)),
-                                "folderUid": item.get("folderUid", None),
-                                "folderTitle": str(item.get("folderTitle", None)),
+                                key: str(value)
+                                for key, value in {
+                                    "displayName": title,
+                                    "id": item["id"],
+                                    "uid": uid,
+                                    "title": title,
+                                    "uri": item["uri"],
+                                    "type": item["type"],
+                                    "folderId": item.get("folderId"),
+                                    "folderUid": item.get("folderUid"),
+                                    "folderTitle": item.get("folderTitle"),
+                                }.items()
+                                if value is not None
                             },
                         ),
                         StatusClass(removed=False),

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -77,7 +77,6 @@ class GrafanaSource(StatefulIngestionSourceBase):
         return self.report
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
-        # assert self.source_config.service_account_token is not None
         headers = {
             "Authorization": f"Bearer {self.source_config.service_account_token.get_secret_value()}",
             "Content-Type": "application/json",

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -82,8 +82,13 @@ class GrafanaSource(StatefulIngestionSourceBase):
             "Authorization": f"Bearer {self.source_config.service_account_token.get_secret_value()}",
             "Content-Type": "application/json",
         }
-        response = requests.get(f"{self.source_config.url}/api/search", headers=headers)
-        if response.status_code != 200:
+        try:
+            response = requests.get(
+                f"{self.source_config.url}/api/search", headers=headers
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            self.report.report_failure(f"Failed to fetch dashboards: {str(e)}")
             return
         res_json = response.json()
         for item in res_json:

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -51,7 +51,7 @@ class GrafanaReport(StaleEntityRemovalSourceReport):
 class GrafanaSource(StatefulIngestionSourceBase):
     """
     This is experimental source for Grafana. Not a lot of testing done yet.
-    It currently only ingests dashboards and nothig else not even charts.
+    It currently only ingests dashboards and nothing else. (not even charts)
     """
 
     def __init__(self, config: GrafanaSourceConfig, ctx: PipelineContext):

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -63,8 +63,6 @@ class GrafanaSource(StatefulIngestionSourceBase):
     @classmethod
     def create(cls, config_dict, ctx):
         config = GrafanaSourceConfig.parse_obj(config_dict)
-        # TODO remove
-        print(config)
         return cls(config, ctx)
 
     def get_workunit_processors(self) -> List[Optional[MetadataWorkUnitProcessor]]:

--- a/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/grafana/grafana_source.py
@@ -1,0 +1,129 @@
+from typing import Iterable, List, Optional
+
+import requests
+from pydantic import Field, SecretStr
+
+import datahub.emitter.mce_builder as builder
+from datahub.configuration.source_common import PlatformInstanceConfigMixin
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.decorators import (
+    SupportStatus,
+    config_class,
+    platform_name,
+    support_status,
+)
+from datahub.ingestion.api.source import MetadataWorkUnitProcessor
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.state.stale_entity_removal_handler import (
+    StaleEntityRemovalHandler,
+    StaleEntityRemovalSourceReport,
+    StatefulIngestionConfigBase,
+)
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    StatefulIngestionReport,
+    StatefulIngestionSourceBase,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.common import ChangeAuditStamps
+from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import (
+    DashboardSnapshot,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
+from datahub.metadata.schema_classes import DashboardInfoClass
+
+
+class GrafanaSourceConfig(StatefulIngestionConfigBase, PlatformInstanceConfigMixin):
+    url: str = Field(
+        default="",
+        description="Grafana URL in the format http://your-grafana-instance with no trailing slash",
+    )
+    service_account_token: SecretStr = Field(
+        description="Service account token for Grafana"
+    )
+
+
+class GrafanaReport(StaleEntityRemovalSourceReport):
+    pass
+
+
+@platform_name("Grafana")
+@config_class(GrafanaSourceConfig)
+@support_status(SupportStatus.TESTING)
+class GrafanaSource(StatefulIngestionSourceBase):
+    """
+    This is experimental source for Grafana. Not a lot of testing done yet.
+    It currently only ingests dashboards and nothig else not even charts.
+    """
+
+    def __init__(self, config: GrafanaSourceConfig, ctx: PipelineContext):
+        super().__init__(config, ctx)
+        self.source_config = config
+        self.report = GrafanaReport()
+        self.platform = "grafana"
+
+    @classmethod
+    def create(cls, config_dict, ctx):
+        config = GrafanaSourceConfig.parse_obj(config_dict)
+        # TODO remove
+        print(config)
+        return cls(config, ctx)
+
+    def get_workunit_processors(self) -> List[Optional[MetadataWorkUnitProcessor]]:
+        return [
+            *super().get_workunit_processors(),
+            StaleEntityRemovalHandler.create(
+                self, self.source_config, self.ctx
+            ).workunit_processor,
+        ]
+
+    def get_report(self) -> StatefulIngestionReport:
+        return self.report
+
+    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
+        # assert self.source_config.service_account_token is not None
+        headers = {
+            "Authorization": f"Bearer {self.source_config.service_account_token.get_secret_value()}",
+            "Content-Type": "application/json",
+        }
+        response = requests.get(f"{self.source_config.url}/api/search", headers=headers)
+        if response.status_code != 200:
+            return
+        res_json = response.json()
+        for item in res_json:
+            _uid = item["uid"]
+            _title = item["title"]
+            _url = item["url"]
+            full_url = f"{self.source_config.url}{_url}"
+            _folder_id = item.get("folderId", None)
+            if _folder_id is not None:
+                dashboard_urn = builder.make_dashboard_urn(
+                    platform=self.platform,
+                    name=_uid,
+                    platform_instance=self.source_config.platform_instance,
+                )
+                dash_snapshot = DashboardSnapshot(
+                    urn=dashboard_urn,
+                    aspects=[
+                        DashboardInfoClass(
+                            description="",
+                            title=_title,
+                            charts=[],
+                            lastModified=ChangeAuditStamps(),
+                            dashboardUrl=full_url,
+                            customProperties={
+                                "displayName": _title,
+                                "id": str(item["id"]),
+                                "uid": _uid,
+                                "title": _title,
+                                "uri": item["uri"],
+                                "type": item["type"],
+                                "folderId": str(item.get("folderId", None)),
+                                "folderUid": item.get("folderUid", None),
+                                "folderTitle": str(item.get("folderTitle", None)),
+                            },
+                        )
+                    ],
+                )
+                yield MetadataWorkUnit(
+                    id=dashboard_urn,
+                    mce=MetadataChangeEvent(proposedSnapshot=dash_snapshot),
+                )

--- a/metadata-ingestion/tests/integration/grafana/default-dashboard.json
+++ b/metadata-ingestion/tests/integration/grafana/default-dashboard.json
@@ -1,0 +1,25 @@
+{
+    "id": null,
+    "uid": "default",
+    "title": "Default Dashboard",
+    "tags": [],
+    "timezone": "browser",
+    "schemaVersion": 16,
+    "version": 0,
+    "panels": [
+        {
+            "type": "text",
+            "title": "Welcome",
+            "gridPos": {
+                "x": 0,
+                "y": 0,
+                "w": 24,
+                "h": 5
+            },
+            "options": {
+                "content": "Welcome to your Grafana dashboard!",
+                "mode": "markdown"
+            }
+        }
+    ]
+}

--- a/metadata-ingestion/tests/integration/grafana/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/grafana/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+services:
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+    volumes:
+      - grafana-storage:/var/lib/grafana
+      - ./provisioning:/etc/grafana/provisioning
+      - ./default-dashboard.json:/var/lib/grafana/dashboards/default-dashboard.json
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:13
+    container_name: grafana-postgres
+    environment:
+      POSTGRES_DB: grafana
+      POSTGRES_USER: grafana
+      POSTGRES_PASSWORD: grafana
+    volumes:
+      - postgres-storage:/var/lib/postgresql/data
+
+volumes:
+  grafana-storage:
+  postgres-storage:

--- a/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
@@ -1,0 +1,18 @@
+[
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(grafana,default)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test-simple",
+        "lastRunId": "no-run-id-provided"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
@@ -3,6 +3,47 @@
     "entityType": "dashboard",
     "entityUrn": "urn:li:dashboard:(grafana,default)",
     "changeType": "UPSERT",
+    "aspectName": "dashboardInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "displayName": "Default Dashboard",
+                "id": "1",
+                "uid": "default",
+                "title": "Default Dashboard",
+                "uri": "db/default-dashboard",
+                "type": "dash-db",
+                "folderId": "",
+                "folderUid": "",
+                "folderTitle": ""
+            },
+            "title": "Default Dashboard",
+            "description": "",
+            "charts": [],
+            "datasets": [],
+            "lastModified": {
+                "created": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                },
+                "lastModified": {
+                    "time": 0,
+                    "actor": "urn:li:corpuser:unknown"
+                }
+            },
+            "dashboardUrl": "http://localhost:3000/d/default/default-dashboard"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1720785600000,
+        "runId": "grafana-test-simple",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dashboard",
+    "entityUrn": "urn:li:dashboard:(grafana,default)",
+    "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
         "json": {

--- a/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
+++ b/metadata-ingestion/tests/integration/grafana/grafana_mcps_golden.json
@@ -12,11 +12,9 @@
                 "uid": "default",
                 "title": "Default Dashboard",
                 "uri": "db/default-dashboard",
-                "type": "dash-db",
-                "folderId": "",
-                "folderUid": "",
-                "folderTitle": ""
+                "type": "dash-db"
             },
+            "externalUrl": "http://localhost:3000/d/default/default-dashboard",
             "title": "Default Dashboard",
             "description": "",
             "charts": [],
@@ -30,8 +28,7 @@
                     "time": 0,
                     "actor": "urn:li:corpuser:unknown"
                 }
-            },
-            "dashboardUrl": "http://localhost:3000/d/default/default-dashboard"
+            }
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/grafana/provisioning/api-keys/api_keys.yaml
+++ b/metadata-ingestion/tests/integration/grafana/provisioning/api-keys/api_keys.yaml
@@ -1,0 +1,3 @@
+api_keys:
+  - name: 'example-api-key'
+    role: 'Admin'

--- a/metadata-ingestion/tests/integration/grafana/provisioning/dashboards/dashboard.yaml
+++ b/metadata-ingestion/tests/integration/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/metadata-ingestion/tests/integration/grafana/provisioning/datasources/datasource.yaml
+++ b/metadata-ingestion/tests/integration/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: PostgreSQL
+    type: postgres
+    access: proxy
+    url: postgres:5432
+    database: grafana
+    user: grafana
+    password: grafana
+    jsonData:
+      sslmode: disable

--- a/metadata-ingestion/tests/integration/grafana/provisioning/service_accounts/service_accounts.yaml
+++ b/metadata-ingestion/tests/integration/grafana/provisioning/service_accounts/service_accounts.yaml
@@ -1,0 +1,6 @@
+service_accounts:
+  - name: 'example-service-account'
+    role: 'Admin'
+    apiKeys:
+      - keyName: 'example-api-key'
+        role: 'Admin'

--- a/metadata-ingestion/tests/integration/grafana/test_grafana.py
+++ b/metadata-ingestion/tests/integration/grafana/test_grafana.py
@@ -58,46 +58,6 @@ class GrafanaClient:
             return None
 
 
-# class GrafanaClient:
-#     def __init__(self, url, admin_user, admin_password):
-#         self.url = url
-#         self.auth = (admin_user, admin_password)
-
-#     def get_service_account_api_keys(self, service_account_name):
-#         headers = {
-#             "Content-Type": "application/json",
-#         }
-#         try:
-#             # Retrieve the service account list
-#             response = requests.get(
-#                 f"{self.url}/api/serviceaccounts", headers=headers, auth=self.auth
-#             )
-#             response.raise_for_status()
-#             service_accounts = response.json()
-
-#             # Find the service account by name
-#             service_account = next(
-#                 sa for sa in service_accounts if sa["name"] == service_account_name
-#             )
-#             service_account_id = service_account["id"]
-
-#             # Retrieve API keys for the service account
-#             response = requests.get(
-#                 f"{self.url}/api/serviceaccounts/{service_account_id}/tokens",
-#                 headers=headers,
-#                 auth=self.auth,
-#             )
-#             response.raise_for_status()
-#             api_keys = response.json()
-
-#             # Find the API key by name
-#             api_key = next(key for key in api_keys if key["name"] == "example-api-key")
-#             return api_key["key"]
-#         except requests.exceptions.RequestException as e:
-#             logging.error(f"Error fetching service account API keys: {e}")
-#             return None
-
-
 @pytest.fixture(scope="module")
 def test_resources_dir(pytestconfig):
     return pytestconfig.rootpath / "tests/integration/grafana"
@@ -198,11 +158,6 @@ def test_grafana_ingest(
     else:
         pytest.fail("Grafana did not start in time")
 
-    with open("api_key.txt", "w") as f:
-        f.write(test_api_key)
-        logger.info(f"API key is {test_api_key}")
-
-    breakpoint()
     # Run the metadata ingestion pipeline.
     with fs_helpers.isolated_filesystem(tmp_path):
         # Run grafana ingestion run.

--- a/metadata-ingestion/tests/integration/grafana/test_grafana.py
+++ b/metadata-ingestion/tests/integration/grafana/test_grafana.py
@@ -1,0 +1,236 @@
+import logging
+import time
+from base64 import b64encode
+
+import pytest
+import requests
+from freezegun import freeze_time
+
+from datahub.ingestion.run.pipeline import Pipeline
+from tests.test_helpers import fs_helpers, mce_helpers
+from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+
+pytestmark = pytest.mark.integration_batch_2
+
+FROZEN_TIME = "2024-07-12 12:00:00"
+
+
+logger = logging.getLogger(__name__)
+
+
+class GrafanaClient:
+    def __init__(self, url, admin_user, admin_password):
+        self.url = url
+        self.auth = (admin_user, admin_password)
+        self.headers = {
+            "Authorization": f"Basic {b64encode(f'{admin_user}:{admin_password}'.encode()).decode()}",
+            "Content-Type": "application/json",
+        }
+
+    def create_service_account(self, name, role):
+        service_account_payload = {"name": name, "role": role, "isDisabled": False}
+        try:
+            response = requests.post(
+                f"{self.url}/api/serviceaccounts",
+                headers=self.headers,
+                json=service_account_payload,
+            )
+            response.raise_for_status()
+            service_account = response.json()
+            return service_account
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error creating service account: {e}")
+            return None
+
+    def create_api_key(self, service_account_id, key_name, role):
+        api_key_payload = {"name": key_name, "role": role}
+        try:
+            response = requests.post(
+                f"{self.url}/api/serviceaccounts/{service_account_id}/tokens",
+                headers=self.headers,
+                json=api_key_payload,
+            )
+            response.raise_for_status()
+            api_key = response.json()
+            return api_key["key"]
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error creating API key: {e}")
+            return None
+
+
+# class GrafanaClient:
+#     def __init__(self, url, admin_user, admin_password):
+#         self.url = url
+#         self.auth = (admin_user, admin_password)
+
+#     def get_service_account_api_keys(self, service_account_name):
+#         headers = {
+#             "Content-Type": "application/json",
+#         }
+#         try:
+#             # Retrieve the service account list
+#             response = requests.get(
+#                 f"{self.url}/api/serviceaccounts", headers=headers, auth=self.auth
+#             )
+#             response.raise_for_status()
+#             service_accounts = response.json()
+
+#             # Find the service account by name
+#             service_account = next(
+#                 sa for sa in service_accounts if sa["name"] == service_account_name
+#             )
+#             service_account_id = service_account["id"]
+
+#             # Retrieve API keys for the service account
+#             response = requests.get(
+#                 f"{self.url}/api/serviceaccounts/{service_account_id}/tokens",
+#                 headers=headers,
+#                 auth=self.auth,
+#             )
+#             response.raise_for_status()
+#             api_keys = response.json()
+
+#             # Find the API key by name
+#             api_key = next(key for key in api_keys if key["name"] == "example-api-key")
+#             return api_key["key"]
+#         except requests.exceptions.RequestException as e:
+#             logging.error(f"Error fetching service account API keys: {e}")
+#             return None
+
+
+@pytest.fixture(scope="module")
+def test_resources_dir(pytestconfig):
+    return pytestconfig.rootpath / "tests/integration/grafana"
+
+
+@pytest.fixture(scope="module")
+def test_api_key():
+    # Example usage:
+    url = "http://localhost:3000"
+    admin_user = "admin"
+    admin_password = "admin"
+
+    grafana_client = GrafanaClient(url, admin_user, admin_password)
+
+    # Step 1: Create the service account
+    service_account = grafana_client.create_service_account(
+        name="example-service-account", role="Viewer"
+    )
+    if service_account:
+        print(f"Service Account Created: {service_account}")
+
+        # Step 2: Create the API key for the service account
+        api_key = grafana_client.create_api_key(
+            service_account_id=service_account["id"],
+            key_name="example-api-key",
+            role="Admin",
+        )
+        if api_key:
+            print("Service Account API Key:", api_key)
+            return api_key
+        else:
+            print("Failed to create API key for the service account")
+    else:
+        print("Failed to create service account")
+
+
+@pytest.fixture(scope="module")
+def loaded_grafana(docker_compose_runner, test_resources_dir):
+    with docker_compose_runner(
+        test_resources_dir / "docker-compose.yml", "grafana"
+    ) as docker_services:
+        wait_for_port(
+            docker_services,
+            container_name="grafana",
+            container_port=3000,
+            timeout=300,
+        )
+        yield docker_services
+
+    # The Grafana image can be large, so we remove it after the test.
+    cleanup_image("grafana/grafana")
+
+
+@freeze_time(FROZEN_TIME)
+def test_grafana_dashboard(loaded_grafana, pytestconfig, tmp_path, test_resources_dir):
+    # Wait for Grafana to be up and running
+    url = "http://localhost:3000/api/health"
+    for i in range(30):
+        logging.info("waiting for Grafana to start...")
+        time.sleep(5)
+        resp = requests.get(url)
+        if resp.status_code == 200:
+            logging.info(f"Grafana started after waiting {i*5} seconds")
+            break
+    else:
+        pytest.fail("Grafana did not start in time")
+
+    # Check if the default dashboard is loaded
+    dashboard_url = "http://localhost:3000/api/dashboards/uid/default"
+    resp = requests.get(dashboard_url, auth=("admin", "admin"))
+    assert resp.status_code == 200, "Failed to load default dashboard"
+    dashboard = resp.json()
+
+    assert (
+        dashboard["dashboard"]["title"] == "Default Dashboard"
+    ), "Default dashboard title mismatch"
+    assert any(
+        panel["type"] == "text" for panel in dashboard["dashboard"]["panels"]
+    ), "Default dashboard missing text panel"
+
+    # Verify the output. (You can add further checks here if needed)
+    logging.info("Default dashboard verified successfully")
+
+
+@freeze_time(FROZEN_TIME)
+def test_grafana_ingest(
+    loaded_grafana, pytestconfig, tmp_path, test_resources_dir, test_api_key
+):
+    # Wait for Grafana to be up and running
+    url = "http://localhost:3000/api/health"
+    for i in range(30):
+        logging.info("waiting for Grafana to start...")
+        time.sleep(5)
+        resp = requests.get(url)
+        if resp.status_code == 200:
+            logging.info(f"Grafana started after waiting {i*5} seconds")
+            break
+    else:
+        pytest.fail("Grafana did not start in time")
+
+    with open("api_key.txt", "w") as f:
+        f.write(test_api_key)
+        logger.info(f"API key is {test_api_key}")
+
+    breakpoint()
+    # Run the metadata ingestion pipeline.
+    with fs_helpers.isolated_filesystem(tmp_path):
+        # Run grafana ingestion run.
+        pipeline = Pipeline.create(
+            {
+                "run_id": "grafana-test-simple",
+                "source": {
+                    "type": "grafana",
+                    "config": {
+                        "url": "http://localhost:3000",
+                        "service_account_token": test_api_key,
+                    },
+                },
+                "sink": {
+                    "type": "file",
+                    "config": {"filename": "./grafana_mcps.json"},
+                },
+            }
+        )
+        pipeline.run()
+        pipeline.raise_from_status()
+
+        # Verify the output.
+        mce_helpers.check_golden_file(
+            pytestconfig,
+            output_path="grafana_mcps.json",
+            golden_path=test_resources_dir / "grafana_mcps_golden.json",
+            ignore_paths=[
+                r"root\[\d+\]\['aspect'\]\['json'\]\['customProperties'\]\['last_event_time'\]",
+            ],
+        )


### PR DESCRIPTION
Barebones grafana connector which ingests dashboards. It allows to document grafana dashboards which can help engineers on-call to discover dashboards. While charts would be great to have but that will take longer so just ingesting dashboards for now. This allows DataHub to be usable for DevOps members on call to document and discover dashboards.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Grafana integration for ingesting dashboards, including configuration for Grafana URL and service account token.
  - Introduced default Grafana dashboard configuration and provisioning setup via YAML files (API keys, dashboards, datasources, service accounts).
  - Added Docker Compose setup for Grafana with PostgreSQL.

- **Tests**
  - Implemented test suite for Grafana integration, including tests for service account creation, API key handling, and metadata ingestion verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->