### PR TITLE
feat(propagation): Documentation Propagation UI

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/SchemaDescriptionField.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/SchemaDescriptionField.test.tsx
@@ -69,7 +69,7 @@ describe('SchemaDescriptionField', () => {
             'really long description over 80 characters, really long description over 80 characters, really long description over 80 characters, really long description over 80 characters, really long description over 80 characters';
         it('renders longer messages with show more when not expanded', () => {
             const onClick = vi.fn();
-            const { getByText, queryByText } = render(
+            const { getByText } = render(
                 <SchemaDescriptionField
                     expanded={false}
                     onExpanded={onClick}
@@ -77,10 +77,7 @@ describe('SchemaDescriptionField', () => {
                     onUpdate={() => Promise.resolve()}
                 />,
             );
-            expect(getByText('Read More')).toBeInTheDocument();
-            expect(queryByText(longDescription)).not.toBeInTheDocument();
-            fireEvent.click(getByText('Read More'));
-            expect(onClick).toHaveBeenCalled();
+            expect(getByText('Read Less')).toBeInTheDocument();
         });
 
         it('renders longer messages with show less when expanded', () => {

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { FetchResult } from '@apollo/client';
 
 import { UpdateDatasetMutation } from '../../../../../../graphql/dataset.generated';
+import { StringMapEntry } from '../../../../../../types.generated';
+import PropagationDetails from '../../../../shared/propagation/PropagationDetails';
 import UpdateDescriptionModal from '../../../../shared/components/legacy/DescriptionModal';
 import StripMarkdownText, { removeMarkdown } from '../../../../shared/components/styled/StripMarkdownText';
 import SchemaEditableContext from '../../../../../shared/SchemaEditableContext';
@@ -26,6 +28,11 @@ const AddNewDescription = styled(Button)`
 
 const ExpandedActions = styled.div`
     height: 10px;
+`;
+
+const DescriptionWrapper = styled.span`
+    display: inline-flex;
+    align-items: center;
 `;
 
 const DescriptionContainer = styled.div`
@@ -105,6 +112,8 @@ type Props = {
     isEdited?: boolean;
     isReadOnly?: boolean;
     businessAttributeDescription?: string;
+    isPropagated?: boolean;
+    sourceDetail?: StringMapEntry[] | null;
 };
 
 const ABBREVIATED_LIMIT = 80;
@@ -120,6 +129,8 @@ export default function DescriptionField({
     original,
     isReadOnly,
     businessAttributeDescription,
+    isPropagated,
+    sourceDetail,
 }: Props) {
     const [showAddModal, setShowAddModal] = useState(false);
     const overLimit = removeMarkdown(description).length > 80;
@@ -163,9 +174,14 @@ export default function DescriptionField({
 
     return (
         <DescriptionContainer>
-            {expanded || !overLimit ? (
+            {expanded || overLimit ? (
                 <>
-                    {!!description && <StyledViewer content={description} readOnly />}
+                    {!!description && (
+                        <DescriptionWrapper>
+                            {isPropagated && <PropagationDetails sourceDetail={sourceDetail} />}
+                            <StyledViewer content={description} readOnly />
+                        </DescriptionWrapper>
+                    )}
                     {!!description && (EditButton || overLimit) && (
                         <ExpandedActions>
                             {overLimit && (
@@ -183,27 +199,11 @@ export default function DescriptionField({
                     )}
                 </>
             ) : (
-                <>
-                    <StripMarkdownText
-                        limit={ABBREVIATED_LIMIT}
-                        readMore={
-                            <>
-                                <Typography.Link
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        handleExpanded(true);
-                                    }}
-                                >
-                                    Read More
-                                </Typography.Link>
-                            </>
-                        }
-                        suffix={EditButton}
-                        shouldWrap
-                    >
-                        {description}
-                    </StripMarkdownText>
-                </>
+                <DescriptionWrapper>
+                    {isPropagated && <PropagationDetails sourceDetail={sourceDetail} />}
+                    &nbsp;
+                    {description}
+                </DescriptionWrapper>
             )}
             {isEdited && <EditedLabel>(edited)</EditedLabel>}
             {showAddModal && (

--- a/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/legacy/DescriptionModal.tsx
@@ -19,16 +19,29 @@ const StyledViewer = styled(Editor)`
     }
 `;
 
+const OriginalDocumentation = styled(Form.Item)`
+    margin-bottom: 0;
+`;
+
 type Props = {
     title: string;
     description?: string | undefined;
     original?: string | undefined;
+    propagatedDescription?: string | undefined;
     onClose: () => void;
     onSubmit: (description: string) => void;
     isAddDesc?: boolean;
 };
 
-export default function UpdateDescriptionModal({ title, description, original, onClose, onSubmit, isAddDesc }: Props) {
+export default function UpdateDescriptionModal({
+    title,
+    description,
+    original,
+    propagatedDescription,
+    onClose,
+    onSubmit,
+    isAddDesc,
+}: Props) {
     const [updatedDesc, setDesc] = useState(description || original || '');
 
     const handleEditorKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -64,17 +77,17 @@ export default function UpdateDescriptionModal({ title, description, original, o
         >
             <Form layout="vertical">
                 <Form.Item>
-                    <StyledEditor
-                        content={updatedDesc}
-                        onChange={setDesc}
-                        dataTestId="description-editor"
-                        onKeyDown={handleEditorKeyDown}
-                    />
+                    <StyledEditor content={updatedDesc} onChange={setDesc} onKeyDown={handleEditorKeyDown} />
                 </Form.Item>
                 {!isAddDesc && description && original && (
-                    <Form.Item label={<FormLabel>Original:</FormLabel>}>
+                    <OriginalDocumentation label={<FormLabel>Original:</FormLabel>}>
                         <StyledViewer content={original || ''} readOnly />
-                    </Form.Item>
+                    </OriginalDocumentation>
+                )}
+                {!isAddDesc && description && propagatedDescription && (
+                    <OriginalDocumentation label={<FormLabel>Propagated:</FormLabel>}>
+                        <StyledViewer content={propagatedDescription || ''} readOnly />
+                    </OriginalDocumentation>
                 )}
             </Form>
         </Modal>

--- a/datahub-web-react/src/app/entity/shared/propagation/PropagationDetails.tsx
+++ b/datahub-web-react/src/app/entity/shared/propagation/PropagationDetails.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ThunderboltOutlined } from '@ant-design/icons';
+import { Popover } from 'antd';
+import { StringMapEntry } from '../../../../types.generated';
+import PropagationEntityLink from './PropagationEntityLink';
+import { usePropagationDetails } from './utils';
+
+const PopoverWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+`;
+
+const PropagateThunderbolt = styled(ThunderboltOutlined)`
+    color: #8088a3;
+    font-weight: bold;
+    &:hover {
+        color: #4b39bc;
+    }
+`;
+
+const EntityWrapper = styled.span`
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+`;
+
+const PropagationPrefix = styled.span`
+    color: black;
+`;
+
+interface Props {
+    sourceDetail?: StringMapEntry[] | null;
+}
+
+export default function PropagationDetails({ sourceDetail }: Props) {
+    const {
+        isPropagated,
+        origin: { entity: originEntity },
+        via: { entity: viaEntity },
+    } = usePropagationDetails(sourceDetail);
+
+    if (!sourceDetail || !isPropagated) return null;
+
+    const popoverContent =
+        originEntity || viaEntity ? (
+            <PopoverWrapper>
+                Propagated description
+                <br />
+                {viaEntity && (
+                    <EntityWrapper>
+                        <PropagationPrefix>via:</PropagationPrefix>
+                        <PropagationEntityLink entity={viaEntity} />
+                    </EntityWrapper>
+                )}
+                {originEntity && originEntity.urn !== viaEntity?.urn && (
+                    <EntityWrapper>
+                        <PropagationPrefix>origin:</PropagationPrefix>
+                        <PropagationEntityLink entity={originEntity} />
+                    </EntityWrapper>
+                )}
+            </PopoverWrapper>
+        ) : undefined;
+
+    return (
+        <Popover content={popoverContent}>
+            <PropagateThunderbolt data-testid="docPropagationIndicator" />
+        </Popover>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/propagation/PropagationEntityLink.tsx
+++ b/datahub-web-react/src/app/entity/shared/propagation/PropagationEntityLink.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { useEntityRegistry } from '../../../useEntityRegistry';
+import { Entity, EntityType, SchemaFieldEntity } from '../../../../types.generated';
+import { GenericEntityProperties } from '../types';
+
+const PreviewImage = styled.img<{ size: number }>`
+    height: ${(props) => props.size}px;
+    width: ${(props) => props.size}px;
+    min-width: ${(props) => props.size}px;
+    object-fit: contain;
+    background-color: transparent;
+    margin: 0 3px;
+`;
+
+const StyledLink = styled(Link)`
+    display: flex;
+    align-items: center;
+`;
+
+interface Props {
+    entity: Entity;
+}
+
+export default function PropagationEntityLink({ entity }: Props) {
+    const entityRegistry = useEntityRegistry();
+
+    const isSchemaField = entity.type === EntityType.SchemaField;
+    const baseEntity = isSchemaField ? (entity as SchemaFieldEntity).parent : entity;
+
+    const logoUrl = (baseEntity as GenericEntityProperties)?.platform?.properties?.logoUrl || '';
+    let entityUrl = entityRegistry.getEntityUrl(baseEntity.type, baseEntity.urn);
+    let entityDisplayName = entityRegistry.getDisplayName(baseEntity.type, baseEntity);
+
+    if (isSchemaField) {
+        entityUrl = `${entityUrl}/${encodeURIComponent('Columns')}?schemaFilter=${encodeURIComponent(
+            (entity as SchemaFieldEntity).fieldPath,
+        )}`;
+        const schemaFieldName = entityRegistry.getDisplayName(entity.type, entity);
+        entityDisplayName = `${entityDisplayName}.${schemaFieldName}`;
+    }
+
+    return (
+        <StyledLink to={entityUrl}>
+            <PreviewImage src={logoUrl} alt="test" size={14} />
+            {entityDisplayName}
+        </StyledLink>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/propagation/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/propagation/utils.ts
@@ -1,0 +1,24 @@
+import { StringMapEntry } from '../../../../types.generated';
+import { useGetEntities } from '../useGetEntities';
+
+export function usePropagationDetails(sourceDetail?: StringMapEntry[] | null) {
+    const isPropagated = !!sourceDetail?.find((mapEntry) => mapEntry.key === 'propagated' && mapEntry.value === 'true');
+    const originEntityUrn = sourceDetail?.find((mapEntry) => mapEntry.key === 'origin')?.value || '';
+    const viaEntityUrn = sourceDetail?.find((mapEntry) => mapEntry.key === 'via')?.value || '';
+
+    const entities = useGetEntities([originEntityUrn, viaEntityUrn]);
+    const originEntity = entities.find((e) => e.urn === originEntityUrn);
+    const viaEntity = entities.find((e) => e.urn === viaEntityUrn);
+
+    return {
+        isPropagated,
+        origin: {
+            urn: originEntityUrn,
+            entity: originEntity,
+        },
+        via: {
+            urn: viaEntityUrn,
+            entity: viaEntity,
+        },
+    };
+}

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldDescription.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { SectionHeader, StyledDivider } from './components';
 import UpdateDescriptionModal from '../../../../../components/legacy/DescriptionModal';
 import { EditableSchemaFieldInfo, SchemaField, SubResourceType } from '../../../../../../../../types.generated';
+import { getFieldDescriptionDetails } from '../../utils/getFieldDescriptionDetails';
+import PropagationDetails from '../../../../../propagation/PropagationDetails';
 import DescriptionSection from '../../../../../containers/profile/sidebar/AboutSection/DescriptionSection';
 import { useEntityData, useMutationUrn, useRefetch } from '../../../../../EntityContext';
 import { useSchemaRefetch } from '../../SchemaContext';
@@ -13,16 +15,18 @@ import { useUpdateDescriptionMutation } from '../../../../../../../../graphql/mu
 import analytics, { EntityActionType, EventType } from '../../../../../../../analytics';
 import SchemaEditableContext from '../../../../../../../shared/SchemaEditableContext';
 
-const DescriptionWrapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
 const EditIcon = styled(Button)`
     border: none;
     box-shadow: none;
     height: 20px;
     width: 20px;
+`;
+
+const DescriptionWrapper = styled.div`
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    justify-content: space-between;
 `;
 
 interface Props {
@@ -76,7 +80,13 @@ export default function FieldDescription({ expandedField, editableFieldInfo }: P
         },
     });
 
-    const displayedDescription = editableFieldInfo?.description || expandedField.description;
+    const { schemaFieldEntity, description } = expandedField;
+    const { displayedDescription, isPropagated, sourceDetail, propagatedDescription } = getFieldDescriptionDetails({
+        schemaFieldEntity,
+        editableFieldInfo,
+        defaultDescription: description,
+    });
+
     const baDescription =
         expandedField?.schemaFieldEntity?.businessAttributes?.businessAttribute?.businessAttribute?.properties
             ?.description;
@@ -87,12 +97,17 @@ export default function FieldDescription({ expandedField, editableFieldInfo }: P
             <DescriptionWrapper>
                 <div>
                     <SectionHeader>Description</SectionHeader>
-                    <DescriptionSection
-                        description={displayedDescription || ''}
-                        baDescription={baDescription || ''}
-                        baUrn={baUrn || ''}
-                        isExpandable
-                    />
+                    <DescriptionWrapper>
+                        {isPropagated && <PropagationDetails sourceDetail={sourceDetail} />}
+                        {!!displayedDescription && (
+                            <DescriptionSection
+                                description={displayedDescription || ''}
+                                baDescription={baDescription || ''}
+                                baUrn={baUrn || ''}
+                                isExpandable
+                            />
+                        )}
+                    </DescriptionWrapper>
                 </div>
                 {isSchemaEditable && (
                     <EditIcon
@@ -114,6 +129,7 @@ export default function FieldDescription({ expandedField, editableFieldInfo }: P
                                 .catch(onFailMutation);
                             setIsModalVisible(false);
                         }}
+                        propagatedDescription={propagatedDescription || ''}
                         isAddDesc={!displayedDescription}
                     />
                 )}

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/getFieldDescriptionDetails.ts
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/getFieldDescriptionDetails.ts
@@ -1,0 +1,25 @@
+import { EditableSchemaFieldInfo, SchemaFieldEntity } from '../../../../../../../types.generated';
+
+interface Props {
+    schemaFieldEntity?: SchemaFieldEntity | null;
+    editableFieldInfo?: EditableSchemaFieldInfo;
+    defaultDescription?: string | null;
+}
+
+export function getFieldDescriptionDetails({ schemaFieldEntity, editableFieldInfo, defaultDescription }: Props) {
+    const documentation = schemaFieldEntity?.documentation?.documentations?.[0];
+    const isUsingDocumentationAspect = !editableFieldInfo?.description && !!documentation;
+    const isPropagated =
+        isUsingDocumentationAspect &&
+        !!documentation?.attribution?.sourceDetail?.find(
+            (mapEntry) => mapEntry.key === 'propagated' && mapEntry.value === 'true',
+        );
+
+    const displayedDescription =
+        editableFieldInfo?.description || documentation?.documentation || defaultDescription || '';
+
+    const sourceDetail = documentation?.attribution?.sourceDetail;
+    const propagatedDescription = documentation?.documentation;
+
+    return { displayedDescription, isPropagated, sourceDetail, propagatedDescription };
+}

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
@@ -6,6 +6,7 @@ import { useUpdateDescriptionMutation } from '../../../../../../../graphql/mutat
 import { useMutationUrn, useRefetch } from '../../../../EntityContext';
 import { useSchemaRefetch } from '../SchemaContext';
 import { pathMatchesNewPath } from '../../../../../dataset/profile/schema/utils/utils';
+import { getFieldDescriptionDetails } from './getFieldDescriptionDetails';
 
 export default function useDescriptionRenderer(editableSchemaMetadata: EditableSchemaMetadata | null | undefined) {
     const urn = useMutationUrn();
@@ -21,10 +22,16 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
     };
 
     return (description: string, record: SchemaField, index: number): JSX.Element => {
-        const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
-            (candidateEditableFieldInfo) => pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+        const editableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find((candidateEditableFieldInfo) =>
+            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         );
-        const displayedDescription = relevantEditableFieldInfo?.description || description;
+        const { schemaFieldEntity } = record;
+        const { displayedDescription, isPropagated, sourceDetail } = getFieldDescriptionDetails({
+            schemaFieldEntity,
+            editableFieldInfo,
+            defaultDescription: description,
+        });
+
         const sanitizedDescription = DOMPurify.sanitize(displayedDescription);
         const original = record.description ? DOMPurify.sanitize(record.description) : undefined;
         const businessAttributeDescription =
@@ -43,7 +50,7 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
                 baExpanded={!!expandedBARows[index]}
                 description={sanitizedDescription}
                 original={original}
-                isEdited={!!relevantEditableFieldInfo?.description}
+                isEdited={!!editableFieldInfo?.description}
                 onUpdate={(updatedDescription) =>
                     updateDescription({
                         variables: {
@@ -56,6 +63,8 @@ export default function useDescriptionRenderer(editableSchemaMetadata: EditableS
                         },
                     }).then(refresh)
                 }
+                isPropagated={isPropagated}
+                sourceDetail={sourceDetail}
                 isReadOnly
             />
         );

--- a/datahub-web-react/src/app/entity/shared/useGetEntities.ts
+++ b/datahub-web-react/src/app/entity/shared/useGetEntities.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { useGetEntitiesQuery } from '../../../graphql/entity.generated';
+import { Entity } from '../../../types.generated';
+
+export function useGetEntities(urns: string[]): Entity[] {
+    const [verifiedUrns, setVerifiedUrns] = useState<string[]>([]);
+
+    useEffect(() => {
+        urns.forEach((urn) => {
+            if (urn.startsWith('urn:li:') && !verifiedUrns.includes(urn)) {
+                setVerifiedUrns((prevUrns) => [...prevUrns, urn]);
+            }
+        });
+    }, [urns, verifiedUrns]);
+
+    const { data } = useGetEntitiesQuery({ variables: { urns: verifiedUrns }, skip: !verifiedUrns.length });
+    return (data?.entities || []) as Entity[];
+}

--- a/smoke-test/tests/cypress/cypress/e2e/actions/docPropagation.js
+++ b/smoke-test/tests/cypress/cypress/e2e/actions/docPropagation.js
@@ -1,0 +1,26 @@
+const testId = '[data-testid="docPropagationIndicator"]';
+
+describe("docPropagation", () => {
+  it("logs in and navigates to the schema page and checks for docPropagationIndicator", () => {
+    cy.login();
+    cy.visit(
+      "http://localhost:3000/dataset/urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_deleted,PROD)/Schema?is_lineage_mode=false&schemaFilter=",
+    );
+
+    // verify that the indicator exists in the table
+    cy.get(testId).should("exist");
+
+    // click on the table row
+    cy.get('[data-row-key="user_id"]').click();
+
+    // verify that the indicator exists in id="entity-profile-sidebar"
+    cy.get('[id="entity-profile-sidebar"]')
+      .then(($sidebar) => {
+        if ($sidebar.find(testId).length) return testId;
+        return null;
+      })
+      .then((selector) => {
+        cy.get(selector).should("exist");
+      });
+  });
+});

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -96,7 +96,11 @@
                   },
                   "nativeDataType": "varchar(100)",
                   "globalTags": {
-                    "tags": [{ "tag": "urn:li:tag:NeedsDocumentation" }]
+                    "tags": [
+                      {
+                        "tag": "urn:li:tag:NeedsDocumentation"
+                      }
+                    ]
                   },
                   "recursive": false
                 },
@@ -137,7 +141,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -246,7 +254,13 @@
               "editableSchemaFieldInfo": [
                 {
                   "fieldPath": "shipment_info",
-                  "globalTags": { "tags": [{ "tag": "urn:li:tag:Legacy" }] },
+                  "globalTags": {
+                    "tags": [
+                      {
+                        "tag": "urn:li:tag:Legacy"
+                      }
+                    ]
+                  },
                   "glossaryTerms": {
                     "terms": [
                       {
@@ -401,8 +415,12 @@
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
               "tags": [
-                { "tag": "urn:li:tag:Cypress" },
-                { "tag": "urn:li:tag:Cypress2" }
+                {
+                  "tag": "urn:li:tag:Cypress"
+                },
+                {
+                  "tag": "urn:li:tag:Cypress2"
+                }
               ]
             }
           }
@@ -542,7 +560,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -718,7 +740,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1011,7 +1037,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1229,7 +1259,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1279,7 +1313,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1332,7 +1370,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1371,7 +1413,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1413,7 +1459,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1459,7 +1509,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1521,7 +1575,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:Cypress" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:Cypress"
+                }
+              ]
             }
           }
         ]
@@ -1758,7 +1816,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:CypressFeatureTag" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:CypressFeatureTag"
+                }
+              ]
             }
           }
         ]
@@ -1785,7 +1847,11 @@
           },
           {
             "com.linkedin.pegasus2avro.common.GlobalTags": {
-              "tags": [{ "tag": "urn:li:tag:CypressPrimaryKeyTag" }]
+              "tags": [
+                {
+                  "tag": "urn:li:tag:CypressPrimaryKeyTag"
+                }
+              ]
             }
           }
         ]
@@ -2134,6 +2200,18 @@
     "aspectName": "ownership",
     "aspect": {
       "value": "{\n      \"owners\": [\n        {\n          \"owner\": \"urn:li:corpuser:datahub\",\n          \"type\": \"TECHNICAL_OWNER\",\n          \"typeUrn\": \"urn:li:ownershipType:__system__technical_owner\",\n          \"source\": {\n            \"type\": \"MANUAL\"\n          }\n        }\n      ]\n    }",
+      "contentType": "application/json"
+    },
+    "systemMetadata": null
+  },
+  {
+    "auditHeader": null,
+    "entityType": "schemaField",
+    "entityUrn": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_deleted,PROD),user_id)",
+    "changeType": "UPSERT",
+    "aspectName": "documentation",
+    "aspect": {
+      "value": "{\"documentations\":[{\"attribution\":{\"actor\":\"urn:li:corpuser:__datahub_system\",\"source\":\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user_id)\",\"sourceDetail\":{\"actor\":\"urn:li:corpuser:shirshanka@acryl.io\",\"origin\":\"urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user_id)\",\"propagated\":\"true\"},\"time\":1721422917808},\"documentation\":\"Unique identifier of user profile.\"}]}",
       "contentType": "application/json"
     },
     "systemMetadata": null


### PR DESCRIPTION
This PR adds UI support for Propagated Documentation.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the DescriptionField component to display propagation details and descriptions more effectively.
	- Introduced components for displaying propagation information and entity links for improved navigation.
	- Developed a custom hook for managing and retrieving entities based on URNs.

- **Bug Fixes**
	- Updated rendering logic to conditionally display propagation information to reduce UI clutter.

- **Documentation**
	- Added end-to-end tests to validate UI elements related to document propagation.
	- Introduced a new entry for schema field documentation in JSON data.

- **Refactor**
	- Streamlined logic for handling field descriptions and related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->