### PR TITLE
fix(graphql): fix RemoveLinkResolver for glossaries

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1194,7 +1194,7 @@ public class GmsGraphQLEngine {
               .dataFetcher("removeOwner", new RemoveOwnerResolver(entityService))
               .dataFetcher("batchRemoveOwners", new BatchRemoveOwnersResolver(entityService))
               .dataFetcher("addLink", new AddLinkResolver(entityService, this.entityClient))
-              .dataFetcher("removeLink", new RemoveLinkResolver(entityService))
+              .dataFetcher("removeLink", new RemoveLinkResolver(entityService, this.entityClient))
               .dataFetcher("addGroupMembers", new AddGroupMembersResolver(this.groupService))
               .dataFetcher("removeGroupMembers", new RemoveGroupMembersResolver(this.groupService))
               .dataFetcher("createGroup", new CreateGroupResolver(this.groupService))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/RemoveLinkResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/RemoveLinkResolver.java
@@ -9,6 +9,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.exception.AuthorizationException;
 import com.linkedin.datahub.graphql.generated.RemoveLinkInput;
 import com.linkedin.datahub.graphql.resolvers.mutate.util.LinkUtils;
+import com.linkedin.entity.client.EntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -21,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RemoveLinkResolver implements DataFetcher<CompletableFuture<Boolean>> {
 
   private final EntityService _entityService;
+  private final EntityClient _entityClient;
 
   @Override
   public CompletableFuture<Boolean> get(DataFetchingEnvironment environment) throws Exception {
@@ -31,7 +33,7 @@ public class RemoveLinkResolver implements DataFetcher<CompletableFuture<Boolean
     String linkUrl = input.getLinkUrl();
     Urn targetUrn = Urn.createFromString(input.getResourceUrn());
 
-    if (!LinkUtils.isAuthorizedToUpdateLinks(context, targetUrn)) {
+    if (!LinkUtils.isAuthorizedToUpdateLinks(context, targetUrn, _entityClient)) {
       throw new AuthorizationException(
           "Unauthorized to perform this action. Please contact your DataHub administrator.");
     }


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authorization checks for link updates, incorporating a new entity client for more granular controls, particularly for glossary-related entities.
  
- **Bug Fixes**
	- Streamlined authorization logic, removing unnecessary complexity and improving clarity in the link management processes.

- **Refactor**
	- Improved the structure and efficiency of the link update authorization methods, ensuring better functionality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->