### PR TITLE
feat(ui) Enable editing structured props on fields

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldProperties.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldProperties.tsx
@@ -4,6 +4,8 @@ import { SchemaField, StdDataType } from '../../../../../../../../types.generate
 import { SectionHeader, StyledDivider } from './components';
 import { mapStructuredPropertyValues } from '../../../../Properties/useStructuredProperties';
 import StructuredPropertyValue from '../../../../Properties/StructuredPropertyValue';
+import { EditColumn } from '../../../../Properties/Edit/EditColumn';
+import { useGetEntityWithSchema } from '../../useGetEntitySchema';
 
 const PropertyTitle = styled.div`
     font-size: 14px;
@@ -13,6 +15,8 @@ const PropertyTitle = styled.div`
 
 const PropertyWrapper = styled.div`
     margin-bottom: 12px;
+    display: flex;
+    justify-content: space-between;
 `;
 
 const PropertiesWrapper = styled.div`
@@ -29,6 +33,7 @@ interface Props {
 
 export default function FieldProperties({ expandedField }: Props) {
     const { schemaFieldEntity } = expandedField;
+    const { refetch } = useGetEntityWithSchema(true);
 
     if (!schemaFieldEntity?.structuredProperties?.properties?.length) return null;
 
@@ -43,23 +48,33 @@ export default function FieldProperties({ expandedField }: Props) {
                     const hasMultipleValues = valuesData.length > 1;
 
                     return (
-                        <PropertyWrapper>
-                            <PropertyTitle>{structuredProp.structuredProperty.definition.displayName}</PropertyTitle>
-                            {hasMultipleValues ? (
-                                <StyledList>
-                                    {valuesData.map((value) => (
-                                        <li>
+                        <PropertyWrapper key={structuredProp.structuredProperty.urn}>
+                            <div>
+                                <PropertyTitle>
+                                    {structuredProp.structuredProperty.definition.displayName}
+                                </PropertyTitle>
+                                {hasMultipleValues ? (
+                                    <StyledList>
+                                        {valuesData.map((value) => (
+                                            <li>
+                                                <StructuredPropertyValue value={value} isRichText={isRichText} />
+                                            </li>
+                                        ))}
+                                    </StyledList>
+                                ) : (
+                                    <>
+                                        {valuesData.map((value) => (
                                             <StructuredPropertyValue value={value} isRichText={isRichText} />
-                                        </li>
-                                    ))}
-                                </StyledList>
-                            ) : (
-                                <>
-                                    {valuesData.map((value) => (
-                                        <StructuredPropertyValue value={value} isRichText={isRichText} />
-                                    ))}
-                                </>
-                            )}
+                                        ))}
+                                    </>
+                                )}
+                            </div>
+                            <EditColumn
+                                structuredProperty={structuredProp.structuredProperty}
+                                associatedUrn={schemaFieldEntity.urn}
+                                values={valuesData.map((v) => v.value) || []}
+                                refetch={refetch}
+                            />
                         </PropertyWrapper>
                     );
                 })}

--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/Edit/EditColumn.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/Edit/EditColumn.tsx
@@ -1,16 +1,19 @@
 import { Button } from 'antd';
 import React, { useState } from 'react';
-import { PropertyRow } from '../types';
 import EditStructuredPropertyModal from './EditStructuredPropertyModal';
+import { StructuredPropertyEntity } from '../../../../../../types.generated';
 
 interface Props {
-    propertyRow: PropertyRow;
+    structuredProperty?: StructuredPropertyEntity;
+    associatedUrn?: string;
+    values?: (string | number | null)[];
+    refetch?: () => void;
 }
 
-export function EditColumn({ propertyRow }: Props) {
+export function EditColumn({ structuredProperty, associatedUrn, values, refetch }: Props) {
     const [isEditModalVisible, setIsEditModalVisible] = useState(false);
 
-    if (!propertyRow.structuredProperty || propertyRow.structuredProperty?.definition.immutable) {
+    if (!structuredProperty || structuredProperty?.definition.immutable) {
         return null;
     }
 
@@ -21,9 +24,11 @@ export function EditColumn({ propertyRow }: Props) {
             </Button>
             <EditStructuredPropertyModal
                 isOpen={isEditModalVisible}
-                propertyRow={propertyRow}
-                structuredProperty={propertyRow.structuredProperty}
+                structuredProperty={structuredProperty}
+                associatedUrn={associatedUrn}
+                values={values}
                 closeModal={() => setIsEditModalVisible(false)}
+                refetch={refetch}
             />
         </>
     );


### PR DESCRIPTION
This PR enables us to edit existing structured properties on schema fields in the UI.

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/c71b7cde-dc1a-4d2b-830f-45ef30a0309b">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
