### PR TITLE
fix(ingest/lookml): add view load failures to cache

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
@@ -63,10 +63,8 @@ class LookerViewFileLoader:
             with open(path) as file:
                 raw_file_content = file.read()
         except Exception as e:
-            logger.debug(f"An error occurred while reading path {path}", exc_info=True)
-            self.reporter.report_failure(
-                path, f"failed to load view file {path} from disk: {e}"
-            )
+            self.reporter.report_failure("Failed to read lkml file", path, exc=e)
+            self.viewfile_cache[path] = None
             return None
         try:
             logger.debug(f"Loading viewfile {path}")
@@ -91,8 +89,8 @@ class LookerViewFileLoader:
             self.viewfile_cache[path] = looker_viewfile
             return looker_viewfile
         except Exception as e:
-            logger.debug(f"An error occurred while parsing path {path}", exc_info=True)
-            self.reporter.report_failure(path, f"failed to load view file {path}: {e}")
+            self.reporter.report_failure("Failed to parse lkml file", path, exc=e)
+            self.viewfile_cache[path] = None
             return None
 
     def load_viewfile(

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
@@ -31,7 +31,7 @@ class LookerViewFileLoader:
         reporter: LookMLSourceReport,
         liquid_variable: Dict[Any, Any],
     ) -> None:
-        self.viewfile_cache: Dict[str, LookerViewFile] = {}
+        self.viewfile_cache: Dict[str, Optional[LookerViewFile]] = {}
         self._root_project_name = root_project_name
         self._base_projects_folder = base_projects_folder
         self.reporter = reporter

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
@@ -37,9 +37,6 @@ class LookerViewFileLoader:
         self.reporter = reporter
         self.liquid_variable = liquid_variable
 
-    def is_view_seen(self, path: str) -> bool:
-        return path in self.viewfile_cache
-
     def _load_viewfile(
         self, project_name: str, path: str, reporter: LookMLSourceReport
     ) -> Optional[LookerViewFile]:
@@ -56,7 +53,7 @@ class LookerViewFileLoader:
             )
             return None
 
-        if self.is_view_seen(str(path)):
+        if path in self.viewfile_cache:
             return self.viewfile_cache[path]
 
         try:

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_file_loader.py
@@ -63,7 +63,7 @@ class LookerViewFileLoader:
             with open(path) as file:
                 raw_file_content = file.read()
         except Exception as e:
-            self.reporter.report_failure("Failed to read lkml file", path, exc=e)
+            self.reporter.failure("Failed to read lkml file", path, exc=e)
             self.viewfile_cache[path] = None
             return None
         try:
@@ -89,7 +89,7 @@ class LookerViewFileLoader:
             self.viewfile_cache[path] = looker_viewfile
             return looker_viewfile
         except Exception as e:
-            self.reporter.report_failure("Failed to parse lkml file", path, exc=e)
+            self.reporter.failure("Failed to parse lkml file", path, exc=e)
             self.viewfile_cache[path] = None
             return None
 


### PR DESCRIPTION
This ensures that we don't try to read the same file multiple times when we already failed the first time.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling and reporting for Looker view files to enhance error reporting and cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->