### PR TITLE
chore() Set a default lineage filtering end time on backend when a start time is present

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
@@ -255,4 +255,19 @@ public class ResolverUtils {
     Filter result = SearchUtils.combineFilters(null, viewInfo.getDefinition().getFilter());
     return result;
   }
+
+  /**
+   * Simply resolves the end time filter for the search across lineage query. If the start time is
+   * provided, but end time is not provided, we will default to the current time.
+   */
+  public static Long getLineageEndTimeMillis(
+      @Nullable Long startTimeMillis, @Nullable Long endTimeMillis) {
+    if (endTimeMillis != null) {
+      return endTimeMillis;
+    }
+    if (startTimeMillis != null) {
+      return System.currentTimeMillis();
+    }
+    return null;
+  }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/EntityLineageResultResolver.java
@@ -18,6 +18,7 @@ import com.linkedin.datahub.graphql.generated.LineageDirection;
 import com.linkedin.datahub.graphql.generated.LineageInput;
 import com.linkedin.datahub.graphql.generated.LineageRelationship;
 import com.linkedin.datahub.graphql.generated.Restricted;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
 import com.linkedin.metadata.graph.SiblingGraphService;
 import graphql.schema.DataFetcher;
@@ -63,7 +64,10 @@ public class EntityLineageResultResolver
     @Nullable final Integer count = input.getCount(); // Optional!
     @Nullable final Boolean separateSiblings = input.getSeparateSiblings(); // Optional!
     @Nullable final Long startTimeMillis = input.getStartTimeMillis(); // Optional!
-    @Nullable final Long endTimeMillis = input.getEndTimeMillis(); // Optional!
+    @Nullable
+    final Long endTimeMillis =
+        ResolverUtils.getLineageEndTimeMillis(
+            input.getStartTimeMillis(), input.getEndTimeMillis()); // Optional!
 
     com.linkedin.metadata.graph.LineageDirection resolvedDirection =
         com.linkedin.metadata.graph.LineageDirection.valueOf(lineageDirection.toString());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
@@ -78,7 +78,8 @@ public class ScrollAcrossLineageResolver
     @Nullable
     Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
-    Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
+    Long endTimeMillis =
+        SearchUtils.getLineageEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
 
     final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolver.java
@@ -79,7 +79,7 @@ public class ScrollAcrossLineageResolver
     Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
     Long endTimeMillis =
-        SearchUtils.getLineageEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
+        ResolverUtils.getLineageEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
 
     final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
@@ -111,7 +111,8 @@ public class SearchAcrossLineageResolver
     @Nullable
     Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
-    Long endTimeMillis = getEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
+    Long endTimeMillis =
+        SearchUtils.getLineageEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
 
     final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {
@@ -197,19 +198,5 @@ public class SearchAcrossLineageResolver
         },
         this.getClass().getSimpleName(),
         "get");
-  }
-
-  /**
-   * Simply resolves the end time filter for the search across lineage query. If the start time is
-   * provided, but end time is not provided, we will default to the current time.
-   */
-  private Long getEndTimeMillis(@Nullable Long startTimeMillis, @Nullable Long endTimeMillis) {
-    if (endTimeMillis != null) {
-      return endTimeMillis;
-    }
-    if (startTimeMillis != null) {
-      return System.currentTimeMillis();
-    }
-    return null;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
@@ -112,7 +112,7 @@ public class SearchAcrossLineageResolver
     Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
     Long endTimeMillis =
-        SearchUtils.getLineageEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
+        ResolverUtils.getLineageEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
 
     final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolver.java
@@ -111,7 +111,7 @@ public class SearchAcrossLineageResolver
     @Nullable
     Long startTimeMillis = input.getStartTimeMillis() == null ? null : input.getStartTimeMillis();
     @Nullable
-    Long endTimeMillis = input.getEndTimeMillis() == null ? null : input.getEndTimeMillis();
+    Long endTimeMillis = getEndTimeMillis(input.getStartTimeMillis(), input.getEndTimeMillis());
 
     final LineageFlags lineageFlags = LineageFlagsInputMapper.map(context, input.getLineageFlags());
     if (lineageFlags.getStartTimeMillis() == null && startTimeMillis != null) {
@@ -197,5 +197,19 @@ public class SearchAcrossLineageResolver
         },
         this.getClass().getSimpleName(),
         "get");
