### PR TITLE
fix(docs): make graphql doc gen more automated

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,6 +27,8 @@ concurrency:
 jobs:
   gh-pages:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # We explicitly don't use acryldata/sane-checkout-action because docusaurus runs
       # git commands to determine the last change date for each file.

--- a/docs-website/graphql/generateGraphQLSchema.sh
+++ b/docs-website/graphql/generateGraphQLSchema.sh
@@ -1,22 +1,8 @@
 #!/bin/sh
-rm combined.graphql
+if [ -f "combined.graphql" ] ; then
+    rm "combined.graphql"
+fi
 touch combined.graphql
 echo "Generating combined GraphQL schema..."
 echo "# Auto Generated During Docs Build" >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/actions.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/analytics.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/app.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/auth.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/constraints.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/entity.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/assertions.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/ingestion.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/recommendation.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/search.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/tests.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/timeline.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/step.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/lineage.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/properties.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/forms.graphql >> combined.graphql
-cat ../../datahub-graphql-core/src/main/resources/connection.graphql >> combined.graphql
+cat ../../datahub-graphql-core/src/main/resources/*.graphql >> combined.graphql


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved functionality of the GraphQL schema generation process, allowing automatic inclusion of all GraphQL files in the specified directory.
	- Enhanced GitHub Actions workflow to allow write permissions, improving documentation update capabilities.

- **Bug Fixes**
	- Implemented a conditional check to ensure the safe removal of the `combined.graphql` file, preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->