### PR TITLE
fix(connections) Harden adding /gms to connections in backend

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -629,6 +629,9 @@ def _ensure_valid_gms_url_acryl_cloud(url: str) -> str:
         url = url.replace("http://", "https://")
     if url.endswith("acryl.io"):
         url = f"{url}/gms"
+    elif url.endswith("acryl.io/"):
+        url = f"{url}gms"
+
     return url
 
 


### PR DESCRIPTION
Hardens our resolve around adding `/gms` to connections when it makes sense.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL formatting by ensuring URLs ending with 'acryl.io/' correctly append 'gms' for proper processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->