### PR TITLE
fix(ingestion): enforce lastObserved timestamps in SystemMetadata

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.mutate;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
@@ -84,7 +85,7 @@ public class MutationUtils {
     proposal.setChangeType(ChangeType.UPSERT);
 
     // Assumes proposal is generated first from the builder methods above so SystemMetadata is empty
-    SystemMetadata systemMetadata = new SystemMetadata();
+    SystemMetadata systemMetadata = createDefaultSystemMetadata();
     StringMap properties = new StringMap();
     properties.put(APP_SOURCE, UI_SOURCE);
     systemMetadata.setProperties(properties);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/assertion/DeleteAssertionResolverTest.java
@@ -31,7 +31,7 @@ public class DeleteAssertionResolverTest {
   public void testGetSuccess() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
         .thenReturn(true);
     Mockito.when(
@@ -77,7 +77,7 @@ public class DeleteAssertionResolverTest {
   public void testGetSuccessNoAssertionInfoFound() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
         .thenReturn(true);
     Mockito.when(
@@ -117,7 +117,7 @@ public class DeleteAssertionResolverTest {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
         .thenReturn(false);
 
@@ -149,7 +149,7 @@ public class DeleteAssertionResolverTest {
   public void testGetUnauthorized() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
         .thenReturn(true);
     Mockito.when(
@@ -186,7 +186,7 @@ public class DeleteAssertionResolverTest {
         .when(mockClient)
         .deleteEntity(any(), Mockito.any());
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ASSERTION_URN)), eq(true)))
         .thenReturn(true);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/businessattribute/AddBusinessAttributeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/businessattribute/AddBusinessAttributeResolverTest.java
@@ -29,7 +29,7 @@ public class AddBusinessAttributeResolverTest {
       "urn:li:businessAttribute:7d0c4283-de02-4043-aaf2-698b04274658";
   private static final String RESOURCE_URN =
       "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD),field_bar)";
-  private EntityService mockService;
+  private EntityService<?> mockService;
   private QueryContext mockContext;
   private DataFetchingEnvironment mockEnv;
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/businessattribute/CreateBusinessAttributeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/businessattribute/CreateBusinessAttributeResolverTest.java
@@ -56,7 +56,7 @@ public class CreateBusinessAttributeResolverTest {
           TEST_BUSINESS_ATTRIBUTE_DESCRIPTION,
           SchemaFieldDataType.BOOLEAN);
   private EntityClient mockClient;
-  private EntityService mockService;
+  private EntityService<?> mockService;
   private QueryContext mockContext;
   private DataFetchingEnvironment mockEnv;
   private BusinessAttributeService businessAttributeService;

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/businessattribute/RemoveBusinessAttributeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/businessattribute/RemoveBusinessAttributeResolverTest.java
@@ -31,7 +31,7 @@ public class RemoveBusinessAttributeResolverTest {
       "urn:li:businessAttribute:7d0c4283-de02-4043-aaf2-698b04274658";
   private static final String RESOURCE_URN =
       "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,SampleCypressHiveDataset,PROD),field_bar)";
-  private EntityService mockService;
+  private EntityService<?> mockService;
   private QueryContext mockContext;
   private DataFetchingEnvironment mockEnv;
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/delete/BatchUpdateSoftDeletedResolverTest.java
@@ -33,7 +33,7 @@ public class BatchUpdateSoftDeletedResolverTest {
 
   @Test
   public void testGetSuccessNoExistingStatus() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -84,7 +84,7 @@ public class BatchUpdateSoftDeletedResolverTest {
   public void testGetSuccessExistingStatus() throws Exception {
     final Status originalStatus = new Status().setRemoved(true);
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -133,7 +133,7 @@ public class BatchUpdateSoftDeletedResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -173,7 +173,7 @@ public class BatchUpdateSoftDeletedResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchUpdateSoftDeletedResolver resolver = new BatchUpdateSoftDeletedResolver(mockService);
 
@@ -193,7 +193,7 @@ public class BatchUpdateSoftDeletedResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/BatchUpdateDeprecationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/BatchUpdateDeprecationResolverTest.java
@@ -34,7 +34,7 @@ public class BatchUpdateDeprecationResolverTest {
 
   @Test
   public void testGetSuccessNoExistingDeprecation() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -99,7 +99,7 @@ public class BatchUpdateDeprecationResolverTest {
             .setNote("")
             .setActor(UrnUtils.getUrn("urn:li:corpuser:test"));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -158,7 +158,7 @@ public class BatchUpdateDeprecationResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -202,7 +202,7 @@ public class BatchUpdateDeprecationResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchUpdateDeprecationResolver resolver = new BatchUpdateDeprecationResolver(mockService);
 
@@ -226,7 +226,7 @@ public class BatchUpdateDeprecationResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/UpdateDeprecationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/deprecation/UpdateDeprecationResolverTest.java
@@ -59,7 +59,7 @@ public class UpdateDeprecationResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
 
@@ -83,7 +83,7 @@ public class UpdateDeprecationResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), DEPRECATION_ASPECT_NAME, newDeprecation);
 
-    Mockito.verify(mockClient, Mockito.times(1)).ingestProposal(any(), eq(proposal), eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -120,7 +120,7 @@ public class UpdateDeprecationResolverTest {
                                 new EnvelopedAspect()
                                     .setValue(new Aspect(originalDeprecation.data())))))));
 
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
 
@@ -144,7 +144,7 @@ public class UpdateDeprecationResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), DEPRECATION_ASPECT_NAME, newDeprecation);
 
-    Mockito.verify(mockClient, Mockito.times(1)).ingestProposal(any(), eq(proposal), eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -169,7 +169,7 @@ public class UpdateDeprecationResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(false);
 
@@ -190,7 +190,7 @@ public class UpdateDeprecationResolverTest {
   public void testGetUnauthorized() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     UpdateDeprecationResolver resolver = new UpdateDeprecationResolver(mockClient, mockService);
 
     // Execute resolver
@@ -206,7 +206,7 @@ public class UpdateDeprecationResolverTest {
   @Test
   public void testGetEntityClientException() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     Mockito.doThrow(RemoteInvocationException.class)
         .when(mockClient)
         .ingestProposal(any(), Mockito.any(), anyBoolean());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/BatchSetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/BatchSetDomainResolverTest.java
@@ -39,7 +39,7 @@ public class BatchSetDomainResolverTest {
 
   @Test
   public void testGetSuccessNoExistingDomains() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -105,7 +105,7 @@ public class BatchSetDomainResolverTest {
         new Domains()
             .setDomains(new UrnArray(ImmutableList.of(Urn.createFromString(TEST_DOMAIN_1_URN))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -176,7 +176,7 @@ public class BatchSetDomainResolverTest {
         new Domains()
             .setDomains(new UrnArray(ImmutableList.of(Urn.createFromString(TEST_DOMAIN_1_URN))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -233,7 +233,7 @@ public class BatchSetDomainResolverTest {
 
   @Test
   public void testGetFailureDomainDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -268,7 +268,7 @@ public class BatchSetDomainResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -312,7 +312,7 @@ public class BatchSetDomainResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchSetDomainResolver resolver = new BatchSetDomainResolver(mockService);
 
@@ -334,7 +334,7 @@ public class BatchSetDomainResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/CreateDomainResolverTest.java
@@ -53,7 +53,7 @@ public class CreateDomainResolverTest {
   public void testGetSuccess() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
@@ -103,7 +103,7 @@ public class CreateDomainResolverTest {
   @Test
   public void testGetSuccessNoParentDomain() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
@@ -146,7 +146,7 @@ public class CreateDomainResolverTest {
   @Test
   public void testGetInvalidParent() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
@@ -164,7 +164,7 @@ public class CreateDomainResolverTest {
   @Test
   public void testGetNameConflict() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
 
     Mockito.when(mockClient.exists(any(), Mockito.eq(TEST_DOMAIN_URN))).thenReturn(false);
@@ -218,7 +218,7 @@ public class CreateDomainResolverTest {
   public void testGetUnauthorized() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     CreateDomainResolver resolver = new CreateDomainResolver(mockClient, mockService);
 
     // Execute resolver
@@ -235,7 +235,7 @@ public class CreateDomainResolverTest {
   public void testGetEntityClientException() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.doThrow(RemoteInvocationException.class)
         .when(mockClient)
         .ingestProposal(any(), Mockito.any(), Mockito.eq(false));

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/MoveDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/MoveDomainResolverTest.java
@@ -40,7 +40,7 @@ public class MoveDomainResolverTest {
   private static final CorpuserUrn TEST_ACTOR_URN = new CorpuserUrn("test");
 
   private MetadataChangeProposal setupTests(
-      DataFetchingEnvironment mockEnv, EntityService mockService, EntityClient mockClient)
+      DataFetchingEnvironment mockEnv, EntityService<?> mockService, EntityClient mockClient)
       throws Exception {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
@@ -77,7 +77,7 @@ public class MoveDomainResolverTest {
 
   @Test
   public void testGetSuccess() throws Exception {
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(
             mockService.exists(
@@ -100,7 +100,7 @@ public class MoveDomainResolverTest {
 
   @Test
   public void testGetFailureEntityDoesNotExist() throws Exception {
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
         .thenReturn(true);
@@ -127,7 +127,7 @@ public class MoveDomainResolverTest {
 
   @Test
   public void testGetFailureParentDoesNotExist() throws Exception {
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
         .thenReturn(false);
@@ -143,7 +143,7 @@ public class MoveDomainResolverTest {
 
   @Test
   public void testGetFailureParentIsNotDomain() throws Exception {
-    EntityService mockService = Mockito.mock(EntityService.class);
+    EntityService<?> mockService = Mockito.mock(EntityService.class);
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(PARENT_DOMAIN_URN)), eq(true)))
         .thenReturn(true);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/SetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/SetDomainResolverTest.java
@@ -59,7 +59,7 @@ public class SetDomainResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
@@ -82,8 +82,7 @@ public class SetDomainResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), DOMAINS_ASPECT_NAME, newDomains);
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -122,7 +121,7 @@ public class SetDomainResolverTest {
                                 new EnvelopedAspect()
                                     .setValue(new Aspect(originalDomains.data())))))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
@@ -145,8 +144,7 @@ public class SetDomainResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), DOMAINS_ASPECT_NAME, newDomains);
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -175,7 +173,7 @@ public class SetDomainResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
@@ -214,7 +212,7 @@ public class SetDomainResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(false);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_NEW_DOMAIN_URN)), eq(true)))
@@ -237,7 +235,7 @@ public class SetDomainResolverTest {
   public void testGetUnauthorized() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     SetDomainResolver resolver = new SetDomainResolver(mockClient, mockService);
 
     // Execute resolver

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/UnsetDomainResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/domain/UnsetDomainResolverTest.java
@@ -58,7 +58,7 @@ public class UnsetDomainResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
 
@@ -76,8 +76,7 @@ public class UnsetDomainResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), DOMAINS_ASPECT_NAME, newDomains);
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -113,7 +112,7 @@ public class UnsetDomainResolverTest {
                                 new EnvelopedAspect()
                                     .setValue(new Aspect(originalDomains.data())))))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(true);
 
@@ -131,8 +130,7 @@ public class UnsetDomainResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), DOMAINS_ASPECT_NAME, newDomains);
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -158,7 +156,7 @@ public class UnsetDomainResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(false);
 
@@ -178,7 +176,7 @@ public class UnsetDomainResolverTest {
   public void testGetUnauthorized() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     UnsetDomainResolver resolver = new UnsetDomainResolver(mockClient, mockService);
 
     // Execute resolver

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/embed/UpdateEmbedResolverTest.java
@@ -39,7 +39,7 @@ public class UpdateEmbedResolverTest {
 
   @Test
   public void testGetSuccessNoExistingEmbed() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -68,7 +68,6 @@ public class UpdateEmbedResolverTest {
             Urn.createFromString(TEST_ENTITY_URN), EMBED_ASPECT_NAME, newEmbed);
 
     verifySingleIngestProposal(mockService, 1, proposal);
-    ;
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -79,7 +78,7 @@ public class UpdateEmbedResolverTest {
     Embed originalEmbed = new Embed().setRenderUrl("https://otherurl.com");
 
     // Create resolver
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -132,7 +131,7 @@ public class UpdateEmbedResolverTest {
                     .setUrn(Urn.createFromString(TEST_ENTITY_URN))
                     .setAspects(new EnvelopedAspectMap(Collections.emptyMap()))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(false);
 
@@ -154,7 +153,7 @@ public class UpdateEmbedResolverTest {
   @Test
   public void testGetUnauthorized() throws Exception {
     // Create resolver
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     UpdateEmbedResolver resolver = new UpdateEmbedResolver(mockService);
 
     // Execute resolver
@@ -171,7 +170,7 @@ public class UpdateEmbedResolverTest {
   @Test
   public void testGetEntityClientException() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.doThrow(RemoteInvocationException.class)
         .when(mockClient)
         .ingestProposal(any(), Mockito.any());

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/AddRelatedTermsResolverTest.java
@@ -28,7 +28,7 @@ public class AddRelatedTermsResolverTest {
   private static final String DATASET_URN = "urn:li:dataset:(test,test,test)";
 
   private EntityService setUpService() {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(
             mockService.getAspect(
                 any(),
@@ -41,7 +41,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetSuccessIsRelatedNonExistent() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
@@ -75,7 +75,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetSuccessHasRelatedNonExistent() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
@@ -109,7 +109,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetFailAddSelfAsRelatedTerm() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
@@ -131,7 +131,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetFailAddNonTermAsRelatedTerm() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
@@ -153,7 +153,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetFailAddNonExistentTermAsRelatedTerm() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
@@ -177,7 +177,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetFailAddToNonExistentUrn() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
@@ -201,7 +201,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testGetFailAddToNonTerm() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(DATASET_URN)), eq(true)))
@@ -225,7 +225,7 @@ public class AddRelatedTermsResolverTest {
 
   @Test
   public void testFailNoPermissions() throws Exception {
-    EntityService mockService = setUpService();
+    EntityService<?> mockService = setUpService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryNodeResolverTest.java
@@ -2,8 +2,8 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockEntityService;
+import static com.linkedin.datahub.graphql.TestUtils.verifyIngestProposal;
 import static com.linkedin.metadata.Constants.*;
-import static org.mockito.ArgumentMatchers.any;
 
 import com.datahub.authentication.Authentication;
 import com.linkedin.common.urn.GlossaryNodeUrn;
@@ -63,7 +63,7 @@ public class CreateGlossaryNodeResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     final MetadataChangeProposal proposal =
         setupTest(mockEnv, TEST_INPUT, "test-description", parentNodeUrn);
@@ -71,14 +71,13 @@ public class CreateGlossaryNodeResolverTest {
     CreateGlossaryNodeResolver resolver = new CreateGlossaryNodeResolver(mockClient, mockService);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 
   @Test
   public void testGetSuccessNoDescription() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     final MetadataChangeProposal proposal =
         setupTest(mockEnv, TEST_INPUT_NO_DESCRIPTION, "", parentNodeUrn);
@@ -86,14 +85,13 @@ public class CreateGlossaryNodeResolverTest {
     CreateGlossaryNodeResolver resolver = new CreateGlossaryNodeResolver(mockClient, mockService);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 
   @Test
   public void testGetSuccessNoParentNode() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     final MetadataChangeProposal proposal =
         setupTest(mockEnv, TEST_INPUT_NO_PARENT_NODE, "test-description", null);
@@ -101,7 +99,6 @@ public class CreateGlossaryNodeResolverTest {
     CreateGlossaryNodeResolver resolver = new CreateGlossaryNodeResolver(mockClient, mockService);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/CreateGlossaryTermResolverTest.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.graphql.resolvers.glossary;
 
 import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
 import static com.linkedin.datahub.graphql.TestUtils.getMockEntityService;
+import static com.linkedin.datahub.graphql.TestUtils.verifyIngestProposal;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -81,7 +82,7 @@ public class CreateGlossaryTermResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     EntityClient mockClient = initMockClient();
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     final MetadataChangeProposal proposal =
         setupTest(mockEnv, TEST_INPUT, "test-description", parentNodeUrn);
@@ -89,14 +90,13 @@ public class CreateGlossaryTermResolverTest {
     CreateGlossaryTermResolver resolver = new CreateGlossaryTermResolver(mockClient, mockService);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 
   @Test
   public void testGetSuccessNoDescription() throws Exception {
     EntityClient mockClient = initMockClient();
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     final MetadataChangeProposal proposal =
         setupTest(mockEnv, TEST_INPUT_NO_DESCRIPTION, "", parentNodeUrn);
@@ -104,14 +104,13 @@ public class CreateGlossaryTermResolverTest {
     CreateGlossaryTermResolver resolver = new CreateGlossaryTermResolver(mockClient, mockService);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 
   @Test
   public void testGetSuccessNoParentNode() throws Exception {
     EntityClient mockClient = initMockClient();
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
     final MetadataChangeProposal proposal =
         setupTest(mockEnv, TEST_INPUT_NO_PARENT_NODE, "test-description", null);
@@ -119,8 +118,7 @@ public class CreateGlossaryTermResolverTest {
     CreateGlossaryTermResolver resolver = new CreateGlossaryTermResolver(mockClient, mockService);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 
   @Test
@@ -157,7 +155,7 @@ public class CreateGlossaryTermResolverTest {
                 Mockito.eq(Collections.singleton(GLOSSARY_TERM_INFO_ASPECT_NAME))))
         .thenReturn(result);
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
 
     CreateGlossaryEntityInput input =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/DeleteGlossaryEntityResolverTest.java
@@ -25,7 +25,7 @@ public class DeleteGlossaryEntityResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_URN)), eq(true)))
         .thenReturn(true);
@@ -50,7 +50,7 @@ public class DeleteGlossaryEntityResolverTest {
         .when(mockClient)
         .deleteEntity(any(), Mockito.any());
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_TERM_URN)), eq(true)))
         .thenReturn(true);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/RemoveRelatedTermsResolverTest.java
@@ -36,7 +36,7 @@ public class RemoveRelatedTermsResolverTest {
     GlossaryTermUrn term2Urn = GlossaryTermUrn.createFromString(TEST_TERM_2_URN);
     final GlossaryRelatedTerms relatedTerms = new GlossaryRelatedTerms();
     relatedTerms.setIsRelatedTerms(new GlossaryTermUrnArray(Arrays.asList(term1Urn, term2Urn)));
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(
             mockService.getAspect(
                 any(),
@@ -71,7 +71,7 @@ public class RemoveRelatedTermsResolverTest {
     GlossaryTermUrn term2Urn = GlossaryTermUrn.createFromString(TEST_TERM_2_URN);
     final GlossaryRelatedTerms relatedTerms = new GlossaryRelatedTerms();
     relatedTerms.setHasRelatedTerms(new GlossaryTermUrnArray(Arrays.asList(term1Urn, term2Urn)));
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(
             mockService.getAspect(
                 any(),
@@ -102,7 +102,7 @@ public class RemoveRelatedTermsResolverTest {
 
   @Test
   public void testFailAspectDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(
             mockService.getAspect(
                 any(),
@@ -135,7 +135,7 @@ public class RemoveRelatedTermsResolverTest {
     GlossaryTermUrn term2Urn = GlossaryTermUrn.createFromString(TEST_TERM_2_URN);
     final GlossaryRelatedTerms relatedTerms = new GlossaryRelatedTerms();
     relatedTerms.setIsRelatedTerms(new GlossaryTermUrnArray(Arrays.asList(term1Urn, term2Urn)));
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(
             mockService.getAspect(
                 any(),

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateNameResolverTest.java
@@ -42,7 +42,7 @@ public class UpdateNameResolverTest {
   private static final CorpuserUrn TEST_ACTOR_URN = new CorpuserUrn("test");
 
   private MetadataChangeProposal setupTests(
-      DataFetchingEnvironment mockEnv, EntityService mockService) throws Exception {
+      DataFetchingEnvironment mockEnv, EntityService<?> mockService) throws Exception {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
     Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
@@ -65,7 +65,7 @@ public class UpdateNameResolverTest {
 
   @Test
   public void testGetSuccess() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(
             mockService.exists(
@@ -83,7 +83,7 @@ public class UpdateNameResolverTest {
 
   @Test
   public void testGetSuccessForNode() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(NODE_URN)), eq(true)))
         .thenReturn(true);
@@ -117,7 +117,7 @@ public class UpdateNameResolverTest {
 
   @Test
   public void testGetSuccessForDomain() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(DOMAIN_URN)), eq(true)))
         .thenReturn(true);
@@ -163,7 +163,7 @@ public class UpdateNameResolverTest {
 
   @Test
   public void testGetFailureEntityDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(
             mockService.exists(

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateParentNodeResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/glossary/UpdateParentNodeResolverTest.java
@@ -43,7 +43,7 @@ public class UpdateParentNodeResolverTest {
   private static final CorpuserUrn TEST_ACTOR_URN = new CorpuserUrn("test");
 
   private MetadataChangeProposal setupTests(
-      DataFetchingEnvironment mockEnv, EntityService mockService) throws Exception {
+      DataFetchingEnvironment mockEnv, EntityService<?> mockService) throws Exception {
     QueryContext mockContext = getMockAllowContext();
     Mockito.when(mockContext.getAuthentication()).thenReturn(Mockito.mock(Authentication.class));
     Mockito.when(mockContext.getActorUrn()).thenReturn(TEST_ACTOR_URN.toString());
@@ -67,7 +67,7 @@ public class UpdateParentNodeResolverTest {
 
   @Test
   public void testGetSuccess() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TERM_URN)), eq(true)))
         .thenReturn(true);
@@ -89,7 +89,7 @@ public class UpdateParentNodeResolverTest {
 
   @Test
   public void testGetSuccessForNode() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(NODE_URN)), eq(true)))
         .thenReturn(true);
@@ -129,7 +129,7 @@ public class UpdateParentNodeResolverTest {
 
   @Test
   public void testGetFailureEntityDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TERM_URN)), eq(true)))
         .thenReturn(false);
@@ -149,7 +149,7 @@ public class UpdateParentNodeResolverTest {
 
   @Test
   public void testGetFailureNodeDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TERM_URN)), eq(true)))
         .thenReturn(true);
@@ -169,7 +169,7 @@ public class UpdateParentNodeResolverTest {
 
   @Test
   public void testGetFailureParentIsNotNode() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TERM_URN)), eq(true)))
         .thenReturn(true);

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/UpsertIngestionSourceResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/ingest/source/UpsertIngestionSourceResolverTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.ingest.source;
 
+import static com.linkedin.datahub.graphql.TestUtils.verifyIngestProposal;
 import static com.linkedin.datahub.graphql.resolvers.ingest.IngestTestUtils.*;
 import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,13 +67,11 @@ public class UpsertIngestionSourceResolverTest {
             .setExecutorId(TEST_INPUT.getConfig().getExecutorId())
             .setDebugMode(TEST_INPUT.getConfig().getDebugMode()));
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(
-            any(),
-            Mockito.eq(
-                MutationUtils.buildMetadataChangeProposalWithUrn(
-                    TEST_INGESTION_SOURCE_URN, INGESTION_INFO_ASPECT_NAME, info)),
-            Mockito.eq(false));
+    verifyIngestProposal(
+        mockClient,
+        1,
+        MutationUtils.buildMetadataChangeProposalWithUrn(
+            TEST_INGESTION_SOURCE_URN, INGESTION_INFO_ASPECT_NAME, info));
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/SiblingsUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/SiblingsUtilsTest.java
@@ -31,7 +31,7 @@ public class SiblingsUtilsTest {
   public void testGetSiblingUrns() {
     UrnArray siblingUrns =
         new UrnArray(UrnUtils.getUrn(TEST_DATASET_URN2), UrnUtils.getUrn(TEST_DATASET_URN3));
-    EntityService mockService = mock(EntityService.class);
+    EntityService<?> mockService = mock(EntityService.class);
     Mockito.when(
             mockService.getLatestAspect(
                 any(), eq(UrnUtils.getUrn(TEST_DATASET_URN1)), eq(SIBLINGS_ASPECT_NAME)))
@@ -45,7 +45,7 @@ public class SiblingsUtilsTest {
 
   @Test
   public void testGetSiblingUrnsWithoutSiblings() {
-    EntityService mockService = mock(EntityService.class);
+    EntityService<?> mockService = mock(EntityService.class);
     Mockito.when(
             mockService.getLatestAspect(
                 any(), eq(UrnUtils.getUrn(TEST_DATASET_URN1)), eq(SIBLINGS_ASPECT_NAME)))
@@ -59,7 +59,7 @@ public class SiblingsUtilsTest {
 
   @Test
   public void testGetSiblingUrnsWithSiblingsAspect() {
-    EntityService mockService = mock(EntityService.class);
+    EntityService<?> mockService = mock(EntityService.class);
     Mockito.when(
             mockService.getLatestAspect(
                 any(), eq(UrnUtils.getUrn(TEST_DATASET_URN1)), eq(SIBLINGS_ASPECT_NAME)))

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateUserSettingResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/mutate/UpdateUserSettingResolverTest.java
@@ -23,7 +23,7 @@ public class UpdateUserSettingResolverTest {
 
   @Test
   public void testWriteCorpUserSettings() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_USER_URN)), eq(true)))
         .thenReturn(true);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/operation/ReportOperationResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/operation/ReportOperationResolverTest.java
@@ -57,8 +57,7 @@ public class ReportOperationResolverTest {
     Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
     resolver.get(mockEnv).get();
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(expectedProposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, expectedProposal);
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/AddOwnersResolverTest.java
@@ -38,7 +38,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetSuccessNoExistingOwners() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -101,7 +101,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetSuccessExistingOwnerNewType() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     com.linkedin.common.Ownership oldOwnership =
         new Ownership()
@@ -167,7 +167,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetSuccessDeprecatedTypeToOwnershipType() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     com.linkedin.common.Ownership oldOwnership =
         new Ownership()
@@ -230,7 +230,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetSuccessMultipleOwnerTypes() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     com.linkedin.common.Ownership oldOwnership =
         new Ownership()
@@ -328,7 +328,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetFailureOwnerDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -366,7 +366,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -404,7 +404,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     AddOwnersResolver resolver = new AddOwnersResolver(mockService);
 
@@ -429,7 +429,7 @@ public class AddOwnersResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchAddOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchAddOwnersResolverTest.java
@@ -38,7 +38,7 @@ public class BatchAddOwnersResolverTest {
 
   @Test
   public void testGetSuccessNoExistingOwners() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -126,7 +126,7 @@ public class BatchAddOwnersResolverTest {
                         new Owner()
                             .setOwner(Urn.createFromString(TEST_OWNER_URN_1))
                             .setType(OwnershipType.TECHNICAL_OWNER))));
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -217,7 +217,7 @@ public class BatchAddOwnersResolverTest {
 
   @Test
   public void testGetFailureOwnerDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -267,7 +267,7 @@ public class BatchAddOwnersResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -326,7 +326,7 @@ public class BatchAddOwnersResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchAddOwnersResolver resolver = new BatchAddOwnersResolver(mockService);
 
@@ -363,7 +363,7 @@ public class BatchAddOwnersResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchRemoveOwnersResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/owner/BatchRemoveOwnersResolverTest.java
@@ -35,7 +35,7 @@ public class BatchRemoveOwnersResolverTest {
 
   @Test
   public void testGetSuccessNoExistingOwners() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -83,7 +83,7 @@ public class BatchRemoveOwnersResolverTest {
 
   @Test
   public void testGetSuccessExistingOwners() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     final Ownership oldOwners1 =
         new Ownership()
@@ -150,7 +150,7 @@ public class BatchRemoveOwnersResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -195,7 +195,7 @@ public class BatchRemoveOwnersResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchRemoveOwnersResolver resolver = new BatchRemoveOwnersResolver(mockService);
 
@@ -218,7 +218,7 @@ public class BatchRemoveOwnersResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/AddTagsResolverTest.java
@@ -35,7 +35,7 @@ public class AddTagsResolverTest {
 
   @Test
   public void testGetSuccessNoExistingTags() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -94,7 +94,7 @@ public class AddTagsResolverTest {
                     ImmutableList.of(
                         new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN)))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -146,7 +146,7 @@ public class AddTagsResolverTest {
 
   @Test
   public void testGetFailureTagDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -177,7 +177,7 @@ public class AddTagsResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -208,7 +208,7 @@ public class AddTagsResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     AddTagsResolver resolver = new AddTagsResolver(mockService);
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchAddTagsResolverTest.java
@@ -39,7 +39,7 @@ public class BatchAddTagsResolverTest {
 
   @Test
   public void testGetSuccessNoExistingTags() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -115,7 +115,7 @@ public class BatchAddTagsResolverTest {
                     ImmutableList.of(
                         new TagAssociation().setTag(TagUrn.createFromString(TEST_TAG_1_URN)))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -184,7 +184,7 @@ public class BatchAddTagsResolverTest {
 
   @Test
   public void testGetFailureTagDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -218,7 +218,7 @@ public class BatchAddTagsResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -263,7 +263,7 @@ public class BatchAddTagsResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchAddTagsResolver resolver = new BatchAddTagsResolver(mockService);
 
@@ -286,7 +286,7 @@ public class BatchAddTagsResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/BatchRemoveTagsResolverTest.java
@@ -42,7 +42,7 @@ public class BatchRemoveTagsResolverTest {
 
   @Test
   public void testGetSuccessNoExistingTags() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -104,7 +104,7 @@ public class BatchRemoveTagsResolverTest {
 
   @Test
   public void testGetSuccessExistingTags() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     final GlobalTags oldTags1 =
         new GlobalTags()
@@ -177,7 +177,7 @@ public class BatchRemoveTagsResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -222,7 +222,7 @@ public class BatchRemoveTagsResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchRemoveTagsResolver resolver = new BatchRemoveTagsResolver(mockService);
 
@@ -245,7 +245,7 @@ public class BatchRemoveTagsResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/CreateTagResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/CreateTagResolverTest.java
@@ -27,7 +27,7 @@ public class CreateTagResolverTest {
   @Test
   public void testGetSuccess() throws Exception {
     // Create resolver
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.when(
             mockClient.ingestProposal(
@@ -53,14 +53,13 @@ public class CreateTagResolverTest {
             key, TAG_ENTITY_NAME, TAG_PROPERTIES_ASPECT_NAME, props);
 
     // Not ideal to match against "any", but we don't know the auto-generated execution request id
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
   }
 
   @Test
   public void testGetUnauthorized() throws Exception {
     // Create resolver
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     CreateTagResolver resolver = new CreateTagResolver(mockClient, mockService);
 
@@ -77,7 +76,7 @@ public class CreateTagResolverTest {
   @Test
   public void testGetEntityClientException() throws Exception {
     // Create resolver
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     EntityClient mockClient = Mockito.mock(EntityClient.class);
     Mockito.doThrow(RuntimeException.class)
         .when(mockClient)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/SetTagColorResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/tag/SetTagColorResolverTest.java
@@ -38,7 +38,7 @@ public class SetTagColorResolverTest {
   public void testGetSuccessExistingProperties() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     // Test setting the domain
     final TagProperties oldTagProperties = new TagProperties().setName("Test Tag");
@@ -69,8 +69,7 @@ public class SetTagColorResolverTest {
         MutationUtils.buildMetadataChangeProposalWithUrn(
             UrnUtils.getUrn(TEST_ENTITY_URN), TAG_PROPERTIES_ASPECT_NAME, newTagProperties);
 
-    Mockito.verify(mockClient, Mockito.times(1))
-        .ingestProposal(any(), Mockito.eq(proposal), Mockito.eq(false));
+    verifyIngestProposal(mockClient, 1, proposal);
 
     Mockito.verify(mockService, Mockito.times(1))
         .exists(any(), Mockito.eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true));
@@ -80,7 +79,7 @@ public class SetTagColorResolverTest {
   public void testGetFailureNoExistingProperties() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     // Test setting the domain
     Mockito.when(
@@ -135,7 +134,7 @@ public class SetTagColorResolverTest {
                             ImmutableMap.of(
                                 Constants.TAG_PROPERTIES_ASPECT_NAME, oldTagPropertiesAspect)))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     Mockito.when(mockService.exists(any(), eq(Urn.createFromString(TEST_ENTITY_URN)), eq(true)))
         .thenReturn(false);
 
@@ -155,7 +154,7 @@ public class SetTagColorResolverTest {
   public void testGetUnauthorized() throws Exception {
     // Create resolver
     EntityClient mockClient = Mockito.mock(EntityClient.class);
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
     SetTagColorResolver resolver = new SetTagColorResolver(mockClient, mockService);
 
     // Execute resolver

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/AddTermsResolverTest.java
@@ -32,7 +32,7 @@ public class AddTermsResolverTest {
 
   @Test
   public void testGetSuccessNoExistingTerms() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -82,7 +82,7 @@ public class AddTermsResolverTest {
                         new GlossaryTermAssociation()
                             .setUrn(GlossaryTermUrn.createFromString(TEST_TERM_1_URN)))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -124,7 +124,7 @@ public class AddTermsResolverTest {
 
   @Test
   public void testGetFailureTermDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -156,7 +156,7 @@ public class AddTermsResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -188,7 +188,7 @@ public class AddTermsResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     AddTermsResolver resolver = new AddTermsResolver(mockService);
 
@@ -207,7 +207,7 @@ public class AddTermsResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchAddTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchAddTermsResolverTest.java
@@ -35,7 +35,7 @@ public class BatchAddTermsResolverTest {
 
   @Test
   public void testGetSuccessNoExistingTerms() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -99,7 +99,7 @@ public class BatchAddTermsResolverTest {
                         new GlossaryTermAssociation()
                             .setUrn(GlossaryTermUrn.createFromString(TEST_GLOSSARY_TERM_1_URN)))));
 
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -155,7 +155,7 @@ public class BatchAddTermsResolverTest {
 
   @Test
   public void testGetFailureTagDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -189,7 +189,7 @@ public class BatchAddTermsResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -234,7 +234,7 @@ public class BatchAddTermsResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchAddTermsResolver resolver = new BatchAddTermsResolver(mockService);
 
@@ -256,7 +256,7 @@ public class BatchAddTermsResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchRemoveTermsResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/term/BatchRemoveTermsResolverTest.java
@@ -35,7 +35,7 @@ public class BatchRemoveTermsResolverTest {
 
   @Test
   public void testGetSuccessNoExistingTerms() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -82,7 +82,7 @@ public class BatchRemoveTermsResolverTest {
 
   @Test
   public void testGetSuccessExistingTerms() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     final GlossaryTerms oldTerms1 =
         new GlossaryTerms()
@@ -148,7 +148,7 @@ public class BatchRemoveTermsResolverTest {
 
   @Test
   public void testGetFailureResourceDoesNotExist() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.when(
             mockService.getAspect(
@@ -192,7 +192,7 @@ public class BatchRemoveTermsResolverTest {
 
   @Test
   public void testGetUnauthorized() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     BatchRemoveTermsResolver resolver = new BatchRemoveTermsResolver(mockService);
 
@@ -214,7 +214,7 @@ public class BatchRemoveTermsResolverTest {
 
   @Test
   public void testGetEntityClientException() throws Exception {
-    EntityService mockService = getMockEntityService();
+    EntityService<?> mockService = getMockEntityService();
 
     Mockito.doThrow(RuntimeException.class)
         .when(mockService)

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/browsepaths/BackfillBrowsePathsV2Step.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/browsepaths/BackfillBrowsePathsV2Step.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.upgrade.system.browsepaths;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -29,7 +30,6 @@ import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
-import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Set;
 import java.util.function.Function;
@@ -208,8 +208,7 @@ public class BackfillBrowsePathsV2Step implements UpgradeStep {
     proposal.setEntityType(urn.getEntityType());
     proposal.setAspectName(Constants.BROWSE_PATHS_V2_ASPECT_NAME);
     proposal.setChangeType(ChangeType.UPSERT);
-    proposal.setSystemMetadata(
-        new SystemMetadata().setRunId(DEFAULT_RUN_ID).setLastObserved(System.currentTimeMillis()));
+    proposal.setSystemMetadata(createDefaultSystemMetadata());
     proposal.setAspect(GenericRecordUtils.serializeAspect(browsePathsV2));
     entityService.ingestProposal(opContext, proposal, auditStamp, true);
   }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/policyfields/BackfillPolicyFieldsStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/policyfields/BackfillPolicyFieldsStep.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.upgrade.system.policyfields;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
@@ -25,7 +26,6 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchService;
-import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.policy.DataHubPolicyInfo;
 import io.datahubproject.metadata.context.OperationContext;
 import java.net.URISyntaxException;
@@ -234,9 +234,7 @@ public class BackfillPolicyFieldsStep implements UpgradeStep {
                   null,
                   infoAspect,
                   null,
-                  new SystemMetadata()
-                      .setRunId(DEFAULT_RUN_ID)
-                      .setLastObserved(System.currentTimeMillis()),
+                  createDefaultSystemMetadata(),
                   auditStamp,
                   ChangeType.RESTATE)
               .getFirst());

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/EntityApiUtils.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/EntityApiUtils.java
@@ -1,6 +1,6 @@
 package com.linkedin.metadata.entity;
 
-import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 
 import com.datahub.util.RecordUtils;
 import com.linkedin.common.urn.Urn;
@@ -37,10 +37,7 @@ public class EntityApiUtils {
 
   public static SystemMetadata parseSystemMetadata(String jsonSystemMetadata) {
     if (jsonSystemMetadata == null || jsonSystemMetadata.equals("")) {
-      SystemMetadata response = new SystemMetadata();
-      response.setRunId(DEFAULT_RUN_ID);
-      response.setLastObserved(0);
-      return response;
+      return createDefaultSystemMetadata();
     }
     return RecordUtils.toRecordTemplate(SystemMetadata.class, jsonSystemMetadata);
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -2,7 +2,6 @@ package com.linkedin.metadata.entity;
 
 import static com.linkedin.metadata.Constants.APP_SOURCE;
 import static com.linkedin.metadata.Constants.ASPECT_LATEST_VERSION;
-import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
 import static com.linkedin.metadata.Constants.FORCE_INDEXING_KEY;
 import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.SYSTEM_ACTOR;
@@ -10,6 +9,7 @@ import static com.linkedin.metadata.Constants.UI_SOURCE;
 import static com.linkedin.metadata.utils.PegasusUtils.constructMCL;
 import static com.linkedin.metadata.utils.PegasusUtils.getDataTemplateClassFromSchema;
 import static com.linkedin.metadata.utils.PegasusUtils.urnToEntityName;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 import static com.linkedin.metadata.utils.metrics.ExceptionUtils.collectMetrics;
 
 import com.codahale.metrics.Timer;
@@ -1835,10 +1835,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
   @Override
   public SystemMetadata ingestEntity(
       @Nonnull OperationContext opContext, Entity entity, AuditStamp auditStamp) {
-    SystemMetadata generatedSystemMetadata = new SystemMetadata();
-    generatedSystemMetadata.setRunId(DEFAULT_RUN_ID);
-    generatedSystemMetadata.setLastObserved(System.currentTimeMillis());
-
+    SystemMetadata generatedSystemMetadata = createDefaultSystemMetadata();
     ingestEntity(opContext, entity, auditStamp, generatedSystemMetadata);
     return generatedSystemMetadata;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/AspectGenerationUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/AspectGenerationUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.metadata;
 
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
+
 import com.linkedin.chart.ChartInfo;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.ChangeAuditStamps;
@@ -48,11 +50,10 @@ public class AspectGenerationUtils {
       @Nonnull String runId,
       @Nonnull String lastRunId,
       @Nullable String version) {
-    SystemMetadata metadata = new SystemMetadata();
-    metadata.setLastObserved(lastObserved);
-    metadata.setRunId(runId);
+    SystemMetadata metadata = createDefaultSystemMetadata(runId);
     metadata.setLastRunId(lastRunId);
     metadata.setVersion(version, SetMode.IGNORE_NULL);
+    metadata.setLastObserved(lastObserved);
     return metadata;
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
@@ -602,8 +602,9 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
 
     GenericAspect aspect = GenericRecordUtils.serializeAspect(pairToIngest.get(0).getSecond());
 
+    SystemMetadata initialSystemMetadata = AspectGenerationUtils.createSystemMetadata(1);
     initialChangeLog.setAspect(aspect);
-    initialChangeLog.setSystemMetadata(AspectGenerationUtils.createSystemMetadata(1));
+    initialChangeLog.setSystemMetadata(initialSystemMetadata);
     initialChangeLog.setEntityKeyAspect(
         GenericRecordUtils.serializeAspect(
             EntityKeyUtils.convertUrnToEntityKey(
@@ -620,7 +621,7 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
     restateChangeLog.setSystemMetadata(AspectGenerationUtils.createSystemMetadata(1));
     restateChangeLog.setPreviousAspectValue(aspect);
     restateChangeLog.setPreviousSystemMetadata(
-        simulatePullFromDB(AspectGenerationUtils.createSystemMetadata(1), SystemMetadata.class));
+        simulatePullFromDB(initialSystemMetadata, SystemMetadata.class));
     restateChangeLog.setEntityKeyAspect(
         GenericRecordUtils.serializeAspect(
             EntityKeyUtils.convertUrnToEntityKey(

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2Step.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/BackfillBrowsePathsV2Step.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.boot.steps;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -23,7 +24,6 @@ import com.linkedin.metadata.search.SearchEntity;
 import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
-import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -152,8 +152,7 @@ public class BackfillBrowsePathsV2Step extends UpgradeStep {
     proposal.setEntityType(urn.getEntityType());
     proposal.setAspectName(Constants.BROWSE_PATHS_V2_ASPECT_NAME);
     proposal.setChangeType(ChangeType.UPSERT);
-    proposal.setSystemMetadata(
-        new SystemMetadata().setRunId(DEFAULT_RUN_ID).setLastObserved(System.currentTimeMillis()));
+    proposal.setSystemMetadata(createDefaultSystemMetadata());
     proposal.setAspect(GenericRecordUtils.serializeAspect(browsePathsV2));
     entityService.ingestProposal(systemOperationContext, proposal, auditStamp, false);
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/UpgradeDefaultBrowsePathsStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/UpgradeDefaultBrowsePathsStep.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.boot.steps;
 
 import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSystemMetadata;
 
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
@@ -17,7 +18,6 @@ import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.search.utils.BrowsePathUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
-import com.linkedin.mxe.SystemMetadata;
 import io.datahubproject.metadata.context.OperationContext;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -138,8 +138,7 @@ public class UpgradeDefaultBrowsePathsStep extends UpgradeStep {
     proposal.setEntityType(urn.getEntityType());
     proposal.setAspectName(Constants.BROWSE_PATHS_ASPECT_NAME);
     proposal.setChangeType(ChangeType.UPSERT);
-    proposal.setSystemMetadata(
-        new SystemMetadata().setRunId(DEFAULT_RUN_ID).setLastObserved(System.currentTimeMillis()));
+    proposal.setSystemMetadata(createDefaultSystemMetadata());
     proposal.setAspect(GenericRecordUtils.serializeAspect(newPaths));
     entityService.ingestProposal(opContext, proposal, auditStamp, false);
   }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/SystemMetadataUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/SystemMetadataUtils.java
@@ -1,6 +1,8 @@
 package com.linkedin.metadata.utils;
 
-import com.linkedin.metadata.Constants;
+import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
+
+import com.linkedin.data.template.SetMode;
 import com.linkedin.mxe.SystemMetadata;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -11,13 +13,25 @@ public class SystemMetadataUtils {
   private SystemMetadataUtils() {}
 
   public static SystemMetadata createDefaultSystemMetadata() {
-    return new SystemMetadata()
-        .setRunId(Constants.DEFAULT_RUN_ID)
-        .setLastObserved(System.currentTimeMillis());
+    return generateSystemMetadataIfEmpty(null);
+  }
+
+  public static SystemMetadata createDefaultSystemMetadata(@Nullable String runId) {
+    return generateSystemMetadataIfEmpty(
+        new SystemMetadata()
+            .setRunId(runId, SetMode.REMOVE_IF_NULL)
+            .setLastObserved(System.currentTimeMillis()));
   }
 
   public static SystemMetadata generateSystemMetadataIfEmpty(
       @Nullable SystemMetadata systemMetadata) {
-    return systemMetadata == null ? createDefaultSystemMetadata() : systemMetadata;
+    SystemMetadata result = systemMetadata == null ? new SystemMetadata() : systemMetadata;
+    if (result.getRunId() == null) {
+      result.setRunId(DEFAULT_RUN_ID);
+    }
+    if (!result.hasLastObserved() || result.getLastObserved() == 0) {
+      result.setLastObserved(System.currentTimeMillis());
+    }
+    return result;
   }
 }


### PR DESCRIPTION
Close gaps in the generation of lastObserved timestamps in SystemMetadata.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->