### PR TITLE
chore(vulnerability): Comparison of narrow type with wide type in loop condition

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/models/extractor/FieldExtractor.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/extractor/FieldExtractor.java
@@ -63,7 +63,7 @@ public class FieldExtractor {
         } else {
           List<Object> valueList = (List<Object>) value.get();
           // If the field is a nested list of values, flatten it
-          for (int i = 0; i < numArrayWildcards - 1; i++) {
+          for (long i = 0; i < numArrayWildcards - 1; i++) {
             valueList =
                 valueList.stream()
                     .flatMap(v -> ((List<Object>) v).stream())

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestDataPlatformInstancesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestDataPlatformInstancesStep.java
@@ -61,7 +61,7 @@ public class IngestDataPlatformInstancesStep implements BootstrapStep {
     long numEntities = _migrationsDao.countEntities();
     int start = 0;
 
-    while (start < numEntities) {
+    while (start < (int) numEntities) {
       log.info(
           "Reading urns {} to {} from the aspects table to generate dataplatform instance aspects",
           start,


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

# Background:
![image](https://github.com/user-attachments/assets/1adbdcf7-cb17-4730-ad4b-254eebf8c32c)

---

![image](https://github.com/user-attachments/assets/e132a666-1f10-41fb-9aa5-d81f2877d2fc)


CodeQL scans detect high vulnerability in the code base. Its due to Comparison of narrow type with wide type in loop condition. Its typecasted to int, rather than changing `start` to long as its used in `listAllUrns` which expects int and is used in numerous places. CodeQL detects it as vulnerability and by resolving this, the overall vulnerabilty score improves. And it had no impacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the handling of large datasets in the field extraction process for enhanced robustness.
  - Addressed potential risks in data ingestion by refining loop conditions related to entity counts.

These changes aim to enhance the performance and reliability of data processing within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->