### PR TITLE
test(openAPI v3): search openAPI test has been added

### DIFF
--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -1,8 +1,8 @@
 import pytest
 import requests
+
 from tests.test_result_msg import add_datahub_stats
-from tests.utils import get_frontend_session, get_frontend_url
-from tests.utils import get_gms_url
+from tests.utils import get_frontend_session, get_frontend_url, get_gms_url
 
 BASE_URL_V3 = f"{get_gms_url()}/openapi/v3"
 
@@ -32,6 +32,7 @@ ENTITY_TO_MAP = {
     "glossaryNode": "GLOSSARY_NODE",
     "mlModel": "MLMODEL",
 }
+
 
 def _get_search_result(frontend_session, entity: str):
     json = {
@@ -92,7 +93,6 @@ def _get_search_result(frontend_session, entity: str):
         ("mlModel", "mlModel"),
     ],
 )
-
 def test_search_works(entity_type, api_name):
     frontend_session = get_frontend_session()
     search_result = _get_search_result(frontend_session, entity_type)
@@ -125,7 +125,7 @@ def test_search_works(entity_type, api_name):
     res_data = response.json()
     assert res_data["data"], f"res_data was {res_data}"
     assert res_data["data"][api_name]["urn"] == first_urn, f"res_data was {res_data}"
-    
+
     print(f"Response entity_type {entity_type}")
     print(f"Response first_urn {first_urn}")
 
@@ -141,9 +141,9 @@ def test_search_works(entity_type, api_name):
     print(f"Entity Data for URN {first_urn}: {actual_data}")
 
     # Simulated expected data, ideally this should be obtained from a reliable source
-    expected_data = {
-        "urn": first_urn
-    }
+    expected_data = {"urn": first_urn}
 
     # Validate that the data from OpenAPI matches the expected data
-    assert actual_data["urn"] == expected_data["urn"], f"Mismatch: expected {expected_data}, got {actual_data}"
+    assert (
+        actual_data["urn"] == expected_data["urn"]
+    ), f"Mismatch: expected {expected_data}, got {actual_data}"

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -6,10 +6,6 @@ from tests.utils import get_frontend_session, get_frontend_url, get_gms_url
 
 BASE_URL_V3 = f"{get_gms_url()}/openapi/v3"
 
-restli_default_headers = {
-    "X-RestLi-Protocol-Version": "2.0.0",
-}
-
 default_headers = {
     "Content-Type": "application/json",
 }
@@ -66,16 +62,8 @@ def _get_search_result(frontend_session, entity: str):
         ("chart", "chart"),
         ("dataset", "dataset"),
         ("dashboard", "dashboard"),
-        (
-            # Task
-            "dataJob",
-            "dataJob",
-        ),
-        (
-            # Pipeline
-            "dataFlow",
-            "dataFlow",
-        ),
+        ("dataJob", "dataJob"),
+        ("dataFlow", "dataFlow"),
         ("container", "container"),
         ("tag", "tag"),
         ("corpUser", "corpUser"),
@@ -85,11 +73,7 @@ def _get_search_result(frontend_session, entity: str):
         ("mlPrimaryKey", "mlPrimaryKey"),
         ("corpGroup", "corpGroup"),
         ("mlFeatureTable", "mlFeatureTable"),
-        (
-            # Term group
-            "glossaryNode",
-            "glossaryNode",
-        ),
+        ("glossaryNode", "glossaryNode"),
         ("mlModel", "mlModel"),
     ],
 )
@@ -126,13 +110,40 @@ def test_search_works(entity_type, api_name):
     assert res_data["data"], f"res_data was {res_data}"
     assert res_data["data"][api_name]["urn"] == first_urn, f"res_data was {res_data}"
 
-    print(f"Response entity_type {entity_type}")
-    print(f"Response first_urn {first_urn}")
 
-    if not entity_type or not first_urn:
-        pytest.skip("No dynamic data available")
+@pytest.mark.read_only
+@pytest.mark.parametrize(
+    "entity_type",
+    [
+        "chart",
+        "dataset",
+        "dashboard",
+        "dataJob",
+        "dataFlow",
+        "container",
+        "tag",
+        "corpUser",
+        "mlFeature",
+        "glossaryTerm",
+        "domain",
+        "mlPrimaryKey",
+        "corpGroup",
+        "mlFeatureTable",
+        "glossaryNode",
+        "mlModel",
+    ],
+)
+def test_openapi_v3_entity(entity_type):
+    frontend_session = get_frontend_session()
+    search_result = _get_search_result(frontend_session, entity_type)
+    num_entities = search_result["total"]
+    if num_entities == 0:
+        print(f"[WARN] No results for {entity_type}")
+        return
+    entities = search_result["searchResults"]
 
-    # Fetch actual data from the OpenAPI v3 endpoint
+    first_urn = entities[0]["entity"]["urn"]
+
     session = requests.Session()
     url = f"{BASE_URL_V3}/entity/{entity_type}/{first_urn}"
     response = session.get(url, headers=default_headers)
@@ -140,10 +151,8 @@ def test_search_works(entity_type, api_name):
     actual_data = response.json()
     print(f"Entity Data for URN {first_urn}: {actual_data}")
 
-    # Simulated expected data, ideally this should be obtained from a reliable source
     expected_data = {"urn": first_urn}
 
-    # Validate that the data from OpenAPI matches the expected data
     assert (
         actual_data["urn"] == expected_data["urn"]
     ), f"Mismatch: expected {expected_data}, got {actual_data}"


### PR DESCRIPTION
This PR is for new pytest on search openAPI for v3 version

 ## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable) - [CUS-2291 : Add read only test for OpenAPI search](https://linear.app/acryl-data/issue/CUS-2291/add-read-only-test-for-openapi-search)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test function to verify search results for various entity types using the OpenAPI v3 endpoint.
	- Added standardized headers for API requests to ensure correct formatting.
- **Improvements**
	- Enhanced the handling of entity types for better clarity and maintainability in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->