### PR TITLE
fix(ingest/bigquery): use small batch size if use_tables_list_query_v2 is set

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
@@ -985,7 +985,7 @@ class BigQuerySchemaGenerator:
             # https://cloud.google.com/bigquery/docs/information-schema-partitions
             max_batch_size: int = (
                 self.config.number_of_datasets_process_in_batch
-                if not self.config.is_profiling_enabled()
+                if not self.config.have_table_data_read_permission
                 else self.config.number_of_datasets_process_in_batch_if_profiling_enabled
             )
 


### PR DESCRIPTION


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data ingestion logic to prioritize permissions for reading table data when determining batch sizes.
  
- **Bug Fixes**
	- Resolved issues related to batch size calculations that previously relied solely on profiling status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->