### PR TITLE
fix(structured properties): allow application of structured properties without schema file

### DIFF
--- a/metadata-ingestion/src/datahub/api/entities/dataset/dataset.py
+++ b/metadata-ingestion/src/datahub/api/entities/dataset/dataset.py
@@ -257,56 +257,56 @@ class Dataset(BaseModel):
                     )
                     yield mcp
 
-                if self.schema_metadata.fields:
-                    for field in self.schema_metadata.fields:
-                        field_urn = field.urn or make_schema_field_urn(
-                            self.urn, field.id  # type: ignore[arg-type]
+            if self.schema_metadata.fields:
+                for field in self.schema_metadata.fields:
+                    field_urn = field.urn or make_schema_field_urn(
+                        self.urn, field.id  # type: ignore[arg-type]
+                    )
+                    assert field_urn.startswith("urn:li:schemaField:")
+
+                    if field.globalTags:
+                        mcp = MetadataChangeProposalWrapper(
+                            entityUrn=field_urn,
+                            aspect=GlobalTagsClass(
+                                tags=[
+                                    TagAssociationClass(tag=make_tag_urn(tag))
+                                    for tag in field.globalTags
+                                ]
+                            ),
                         )
-                        assert field_urn.startswith("urn:li:schemaField:")
+                        yield mcp
 
-                        if field.globalTags:
-                            mcp = MetadataChangeProposalWrapper(
-                                entityUrn=field_urn,
-                                aspect=GlobalTagsClass(
-                                    tags=[
-                                        TagAssociationClass(tag=make_tag_urn(tag))
-                                        for tag in field.globalTags
-                                    ]
-                                ),
-                            )
-                            yield mcp
+                    if field.glossaryTerms:
+                        mcp = MetadataChangeProposalWrapper(
+                            entityUrn=field_urn,
+                            aspect=GlossaryTermsClass(
+                                terms=[
+                                    GlossaryTermAssociationClass(
+                                        urn=make_term_urn(term)
+                                    )
+                                    for term in field.glossaryTerms
+                                ],
+                                auditStamp=self._mint_auditstamp("yaml"),
+                            ),
+                        )
+                        yield mcp
 
-                        if field.glossaryTerms:
-                            mcp = MetadataChangeProposalWrapper(
-                                entityUrn=field_urn,
-                                aspect=GlossaryTermsClass(
-                                    terms=[
-                                        GlossaryTermAssociationClass(
-                                            urn=make_term_urn(term)
-                                        )
-                                        for term in field.glossaryTerms
-                                    ],
-                                    auditStamp=self._mint_auditstamp("yaml"),
-                                ),
-                            )
-                            yield mcp
-
-                        if field.structured_properties:
-                            mcp = MetadataChangeProposalWrapper(
-                                entityUrn=field_urn,
-                                aspect=StructuredPropertiesClass(
-                                    properties=[
-                                        StructuredPropertyValueAssignmentClass(
-                                            propertyUrn=f"urn:li:structuredProperty:{prop_key}",
-                                            values=prop_value
-                                            if isinstance(prop_value, list)
-                                            else [prop_value],
-                                        )
-                                        for prop_key, prop_value in field.structured_properties.items()
-                                    ]
-                                ),
-                            )
-                            yield mcp
+                    if field.structured_properties:
+                        mcp = MetadataChangeProposalWrapper(
+                            entityUrn=field_urn,
+                            aspect=StructuredPropertiesClass(
+                                properties=[
+                                    StructuredPropertyValueAssignmentClass(
+                                        propertyUrn=f"urn:li:structuredProperty:{prop_key}",
+                                        values=prop_value
+                                        if isinstance(prop_value, list)
+                                        else [prop_value],
+                                    )
+                                    for prop_key, prop_value in field.structured_properties.items()
+                                ]
+                            ),
+                        )
+                        yield mcp
 
         if self.subtype or self.subtypes:
             mcp = MetadataChangeProposalWrapper(


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling of metadata fields within the `generate_mcp` method of the `Dataset` class, ensuring better organization and validation of metadata properties.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->