### PR TITLE
fix: make class recognize parent when parent uses "capability" decorator

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/decorators.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/decorators.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Dict, Optional, Type
+from typing import Callable, Dict, Optional, Type, TypeVar
 
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceCapability
+
+T = TypeVar("T")
 
 
 def config_class(config_cls: Type) -> Callable[[Type], Type]:
@@ -87,12 +89,12 @@ class CapabilitySetting:
 
 def capability(
     capability_name: SourceCapability, description: str, supported: bool = True
-) -> Callable[[Type], Type]:
+) -> Callable[[Type[T]], Type[T]]:
     """
     A decorator to mark a source as having a certain capability
     """
 
-    def wrapper(cls: Type) -> Type:
+    def wrapper(cls: Type[T]) -> Type[T]:
         if not hasattr(cls, "__capabilities") or any(
             # It's from this class and not a superclass.
             cls.__capabilities is getattr(base, "__capabilities", None)


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
