### PR TITLE
feat(ingest/bigquery): improve handling of information schema in sql parser

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_audit.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_audit.py
@@ -80,8 +80,8 @@ class BigqueryTableIdentifier:
 
     @classmethod
     def from_string_name(cls, table: str) -> "BigqueryTableIdentifier":
-        parts = table.split(".")
-        # If the table name contains dollar sign, it is a referrence to a partitioned table and we have to strip it
+        parts = table.split(".", maxsplit=2)
+        # If the table name contains dollar sign, it is a reference to a partitioned table and we have to strip it
         table = parts[2].split("$", 1)[0]
         return cls(parts[0], parts[1], table)
 

--- a/metadata-ingestion/src/datahub/sql_parsing/_models.py
+++ b/metadata-ingestion/src/datahub/sql_parsing/_models.py
@@ -77,8 +77,20 @@ class _TableName(_FrozenModel):
         default_db: Optional[str] = None,
         default_schema: Optional[str] = None,
     ) -> "_TableName":
+        if isinstance(table.this, sqlglot.exp.Dot):
+            # For tables that are more than 3 parts, the extra parts will be in a Dot.
+            # For now, we just merge them into the table name.
+            parts = []
+            exp = table.this
+            while isinstance(exp, sqlglot.exp.Dot):
+                parts.append(exp.this.name)
+                exp = exp.expression
+            parts.append(exp.name)
+            table_name = ".".join(parts)
+        else:
+            table_name = table.this.name
         return cls(
             database=table.catalog or default_db,
             db_schema=table.db or default_schema,
-            table=table.this.name,
+            table=table_name,
         )

--- a/metadata-ingestion/tests/unit/sql_parsing/goldens/test_bigquery_information_schema_query.json
+++ b/metadata-ingestion/tests/unit/sql_parsing/goldens/test_bigquery_information_schema_query.json
@@ -1,0 +1,183 @@
+{
+    "query_type": "SELECT",
+    "query_type_props": {},
+    "query_fingerprint": "772187d1c6ce8dbed2dd1ba79975b108d4e733015ffb7bcbf9b7146e64cf9914",
+    "in_tables": [
+        "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+        "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS,PROD)"
+    ],
+    "out_tables": [],
+    "column_lineage": [
+        {
+            "downstream": {
+                "table": null,
+                "column": "table_catalog",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "table_catalog"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "table_schema",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "table_schema"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "table_name",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "table_name"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "column_name",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "column_name"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "ordinal_position",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "ordinal_position"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "field_path",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS,PROD)",
+                    "column": "field_path"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "is_nullable",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "is_nullable"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "data_type",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "data_type"
+                },
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS,PROD)",
+                    "column": "field_path"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "comment",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": []
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "is_hidden",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "is_hidden"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "is_partitioning_column",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "is_partitioning_column"
+                }
+            ]
+        },
+        {
+            "downstream": {
+                "table": null,
+                "column": "clustering_ordinal_position",
+                "column_type": null,
+                "native_column_type": null
+            },
+            "upstreams": [
+                {
+                    "table": "urn:li:dataset:(urn:li:dataPlatform:bigquery,acryl-staging-2.smoke_test_db_4.INFORMATION_SCHEMA.COLUMNS,PROD)",
+                    "column": "clustering_ordinal_position"
+                }
+            ]
+        }
+    ],
+    "debug_info": {
+        "confidence": 0.2,
+        "generalized_statement": "SELECT c.table_catalog AS table_catalog, c.table_schema AS table_schema, c.table_name AS table_name, c.column_name AS column_name, c.ordinal_position AS ordinal_position, cfp.field_path AS field_path, c.is_nullable AS is_nullable, CASE WHEN CONTAINS_SUBSTR(field_path, ?) THEN NULL ELSE c.data_type END AS data_type, description AS comment, c.is_hidden AS is_hidden, c.is_partitioning_column AS is_partitioning_column, c.clustering_ordinal_position AS clustering_ordinal_position FROM `acryl-staging-2`.`smoke_test_db_4`.INFORMATION_SCHEMA.COLUMNS AS c JOIN `acryl-staging-2`.`smoke_test_db_4`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS AS cfp ON cfp.table_name = c.table_name AND cfp.column_name = c.column_name ORDER BY table_catalog, table_schema, table_name, ordinal_position ASC, data_type DESC"
+    }
+}

--- a/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
+++ b/metadata-ingestion/tests/unit/sql_parsing/test_sqlglot_lineage.py
@@ -1171,3 +1171,34 @@ INSERT INTO my_table (id, month, total_cost, area)
         dialect="sqlite",
         expected_file=RESOURCE_DIR / "test_sqlite_insert_into_values.json",
     )
+
+
+def test_bigquery_information_schema_query() -> None:
+    # Special case - the BigQuery INFORMATION_SCHEMA views are prefixed with a
+    # project + possibly a dataset/region, so sometimes are 4 parts instead of 3.
+    # https://cloud.google.com/bigquery/docs/information-schema-intro#syntax
+
+    assert_sql_result(
+        """\
+select
+  c.table_catalog as table_catalog,
+  c.table_schema as table_schema,
+  c.table_name as table_name,
+  c.column_name as column_name,
+  c.ordinal_position as ordinal_position,
+  cfp.field_path as field_path,
+  c.is_nullable as is_nullable,
+  CASE WHEN CONTAINS_SUBSTR(field_path, ".") THEN NULL ELSE c.data_type END as data_type,
+  description as comment,
+  c.is_hidden as is_hidden,
+  c.is_partitioning_column as is_partitioning_column,
+  c.clustering_ordinal_position as clustering_ordinal_position,
+from
+  `acryl-staging-2`.`smoke_test_db_4`.INFORMATION_SCHEMA.COLUMNS c
+  join `acryl-staging-2`.`smoke_test_db_4`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS as cfp on cfp.table_name = c.table_name
+  and cfp.column_name = c.column_name
+ORDER BY
+  table_catalog, table_schema, table_name, ordinal_position ASC, data_type DESC""",
+        dialect="bigquery",
+        expected_file=RESOURCE_DIR / "test_bigquery_information_schema_query.json",
+    )


### PR DESCRIPTION

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parsing capabilities for SQL tables with complex names in BigQuery.
	- Introduced a structured representation of SQL queries targeting BigQuery INFORMATION_SCHEMA, improving data governance and lineage tracking.
	- Added a new test validating the parsing of SQL queries for BigQuery INFORMATION_SCHEMA views.

- **Bug Fixes**
	- Improved the handling of table names in `BigqueryTableIdentifier` to avoid incorrect parsing with additional periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->