### PR TITLE
feat(rest-emitter): adding async flag to rest emitter

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -273,7 +273,7 @@ class DataHubRestEmitter(Closeable, Emitter):
             ensure_has_system_metadata(mcp)
 
         mcp_objs = [pre_json_transform(mcp.to_obj()) for mcp in mcps]
-        payload_dict = {"proposals": mcp_objs}
+        payload_dict: dict = {"proposals": mcp_objs}
 
         if async_flag is not None:
             payload_dict["async"] = "true" if async_flag else "false"

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -206,7 +206,7 @@ class DataHubRestEmitter(Closeable, Emitter):
             UsageAggregation,
         ],
         callback: Optional[Callable[[Exception, str], None]] = None,
-        async_flag: bool = True,
+        async_flag: Optional[bool] = None,
     ) -> None:
         try:
             if isinstance(item, UsageAggregation):
@@ -248,29 +248,37 @@ class DataHubRestEmitter(Closeable, Emitter):
     def emit_mcp(
         self,
         mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper],
-        async_flag: bool = True,
+        async_flag: Optional[bool] = None,
     ) -> None:
         url = f"{self._gms_server}/aspects?action=ingestProposal"
         ensure_has_system_metadata(mcp)
-        async_param_value = "true" if async_flag else "false"
 
         mcp_obj = pre_json_transform(mcp.to_obj())
-        payload = json.dumps({"proposal": mcp_obj, "async": async_param_value})
+        payload_dict = {"proposal": mcp_obj}
+
+        if async_flag is not None:
+            payload_dict["async"] = "true" if async_flag else "false"
+
+        payload = json.dumps(payload_dict)
 
         self._emit_generic(url, payload)
 
     def emit_mcps(
         self,
         mcps: List[Union[MetadataChangeProposal, MetadataChangeProposalWrapper]],
-        async_flag: bool = True,
+        async_flag: Optional[bool] = None,
     ) -> None:
         url = f"{self._gms_server}/aspects?action=ingestProposalBatch"
         for mcp in mcps:
             ensure_has_system_metadata(mcp)
-        async_param_value = "true" if async_flag else "false"
 
         mcp_objs = [pre_json_transform(mcp.to_obj()) for mcp in mcps]
-        payload = json.dumps({"proposals": mcp_objs, "async": async_param_value})
+        payload_dict = {"proposals": mcp_objs}
+
+        if async_flag is not None:
+            payload_dict["async"] = "true" if async_flag else "false"
+
+        payload = json.dumps(payload_dict)
 
         self._emit_generic(url, payload)
 

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -246,7 +246,9 @@ class DataHubRestEmitter(Closeable, Emitter):
         self._emit_generic(url, payload)
 
     def emit_mcp(
-        self, mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper], async_flag: bool = True
+        self,
+        mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper],
+        async_flag: bool = True,
     ) -> None:
         url = f"{self._gms_server}/aspects?action=ingestProposal"
         ensure_has_system_metadata(mcp)
@@ -258,7 +260,9 @@ class DataHubRestEmitter(Closeable, Emitter):
         self._emit_generic(url, payload)
 
     def emit_mcps(
-        self, mcps: List[Union[MetadataChangeProposal, MetadataChangeProposalWrapper]], async_flag: bool = True
+        self,
+        mcps: List[Union[MetadataChangeProposal, MetadataChangeProposalWrapper]],
+        async_flag: bool = True,
     ) -> None:
         url = f"{self._gms_server}/aspects?action=ingestProposalBatch"
         for mcp in mcps:

--- a/metadata-ingestion/tests/test_helpers/graph_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/graph_helpers.py
@@ -111,6 +111,7 @@ class MockDataHubGraph(DataHubGraph):
             UsageAggregationClass,
         ],
         callback: Union[Callable[[Exception, str], None], None] = None,
+        async_flag: Optional[bool] = None,
     ) -> None:
         self.emitted.append(item)  # type: ignore
 
@@ -118,7 +119,9 @@ class MockDataHubGraph(DataHubGraph):
         self.emitted.append(mce)
 
     def emit_mcp(
-        self, mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper]
+        self,
+        mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper],
+        async_flag: Optional[bool] = None,
     ) -> None:
         self.emitted.append(mcp)
 


### PR DESCRIPTION
This allows users of the SDK to emit async to control how GMS handles the message.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `emit_mcp` and `emit_mcps` methods now accept an `async_flag` parameter to enable or disable asynchronous operation. 

- **Improvements**
  - Default value for the `async_flag` parameter has been updated for better flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->