### PR TITLE
fix : added support for multiple values for CONTAIN, START_WITH and END_WITH operators

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -555,24 +555,89 @@ public class ESUtils {
                 aspectRetriever)
             .queryName(queryName != null ? queryName : fieldName);
       } else if (condition == Condition.CONTAIN) {
-        return QueryBuilders.wildcardQuery(
-                toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
-                "*" + ESUtils.escapeReservedCharacters(criterion.getValue().trim()) + "*")
-            .queryName(queryName != null ? queryName : fieldName);
+        return buildContainsConditionFromCriterion(
+                fieldName, criterion, queryName, isTimeseries, aspectRetriever);
       } else if (condition == Condition.START_WITH) {
-        return QueryBuilders.wildcardQuery(
-                toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
-                ESUtils.escapeReservedCharacters(criterion.getValue().trim()) + "*")
-            .queryName(queryName != null ? queryName : fieldName);
+        return buildStartsWithConditionFromCriterion(
+                fieldName, criterion, queryName, isTimeseries, aspectRetriever);
       } else if (condition == Condition.END_WITH) {
-        return QueryBuilders.wildcardQuery(
-                toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
-                "*" + ESUtils.escapeReservedCharacters(criterion.getValue().trim()))
-            .queryName(queryName != null ? queryName : fieldName);
+        return buildEndsWithConditionFromCriterion(
+                fieldName, criterion, queryName, isTimeseries, aspectRetriever);
       }
     }
     throw new UnsupportedOperationException("Unsupported condition: " + condition);
   }
