### PR TITLE
feat(ece): support custom ownership type urns in ECE generation

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/OwnerChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/OwnerChangeEvent.java
@@ -42,7 +42,7 @@ public class OwnerChangeEvent extends ChangeEvent {
 
   private static ImmutableMap<String, Object> buildParameters(
       Urn ownerUrn, OwnershipType ownerType, Urn ownerTypeUrn) {
-    var builder =
+    ImmutableMap.Builder<String, Object> builder =
         new ImmutableMap.Builder<String, Object>()
             .put("ownerUrn", ownerUrn.toString())
             .put("ownerType", ownerType.toString());

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/OwnerChangeEvent.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/data/entity/OwnerChangeEvent.java
@@ -27,17 +27,29 @@ public class OwnerChangeEvent extends ChangeEvent {
       SemanticChangeType semVerChange,
       String description,
       Urn ownerUrn,
-      OwnershipType ownerType) {
+      OwnershipType ownerType,
+      Urn ownerTypeUrn) {
     super(
         entityUrn,
         category,
         operation,
         modifier,
-        ImmutableMap.of(
-            "ownerUrn", ownerUrn.toString(),
-            "ownerType", ownerType.toString()),
+        buildParameters(ownerUrn, ownerType, ownerTypeUrn),
         auditStamp,
         semVerChange,
         description);
+  }
+
+  private static ImmutableMap<String, Object> buildParameters(
+      Urn ownerUrn, OwnershipType ownerType, Urn ownerTypeUrn) {
+    var builder =
+        new ImmutableMap.Builder<String, Object>()
+            .put("ownerUrn", ownerUrn.toString())
+            .put("ownerType", ownerType.toString());
+    if (ownerTypeUrn != null) {
+      builder.put("ownerTypeUrn", ownerTypeUrn.toString());
+    }
+
+    return builder.build();
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/OwnershipChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/OwnershipChangeEventGenerator.java
@@ -62,6 +62,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
                           entityUrn))
                   .ownerUrn(targetOwner.getOwner())
                   .ownerType(targetOwner.getType())
+                  .ownerTypeUrn(targetOwner.getTypeUrn())
                   .auditStamp(auditStamp)
                   .build());
         }
@@ -84,6 +85,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
                         entityUrn))
                 .ownerUrn(baseOwner.getOwner())
                 .ownerType(baseOwner.getType())
+                .ownerTypeUrn(baseOwner.getTypeUrn())
                 .auditStamp(auditStamp)
                 .build());
         ++baseOwnerIdx;
@@ -104,6 +106,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
                         entityUrn))
                 .ownerUrn(targetOwner.getOwner())
                 .ownerType(targetOwner.getType())
+                .ownerTypeUrn(targetOwner.getTypeUrn())
                 .auditStamp(auditStamp)
                 .build());
         ++targetOwnerIdx;
@@ -128,6 +131,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
                       entityUrn))
               .ownerUrn(baseOwner.getOwner())
               .ownerType(baseOwner.getType())
+              .ownerTypeUrn(baseOwner.getTypeUrn())
               .auditStamp(auditStamp)
               .build());
       ++baseOwnerIdx;
@@ -150,6 +154,7 @@ public class OwnershipChangeEventGenerator extends EntityChangeEventGenerator<Ow
                       entityUrn))
               .ownerUrn(targetOwner.getOwner())
               .ownerType(targetOwner.getType())
+              .ownerTypeUrn(targetOwner.getTypeUrn())
               .auditStamp(auditStamp)
               .build());
       ++targetOwnerIdx;

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/event/EntityChangeEventGeneratorHookTest.java
@@ -309,11 +309,16 @@ public class EntityChangeEventGeneratorHookTest {
     final Ownership newOwners = new Ownership();
     final Urn ownerUrn1 = Urn.createFromString("urn:li:corpuser:test1");
     final Urn ownerUrn2 = Urn.createFromString("urn:li:corpuser:test2");
+    final Urn ownerUrn3 = Urn.createFromString("urn:li:corpuser:test3");
     newOwners.setOwners(
         new OwnerArray(
             ImmutableList.of(
                 new Owner().setOwner(ownerUrn1).setType(OwnershipType.TECHNICAL_OWNER),
-                new Owner().setOwner(ownerUrn2).setType(OwnershipType.BUSINESS_OWNER))));
+                new Owner().setOwner(ownerUrn2).setType(OwnershipType.BUSINESS_OWNER),
+                new Owner()
+                    .setOwner(ownerUrn3)
+                    .setType(OwnershipType.CUSTOM)
+                    .setTypeUrn(Urn.createFromString("urn:li:ownershipType:my_custom_type")))));
     final Ownership prevOwners = new Ownership();
     prevOwners.setOwners(new OwnerArray());
     event.setAspect(GenericRecordUtils.serializeAspect(newOwners));
@@ -354,7 +359,24 @@ public class EntityChangeEventGeneratorHookTest {
                 "ownerType",
                 OwnershipType.BUSINESS_OWNER.toString()),
             actorUrn);
-    verifyProducePlatformEvent(_mockClient, platformEvent2, true);
+    verifyProducePlatformEvent(_mockClient, platformEvent2, false);
+
+    PlatformEvent platformEvent3 =
+        createChangeEvent(
+            DATASET_ENTITY_NAME,
+            Urn.createFromString(TEST_DATASET_URN),
+            ChangeCategory.OWNER,
+            ChangeOperation.ADD,
+            ownerUrn3.toString(),
+            ImmutableMap.of(
+                "ownerUrn",
+                ownerUrn3.toString(),
+                "ownerType",
+                OwnershipType.CUSTOM.toString(),
+                "ownerTypeUrn",
+                "urn:li:ownershipType:my_custom_type"),
+            actorUrn);
+    verifyProducePlatformEvent(_mockClient, platformEvent3, true);
   }
 
   @Test


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced ownership change tracking with the ability to include optional owner type information.
	- Introduced a new ownership type for better granularity in ownership change events.

- **Bug Fixes**
	- Adjusted verification logic for ownership events to account for new ownership types.

- **Tests**
	- Updated tests to include new ownership scenarios and verify the integration of custom ownership types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->