### PR TITLE
feat(ingestion): include env on containerProperties aspect of container [WIP]

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mcp_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp_builder.py
@@ -189,6 +189,7 @@ def gen_containers(
     qualified_name: Optional[str] = None,
     created: Optional[int] = None,
     last_modified: Optional[int] = None,
+    env: Optional[str] = None,
 ) -> Iterable[MetadataWorkUnit]:
     container_urn = container_key.as_urn()
     yield MetadataChangeProposalWrapper(
@@ -207,6 +208,7 @@ def gen_containers(
             lastModified=TimeStamp(time=last_modified)
             if last_modified is not None
             else None,
+            env=env,
         ),
     ).as_workunit()
 

--- a/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/container/ContainerProperties.pdl
@@ -3,6 +3,7 @@ namespace com.linkedin.container
 import com.linkedin.common.CustomProperties
 import com.linkedin.common.ExternalReference
 import com.linkedin.common.TimeStamp
+import com.linkedin.common.FabricType
 
 /**
  * Information about a Asset Container as received from a 3rd party source system
@@ -62,4 +63,15 @@ record ContainerProperties includes CustomProperties, ExternalReference {
     }
   }
   lastModified: optional TimeStamp
+
+  /**
+   * Environment for this container
+   */
+  @Searchable = {
+      "fieldType": "KEYWORD",
+      "addToFilters": true,
+      "filterNameOverride": "Environment",
+      "queryByDefault": false
+  }
+  env: optional FabricType
 }


### PR DESCRIPTION
This PR include below change:

1. Include `env` on `containerProperties` aspect of container
2. Set the `env` value by ingestors 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
