### PR TITLE
fix(ingest/redshift): replace r'\n' with '\n' to avoid token error redshift serverless…

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift_schema.py
@@ -504,7 +504,11 @@ class RedshiftDataDictionary:
                 yield AlterTableRow(
                     transaction_id=row[field_names.index("transaction_id")],
                     session_id=session_id,
-                    query_text=row[field_names.index("query_text")],
+                    # See https://docs.aws.amazon.com/redshift/latest/dg/r_STL_QUERYTEXT.html
+                    # for why we need to replace the \n with a newline.
+                    query_text=row[field_names.index("query_text")].replace(
+                        r"\n", "\n"
+                    ),
                     start_time=row[field_names.index("start_time")],
                 )
             rows = cursor.fetchmany()


### PR DESCRIPTION
… ingestion

Fixes #11109

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced formatting of query text in the Redshift ingestion process for improved readability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->