### PR TITLE
docs(custom properties): Remove duplicate from sidebar

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -816,7 +816,6 @@ module.exports = {
     },
     {
       "API & SDK Guides": [
-        "docs/api/tutorials/custom-properties",
         "docs/api/tutorials/datasets",
         "docs/api/tutorials/deprecation",
         "docs/api/tutorials/descriptions",


### PR DESCRIPTION
Custom Properties appears twice in the sidebar. Removes one of them.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined navigation by removing the "Custom Properties" tutorial from the documentation sidebar, enhancing accessibility to relevant resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->