### PR TITLE
feat(mcp-mutator): new mcp mutator plugin

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/ReadItem.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/ReadItem.java
@@ -5,6 +5,7 @@ import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.SystemMetadata;
 import java.lang.reflect.InvocationTargetException;
 import javax.annotation.Nonnull;
@@ -26,6 +27,9 @@ public interface ReadItem {
    */
   @Nonnull
   default String getAspectName() {
+    if (getAspectSpec() == null) {
+      return GenericAspect.dataSchema().getName();
+    }
     return getAspectSpec().getName();
   }
 
@@ -72,6 +76,6 @@ public interface ReadItem {
    *
    * @return aspect's specification
    */
-  @Nonnull
+  @Nullable
   AspectSpec getAspectSpec();
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/batch/AspectsBatch.java
@@ -84,6 +84,13 @@ public interface AspectsBatch {
     }
   }
 
+  default Stream<MCPItem> applyProposalMutationHooks(
+      Collection<MCPItem> proposedItems, @Nonnull RetrieverContext retrieverContext) {
+    return retrieverContext.getAspectRetriever().getEntityRegistry().getAllMutationHooks().stream()
+        .flatMap(
+            mutationHook -> mutationHook.applyProposalMutation(proposedItems, retrieverContext));
+  }
+
   default <T extends BatchItem> ValidationExceptionCollection validateProposed(
       Collection<T> mcpItems) {
     return validateProposed(mcpItems, getRetrieverContext());

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
@@ -3,7 +3,6 @@ package com.linkedin.metadata.aspect.plugins;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
-import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -25,20 +24,13 @@ public abstract class PluginSpec {
   }
 
   public boolean shouldApply(
-      @Nullable ChangeType changeType, @Nonnull Urn entityUrn, @Nonnull AspectSpec aspectSpec) {
-    return shouldApply(changeType, entityUrn.getEntityType(), aspectSpec);
+      @Nullable ChangeType changeType, @Nonnull Urn entityUrn, @Nonnull String aspectName) {
+    return shouldApply(changeType, entityUrn.getEntityType(), aspectName);
   }
 
   public boolean shouldApply(
-      @Nullable ChangeType changeType,
-      @Nonnull EntitySpec entitySpec,
-      @Nonnull AspectSpec aspectSpec) {
-    return shouldApply(changeType, entitySpec.getName(), aspectSpec.getName());
-  }
-
-  public boolean shouldApply(
-      @Nullable ChangeType changeType, @Nonnull String entityName, @Nonnull AspectSpec aspectSpec) {
-    return shouldApply(changeType, entityName, aspectSpec.getName());
+      @Nullable ChangeType changeType, @Nonnull EntitySpec entitySpec, @Nonnull String aspectName) {
+    return shouldApply(changeType, entitySpec.getName(), aspectName);
   }
 
   public boolean shouldApply(
@@ -49,8 +41,8 @@ public abstract class PluginSpec {
   }
 
   protected boolean isEntityAspectSupported(
-      @Nonnull EntitySpec entitySpec, @Nonnull AspectSpec aspectSpec) {
-    return isEntityAspectSupported(entitySpec.getName(), aspectSpec.getName());
+      @Nonnull EntitySpec entitySpec, @Nonnull String aspectName) {
+    return isEntityAspectSupported(entitySpec.getName(), aspectName);
   }
 
   protected boolean isEntityAspectSupported(

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCLSideEffect.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCLSideEffect.java
@@ -24,7 +24,7 @@ public abstract class MCLSideEffect extends PluginSpec
       @Nonnull Collection<MCLItem> batchItems, @Nonnull RetrieverContext retrieverContext) {
     return applyMCLSideEffect(
         batchItems.stream()
-            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectSpec()))
+            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCPSideEffect.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MCPSideEffect.java
@@ -25,7 +25,7 @@ public abstract class MCPSideEffect extends PluginSpec
       Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
     return applyMCPSideEffect(
         changeMCPS.stream()
-            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectSpec()))
+            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }
@@ -41,7 +41,7 @@ public abstract class MCPSideEffect extends PluginSpec
       Collection<MCLItem> mclItems, @Nonnull RetrieverContext retrieverContext) {
     return postMCPSideEffect(
         mclItems.stream()
-            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectSpec()))
+            .filter(item -> shouldApply(item.getChangeType(), item.getUrn(), item.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MutationHook.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/hooks/MutationHook.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.aspect.plugins.hooks;
 import com.linkedin.metadata.aspect.ReadItem;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.plugins.PluginSpec;
 import com.linkedin.util.Pair;
 import java.util.Collection;
@@ -24,7 +25,7 @@ public abstract class MutationHook extends PluginSpec {
       @Nonnull Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
     return writeMutation(
         changeMCPS.stream()
-            .filter(i -> shouldApply(i.getChangeType(), i.getEntitySpec(), i.getAspectSpec()))
+            .filter(i -> shouldApply(i.getChangeType(), i.getEntitySpec(), i.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }
@@ -34,7 +35,23 @@ public abstract class MutationHook extends PluginSpec {
       @Nonnull Collection<ReadItem> items, @Nonnull RetrieverContext retrieverContext) {
     return readMutation(
         items.stream()
-            .filter(i -> isEntityAspectSupported(i.getEntitySpec(), i.getAspectSpec()))
+            .filter(i -> isEntityAspectSupported(i.getEntitySpec(), i.getAspectName()))
+            .collect(Collectors.toList()),
+        retrieverContext);
+  }
+
+  /**
+   * Apply Proposal mutations prior to validation
+   *
+   * @param mcpItems wrapper for MCP
+   * @param retrieverContext retriever context
+   * @return stream of mutated Proposal items
+   */
+  public final Stream<MCPItem> applyProposalMutation(
+      @Nonnull Collection<MCPItem> mcpItems, @Nonnull RetrieverContext retrieverContext) {
+    return proposalMutation(
+        mcpItems.stream()
+            .filter(i -> shouldApply(i.getChangeType(), i.getEntitySpec(), i.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }
@@ -47,5 +64,10 @@ public abstract class MutationHook extends PluginSpec {
   protected Stream<Pair<ChangeMCP, Boolean>> writeMutation(
       @Nonnull Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
     return changeMCPS.stream().map(i -> Pair.of(i, false));
+  }
+
+  protected Stream<MCPItem> proposalMutation(
+      @Nonnull Collection<MCPItem> mcpItems, @Nonnull RetrieverContext retrieverContext) {
+    return Stream.empty();
   }
 }

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/validation/AspectPayloadValidator.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/validation/AspectPayloadValidator.java
@@ -22,7 +22,7 @@ public abstract class AspectPayloadValidator extends PluginSpec {
       @Nonnull RetrieverContext retrieverContext) {
     return validateProposedAspects(
         mcpItems.stream()
-            .filter(i -> shouldApply(i.getChangeType(), i.getUrn(), i.getAspectSpec()))
+            .filter(i -> shouldApply(i.getChangeType(), i.getUrn(), i.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }
@@ -37,7 +37,7 @@ public abstract class AspectPayloadValidator extends PluginSpec {
       @Nonnull Collection<ChangeMCP> changeMCPs, @Nonnull RetrieverContext retrieverContext) {
     return validatePreCommitAspects(
         changeMCPs.stream()
-            .filter(i -> shouldApply(i.getChangeType(), i.getUrn(), i.getAspectSpec()))
+            .filter(i -> shouldApply(i.getChangeType(), i.getUrn(), i.getAspectName()))
             .collect(Collectors.toList()),
         retrieverContext);
   }

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   api project(':metadata-service:services')
   api project(':metadata-operation-context')
 
+  implementation spec.product.pegasus.restliServer
   implementation spec.product.pegasus.data
   implementation spec.product.pegasus.generator
 

--- a/metadata-io/metadata-io-api/build.gradle
+++ b/metadata-io/metadata-io-api/build.gradle
@@ -8,4 +8,11 @@ dependencies {
   implementation project(':metadata-utils')
   compileOnly externalDependency.lombok
   annotationProcessor externalDependency.lombok
+
+  testImplementation(externalDependency.testng)
+  testImplementation(externalDependency.mockito)
+  testImplementation(testFixtures(project(":entity-registry")))
+  testImplementation project(':metadata-operation-context')
+  testImplementation externalDependency.lombok
+  testAnnotationProcessor externalDependency.lombok
 }

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/ProposedItem.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/ProposedItem.java
@@ -1,0 +1,80 @@
+package com.linkedin.metadata.entity.ebean.batch;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.mxe.SystemMetadata;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+/** Represents an unvalidated wrapped MCP */
+@Slf4j
+@Getter
+@Builder(toBuilder = true)
+public class ProposedItem implements MCPItem {
+  @Nonnull private final MetadataChangeProposal metadataChangeProposal;
+  @Nonnull private final AuditStamp auditStamp;
+  // derived
+  @Nonnull private EntitySpec entitySpec;
+  @Nullable private AspectSpec aspectSpec;
+
+  @Nonnull
+  @Override
+  public String getAspectName() {
+    if (metadataChangeProposal.getAspectName() != null) {
+      return metadataChangeProposal.getAspectName();
+    } else {
+      return MCPItem.super.getAspectName();
+    }
+  }
+
+  @Nullable
+  public AspectSpec getAspectSpec() {
+    if (aspectSpec != null) {
+      return aspectSpec;
+    }
+    if (entitySpec.getAspectSpecMap().containsKey(getAspectName())) {
+      return entitySpec.getAspectSpecMap().get(getAspectName());
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public RecordTemplate getRecordTemplate() {
+    if (getAspectSpec() != null) {
+      return GenericRecordUtils.deserializeAspect(
+          getMetadataChangeProposal().getAspect().getValue(),
+          getMetadataChangeProposal().getAspect().getContentType(),
+          getAspectSpec());
+    }
+    return null;
+  }
+
+  @Nonnull
+  @Override
+  public Urn getUrn() {
+    return metadataChangeProposal.getEntityUrn();
+  }
+
+  @Nullable
+  @Override
+  public SystemMetadata getSystemMetadata() {
+    return metadataChangeProposal.getSystemMetadata();
+  }
+
+  @Nonnull
+  @Override
+  public ChangeType getChangeType() {
+    return metadataChangeProposal.getChangeType();
+  }
+}

--- a/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/AspectsBatchImplTest.java
+++ b/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/AspectsBatchImplTest.java
@@ -1,0 +1,320 @@
+package com.linkedin.metadata.entity.ebean.batch;
+
+import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTIES_ASPECT_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.Status;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.ByteString;
+import com.linkedin.data.schema.annotation.PathSpecBasedSchemaAnnotationVisitor;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
+import com.linkedin.metadata.aspect.patch.PatchOperationType;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.models.registry.EntityRegistryException;
+import com.linkedin.metadata.models.registry.MergedEntityRegistry;
+import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
+import com.linkedin.metadata.snapshot.Snapshot;
+import com.linkedin.metadata.utils.AuditStampUtils;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.GenericAspect;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.mxe.SystemMetadata;
+import com.linkedin.structured.StructuredProperties;
+import com.linkedin.structured.StructuredPropertyValueAssignmentArray;
+import com.linkedin.util.Pair;
+import io.datahubproject.metadata.context.RetrieverContext;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class AspectsBatchImplTest {
+  private EntityRegistry testRegistry;
+  private AspectRetriever mockAspectRetriever;
+  private RetrieverContext retrieverContext;
+
+  @BeforeTest
+  public void beforeTest() throws EntityRegistryException {
+    PathSpecBasedSchemaAnnotationVisitor.class
+        .getClassLoader()
+        .setClassAssertionStatus(PathSpecBasedSchemaAnnotationVisitor.class.getName(), false);
+
+    EntityRegistry snapshotEntityRegistry = new SnapshotEntityRegistry();
+    EntityRegistry configEntityRegistry =
+        new ConfigEntityRegistry(
+            Snapshot.class.getClassLoader().getResourceAsStream("AspectsBatchImplTest.yaml"));
+    this.testRegistry =
+        new MergedEntityRegistry(snapshotEntityRegistry).apply(configEntityRegistry);
+  }
+
+  @BeforeMethod
+  public void setup() {
+    this.mockAspectRetriever = mock(AspectRetriever.class);
+    when(this.mockAspectRetriever.getEntityRegistry()).thenReturn(testRegistry);
+    this.retrieverContext =
+        RetrieverContext.builder()
+            .searchRetriever(mock(SearchRetriever.class))
+            .aspectRetriever(mockAspectRetriever)
+            .graphRetriever(mock(GraphRetriever.class))
+            .build();
+  }
+
+  @Test
+  public void toUpsertBatchItemsChangeItemTest() {
+    List<ChangeItemImpl> testItems =
+        List.of(
+            ChangeItemImpl.builder()
+                .urn(
+                    UrnUtils.getUrn(
+                        "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)"))
+                .changeType(ChangeType.UPSERT)
+                .aspectName(STATUS_ASPECT_NAME)
+                .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                .aspectSpec(
+                    testRegistry
+                        .getEntitySpec(DATASET_ENTITY_NAME)
+                        .getAspectSpec(STATUS_ASPECT_NAME))
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .recordTemplate(new Status().setRemoved(true))
+                .build(mockAspectRetriever),
+            ChangeItemImpl.builder()
+                .urn(
+                    UrnUtils.getUrn(
+                        "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"))
+                .changeType(ChangeType.UPSERT)
+                .aspectName(STATUS_ASPECT_NAME)
+                .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                .aspectSpec(
+                    testRegistry
+                        .getEntitySpec(DATASET_ENTITY_NAME)
+                        .getAspectSpec(STATUS_ASPECT_NAME))
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .recordTemplate(new Status().setRemoved(false))
+                .build(mockAspectRetriever));
+
+    AspectsBatchImpl testBatch =
+        AspectsBatchImpl.builder().items(testItems).retrieverContext(retrieverContext).build();
+
+    assertEquals(
+        testBatch.toUpsertBatchItems(Map.of()),
+        Pair.of(Map.of(), testItems),
+        "Expected noop, pass through with no additional MCPs or changes");
+  }
+
+  @Test
+  public void toUpsertBatchItemsPatchItemTest() {
+    GenericJsonPatch.PatchOp testPatchOp = new GenericJsonPatch.PatchOp();
+    testPatchOp.setOp(PatchOperationType.REMOVE.getValue());
+    testPatchOp.setPath(
+        String.format(
+            "/properties/%s", "urn:li:structuredProperty:io.acryl.privacy.retentionTime"));
+
+    List<PatchItemImpl> testItems =
+        List.of(
+            PatchItemImpl.builder()
+                .urn(
+                    UrnUtils.getUrn(
+                        "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)"))
+                .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                .aspectName(STRUCTURED_PROPERTIES_ASPECT_NAME)
+                .aspectSpec(
+                    testRegistry
+                        .getEntitySpec(DATASET_ENTITY_NAME)
+                        .getAspectSpec(STRUCTURED_PROPERTIES_ASPECT_NAME))
+                .patch(
+                    GenericJsonPatch.builder()
+                        .arrayPrimaryKeys(Map.of("properties", List.of("propertyUrn")))
+                        .patch(List.of(testPatchOp))
+                        .build()
+                        .getJsonPatch())
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .build(retrieverContext.getAspectRetriever().getEntityRegistry()),
+            PatchItemImpl.builder()
+                .urn(
+                    UrnUtils.getUrn(
+                        "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"))
+                .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                .aspectName(STRUCTURED_PROPERTIES_ASPECT_NAME)
+                .aspectSpec(
+                    testRegistry
+                        .getEntitySpec(DATASET_ENTITY_NAME)
+                        .getAspectSpec(STRUCTURED_PROPERTIES_ASPECT_NAME))
+                .patch(
+                    GenericJsonPatch.builder()
+                        .arrayPrimaryKeys(Map.of("properties", List.of("propertyUrn")))
+                        .patch(List.of(testPatchOp))
+                        .build()
+                        .getJsonPatch())
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .build(retrieverContext.getAspectRetriever().getEntityRegistry()));
+
+    AspectsBatchImpl testBatch =
+        AspectsBatchImpl.builder().items(testItems).retrieverContext(retrieverContext).build();
+
+    assertEquals(
+        testBatch.toUpsertBatchItems(Map.of()),
+        Pair.of(
+            Map.of(),
+            List.of(
+                ChangeItemImpl.builder()
+                    .urn(
+                        UrnUtils.getUrn(
+                            "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)"))
+                    .changeType(ChangeType.UPSERT)
+                    .aspectName(STRUCTURED_PROPERTIES_ASPECT_NAME)
+                    .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                    .aspectSpec(
+                        testRegistry
+                            .getEntitySpec(DATASET_ENTITY_NAME)
+                            .getAspectSpec(STRUCTURED_PROPERTIES_ASPECT_NAME))
+                    .auditStamp(testItems.get(0).getAuditStamp())
+                    .recordTemplate(
+                        new StructuredProperties()
+                            .setProperties(new StructuredPropertyValueAssignmentArray()))
+                    .systemMetadata(testItems.get(0).getSystemMetadata())
+                    .build(mockAspectRetriever),
+                ChangeItemImpl.builder()
+                    .urn(
+                        UrnUtils.getUrn(
+                            "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"))
+                    .changeType(ChangeType.UPSERT)
+                    .aspectName(STRUCTURED_PROPERTIES_ASPECT_NAME)
+                    .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                    .aspectSpec(
+                        testRegistry
+                            .getEntitySpec(DATASET_ENTITY_NAME)
+                            .getAspectSpec(STRUCTURED_PROPERTIES_ASPECT_NAME))
+                    .auditStamp(testItems.get(1).getAuditStamp())
+                    .recordTemplate(
+                        new StructuredProperties()
+                            .setProperties(new StructuredPropertyValueAssignmentArray()))
+                    .systemMetadata(testItems.get(1).getSystemMetadata())
+                    .build(mockAspectRetriever))),
+        "Expected patch items converted to upsert change items");
+  }
+
+  @Test
+  public void toUpsertBatchItemsProposedItemTest() {
+    List<ProposedItem> testItems =
+        List.of(
+            ProposedItem.builder()
+                .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                .metadataChangeProposal(
+                    new MetadataChangeProposal()
+                        .setEntityUrn(
+                            UrnUtils.getUrn(
+                                "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)"))
+                        .setAspectName("my-custom-aspect")
+                        .setEntityType(DATASET_ENTITY_NAME)
+                        .setChangeType(ChangeType.UPSERT)
+                        .setAspect(
+                            new GenericAspect()
+                                .setContentType("application/json")
+                                .setValue(
+                                    ByteString.copyString(
+                                        "{\"foo\":\"bar\"}", StandardCharsets.UTF_8)))
+                        .setSystemMetadata(new SystemMetadata()))
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .build(),
+            ProposedItem.builder()
+                .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                .metadataChangeProposal(
+                    new MetadataChangeProposal()
+                        .setEntityUrn(
+                            UrnUtils.getUrn(
+                                "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"))
+                        .setAspectName("my-custom-aspect")
+                        .setEntityType(DATASET_ENTITY_NAME)
+                        .setChangeType(ChangeType.UPSERT)
+                        .setAspect(
+                            new GenericAspect()
+                                .setContentType("application/json")
+                                .setValue(
+                                    ByteString.copyString(
+                                        "{\"foo\":\"bar\"}", StandardCharsets.UTF_8)))
+                        .setSystemMetadata(new SystemMetadata()))
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .build());
+
+    AspectsBatchImpl testBatch =
+        AspectsBatchImpl.builder().items(testItems).retrieverContext(retrieverContext).build();
+
+    assertEquals(
+        testBatch.toUpsertBatchItems(Map.of()),
+        Pair.of(
+            Map.of(),
+            List.of(
+                ChangeItemImpl.builder()
+                    .urn(
+                        UrnUtils.getUrn(
+                            "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)"))
+                    .changeType(ChangeType.UPSERT)
+                    .aspectName(STATUS_ASPECT_NAME)
+                    .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                    .aspectSpec(
+                        testRegistry
+                            .getEntitySpec(DATASET_ENTITY_NAME)
+                            .getAspectSpec(STATUS_ASPECT_NAME))
+                    .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                    .systemMetadata(testItems.get(0).getSystemMetadata())
+                    .recordTemplate(new Status().setRemoved(false))
+                    .build(mockAspectRetriever),
+                ChangeItemImpl.builder()
+                    .urn(
+                        UrnUtils.getUrn(
+                            "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)"))
+                    .changeType(ChangeType.UPSERT)
+                    .aspectName(STATUS_ASPECT_NAME)
+                    .entitySpec(testRegistry.getEntitySpec(DATASET_ENTITY_NAME))
+                    .aspectSpec(
+                        testRegistry
+                            .getEntitySpec(DATASET_ENTITY_NAME)
+                            .getAspectSpec(STATUS_ASPECT_NAME))
+                    .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                    .systemMetadata(testItems.get(1).getSystemMetadata())
+                    .recordTemplate(new Status().setRemoved(false))
+                    .build(mockAspectRetriever))),
+        "Mutation to status aspect");
+  }
+
+  /** Converts unsupported to status aspect */
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class TestMutator extends MutationHook {
+    private AspectPluginConfig config;
+
+    @Override
+    protected Stream<MCPItem> proposalMutation(
+        @Nonnull Collection<MCPItem> mcpItems,
+        @Nonnull com.linkedin.metadata.aspect.RetrieverContext retrieverContext) {
+      return mcpItems.stream()
+          .peek(
+              item ->
+                  item.getMetadataChangeProposal()
+                      .setAspectName(STATUS_ASPECT_NAME)
+                      .setAspect(
+                          GenericRecordUtils.serializeAspect(new Status().setRemoved(false))));
+    }
+  }
+}

--- a/metadata-io/metadata-io-api/src/test/resources/AspectsBatchImplTest.yaml
+++ b/metadata-io/metadata-io-api/src/test/resources/AspectsBatchImplTest.yaml
@@ -1,0 +1,19 @@
+entities:
+  - name: dataset
+    doc: Datasets represent logical or physical data assets stored or represented in various data platforms. Tables, Views, Streams are all instances of datasets.
+    category: core
+    keyAspect: datasetKey
+    aspects:
+      - status
+      - structuredProperties
+plugins:
+  mutationHooks:
+    - className: 'com.linkedin.metadata.entity.ebean.batch.AspectsBatchImplTest$TestMutator'
+      packageScan:
+        - 'com.linkedin.metadata.entity.ebean.batch'
+      enabled: true
+      supportedOperations:
+        - UPSERT
+      supportedEntityAspectNames:
+        - entityName: 'dataset'
+          aspectName: '*'

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutator.java
@@ -1,0 +1,80 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import com.datahub.util.exception.ModelConversionException;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.transform.filter.request.MaskTree;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.metadata.entity.validation.ValidationApiUtils;
+import com.linkedin.metadata.entity.validation.ValidationException;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.GenericAspect;
+import com.linkedin.restli.internal.server.util.RestUtils;
+import java.util.Collection;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/** This mutator will log and drop unknown aspects. It will also log and drop unknown fields. */
+@Slf4j
+@Setter
+@Getter
+@Accessors(chain = true)
+public class IgnoreUnknownMutator extends MutationHook {
+  @Nonnull private AspectPluginConfig config;
+
+  @Override
+  protected Stream<MCPItem> proposalMutation(
+      @Nonnull Collection<MCPItem> mcpItems, @Nonnull RetrieverContext retrieverContext) {
+    return mcpItems.stream()
+        .filter(
+            item -> {
+              if (item.getEntitySpec().getAspectSpec(item.getAspectName()) == null) {
+                log.warn(
+                    "Dropping unknown aspect {} on entity {}",
+                    item.getAspectName(),
+                    item.getAspectSpec().getName());
+                return false;
+              }
+              if (!"application/json"
+                  .equals(item.getMetadataChangeProposal().getAspect().getContentType())) {
+                log.warn(
+                    "Dropping unknown content type {} for aspect {} on entity {}",
+                    item.getMetadataChangeProposal().getAspect().getContentType(),
+                    item.getAspectName(),
+                    item.getEntitySpec().getName());
+                return false;
+              }
+              return true;
+            })
+        .peek(
+            item -> {
+              try {
+                AspectSpec aspectSpec = item.getEntitySpec().getAspectSpec(item.getAspectName());
+                GenericAspect aspect = item.getMetadataChangeProposal().getAspect();
+                RecordTemplate recordTemplate =
+                    GenericRecordUtils.deserializeAspect(
+                        aspect.getValue(), aspect.getContentType(), aspectSpec);
+                try {
+                  ValidationApiUtils.validateOrThrow(recordTemplate);
+                } catch (ValidationException | ModelConversionException e) {
+                  log.warn(
+                      "Failed to validate aspect. Coercing aspect {} on entity {}",
+                      item.getAspectName(),
+                      item.getEntitySpec().getName());
+                  RestUtils.trimRecordTemplate(recordTemplate, new MaskTree(), false);
+                  item.getMetadataChangeProposal()
+                      .setAspect(GenericRecordUtils.serializeAspect(recordTemplate));
+                }
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutatorTest.java
@@ -1,0 +1,143 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATASET_PROPERTIES_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.GLOBAL_TAGS_ASPECT_NAME;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociation;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.urn.TagUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.ByteString;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.dataset.DatasetProperties;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.metadata.entity.ebean.batch.ProposedItem;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.utils.AuditStampUtils;
+import com.linkedin.mxe.GenericAspect;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.mxe.SystemMetadata;
+import com.linkedin.test.metadata.aspect.TestEntityRegistry;
+import io.datahubproject.metadata.context.RetrieverContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class IgnoreUnknownMutatorTest {
+  private static final EntityRegistry TEST_REGISTRY = new TestEntityRegistry();
+  private static final AspectPluginConfig TEST_PLUGIN_CONFIG =
+      AspectPluginConfig.builder()
+          .className(IgnoreUnknownMutator.class.getName())
+          .enabled(true)
+          .supportedOperations(List.of("UPSERT"))
+          .supportedEntityAspectNames(
+              List.of(
+                  AspectPluginConfig.EntityAspectName.builder()
+                      .entityName(DATASET_ENTITY_NAME)
+                      .aspectName("*")
+                      .build()))
+          .build();
+  private static final Urn TEST_DATASET_URN =
+      UrnUtils.getUrn(
+          "urn:li:dataset:(urn:li:dataPlatform:postgres,calm-pagoda-323403.jaffle_shop.customers,PROD)");
+  private AspectRetriever mockAspectRetriever;
+  private RetrieverContext retrieverContext;
+
+  @BeforeMethod
+  public void setup() {
+    mockAspectRetriever = mock(AspectRetriever.class);
+    retrieverContext =
+        RetrieverContext.builder()
+            .searchRetriever(mock(SearchRetriever.class))
+            .aspectRetriever(mockAspectRetriever)
+            .graphRetriever(TestOperationContexts.emptyGraphRetriever)
+            .build();
+  }
+
+  @Test
+  public void testUnknownFieldInTagAssociationArray() throws URISyntaxException {
+    IgnoreUnknownMutator test = new IgnoreUnknownMutator();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    List<MCPItem> testItems =
+        List.of(
+            ProposedItem.builder()
+                .entitySpec(TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME))
+                .metadataChangeProposal(
+                    new MetadataChangeProposal()
+                        .setEntityUrn(TEST_DATASET_URN)
+                        .setAspectName(GLOBAL_TAGS_ASPECT_NAME)
+                        .setEntityType(DATASET_ENTITY_NAME)
+                        .setChangeType(ChangeType.UPSERT)
+                        .setAspect(
+                            new GenericAspect()
+                                .setContentType("application/json")
+                                .setValue(
+                                    ByteString.copyString(
+                                        "{\"tags\":[{\"tag\":\"urn:li:tag:Legacy\",\"foo\":\"bar\"}]}",
+                                        StandardCharsets.UTF_8)))
+                        .setSystemMetadata(new SystemMetadata()))
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .build());
+
+    List<MCPItem> result = test.proposalMutation(testItems, retrieverContext).toList();
+
+    assertEquals(1, result.size());
+    assertEquals(
+        result.get(0).getAspect(GlobalTags.class),
+        new GlobalTags()
+            .setTags(
+                new TagAssociationArray(
+                    List.of(
+                        new TagAssociation()
+                            .setTag(TagUrn.createFromString("urn:li:tag:Legacy"))))));
+  }
+
+  @Test
+  public void testUnknownFieldDatasetProperties() throws URISyntaxException {
+    IgnoreUnknownMutator test = new IgnoreUnknownMutator();
+    test.setConfig(TEST_PLUGIN_CONFIG);
+
+    List<MCPItem> testItems =
+        List.of(
+            ProposedItem.builder()
+                .entitySpec(TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME))
+                .metadataChangeProposal(
+                    new MetadataChangeProposal()
+                        .setEntityUrn(TEST_DATASET_URN)
+                        .setAspectName(DATASET_PROPERTIES_ASPECT_NAME)
+                        .setEntityType(DATASET_ENTITY_NAME)
+                        .setChangeType(ChangeType.UPSERT)
+                        .setAspect(
+                            new GenericAspect()
+                                .setContentType("application/json")
+                                .setValue(
+                                    ByteString.copyString(
+                                        "{\"foo\":\"bar\",\"customProperties\":{\"prop2\":\"pikachu\",\"prop1\":\"fakeprop\"}}",
+                                        StandardCharsets.UTF_8)))
+                        .setSystemMetadata(new SystemMetadata()))
+                .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+                .build());
+
+    List<MCPItem> result = test.proposalMutation(testItems, retrieverContext).toList();
+
+    assertEquals(1, result.size());
+    assertEquals(
+        result.get(0).getAspect(DatasetProperties.class),
+        new DatasetProperties()
+            .setCustomProperties(new StringMap(Map.of("prop1", "fakeprop", "prop2", "pikachu"))));
+  }
+}

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MaeConsumerApplication.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MaeConsumerApplication.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.FilterType;
       "com.linkedin.gms.factory.context",
       "com.linkedin.gms.factory.timeseries",
       "com.linkedin.gms.factory.assertion",
+      "com.linkedin.gms.factory.plugins"
     },
     excludeFilters = {
       @ComponentScan.Filter(

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import com.datahub.authentication.Authentication;
 import com.datahub.metadata.ingestion.IngestionScheduler;
 import com.linkedin.entity.client.SystemEntityClient;
+import com.linkedin.gms.factory.plugins.SpringStandardPluginConfiguration;
 import com.linkedin.metadata.boot.kafka.DataHubUpgradeKafkaListener;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -85,4 +86,6 @@ public class MCLSpringCommonTestConfiguration {
         indexConvention,
         mock(RetrieverContext.class));
   }
+
+  @MockBean SpringStandardPluginConfiguration springStandardPluginConfiguration;
 }

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceConsumerApplication.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceConsumerApplication.java
@@ -33,7 +33,8 @@ import org.springframework.context.annotation.PropertySource;
       "com.linkedin.gms.factory.form",
       "com.linkedin.metadata.dao.producer",
       "io.datahubproject.metadata.jobs.common.health.kafka",
-      "com.linkedin.gms.factory.context"
+      "com.linkedin.gms.factory.context",
+      "com.linkedin.gms.factory.plugins"
     },
     excludeFilters = {
       @ComponentScan.Filter(

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -664,3 +664,9 @@ plugins:
           aspectName: 'schemaMetadata'
         - entityName: '*'
           aspectName: 'editableSchemaMetadata'
+    - className: 'com.linkedin.metadata.aspect.plugins.hooks.MutationHook'
+      enabled: true
+      spring:
+        enabled: true
+      packageScan:
+        - com.linkedin.gms.factory.plugins

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
@@ -35,6 +35,7 @@ public class RequestContext implements ContextInterface {
   @Nonnull private final String requestID;
 
   @Nonnull private final String userAgent;
+  @Builder.Default private boolean validated = true;
 
   public RequestContext(
       @Nonnull String actorUrn,

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -466,6 +466,8 @@ businessAttribute:
   keepAliveTime: ${BUSINESS_ATTRIBUTE_PROPAGATION_CONCURRENCY_KEEP_ALIVE:60} # Number of seconds to keep inactive threads alive
 
 metadataChangeProposal:
+  validation:
+    ignoreUnknown: ${MCP_VALIDATION_IGNORE_UNKNOWN:true}
   throttle:
     updateIntervalMs: ${MCP_THROTTLE_UPDATE_INTERVAL_MS:60000}
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/ConfigEntityRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/ConfigEntityRegistryFactory.java
@@ -1,6 +1,7 @@
 package com.linkedin.gms.factory.entityregistry;
 
 import com.datahub.plugins.metadata.aspect.SpringPluginFactory;
+import com.linkedin.gms.factory.plugins.SpringStandardPluginConfiguration;
 import com.linkedin.metadata.aspect.plugins.PluginFactory;
 import com.linkedin.metadata.aspect.plugins.config.PluginConfiguration;
 import com.linkedin.metadata.models.registry.ConfigEntityRegistry;
@@ -29,7 +30,9 @@ public class ConfigEntityRegistryFactory {
 
   @Bean(name = "configEntityRegistry")
   @Nonnull
-  protected ConfigEntityRegistry getInstance() throws IOException, EntityRegistryException {
+  protected ConfigEntityRegistry getInstance(
+      SpringStandardPluginConfiguration springStandardPluginConfiguration)
+      throws IOException, EntityRegistryException {
     BiFunction<PluginConfiguration, List<ClassLoader>, PluginFactory> pluginFactoryProvider =
         (config, loaders) -> new SpringPluginFactory(applicationContext, config, loaders);
     if (entityRegistryConfigPath != null) {

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -1,0 +1,33 @@
+package com.linkedin.gms.factory.plugins;
+
+import com.linkedin.metadata.aspect.hooks.IgnoreUnknownMutator;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringStandardPluginConfiguration {
+
+  @Value("${metadataChangeProposal.validation.ignoreUnknown}")
+  private boolean ignoreUnknownEnabled;
+
+  @Bean
+  public MutationHook ignoreUnknownMutator() {
+    return new IgnoreUnknownMutator()
+        .setConfig(
+            AspectPluginConfig.builder()
+                .className(IgnoreUnknownMutator.class.getName())
+                .enabled(ignoreUnknownEnabled)
+                .supportedOperations(List.of("CREATE", "CREATE_ENTITY", "UPSERT"))
+                .supportedEntityAspectNames(
+                    List.of(
+                        AspectPluginConfig.EntityAspectName.builder()
+                            .entityName("*")
+                            .aspectName("*")
+                            .build()))
+                .build());
+  }
+}

--- a/metadata-service/plugin/src/main/java/com/datahub/plugins/metadata/aspect/SpringPluginFactory.java
+++ b/metadata-service/plugin/src/main/java/com/datahub/plugins/metadata/aspect/SpringPluginFactory.java
@@ -78,6 +78,15 @@ public class SpringPluginFactory extends PluginFactory {
         config -> config.getSpring() != null && config.getSpring().isEnabled());
   }
 
+  @Nonnull
+  @Override
+  public List<ClassLoader> getClassLoaders() {
+    if (!super.getClassLoaders().isEmpty()) {
+      return super.getClassLoaders();
+    }
+    return List.of(SpringPluginFactory.class.getClassLoader());
+  }
+
   /**
    * Override to inject classes from Spring
    *
@@ -137,7 +146,8 @@ public class SpringPluginFactory extends PluginFactory {
           log.warn(
               "Failed to load class {} from loader {}",
               config.getClassName(),
-              classLoader.getName());
+              classLoader.getName(),
+              e);
         }
       }
 

--- a/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.PropertySource;
       "com.linkedin.gms.factory.search",
       "com.linkedin.gms.factory.secret",
       "com.linkedin.gms.factory.timeseries",
+      "com.linkedin.gms.factory.plugins"
     })
 @PropertySource(value = "classpath:/application.yaml", factory = YamlPropertySourceFactory.class)
 @Configuration


### PR DESCRIPTION
MCP Mutator capability added to the MutationHook. It is capable of mutating incoming MCP before validation. A new ProposedItem can now be used which allows mutation by this new mutator type. An example plugin was created to drop unknown fields.

Not yet tied into APIs, future work.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced mutation hooks to handle and process metadata change proposals.
  - Added configuration options to control validation behavior for unknown fields.

- **Bug Fixes**
  - Improved null handling in various methods to prevent potential errors.

- **Tests**
  - Added comprehensive test cases for new mutation hook behaviors and batch processing logic.

- **Chores**
  - Updated project dependencies to include necessary libraries for new features.
  - Enhanced configuration files to support new functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->