### PR TITLE
fix(structuredProps) Fix casing bug in StructuredPropertiesValidator

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/validation/StructuredPropertiesValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/validation/StructuredPropertiesValidator.java
@@ -356,7 +356,7 @@ public class StructuredPropertiesValidator extends AspectPayloadValidator {
                 throw new RuntimeException(e);
               }
               String allowedEntityName = getValueTypeId(typeUrn);
-              if (typeValue.getEntityType().equals(allowedEntityName)) {
+              if (typeValue.getEntityType().equalsIgnoreCase(allowedEntityName)) {
                 matchedAny = true;
               }
             }


### PR DESCRIPTION
Fixes a bug in the structured properties validator where we were comparing entity types in the `allowedTypes` section and one was lowercased in the method `getValueTypeId` and the other was not. So in the case of how this bug was discovered, we were saying `corpGroup != corpgroup`. Now we check and ignore casing.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation logic to support case-insensitive entity type comparisons, improving input flexibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->