### PR TITLE
Fix: bug fix for empty key values pair in elastic search mapping

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -287,8 +287,10 @@ public class SearchDocumentTransformer {
           .forEach(
               fieldValue -> {
                 String[] keyValues = fieldValue.toString().split("=");
-                String key = keyValues[0];
-                String value = keyValues[1];
+                String key = keyValues[0], value = "";
+                if (keyValues.length > 1) {
+                  value = keyValues[1];
+                }
                 dictDoc.put(key, value);
               });
       searchDocument.set(fieldName, dictDoc);

--- a/metadata-io/src/test/java/com/linkedin/metadata/TestEntityUtil.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/TestEntityUtil.java
@@ -65,6 +65,8 @@ public class TestEntityUtil {
                 "value1",
                 "key2",
                 "value2",
+                "key3",
+                "",
                 "shortValue",
                 "123",
                 "longValue",

--- a/metadata-io/src/test/java/com/linkedin/metadata/extractor/FieldExtractorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/extractor/FieldExtractorTest.java
@@ -57,7 +57,8 @@ public class FieldExtractorTest {
         ImmutableList.of("key1=value1", "key2=value2", "shortValue=123", "longValue=0123456789"));
     assertEquals(
         result.get(nameToSpec.get("esObjectField")),
-        ImmutableList.of("key1=value1", "key2=value2", "shortValue=123", "longValue=0123456789"));
+        ImmutableList.of(
+            "key1=value1", "key2=value2", "shortValue=123", "key3=", "longValue=0123456789"));
   }
 
   @Test
@@ -99,9 +100,6 @@ public class FieldExtractorTest {
         result.get(nameToSpec.get("customProperties")),
         ImmutableList.of(),
         "Expected no matching values because of value limit of 1");
-    assertEquals(
-        result.get(nameToSpec.get("esObjectField")),
-        ImmutableList.of(),
-        "Expected no matching values because of value limit of 1");
+    assertEquals(result.get(nameToSpec.get("esObjectField")), ImmutableList.of("key3="));
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
@@ -85,6 +85,7 @@ public class SearchDocumentTransformerTest {
     assertEquals(parsedJson.get("feature2").asInt(), 1);
     JsonNode browsePathV2 = (JsonNode) parsedJson.get("browsePathV2");
     assertEquals(browsePathV2.asText(), "␟levelOne␟levelTwo");
+    assertEquals(parsedJson.get("esObjectField").get("key3").asText(), "");
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
@@ -126,7 +126,8 @@ public class SearchDocumentTransformerTest {
     assertEquals(
         parsedJson.get("customProperties"),
         JsonNodeFactory.instance.arrayNode().add("shortValue=123"));
-    assertEquals(parsedJson.get("esObjectField"), JsonNodeFactory.instance.arrayNode().add("123"));
+    assertEquals(
+        parsedJson.get("esObjectField"), JsonNodeFactory.instance.arrayNode().add("123").add(""));
 
     searchDocumentTransformer = new SearchDocumentTransformer(1000, 1000, 20);
     snapshot = TestEntityUtil.getSnapshot();
@@ -150,6 +151,7 @@ public class SearchDocumentTransformerTest {
             .add("value1")
             .add("value2")
             .add("123")
+            .add("")
             .add("0123456789"));
   }
 


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of input format in search document processing to improve robustness.
	- Expanded capabilities of test entity information retrieval for more dynamic input.
  
- **Bug Fixes**
	- Improved prevention of runtime exceptions related to input string formats.

- **Tests**
	- Added new assertions in the test suite to validate the transformation logic, ensuring expected JSON structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->