### PR TITLE
feat(docs-site) hiding learn more from cloud page

### DIFF
--- a/docs-website/src/pages/cloud/index.js
+++ b/docs-website/src/pages/cloud/index.js
@@ -34,11 +34,11 @@ function Home() {
               <div className={clsx("hero__subtitle", styles.hero__subtitle)}>
                 Introducing DataHub as a Managed Service
                 <div style={{ fontWeight: "500"}}>with Data Observability and Data Governance built-in.</div>
-                <div className={styles.learnMore}>
+                {/* <div className={styles.learnMore}>
                   <a className={styles.link} href="https://acryldata.io" target="_blank">
                     Learn More  →
                   </a>
-                </div>
+                </div> */}
               </div>
               <Link className="button button--primary button--lg" to="https://www.acryldata.io/datahub-sign-up?utm_source=datahub&utm_medium=referral&utm_campaign=acryl_signup">
                 Book Demo


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified user interface by removing the "Learn More" link from the homepage.

- **Impact**
	- This change may affect navigation and user engagement with the DataHub service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->