+  }
+
+  /**
+   * Simply resolves the end time filter for the search across lineage query. If the start time is
+   * provided, but end time is not provided, we will default to the current time.
+   */
+  private Long getEndTimeMillis(@Nullable Long startTimeMillis, @Nullable Long endTimeMillis) {
+    if (endTimeMillis != null) {
+      return endTimeMillis;
+    }
+    if (startTimeMillis != null) {
+      return System.currentTimeMillis();
+    }
+    return null;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -326,19 +326,4 @@ public class SearchUtils {
     result.setFacets(new ArrayList<>());
     return result;
   }
-
-  /**
-   * Simply resolves the end time filter for the search across lineage query. If the start time is
-   * provided, but end time is not provided, we will default to the current time.
-   */
-  public static Long getLineageEndTimeMillis(
-      @Nullable Long startTimeMillis, @Nullable Long endTimeMillis) {
-    if (endTimeMillis != null) {
-      return endTimeMillis;
-    }
-    if (startTimeMillis != null) {
-      return System.currentTimeMillis();
-    }
-    return null;
-  }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchUtils.java
@@ -326,4 +326,19 @@ public class SearchUtils {
     result.setFacets(new ArrayList<>());
     return result;
   }
+
+  /**
+   * Simply resolves the end time filter for the search across lineage query. If the start time is
+   * provided, but end time is not provided, we will default to the current time.
+   */
+  public static Long getLineageEndTimeMillis(
+      @Nullable Long startTimeMillis, @Nullable Long endTimeMillis) {
+    if (endTimeMillis != null) {
+      return endTimeMillis;
+    }
+    if (startTimeMillis != null) {
+      return System.currentTimeMillis();
+    }
+    return null;
+  }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
@@ -51,7 +51,7 @@ public class LineageFlagsInputMapper
         ResolverUtils.getLineageEndTimeMillis(
             lineageFlags.getStartTimeMillis(), lineageFlags.getEndTimeMillis());
     if (endTimeMillis != null) {
-      result.setEndTimeMillis(lineageFlags.getEndTimeMillis());
+      result.setEndTimeMillis(endTimeMillis);
     }
     if (lineageFlags.getEntitiesExploredPerHopLimit() != null) {
       result.setEntitiesExploredPerHopLimit(lineageFlags.getEntitiesExploredPerHopLimit());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/LineageFlagsInputMapper.java
@@ -6,6 +6,7 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.EntityTypeToPlatforms;
 import com.linkedin.datahub.graphql.generated.LineageFlags;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import java.util.Collections;
@@ -42,11 +43,15 @@ public class LineageFlagsInputMapper
     if (lineageFlags.getIgnoreAsHops() != null) {
       result.setIgnoreAsHops(mapIgnoreAsHops(lineageFlags.getIgnoreAsHops()));
     }
-    if (lineageFlags.getEndTimeMillis() != null) {
-      result.setEndTimeMillis(lineageFlags.getEndTimeMillis());
-    }
     if (lineageFlags.getStartTimeMillis() != null) {
       result.setStartTimeMillis(lineageFlags.getStartTimeMillis());
+    }
+    // Default to "now" if no end time is provided, but start time is provided.
+    Long endTimeMillis =
+        ResolverUtils.getLineageEndTimeMillis(
+            lineageFlags.getStartTimeMillis(), lineageFlags.getEndTimeMillis());
+    if (endTimeMillis != null) {
+      result.setEndTimeMillis(lineageFlags.getEndTimeMillis());
     }
     if (lineageFlags.getEntitiesExploredPerHopLimit() != null) {
       result.setEntitiesExploredPerHopLimit(lineageFlags.getEntitiesExploredPerHopLimit());


### PR DESCRIPTION
## Summary

When a user provides a start time, they'd expect the end time to default to "now". This PR makes that a reality in the search/scroll across lineage resolvers.

## QA

Validated the change locally to make sure no additional edges were hidden. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved the calculation of `endTimeMillis` by using a new utility method, providing more accurate and consistent time handling across lineage queries.
  - Enhanced logic for initializing `lineageFlags` to better manage start and end times.
  
- **New Features**
  - Introduced a method to resolve the end time filter for lineage searches, allowing default to current time if only start time is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->