### PR TITLE
fix(ingest): set lastObserved in sdk when unset

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import typing
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
@@ -403,6 +404,8 @@ def ensure_has_system_metadata(
     if event.systemMetadata is None:
         event.systemMetadata = SystemMetadataClass()
     metadata = event.systemMetadata
+    if metadata.lastObserved == 0:
+        metadata.lastObserved = int(time.time() * 1000)
     if metadata.properties is None:
         metadata.properties = {}
     props = metadata.properties

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -1,7 +1,9 @@
 import json
+from datetime import datetime, timezone
 
 import pytest
 import requests
+from freezegun import freeze_time
 
 import datahub.metadata.schema_classes as models
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
@@ -9,6 +11,7 @@ from datahub.emitter.rest_emitter import DatahubRestEmitter
 
 MOCK_GMS_ENDPOINT = "http://fakegmshost:8080"
 
+FROZEN_TIME = 1618987484580
 basicAuditStamp = models.AuditStampClass(
     time=1618987484580,
     actor="urn:li:corpuser:datahub",
@@ -76,7 +79,7 @@ basicAuditStamp = models.AuditStampClass(
                     }
                 },
                 "systemMetadata": {
-                    "lastObserved": 0,
+                    "lastObserved": FROZEN_TIME,
                     "lastRunId": "no-run-id-provided",
                     "properties": {
                         "clientId": "acryl-datahub",
@@ -134,7 +137,7 @@ basicAuditStamp = models.AuditStampClass(
                     }
                 },
                 "systemMetadata": {
-                    "lastObserved": 0,
+                    "lastObserved": FROZEN_TIME,
                     "lastRunId": "no-run-id-provided",
                     "properties": {
                         "clientId": "acryl-datahub",
@@ -178,7 +181,7 @@ basicAuditStamp = models.AuditStampClass(
                     }
                 },
                 "systemMetadata": {
-                    "lastObserved": 0,
+                    "lastObserved": FROZEN_TIME,
                     "lastRunId": "no-run-id-provided",
                     "properties": {
                         "clientId": "acryl-datahub",
@@ -263,7 +266,7 @@ basicAuditStamp = models.AuditStampClass(
                         "contentType": "application/json",
                     },
                     "systemMetadata": {
-                        "lastObserved": 0,
+                        "lastObserved": FROZEN_TIME,
                         "lastRunId": "no-run-id-provided",
                         "properties": {
                             "clientId": "acryl-datahub",
@@ -276,6 +279,7 @@ basicAuditStamp = models.AuditStampClass(
         ),
     ],
 )
+@freeze_time(datetime.fromtimestamp(FROZEN_TIME / 1000, tz=timezone.utc))
 def test_datahub_rest_emitter(requests_mock, record, path, snapshot):
     def match_request_text(request: requests.Request) -> bool:
         requested_snapshot = request.json()


### PR DESCRIPTION
Fixes a bug from https://github.com/datahub-project/datahub/pull/10829


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced system metadata initialization by ensuring the `lastObserved` timestamp is set to the current time if it is not previously updated.
  
- **Bug Fixes**
	- Correctly initializes metadata to reflect a valid timestamp upon creation, improving data integrity.

- **Tests**
	- Improved stability of tests related to timestamps by introducing a controlled, frozen time scenario for consistent assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->