### PR TITLE
fix(docs): Add correct usage of orFilters in search API docs

### DIFF
--- a/docs/how/search.md
+++ b/docs/how/search.md
@@ -148,24 +148,42 @@ The same GraphQL API that powers the Search UI can be used
 for integrations and programmatic use-cases. 
 
 ```
-# Example query
-{
-  searchAcrossEntities(
-    input: {types: [], query: "*", start: 0, count: 10, filters: [{field: "fieldTags", value: "urn:li:tag:Dimension"}]}
+# Example query - search for datasets matching the example_query_text who have the Dimension tag applied to a schema field and are from the data platform looker
+query searchEntities {
+  search(
+    input: {
+      type: DATASET,
+      query: "example_query_text",
+      orFilters: [
+        {
+          and: [
+            {
+              field: "fieldTags",
+              values: ["urn:li:tag:Dimension"]
+            },
+            {
+              field: "platform",
+              values: ["urn:li:dataPlatform:looker"]
+            }
+          ]
+        }
+      ],
+      start: 0,
+      count: 10
+    }
   ) {
     start
     count
     total
     searchResults {
       entity {
+        urn
         type
         ... on Dataset {
-          urn
-          type
+          name
           platform {
             name
           }
-          name
         }
       }
     }


### PR DESCRIPTION
Previous docs gave examples of using filters in the legacy fashion. This was incorrect. Updated to show how graphql queries should be issued today.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced search functionality with a new query structure for more precise dataset searches.
	- Introduced an `orFilters` array for advanced filtering capabilities based on multiple criteria.
	- Added a `type` field to specify the dataset.

- **Documentation**
	- Updated documentation to reflect changes in the GraphQL query structure, including new input parameters and response modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->