### PR TITLE
build(ingest/airflow): Pinning setuptools to fix click-default-group build issue

### DIFF
--- a/metadata-ingestion-modules/airflow-plugin/build.gradle
+++ b/metadata-ingestion-modules/airflow-plugin/build.gradle
@@ -26,7 +26,7 @@ task environmentSetup(type: Exec) {
   outputs.file(sentinel_file)
   commandLine 'bash', '-c', 
     "${python_executable} -m venv ${venv_name} && set -x && " +
-    "${venv_name}/bin/python -m pip install --upgrade pip uv wheel 'setuptools>=63.0.0' && " +
+    "${venv_name}/bin/python -m pip install --upgrade pip uv wheel 'setuptools>=63.0.0,<72.0.0' && " +
     "touch ${sentinel_file}"
 }
 

--- a/metadata-ingestion-modules/airflow-plugin/pyproject.toml
+++ b/metadata-ingestion-modules/airflow-plugin/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=54.0.0", "wheel", "pip>=21.0.0"]
+# setuptools needs to be less than 72.0.0 to because of an issue with click-default-group==1.2.2 -> https://stackoverflow.com/questions/78806100/no-module-named-setuptools-command-test
+requires = ["setuptools>=54.0.0,<72.0.0", "wheel", "pip>=21.0.0"]
 
 [tool.black]
 extend-exclude = '''

--- a/metadata-ingestion-modules/airflow-plugin/pyproject.toml
+++ b/metadata-ingestion-modules/airflow-plugin/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-# setuptools needs to be less than 72.0.0 to because of an issue with click-default-group==1.2.2 -> https://stackoverflow.com/questions/78806100/no-module-named-setuptools-command-test
-requires = ["setuptools>=54.0.0,<72.0.0", "wheel", "pip>=21.0.0"]
+requires = ["setuptools>=54.0.0", "wheel", "pip>=21.0.0"]
 
 [tool.black]
 extend-exclude = '''


### PR DESCRIPTION
click-default-group setup fails with the latest setuptools:
```
error: Failed to download and build `click-default-group==1.2.2`
  Caused by: Failed to build: `click-default-group==1.2.2`
  Caused by: Build backend failed to determine extra requires with `build_wheel()` with exit status: 1
```

See details here:
https://stackoverflow.com/questions/78806100/no-module-named-setuptools-command-test## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version constraints for `setuptools` to improve compatibility and avoid potential issues with newer versions.
  
- **Bug Fixes**
	- Adjusted requirements to ensure compatibility with the `click-default-group` package, enhancing stability during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->