### PR TITLE
fix(entiy-client): handle null entityUrn case for restli

### DIFF
--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -50,6 +50,7 @@ import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.browse.BrowseResultV2;
 import com.linkedin.metadata.graph.LineageDirection;
+import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.query.AutoCompleteResult;
 import com.linkedin.metadata.query.LineageFlags;
 import com.linkedin.metadata.query.ListResult;
@@ -66,6 +67,7 @@ import com.linkedin.metadata.search.LineageScrollResult;
 import com.linkedin.metadata.search.LineageSearchResult;
 import com.linkedin.metadata.search.ScrollResult;
 import com.linkedin.metadata.search.SearchResult;
+import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.MetadataChangeProposalArray;
 import com.linkedin.mxe.PlatformEvent;
@@ -1063,7 +1065,20 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
     String result =
         sendClientRequest(requestBuilder, opContext.getSessionAuthentication()).getEntity();
     return metadataChangeProposals.stream()
-        .map(proposal -> "success".equals(result) ? proposal.getEntityUrn().toString() : null)
+        .map(
+            proposal -> {
+              if ("success".equals(result)) {
+                if (proposal.getEntityUrn() != null) {
+                  return proposal.getEntityUrn().toString();
+                } else {
+                  EntitySpec entitySpec =
+                      opContext.getEntityRegistry().getEntitySpec(proposal.getEntityType());
+                  return EntityKeyUtils.getUrnFromProposal(proposal, entitySpec.getKeyAspectSpec())
+                      .toString();
+                }
+              }
+              return null;
+            })
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of metadata change proposals, improving the generation of entity URNs even when they are initially unavailable.
	
- **Bug Fixes**
	- Improved robustness in processing proposals by ensuring valid URNs are generated when necessary, reducing the likelihood of errors during batch ingestion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->