### PR TITLE
fix: resolve incorrect variable assignment for SageMaker API call

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/models.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/sagemaker_processors/models.py
@@ -418,7 +418,7 @@ class ModelProcessor:
 
         model_image_groups: Set[str] = set()
         if model_image is not None:
-            model_uri_groups = self.lineage.model_image_to_groups.get(
+            model_image_groups = self.lineage.model_image_to_groups.get(
                 model_image, set()
             )
 


### PR DESCRIPTION
This pull request fixes the incorrect variable assignment during SageMaker model ingestion identified and described in #10893 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved variable naming in the model ingestion process for clarity without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->