### PR TITLE
fix(ui) Fix scroll on the domain sidebar to show all domains

### DIFF
--- a/datahub-web-react/src/app/shared/sidebar/components.tsx
+++ b/datahub-web-react/src/app/shared/sidebar/components.tsx
@@ -8,6 +8,8 @@ export const SidebarWrapper = styled.div<{ width: number }>`
     width: ${(props) => props.width}px;
     min-width: ${(props) => props.width}px;
     display: ${(props) => (props.width ? 'block' : 'none')};
+    display: flex;
+    flex-direction: column;
 `;
 
 export function RotatingTriangle({ isOpen, onClick }: { isOpen: boolean; onClick?: () => void }) {


### PR DESCRIPTION
Fixes a scroll bug for domains sidebars where the last item in the list was getting cut off if there were too many items.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the sidebar layout with a new flexbox design for improved structure and alignment of elements.  
- **Bug Fixes**
	- Maintained existing visibility logic based on the `width` prop while integrating new layout properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->