### PR TITLE
fix(ui/ingest): Support invalid cron jobs

### DIFF
--- a/datahub-web-react/src/app/context/UserContextProvider.tsx
+++ b/datahub-web-react/src/app/context/UserContextProvider.tsx
@@ -127,6 +127,7 @@ const UserContextProvider = ({ children }: { children: React.ReactNode }) => {
     return (
         <UserContext.Provider
             value={{
+                loaded: !!meData,
                 urn: meData?.me?.corpUser?.urn,
                 user: meData?.me?.corpUser as CorpUser,
                 platformPrivileges: meData?.me?.platformPrivileges as PlatformPrivileges,

--- a/datahub-web-react/src/app/context/userContext.tsx
+++ b/datahub-web-react/src/app/context/userContext.tsx
@@ -28,6 +28,7 @@ export type State = {
  * Context about the currently-authenticated user.
  */
 export type UserContextType = {
+    loaded: boolean;
     urn?: string | null;
     user?: CorpUser | null;
     platformPrivileges?: PlatformPrivileges | null;
@@ -53,6 +54,7 @@ export const DEFAULT_STATE: State = {
 };
 
 export const DEFAULT_CONTEXT = {
+    loaded: false,
     urn: undefined,
     user: undefined,
     state: DEFAULT_STATE,

--- a/datahub-web-react/src/app/ingest/ManageIngestionPage.tsx
+++ b/datahub-web-react/src/app/ingest/ManageIngestionPage.tsx
@@ -55,8 +55,7 @@ export const ManageIngestionPage = () => {
     const isIngestionEnabled = config?.managedIngestionConfig.enabled;
     const showIngestionTab = isIngestionEnabled && me && me.platformPrivileges?.manageIngestion;
     const showSecretsTab = isIngestionEnabled && me && me.platformPrivileges?.manageSecrets;
-    const defaultTab = showSecretsTab ? TabType.Secrets : TabType.Sources;
-    const [selectedTab, setSelectedTab] = useState<TabType>(defaultTab);
+    const [selectedTab, setSelectedTab] = useState<TabType>(TabType.Sources);
 
     // defaultTab might not be calculated correctly on mount, if `config` or `me` haven't been loaded yet
     useEffect(() => {

--- a/datahub-web-react/src/app/ingest/ManageIngestionPage.tsx
+++ b/datahub-web-react/src/app/ingest/ManageIngestionPage.tsx
@@ -1,5 +1,5 @@
 import { Tabs, Typography } from 'antd';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { IngestionSourceList } from './source/IngestionSourceList';
 import { useAppConfig } from '../useAppConfig';
@@ -51,12 +51,19 @@ export const ManageIngestionPage = () => {
      * Determines which view should be visible: ingestion sources or secrets.
      */
     const me = useUserContext();
-    const { config } = useAppConfig();
+    const { config, loaded } = useAppConfig();
     const isIngestionEnabled = config?.managedIngestionConfig.enabled;
     const showIngestionTab = isIngestionEnabled && me && me.platformPrivileges?.manageIngestion;
     const showSecretsTab = isIngestionEnabled && me && me.platformPrivileges?.manageSecrets;
-    const defaultTab = showIngestionTab ? TabType.Sources : TabType.Secrets;
+    const defaultTab = showSecretsTab ? TabType.Secrets : TabType.Sources;
     const [selectedTab, setSelectedTab] = useState<TabType>(defaultTab);
+
+    // defaultTab might not be calculated correctly on mount, if `config` or `me` haven't been loaded yet
+    useEffect(() => {
+        if (loaded && me.loaded && !showIngestionTab && selectedTab === TabType.Sources) {
+            setSelectedTab(TabType.Secrets);
+        }
+    }, [loaded, me.loaded, showIngestionTab, selectedTab]);
 
     const onClickTab = (newTab: string) => {
         setSelectedTab(TabType[newTab]);

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
@@ -106,7 +106,13 @@ export function LastExecutionColumn(time: any) {
 }
 
 export function ScheduleColumn(schedule: any, record: any) {
-    const tooltip = schedule && `Runs ${cronstrue.toString(schedule).toLowerCase()} (${record.timezone})`;
+    let tooltip = '';
+    try {
+        tooltip = schedule && `Runs ${cronstrue.toString(schedule).toLowerCase()} (${record.timezone})`;
+    } catch (e) {
+        tooltip = 'Invalid cron schedule';
+        console.debug('Error parsing cron schedule', e);
+    }
     return (
         <Tooltip title={tooltip || 'Not scheduled'}>
             <Typography.Text code>{schedule || 'None'}</Typography.Text>

--- a/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
+++ b/datahub-web-react/src/app/ingest/source/IngestionSourceTableColumns.tsx
@@ -106,7 +106,7 @@ export function LastExecutionColumn(time: any) {
 }
 
 export function ScheduleColumn(schedule: any, record: any) {
-    let tooltip = '';
+    let tooltip: string;
     try {
         tooltip = schedule && `Runs ${cronstrue.toString(schedule).toLowerCase()} (${record.timezone})`;
     } catch (e) {

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
@@ -8,12 +8,6 @@ const ingestion_source_name = `ingestion source ${number}`;
 
 describe("managing secrets for ingestion creation", () => {
   it("create a secret, create ingestion source using a secret, remove a secret", () => {
-    Cypress.on("uncaught:exception", (err, runnable) => {
-      // returning false here prevents Cypress from
-      // failing the test
-      return false;
-    });
-
     // Navigate to the manage ingestion page → secrets
     cy.loginWithCredentials();
     cy.goToIngestionPage();

--- a/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
+++ b/smoke-test/tests/cypress/cypress/e2e/mutations/managing_secrets.js
@@ -8,9 +8,16 @@ const ingestion_source_name = `ingestion source ${number}`;
 
 describe("managing secrets for ingestion creation", () => {
   it("create a secret, create ingestion source using a secret, remove a secret", () => {
+    Cypress.on("uncaught:exception", (err, runnable) => {
+      // returning false here prevents Cypress from
+      // failing the test
+      return false;
+    });
+
     // Navigate to the manage ingestion page → secrets
     cy.loginWithCredentials();
     cy.goToIngestionPage();
+    cy.clickOptionWithText("Secrets");
 
     // Create a new secret
     cy.clickOptionWithTestId("create-secret-button");


### PR DESCRIPTION
Separately, should add some validation on the `datahub ingest deploy` command on cron strings.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `loaded` property in the user context to indicate if user data has been loaded.
	- Updated tab visibility logic in the ingestion management page to reflect user permissions more accurately.
	- Enhanced Cypress tests with improved error handling for managing secrets during ingestion creation.

- **Bug Fixes**
	- Improved error handling in the Ingestion Source table tooltip for cron schedule parsing, ensuring graceful handling of invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->