### PR TITLE
Fix: add auditstamp to upstreams for lineage creation

### DIFF
--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -1,7 +1,8 @@
+from datetime import datetime
 from typing import Dict, Generic, List, Optional, Tuple, TypeVar, Union
 
 from datahub.emitter.mcp_patch_builder import MetadataPatchProposal
-from datahub.metadata.com.linkedin.pegasus2avro.common import TimeStamp
+from datahub.metadata.com.linkedin.pegasus2avro.common import TimeStamp, AuditStamp
 from datahub.metadata.schema_classes import (
     DatasetPropertiesClass as DatasetProperties,
     EditableDatasetPropertiesClass as EditableDatasetProperties,
@@ -122,6 +123,17 @@ class DatasetPatchBuilder(MetadataPatchProposal):
         return self
 
     def add_upstream_lineage(self, upstream: Upstream) -> "DatasetPatchBuilder":
+        default_audit_stamp = AuditStamp(
+            time=0,
+            actor='urn:li:corpuser:unknown',
+            impersonator=None,
+            message=None
+        )
+        if upstream.auditStamp==default_audit_stamp:
+            upstream.auditStamp = AuditStamp(
+                time=int(datetime.now().timestamp() * 1000),
+                actor="urn:li:corpuser:datahub"
+            )
         self._add_patch(
             UpstreamLineage.ASPECT_NAME,
             "add",
@@ -142,6 +154,19 @@ class DatasetPatchBuilder(MetadataPatchProposal):
         return self
 
     def set_upstream_lineages(self, upstreams: List[Upstream]) -> "DatasetPatchBuilder":
+        default_audit_stamp = AuditStamp(
+            time=0,
+            actor='urn:li:corpuser:unknown',
+            impersonator=None,
+            message=None
+        )
+        for upstream in upstreams:
+            if upstream.auditStamp==default_audit_stamp:
+                print("Adding stamp")
+            upstream.auditStamp = AuditStamp(
+                time=int(datetime.now().timestamp() * 1000),
+                actor="urn:li:corpuser:datahub"
+            )
         self._add_patch(
             UpstreamLineage.ASPECT_NAME, "add", path="/upstreams", value=upstreams
         )

--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -162,11 +162,10 @@ class DatasetPatchBuilder(MetadataPatchProposal):
         )
         for upstream in upstreams:
             if upstream.auditStamp==default_audit_stamp:
-                print("Adding stamp")
-            upstream.auditStamp = AuditStamp(
-                time=int(datetime.now().timestamp() * 1000),
-                actor="urn:li:corpuser:datahub"
-            )
+                upstream.auditStamp = AuditStamp(
+                    time=int(datetime.now().timestamp() * 1000),
+                    actor="urn:li:corpuser:datahub"
+                )
         self._add_patch(
             UpstreamLineage.ASPECT_NAME, "add", path="/upstreams", value=upstreams
         )


### PR DESCRIPTION
## Checklist

- [+] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [+] Links to related issues (if applicable)
https://datahubspace.slack.com/archives/C029A3M079U/p1720012910820989
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

We observed an issue we shared over here: 
https://datahubspace.slack.com/archives/C029A3M079U/p1720012910820989
The issue is that when we added an upstream, even when we do not change anything on the other upstreams, others' lastObserved date also changed. This can be seen in the images:

![image (1)](https://github.com/user-attachments/assets/2d50cb53-55a3-4a63-a39e-47473310c183)
![image](https://github.com/user-attachments/assets/b1f848dc-8223-4321-9b90-76c851b957e7)

We observed that while creating the lineage, if we explicitly write the time to auditStamp of the corresponding upstream, the issue is resolved. Therefore, I made the following changes to the lineage adding and lineage setting methods.  

default_audit_stamp is what is written to Upstream's auditStamp when it is not explicitly given during object creation. We checked it over here: https://github.com/datahub-project/datahub/blob/f559dcc282c255e35d10a85f947243b021082aa3/metadata-models/src/main/pegasus/com/linkedin/dataset/Upstream.pdl#L1