### PR TITLE
test(openAPI v1/v2): search openAPI test has been added

### DIFF
--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -210,7 +210,22 @@ def test_openapi_v2_entity(entity_type):
 @pytest.mark.read_only
 @pytest.mark.parametrize(
     "entity_type",
-    ["corpGroup"],
+    [
+        "dataset",
+        "dashboard",
+        "dataJob",
+        "dataFlow",
+        "container",
+        "tag",
+        "corpUser",
+        "mlFeature",
+        "glossaryTerm",
+        "domain",
+        "mlPrimaryKey",
+        "mlFeatureTable",
+        "glossaryNode",
+        "mlModel",
+    ],
 )
 def test_openapi_v1_entity(entity_type):
     frontend_session = get_frontend_session()

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -5,6 +5,9 @@ from tests.test_result_msg import add_datahub_stats
 from tests.utils import get_frontend_session, get_frontend_url, get_gms_url
 
 BASE_URL_V3 = f"{get_gms_url()}/openapi/v3"
+BASE_URL_V2 = f"{get_gms_url()}/openapi/v2"
+BASE_URL_V1 = f"{get_gms_url()}/openapi/v1"
+
 
 default_headers = {
     "Content-Type": "application/json",
@@ -146,6 +149,82 @@ def test_openapi_v3_entity(entity_type):
 
     session = requests.Session()
     url = f"{BASE_URL_V3}/entity/{entity_type}/{first_urn}"
+    response = session.get(url, headers=default_headers)
+    response.raise_for_status()
+    actual_data = response.json()
+    print(f"Entity Data for URN {first_urn}: {actual_data}")
+
+    expected_data = {"urn": first_urn}
+
+    assert (
+        actual_data["urn"] == expected_data["urn"]
+    ), f"Mismatch: expected {expected_data}, got {actual_data}"
+
+
+@pytest.mark.read_only
+@pytest.mark.parametrize(
+    "entity_type",
+    [
+        "dataset",
+        "dashboard",
+        "dataJob",
+        "dataFlow",
+        "container",
+        "tag",
+        "corpUser",
+        "mlFeature",
+        "glossaryTerm",
+        "domain",
+        "mlPrimaryKey",
+        "corpGroup",
+        "mlFeatureTable",
+        "glossaryNode",
+        "mlModel",
+    ],
+)
+def test_openapi_v2_entity(entity_type):
+    frontend_session = get_frontend_session()
+    search_result = _get_search_result(frontend_session, entity_type)
+    num_entities = search_result["total"]
+    if num_entities == 0:
+        print(f"[WARN] No results for {entity_type}")
+        return
+    entities = search_result["searchResults"]
+
+    first_urn = entities[0]["entity"]["urn"]
+
+    session = requests.Session()
+    url = f"{BASE_URL_V2}/entity/{entity_type}/{first_urn}"
+    response = session.get(url, headers=default_headers)
+    response.raise_for_status()
+    actual_data = response.json()
+    print(f"Entity Data for URN {first_urn}: {actual_data}")
+
+    expected_data = {"urn": first_urn}
+
+    assert (
+        actual_data["urn"] == expected_data["urn"]
+    ), f"Mismatch: expected {expected_data}, got {actual_data}"
+
+
+@pytest.mark.read_only
+@pytest.mark.parametrize(
+    "entity_type",
+    ["corpGroup"],
+)
+def test_openapi_v1_entity(entity_type):
+    frontend_session = get_frontend_session()
+    search_result = _get_search_result(frontend_session, entity_type)
+    num_entities = search_result["total"]
+    if num_entities == 0:
+        print(f"[WARN] No results for {entity_type}")
+        return
+    entities = search_result["searchResults"]
+
+    first_urn = entities[0]["entity"]["urn"]
+
+    session = requests.Session()
+    url = f"{BASE_URL_V1}/entity/{entity_type}/{first_urn}"
     response = session.get(url, headers=default_headers)
     response.raise_for_status()
     actual_data = response.json()

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -211,16 +211,9 @@ def test_openapi_v2_entity(entity_type):
 @pytest.mark.parametrize(
     "entity_type",
     [
-        "dataset",
         "dashboard",
-        "dataJob",
         "dataFlow",
-        "container",
-        "tag",
-        "corpUser",
         "mlFeature",
-        "glossaryTerm",
-        "domain",
         "mlPrimaryKey",
         "mlFeatureTable",
         "glossaryNode",

--- a/smoke-test/tests/read_only/test_search.py
+++ b/smoke-test/tests/read_only/test_search.py
@@ -1,8 +1,13 @@
+import logging
+
 import pytest
 import requests
 
 from tests.test_result_msg import add_datahub_stats
 from tests.utils import get_frontend_session, get_frontend_url, get_gms_url
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 BASE_URL_V3 = f"{get_gms_url()}/openapi/v3"
 BASE_URL_V2 = f"{get_gms_url()}/openapi/v2"
@@ -141,7 +146,7 @@ def test_openapi_v3_entity(entity_type):
     search_result = _get_search_result(frontend_session, entity_type)
     num_entities = search_result["total"]
     if num_entities == 0:
-        print(f"[WARN] No results for {entity_type}")
+        logger.warning(f"No results for {entity_type}")
         return
     entities = search_result["searchResults"]
 
@@ -149,10 +154,20 @@ def test_openapi_v3_entity(entity_type):
 
     session = requests.Session()
     url = f"{BASE_URL_V3}/entity/{entity_type}/{first_urn}"
-    response = session.get(url, headers=default_headers)
-    response.raise_for_status()
+    try:
+        response = session.get(url, headers=default_headers)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logger.error(f"HTTP error occurred: {e}")
+        return
+    except Exception as e:
+        logger.error(f"An error occurred: {e}")
+        return
+
     actual_data = response.json()
-    print(f"Entity Data for URN {first_urn}: {actual_data}")
+    logger.info(f"URL: {url}")
+    logger.info(f"Response Status Code: {response.status_code}")
+    logger.info(f"Entity Data for URN {first_urn}: {actual_data}")
 
     expected_data = {"urn": first_urn}
 
@@ -187,7 +202,7 @@ def test_openapi_v2_entity(entity_type):
     search_result = _get_search_result(frontend_session, entity_type)
     num_entities = search_result["total"]
     if num_entities == 0:
-        print(f"[WARN] No results for {entity_type}")
+        logger.warning(f"No results for {entity_type}")
         return
     entities = search_result["searchResults"]
 
@@ -195,10 +210,20 @@ def test_openapi_v2_entity(entity_type):
 
     session = requests.Session()
     url = f"{BASE_URL_V2}/entity/{entity_type}/{first_urn}"
-    response = session.get(url, headers=default_headers)
-    response.raise_for_status()
+    try:
+        response = session.get(url, headers=default_headers)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logger.error(f"HTTP error occurred: {e}")
+        return
+    except Exception as e:
+        logger.error(f"An error occurred: {e}")
+        return
+
     actual_data = response.json()
-    print(f"Entity Data for URN {first_urn}: {actual_data}")
+    logger.info(f"URL: {url}")
+    logger.info(f"Response Status Code: {response.status_code}")
+    logger.info(f"Entity Data for URN {first_urn}: {actual_data}")
 
     expected_data = {"urn": first_urn}
 
@@ -225,7 +250,7 @@ def test_openapi_v1_entity(entity_type):
     search_result = _get_search_result(frontend_session, entity_type)
     num_entities = search_result["total"]
     if num_entities == 0:
-        print(f"[WARN] No results for {entity_type}")
+        logger.warning(f"No results for {entity_type}")
         return
     entities = search_result["searchResults"]
 
@@ -233,10 +258,20 @@ def test_openapi_v1_entity(entity_type):
 
     session = requests.Session()
     url = f"{BASE_URL_V1}/entity/{entity_type}/{first_urn}"
-    response = session.get(url, headers=default_headers)
-    response.raise_for_status()
+    try:
+        response = session.get(url, headers=default_headers)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logger.error(f"HTTP error occurred: {e}")
+        return
+    except Exception as e:
+        logger.error(f"An error occurred: {e}")
+        return
+
     actual_data = response.json()
-    print(f"Entity Data for URN {first_urn}: {actual_data}")
+    logger.info(f"URL: {url}")
+    logger.info(f"Response Status Code: {response.status_code}")
+    logger.info(f"Entity Data for URN {first_urn}: {actual_data}")
 
     expected_data = {"urn": first_urn}
 


### PR DESCRIPTION
This PR is for new pytest on search openAPI for v1 and v2 version
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable) - [CUS-2291 : Add read only test for OpenAPI search](https://linear.app/acryl-data/issue/CUS-2291/add-read-only-test-for-openapi-search)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced new tests for OpenAPI endpoints, enhancing coverage for different entity types across versions v1, v2, and v3.

- **Bug Fixes**
	- Improved robustness of the API testing framework by ensuring response data matches expected structures for various entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->