### PR TITLE
docs(ingest/dbt): update run result paths examples

### DIFF
--- a/metadata-ingestion/docs/sources/dbt/dbt.md
+++ b/metadata-ingestion/docs/sources/dbt/dbt.md
@@ -171,7 +171,7 @@ To integrate with dbt tests, the `dbt` source needs access to the `run_results.j
 1. Run `dbt build`
 2. Copy the `target/run_results.json` file to a separate location. This is important, because otherwise subsequent `dbt` commands will overwrite the run results.
 3. Run `dbt docs generate` to generate the `manifest.json` and `catalog.json` files
-4. The dbt source makes use of the manifest, catalog, and run results file, and hence will need to be moved to a location accessible to the `dbt` source (e.g. s3 or local file system). In the ingestion recipe, the `test_results_path` config must be set to the location of the `run_results.json` file from the `dbt build` or `dbt test` run.
+4. The dbt source makes use of the manifest, catalog, and run results file, and hence will need to be moved to a location accessible to the `dbt` source (e.g. s3 or local file system). In the ingestion recipe, the `run_results_paths` config must be set to the location of the `run_results.json` file from the `dbt build` or `dbt test` run.
 
 The connector will produce the following things:
 
@@ -215,7 +215,8 @@ source:
   config:
     manifest_path: _path_to_manifest_json
     catalog_path: _path_to_catalog_json
-    test_results_path: _path_to_run_results_json
+    run_results_paths:
+      - _path_to_run_results_json
     target_platform: postgres
     entities_enabled:
       test_results: Only
@@ -229,7 +230,8 @@ source:
   config:
     manifest_path: _path_to_manifest_json
     catalog_path: _path_to_catalog_json
-    run_results_path: _path_to_run_results_json
+    run_results_paths:
+      - _path_to_run_results_json
     target_platform: postgres
     entities_enabled:
       test_results: No

--- a/metadata-ingestion/docs/sources/dbt/dbt_recipe.yml
+++ b/metadata-ingestion/docs/sources/dbt/dbt_recipe.yml
@@ -6,7 +6,8 @@ source:
     manifest_path: "${DBT_PROJECT_ROOT}/target/manifest_file.json"
     catalog_path: "${DBT_PROJECT_ROOT}/target/catalog_file.json"
     sources_path: "${DBT_PROJECT_ROOT}/target/sources_file.json" # optional for freshness
-    test_results_path: "${DBT_PROJECT_ROOT}/target/run_results.json" # optional for recording dbt test results after running dbt test
+    run_results_paths:
+      - "${DBT_PROJECT_ROOT}/target/run_results.json" # optional for recording dbt test results after running dbt test
 
     # Options
     target_platform: "my_target_platform_id" # e.g. bigquery/postgres/etc.

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -216,18 +216,32 @@ class DbtTestConfig:
             run_results_files=["sample_dbt_run_results_2.json"],
             source_config_modifiers={},
         ),
+        DbtTestConfig(
+            "dbt-prefer-sql-parser-lineage",
+            "dbt_test_prefer_sql_parser_lineage.json",
+            "dbt_test_prefer_sql_parser_lineage_golden.json",
+            catalog_file="sample_dbt_catalog_2.json",
+            manifest_file="sample_dbt_manifest_2.json",
+            sources_file="sample_dbt_sources_2.json",
+            run_results_files=["sample_dbt_run_results_2.json"],
+            source_config_modifiers={
+                "prefer_sql_parser_lineage": True,
+                "skip_sources_in_lineage": True,
+                "entities_enabled": {"sources": "NO"},
+            },
+        ),
     ],
     ids=lambda dbt_test_config: dbt_test_config.run_id,
 )
 @pytest.mark.integration
 @freeze_time(FROZEN_TIME)
 def test_dbt_ingest(
-        dbt_test_config,
-        test_resources_dir,
-        pytestconfig,
-        tmp_path,
-        mock_time,
-        requests_mock,
+    dbt_test_config,
+    test_resources_dir,
+    pytestconfig,
+    tmp_path,
+    mock_time,
+    requests_mock,
 ):
     config: DbtTestConfig = dbt_test_config
     test_resources_dir = pytestconfig.rootpath / "tests/integration/dbt"

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -216,32 +216,18 @@ class DbtTestConfig:
             run_results_files=["sample_dbt_run_results_2.json"],
             source_config_modifiers={},
         ),
-        DbtTestConfig(
-            "dbt-prefer-sql-parser-lineage",
-            "dbt_test_prefer_sql_parser_lineage.json",
-            "dbt_test_prefer_sql_parser_lineage_golden.json",
-            catalog_file="sample_dbt_catalog_2.json",
-            manifest_file="sample_dbt_manifest_2.json",
-            sources_file="sample_dbt_sources_2.json",
-            run_results_files=["sample_dbt_run_results_2.json"],
-            source_config_modifiers={
-                "prefer_sql_parser_lineage": True,
-                "skip_sources_in_lineage": True,
-                "entities_enabled": {"sources": "NO"},
-            },
-        ),
     ],
     ids=lambda dbt_test_config: dbt_test_config.run_id,
 )
 @pytest.mark.integration
 @freeze_time(FROZEN_TIME)
 def test_dbt_ingest(
-    dbt_test_config,
-    test_resources_dir,
-    pytestconfig,
-    tmp_path,
-    mock_time,
-    requests_mock,
+        dbt_test_config,
+        test_resources_dir,
+        pytestconfig,
+        tmp_path,
+        mock_time,
+        requests_mock,
 ):
     config: DbtTestConfig = dbt_test_config
     test_resources_dir = pytestconfig.rootpath / "tests/integration/dbt"
@@ -339,9 +325,13 @@ def test_dbt_tests(test_resources_dir, pytestconfig, tmp_path, mock_time, **kwar
                         (test_resources_dir / "jaffle_shop_catalog.json").resolve()
                     ),
                     target_platform="postgres",
-                    test_results_path=str(
-                        (test_resources_dir / "jaffle_shop_test_results.json").resolve()
-                    ),
+                    run_results_paths=[
+                        str(
+                            (
+                                test_resources_dir / "jaffle_shop_test_results.json"
+                            ).resolve()
+                        )
+                    ],
                 ),
             ),
             sink=DynamicTypedConfig(type="file", config={"filename": str(output_file)}),
@@ -442,9 +432,13 @@ def test_dbt_tests_only_assertions(
                         (test_resources_dir / "jaffle_shop_catalog.json").resolve()
                     ),
                     target_platform="postgres",
-                    test_results_path=str(
-                        (test_resources_dir / "jaffle_shop_test_results.json").resolve()
-                    ),
+                    run_results_paths=[
+                        str(
+                            (
+                                test_resources_dir / "jaffle_shop_test_results.json"
+                            ).resolve()
+                        )
+                    ],
                     entities_enabled=DBTEntitiesEnabled(
                         test_results=EmitDirective.ONLY
                     ),
@@ -518,9 +512,13 @@ def test_dbt_only_test_definitions_and_results(
                         (test_resources_dir / "jaffle_shop_catalog.json").resolve()
                     ),
                     target_platform="postgres",
-                    test_results_path=str(
-                        (test_resources_dir / "jaffle_shop_test_results.json").resolve()
-                    ),
+                    run_results_paths=[
+                        str(
+                            (
+                                test_resources_dir / "jaffle_shop_test_results.json"
+                            ).resolve()
+                        )
+                    ],
                     entities_enabled=DBTEntitiesEnabled(
                         sources=EmitDirective.NO,
                         seeds=EmitDirective.NO,


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the configuration for handling dbt test result paths, allowing users to specify multiple paths with the new `run_results_paths` parameter.
  
- **Documentation**
  - Refined documentation to clarify the changes in configuration structure and to illustrate the usage of the new parameter format.

- **Bug Fixes**
  - Improved handling of test result paths in the testing framework, enhancing flexibility for users managing dbt test results across multiple files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->