### PR TITLE
feat(cli): Trim report of dataHubExecutionRequestResult to max GMS size

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -81,7 +81,8 @@ profiling:
 - #10498 - Tableau ingestion can now be configured to ingest multiple sites at once and add the sites as containers. The feature is currently only available for Tableau Server.
 - #10466 - Extends configuration in `~/.datahubenv` to match `DatahubClientConfig` object definition. See full configuration in https://datahubproject.io/docs/python-sdk/clients/. The CLI should now respect the updated configurations specified in `~/.datahubenv` across its functions and utilities. This means that for systems where ssl certification is disabled, setting `disable_ssl_verification: true` in `~./datahubenv` will apply to all CLI calls.
 - #11002 - We will not auto-generate a `~/.datahubenv` file. You must either run `datahub init` to create that file, or set environment variables so that the config is loaded.
-
+- #11023 - Added a new parameter to datahub's `put` cli command: `--run-id`. This parameter is useful to associate a given write to an ingestion process. A use-case can be mimick transformers when a transformer for aspect being written does not exist.
+- #11051 - Ingestion reports will now trim the summary text to a maximum of 800k characters to avoid generating `dataHubExecutionRequestResult` that are too large for GMS to handle.
 ## 0.13.3
 
 ### Breaking Changes

--- a/metadata-ingestion/src/datahub/ingestion/reporting/datahub_ingestion_run_summary_provider.py
+++ b/metadata-ingestion/src/datahub/ingestion/reporting/datahub_ingestion_run_summary_provider.py
@@ -209,7 +209,9 @@ class DatahubIngestionRunSummaryProvider(PipelineRunListener):
             status=status,
             startTimeMs=self.start_time_ms,
             durationMs=self.get_cur_time_in_ms() - self.start_time_ms,
-            report=summary,
+            # Truncate summary such that the generated MCP will not exceed GMS's payload limit.
+            # Hardcoding the overall size of dataHubExecutionRequestResult to >1MB by trimming summary to 800,000 chars
+            report=summary[-800000:],
             structuredReport=structured_report,
         )
 

--- a/metadata-ingestion/src/datahub/ingestion/reporting/datahub_ingestion_run_summary_provider.py
+++ b/metadata-ingestion/src/datahub/ingestion/reporting/datahub_ingestion_run_summary_provider.py
@@ -31,6 +31,7 @@ from datahub.metadata.schema_classes import (
 from datahub.utilities.logging_manager import get_log_buffer
 from datahub.utilities.urns.urn import Urn
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -43,6 +44,7 @@ class DatahubIngestionRunSummaryProvider(PipelineRunListener):
     _EXECUTOR_ID: str = "__datahub_cli_"
     _EXECUTION_REQUEST_SOURCE_TYPE: str = "CLI_INGESTION_SOURCE"
     _INGESTION_TASK_NAME: str = "CLI Ingestion"
+    _MAX_SUMMARY_SIZE: int = 800000
 
     @staticmethod
     def get_cur_time_in_ms() -> int:
@@ -211,7 +213,7 @@ class DatahubIngestionRunSummaryProvider(PipelineRunListener):
             durationMs=self.get_cur_time_in_ms() - self.start_time_ms,
             # Truncate summary such that the generated MCP will not exceed GMS's payload limit.
             # Hardcoding the overall size of dataHubExecutionRequestResult to >1MB by trimming summary to 800,000 chars
-            report=summary[-800000:],
+            report=summary[-self._MAX_SUMMARY_SIZE:],
             structuredReport=structured_report,
         )
 


### PR DESCRIPTION
When ingestion jobs have a large log output (i.e. debug logging enabled), the request to send the `dataHubExecutionRequestResult` aspect will fail with 413 payload too large error. 

This will then cause the entire job to exit with status 1, even if the ingestion logic itself run was successful.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `--run-id` parameter for the `put` command, allowing users to associate data writes with specific ingestion processes.
- **Improvements**
	- Updated ingestion reports to limit summary text to a maximum of 800,000 characters to prevent oversized payloads.
	- Revised configuration management to align with the `DatahubClientConfig`, requiring users to initialize or set environment variables for configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->