### PR TITLE
fix(spark-lineage): default timeout for future responses

### DIFF
--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/MetadataResponseFuture.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/MetadataResponseFuture.java
@@ -69,7 +69,7 @@ public class MetadataResponseFuture implements Future<MetadataWriteResponse> {
       return mapper.map(response);
     } else {
       // We wait for the callback to fill this out
-      responseLatch.await();
+      responseLatch.await(timeout, unit);
       return responseReference.get();
     }
   }

--- a/metadata-integration/java/datahub-client/src/main/java/datahub/client/rest/RestEmitter.java
+++ b/metadata-integration/java/datahub-client/src/main/java/datahub/client/rest/RestEmitter.java
@@ -250,6 +250,7 @@ public class RestEmitter implements Emitter {
 
           @Override
           public void failed(Exception ex) {
+            responseLatch.countDown();
             if (callback != null) {
               try {
                 callback.onFailure(ex);
@@ -261,6 +262,7 @@ public class RestEmitter implements Emitter {
 
           @Override
           public void cancelled() {
+            responseLatch.countDown();
             if (callback != null) {
               try {
                 callback.onFailure(new RuntimeException("Cancelled"));
@@ -344,6 +346,7 @@ public class RestEmitter implements Emitter {
 
           @Override
           public void failed(Exception ex) {
+            responseLatch.countDown();
             if (callback != null) {
               try {
                 callback.onFailure(ex);
@@ -355,6 +358,7 @@ public class RestEmitter implements Emitter {
 
           @Override
           public void cancelled() {
+            responseLatch.countDown();
             if (callback != null) {
               try {
                 callback.onFailure(new RuntimeException("Cancelled"));

--- a/metadata-integration/java/spark-lineage-beta/src/main/java/datahub/spark/DatahubEventEmitter.java
+++ b/metadata-integration/java/spark-lineage-beta/src/main/java/datahub/spark/DatahubEventEmitter.java
@@ -39,6 +39,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -53,6 +55,7 @@ public class DatahubEventEmitter extends EventEmitter {
   private final List<DatahubJob> _datahubJobs = new LinkedList<>();
   private final Map<String, MetadataChangeProposalWrapper> schemaMap = new HashMap<>();
   private SparkLineageConf datahubConf;
+  private static final int DEFAULT_TIMEOUT_SEC = 10;
 
   private final EventFormatter eventFormatter = new EventFormatter();
 
@@ -386,8 +389,8 @@ public class DatahubEventEmitter extends EventEmitter {
           .forEach(
               future -> {
                 try {
-                  log.info(future.get().toString());
-                } catch (InterruptedException | ExecutionException e) {
+                  log.info(future.get(DEFAULT_TIMEOUT_SEC, TimeUnit.SECONDS).toString());
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
                   // log error, but don't impact thread
                   log.error("Failed to emit metadata to DataHub", e);
                 }


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced timeout functionality for waiting on responses, improving application responsiveness.
  - Introduced a default timeout for metadata change proposals, preventing indefinite blocking during processing.
  - Improved synchronization in asynchronous operations by ensuring proper management of response handling, enhancing robustness.

- **Bug Fixes**
  - Improved error handling by incorporating new exception management for timeouts in metadata emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->