+
+  private static QueryBuilder buildWildcardQueryWithMultipleValues(
+          @Nonnull final String fieldName,
+          @Nonnull final Criterion criterion,
+          final boolean isTimeseries,
+          @Nullable String queryName,
+          @Nonnull AspectRetriever aspectRetriever,
+          String wildcardPattern) {
+    BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
+
+    for (String value : criterion.getValues()) {
+      boolQuery.should(QueryBuilders.wildcardQuery(
+                      toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
+                      String.format(wildcardPattern, ESUtils.escapeReservedCharacters(value.trim())))
+              .queryName(queryName != null ? queryName : fieldName));
+    }
+    return boolQuery;
+  }
+
+  private static QueryBuilder buildWildcardQueryWithSingleValue(
+          @Nonnull final String fieldName,
+          @Nonnull final Criterion criterion,
+          final boolean isTimeseries,
+          @Nullable String queryName,
+          @Nonnull AspectRetriever aspectRetriever,
+          String wildcardPattern) {
+    return QueryBuilders.wildcardQuery(
+                    toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
+                    String.format(wildcardPattern, ESUtils.escapeReservedCharacters(criterion.getValue().trim())))
+            .queryName(queryName != null ? queryName : fieldName);
+  }
+
+  private static QueryBuilder buildContainsConditionFromCriterion(
+          @Nonnull final String fieldName,
+          @Nonnull final Criterion criterion,
+          @Nullable String queryName,
+          final boolean isTimeseries,
+          @Nonnull AspectRetriever aspectRetriever) {
+
+    if (!criterion.getValues().isEmpty()) {
+      return buildWildcardQueryWithMultipleValues(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s*");
+    }
+    return buildWildcardQueryWithSingleValue(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s*");
+  }
+
+  private static QueryBuilder buildStartsWithConditionFromCriterion(
+          @Nonnull final String fieldName,
+          @Nonnull final Criterion criterion,
+          @Nullable String queryName,
+          final boolean isTimeseries,
+          @Nonnull AspectRetriever aspectRetriever) {
+
+    if (!criterion.getValues().isEmpty()) {
+      return buildWildcardQueryWithMultipleValues(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "%s*");
+    }
+    return buildWildcardQueryWithSingleValue(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "%s*");
+  }
+
+  private static QueryBuilder buildEndsWithConditionFromCriterion(
+          @Nonnull final String fieldName,
+          @Nonnull final Criterion criterion,
+          @Nullable String queryName,
+          final boolean isTimeseries,
+          @Nonnull AspectRetriever aspectRetriever) {
+
+    if (!criterion.getValues().isEmpty()) {
+      return buildWildcardQueryWithMultipleValues(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s");
+    }
+    return buildWildcardQueryWithSingleValue(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s");
+  }
+
 
   private static QueryBuilder buildEqualsConditionFromCriterion(
       @Nonnull final String fieldName,

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -556,88 +556,95 @@ public class ESUtils {
             .queryName(queryName != null ? queryName : fieldName);
       } else if (condition == Condition.CONTAIN) {
         return buildContainsConditionFromCriterion(
-                fieldName, criterion, queryName, isTimeseries, aspectRetriever);
+            fieldName, criterion, queryName, isTimeseries, aspectRetriever);
       } else if (condition == Condition.START_WITH) {
         return buildStartsWithConditionFromCriterion(
-                fieldName, criterion, queryName, isTimeseries, aspectRetriever);
+            fieldName, criterion, queryName, isTimeseries, aspectRetriever);
       } else if (condition == Condition.END_WITH) {
         return buildEndsWithConditionFromCriterion(
-                fieldName, criterion, queryName, isTimeseries, aspectRetriever);
+            fieldName, criterion, queryName, isTimeseries, aspectRetriever);
       }
     }
     throw new UnsupportedOperationException("Unsupported condition: " + condition);
   }
 
   private static QueryBuilder buildWildcardQueryWithMultipleValues(
-          @Nonnull final String fieldName,
-          @Nonnull final Criterion criterion,
-          final boolean isTimeseries,
-          @Nullable String queryName,
-          @Nonnull AspectRetriever aspectRetriever,
-          String wildcardPattern) {
+      @Nonnull final String fieldName,
+      @Nonnull final Criterion criterion,
+      final boolean isTimeseries,
+      @Nullable String queryName,
+      @Nonnull AspectRetriever aspectRetriever,
+      String wildcardPattern) {
     BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
 
     for (String value : criterion.getValues()) {
-      boolQuery.should(QueryBuilders.wildcardQuery(
-                      toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
-                      String.format(wildcardPattern, ESUtils.escapeReservedCharacters(value.trim())))
+      boolQuery.should(
+          QueryBuilders.wildcardQuery(
+                  toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
+                  String.format(wildcardPattern, ESUtils.escapeReservedCharacters(value.trim())))
               .queryName(queryName != null ? queryName : fieldName));
     }
     return boolQuery;
   }
 
   private static QueryBuilder buildWildcardQueryWithSingleValue(
-          @Nonnull final String fieldName,
-          @Nonnull final Criterion criterion,
-          final boolean isTimeseries,
-          @Nullable String queryName,
-          @Nonnull AspectRetriever aspectRetriever,
-          String wildcardPattern) {
+      @Nonnull final String fieldName,
+      @Nonnull final Criterion criterion,
+      final boolean isTimeseries,
+      @Nullable String queryName,
+      @Nonnull AspectRetriever aspectRetriever,
+      String wildcardPattern) {
     return QueryBuilders.wildcardQuery(
-                    toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
-                    String.format(wildcardPattern, ESUtils.escapeReservedCharacters(criterion.getValue().trim())))
-            .queryName(queryName != null ? queryName : fieldName);
+            toKeywordField(criterion.getField(), isTimeseries, aspectRetriever),
+            String.format(
+                wildcardPattern, ESUtils.escapeReservedCharacters(criterion.getValue().trim())))
+        .queryName(queryName != null ? queryName : fieldName);
   }
 
   private static QueryBuilder buildContainsConditionFromCriterion(
-          @Nonnull final String fieldName,
-          @Nonnull final Criterion criterion,
-          @Nullable String queryName,
-          final boolean isTimeseries,
-          @Nonnull AspectRetriever aspectRetriever) {
+      @Nonnull final String fieldName,
+      @Nonnull final Criterion criterion,
+      @Nullable String queryName,
+      final boolean isTimeseries,
+      @Nonnull AspectRetriever aspectRetriever) {
 
     if (!criterion.getValues().isEmpty()) {
-      return buildWildcardQueryWithMultipleValues(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s*");
+      return buildWildcardQueryWithMultipleValues(
+          fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s*");
     }
-    return buildWildcardQueryWithSingleValue(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s*");
+    return buildWildcardQueryWithSingleValue(
+        fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s*");
   }
 
   private static QueryBuilder buildStartsWithConditionFromCriterion(
-          @Nonnull final String fieldName,
-          @Nonnull final Criterion criterion,
-          @Nullable String queryName,
-          final boolean isTimeseries,
-          @Nonnull AspectRetriever aspectRetriever) {
+      @Nonnull final String fieldName,
+      @Nonnull final Criterion criterion,
+      @Nullable String queryName,
+      final boolean isTimeseries,
+      @Nonnull AspectRetriever aspectRetriever) {
 
     if (!criterion.getValues().isEmpty()) {
-      return buildWildcardQueryWithMultipleValues(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "%s*");
+      return buildWildcardQueryWithMultipleValues(
+          fieldName, criterion, isTimeseries, queryName, aspectRetriever, "%s*");
     }
-    return buildWildcardQueryWithSingleValue(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "%s*");
+    return buildWildcardQueryWithSingleValue(
+        fieldName, criterion, isTimeseries, queryName, aspectRetriever, "%s*");
   }
 
   private static QueryBuilder buildEndsWithConditionFromCriterion(
-          @Nonnull final String fieldName,
-          @Nonnull final Criterion criterion,
-          @Nullable String queryName,
-          final boolean isTimeseries,
-          @Nonnull AspectRetriever aspectRetriever) {
+      @Nonnull final String fieldName,
+      @Nonnull final Criterion criterion,
+      @Nullable String queryName,
+      final boolean isTimeseries,
+      @Nonnull AspectRetriever aspectRetriever) {
 
     if (!criterion.getValues().isEmpty()) {
-      return buildWildcardQueryWithMultipleValues(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s");
+      return buildWildcardQueryWithMultipleValues(
+          fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s");
     }
-    return buildWildcardQueryWithSingleValue(fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s");
+    return buildWildcardQueryWithSingleValue(
+        fieldName, criterion, isTimeseries, queryName, aspectRetriever, "*%s");
   }
-
 
   private static QueryBuilder buildEqualsConditionFromCriterion(
       @Nonnull final String fieldName,

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
@@ -148,13 +148,14 @@ public class ESUtilsTest {
   @Test
   public void testGetQueryBuilderFromCriterionContain() {
     final Criterion singleValueCriterion =
-            new Criterion().setField("myTestField").setCondition(Condition.CONTAIN).setValue("value1");
+        new Criterion().setField("myTestField").setCondition(Condition.CONTAIN).setValue("value1");
 
     QueryBuilder result =
-            ESUtils.getQueryBuilderFromCriterion(
-                    singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+        ESUtils.getQueryBuilderFromCriterion(
+            singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
 
-    String expected = "{\n"
+    String expected =
+        "{\n"
             + "  \"wildcard\" : {\n"
             + "    \"myTestField.keyword\" : {\n"
             + "      \"wildcard\" : \"*value1*\",\n"
@@ -167,17 +168,17 @@ public class ESUtilsTest {
     Assert.assertEquals(result.toString(), expected);
 
     final Criterion multiValueCriterion =
-            new Criterion()
-                    .setField("myTestField")
-                    .setCondition(Condition.CONTAIN)
-                    .setValues(new StringArray(ImmutableList.of("value1", "value2")));
+        new Criterion()
+            .setField("myTestField")
+            .setCondition(Condition.CONTAIN)
+            .setValues(new StringArray(ImmutableList.of("value1", "value2")));
 
     result =
-            ESUtils.getQueryBuilderFromCriterion(
-                    multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+        ESUtils.getQueryBuilderFromCriterion(
+            multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
 
-
-    expected = "{\n"
+    expected =
+        "{\n"
             + "  \"bool\" : {\n"
             + "    \"should\" : [\n"
             + "      {\n"
@@ -204,21 +205,23 @@ public class ESUtilsTest {
             + "  }\n"
             + "}";
 
-
     Assert.assertEquals(result.toString(), expected);
-
   }
+
   @Test
-  public void testWildcardQueryBuilderFromCriterionWhenStartsWith()
-  {
+  public void testWildcardQueryBuilderFromCriterionWhenStartsWith() {
     final Criterion singleValueCriterion =
-            new Criterion().setField("myTestField").setCondition(Condition.START_WITH).setValue("value1");
+        new Criterion()
+            .setField("myTestField")
+            .setCondition(Condition.START_WITH)
+            .setValue("value1");
 
     QueryBuilder result =
-            ESUtils.getQueryBuilderFromCriterion(
-                    singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+        ESUtils.getQueryBuilderFromCriterion(
+            singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
 
-    String expected = "{\n"
+    String expected =
+        "{\n"
             + "  \"wildcard\" : {\n"
             + "    \"myTestField.keyword\" : {\n"
             + "      \"wildcard\" : \"value1*\",\n"
@@ -231,17 +234,17 @@ public class ESUtilsTest {
     Assert.assertEquals(result.toString(), expected);
 
     final Criterion multiValueCriterion =
-            new Criterion()
-                    .setField("myTestField")
-                    .setCondition(Condition.START_WITH)
-                    .setValues(new StringArray(ImmutableList.of("value1", "value2")));
+        new Criterion()
+            .setField("myTestField")
+            .setCondition(Condition.START_WITH)
+            .setValues(new StringArray(ImmutableList.of("value1", "value2")));
 
     result =
-            ESUtils.getQueryBuilderFromCriterion(
-                    multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+        ESUtils.getQueryBuilderFromCriterion(
+            multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
 
-
-    expected = "{\n"
+    expected =
+        "{\n"
             + "  \"bool\" : {\n"
             + "    \"should\" : [\n"
             + "      {\n"
@@ -268,21 +271,20 @@ public class ESUtilsTest {
             + "  }\n"
             + "}";
 
-
     Assert.assertEquals(result.toString(), expected);
   }
 
   @Test
-  public void testWildcardQueryBuilderFromCriterionWhenEndsWith()
-  {
+  public void testWildcardQueryBuilderFromCriterionWhenEndsWith() {
     final Criterion singleValueCriterion =
-            new Criterion().setField("myTestField").setCondition(Condition.END_WITH).setValue("value1");
+        new Criterion().setField("myTestField").setCondition(Condition.END_WITH).setValue("value1");
 
     QueryBuilder result =
-            ESUtils.getQueryBuilderFromCriterion(
-                    singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+        ESUtils.getQueryBuilderFromCriterion(
+            singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
 
-    String expected = "{\n"
+    String expected =
+        "{\n"
             + "  \"wildcard\" : {\n"
             + "    \"myTestField.keyword\" : {\n"
             + "      \"wildcard\" : \"*value1\",\n"
@@ -294,17 +296,17 @@ public class ESUtilsTest {
     Assert.assertEquals(result.toString(), expected);
 
     final Criterion multiValueCriterion =
-            new Criterion()
-                    .setField("myTestField")
-                    .setCondition(Condition.END_WITH)
-                    .setValues(new StringArray(ImmutableList.of("value1", "value2")));
+        new Criterion()
+            .setField("myTestField")
+            .setCondition(Condition.END_WITH)
+            .setValues(new StringArray(ImmutableList.of("value1", "value2")));
 
     result =
-            ESUtils.getQueryBuilderFromCriterion(
-                    multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+        ESUtils.getQueryBuilderFromCriterion(
+            multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
 
-
-    expected = "{\n"
+    expected =
+        "{\n"
             + "  \"bool\" : {\n"
             + "    \"should\" : [\n"
             + "      {\n"
@@ -331,10 +333,8 @@ public class ESUtilsTest {
             + "  }\n"
             + "}";
 
-
     Assert.assertEquals(result.toString(), expected);
   }
-
 
   @Test
   public void testGetQueryBuilderFromCriterionExists() {

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
@@ -146,6 +146,197 @@ public class ESUtilsTest {
   }
 
   @Test
+  public void testGetQueryBuilderFromCriterionContain() {
+    final Criterion singleValueCriterion =
+            new Criterion().setField("myTestField").setCondition(Condition.CONTAIN).setValue("value1");
+
+    QueryBuilder result =
+            ESUtils.getQueryBuilderFromCriterion(
+                    singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+
+    String expected = "{\n"
+            + "  \"wildcard\" : {\n"
+            + "    \"myTestField.keyword\" : {\n"
+            + "      \"wildcard\" : \"*value1*\",\n"
+            + "      \"boost\" : 1.0,\n"
+            + "      \"_name\" : \"myTestField\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+    Assert.assertEquals(result.toString(), expected);
+
+    final Criterion multiValueCriterion =
+            new Criterion()
+                    .setField("myTestField")
+                    .setCondition(Condition.CONTAIN)
+                    .setValues(new StringArray(ImmutableList.of("value1", "value2")));
+
+    result =
+            ESUtils.getQueryBuilderFromCriterion(
+                    multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+
+
+    expected = "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"should\" : [\n"
+            + "      {\n"
+            + "        \"wildcard\" : {\n"
+            + "          \"myTestField.keyword\" : {\n"
+            + "            \"wildcard\" : \"*value1*\",\n"
+            + "            \"boost\" : 1.0,\n"
+            + "            \"_name\" : \"myTestField\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"wildcard\" : {\n"
+            + "          \"myTestField.keyword\" : {\n"
+            + "            \"wildcard\" : \"*value2*\",\n"
+            + "            \"boost\" : 1.0,\n"
+            + "            \"_name\" : \"myTestField\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+
+
+    Assert.assertEquals(result.toString(), expected);
+
+  }
+  @Test
+  public void testWildcardQueryBuilderFromCriterionWhenStartsWith()
+  {
+    final Criterion singleValueCriterion =
+            new Criterion().setField("myTestField").setCondition(Condition.START_WITH).setValue("value1");
+
+    QueryBuilder result =
+            ESUtils.getQueryBuilderFromCriterion(
+                    singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+
+    String expected = "{\n"
+            + "  \"wildcard\" : {\n"
+            + "    \"myTestField.keyword\" : {\n"
+            + "      \"wildcard\" : \"value1*\",\n"
+            + "      \"boost\" : 1.0,\n"
+            + "      \"_name\" : \"myTestField\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+    Assert.assertEquals(result.toString(), expected);
+
+    final Criterion multiValueCriterion =
+            new Criterion()
+                    .setField("myTestField")
+                    .setCondition(Condition.START_WITH)
+                    .setValues(new StringArray(ImmutableList.of("value1", "value2")));
+
+    result =
+            ESUtils.getQueryBuilderFromCriterion(
+                    multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+
+
+    expected = "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"should\" : [\n"
+            + "      {\n"
+            + "        \"wildcard\" : {\n"
+            + "          \"myTestField.keyword\" : {\n"
+            + "            \"wildcard\" : \"value1*\",\n"
+            + "            \"boost\" : 1.0,\n"
+            + "            \"_name\" : \"myTestField\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"wildcard\" : {\n"
+            + "          \"myTestField.keyword\" : {\n"
+            + "            \"wildcard\" : \"value2*\",\n"
+            + "            \"boost\" : 1.0,\n"
+            + "            \"_name\" : \"myTestField\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+
+
+    Assert.assertEquals(result.toString(), expected);
+  }
+
+  @Test
+  public void testWildcardQueryBuilderFromCriterionWhenEndsWith()
+  {
+    final Criterion singleValueCriterion =
+            new Criterion().setField("myTestField").setCondition(Condition.END_WITH).setValue("value1");
+
+    QueryBuilder result =
+            ESUtils.getQueryBuilderFromCriterion(
+                    singleValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+
+    String expected = "{\n"
+            + "  \"wildcard\" : {\n"
+            + "    \"myTestField.keyword\" : {\n"
+            + "      \"wildcard\" : \"*value1\",\n"
+            + "      \"boost\" : 1.0,\n"
+            + "      \"_name\" : \"myTestField\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    Assert.assertEquals(result.toString(), expected);
+
+    final Criterion multiValueCriterion =
+            new Criterion()
+                    .setField("myTestField")
+                    .setCondition(Condition.END_WITH)
+                    .setValues(new StringArray(ImmutableList.of("value1", "value2")));
+
+    result =
+            ESUtils.getQueryBuilderFromCriterion(
+                    multiValueCriterion, false, new HashMap<>(), mock(AspectRetriever.class));
+
+
+    expected = "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"should\" : [\n"
+            + "      {\n"
+            + "        \"wildcard\" : {\n"
+            + "          \"myTestField.keyword\" : {\n"
+            + "            \"wildcard\" : \"*value1\",\n"
+            + "            \"boost\" : 1.0,\n"
+            + "            \"_name\" : \"myTestField\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"wildcard\" : {\n"
+            + "          \"myTestField.keyword\" : {\n"
+            + "            \"wildcard\" : \"*value2\",\n"
+            + "            \"boost\" : 1.0,\n"
+            + "            \"_name\" : \"myTestField\"\n"
+            + "          }\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+
+
+    Assert.assertEquals(result.toString(), expected);
+  }
+
+
+  @Test
   public void testGetQueryBuilderFromCriterionExists() {
     final Criterion singleValueCriterion =
         new Criterion().setField("myTestField").setCondition(Condition.EXISTS);


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced query construction methods for better handling of conditions like 'CONTAIN', 'START_WITH', and 'END_WITH'.
	- Improved clarity and modularity in query building through dedicated methods for different conditions.

- **Bug Fixes**
	- Improved accuracy of generated queries under various conditions by refining the query builder logic.

- **Tests**
	- Added comprehensive tests to validate the new query builder functionalities for 'CONTAIN', 'START_WITH', and 'END_WITH' conditions, ensuring correct output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->