### PR TITLE
fix(ui) Fix bug with editing entity names

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityHeader.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityHeader.test.tsx
@@ -3,13 +3,14 @@ import { EntityType } from '../../../../../../types.generated';
 import { getCanEditName } from '../header/EntityHeader';
 
 describe('getCanEditName', () => {
-    const entityDataWithManagePrivileges = { privileges: { canManageEntity: true } };
-    const entityDataWithoutManagePrivileges = { privileges: { canManageEntity: false } };
+    const entityDataWithManagePrivileges = { privileges: { canManageEntity: true, canEditProperties: true } };
+    const entityDataWithoutManagePrivileges = { privileges: { canManageEntity: false, canEditProperties: false } };
 
     it('should return true for Terms if manageGlossaries privilege is true', () => {
         const canEditName = getCanEditName(
             EntityType.GlossaryTerm,
             entityDataWithoutManagePrivileges,
+            true,
             platformPrivileges,
         );
 
@@ -21,6 +22,7 @@ describe('getCanEditName', () => {
         const canEditName = getCanEditName(
             EntityType.GlossaryTerm,
             entityDataWithoutManagePrivileges,
+            true,
             privilegesWithoutGlossaries,
         );
 
@@ -32,6 +34,7 @@ describe('getCanEditName', () => {
         const canEditName = getCanEditName(
             EntityType.GlossaryTerm,
             entityDataWithManagePrivileges,
+            true,
             privilegesWithoutGlossaries,
         );
 
@@ -42,6 +45,7 @@ describe('getCanEditName', () => {
         const canEditName = getCanEditName(
             EntityType.GlossaryNode,
             entityDataWithoutManagePrivileges,
+            true,
             platformPrivileges,
         );
 
@@ -53,6 +57,7 @@ describe('getCanEditName', () => {
         const canEditName = getCanEditName(
             EntityType.GlossaryNode,
             entityDataWithoutManagePrivileges,
+            true,
             privilegesWithoutGlossaries,
         );
 
@@ -64,6 +69,7 @@ describe('getCanEditName', () => {
         const canEditName = getCanEditName(
             EntityType.GlossaryNode,
             entityDataWithManagePrivileges,
+            true,
             privilegesWithoutGlossaries,
         );
 
@@ -71,7 +77,12 @@ describe('getCanEditName', () => {
     });
 
     it('should return true for Domains if manageDomains privilege is true', () => {
-        const canEditName = getCanEditName(EntityType.Domain, entityDataWithoutManagePrivileges, platformPrivileges);
+        const canEditName = getCanEditName(
+            EntityType.Domain,
+            entityDataWithoutManagePrivileges,
+            true,
+            platformPrivileges,
+        );
 
         expect(canEditName).toBe(true);
     });
@@ -81,6 +92,7 @@ describe('getCanEditName', () => {
         const canEditName = getCanEditName(
             EntityType.Domain,
             entityDataWithoutManagePrivileges,
+            true,
             privilegesWithoutDomains,
         );
 
@@ -88,7 +100,30 @@ describe('getCanEditName', () => {
     });
 
     it('should return false for an unsupported entity', () => {
-        const canEditName = getCanEditName(EntityType.Chart, entityDataWithManagePrivileges, platformPrivileges);
+        const canEditName = getCanEditName(EntityType.Chart, entityDataWithManagePrivileges, true, platformPrivileges);
+
+        expect(canEditName).toBe(false);
+    });
+
+    it('should return true for a dataset if canEditProperties is true', () => {
+        const canEditName = getCanEditName(EntityType.Chart, entityDataWithManagePrivileges, true, platformPrivileges);
+
+        expect(canEditName).toBe(false);
+    });
+
+    it('should return false for a dataset if canEditProperties is false', () => {
+        const canEditName = getCanEditName(
+            EntityType.Chart,
+            entityDataWithoutManagePrivileges,
+            true,
+            platformPrivileges,
+        );
+
+        expect(canEditName).toBe(false);
+    });
+
+    it('should return false for a dataset if isEditableDatasetNameEnabled is false', () => {
+        const canEditName = getCanEditName(EntityType.Chart, entityDataWithManagePrivileges, false, platformPrivileges);
 
         expect(canEditName).toBe(false);
     });

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -60,6 +60,7 @@ const TopButtonsWrapper = styled.div`
 export function getCanEditName(
     entityType: EntityType,
     entityData: GenericEntityProperties | null,
+    isEditableDatasetNameEnabled: boolean,
     privileges?: PlatformPrivileges,
 ) {
     switch (entityType) {
@@ -73,7 +74,7 @@ export function getCanEditName(
         case EntityType.BusinessAttribute:
             return privileges?.manageBusinessAttributes;
         case EntityType.Dataset:
-            return entityData?.privileges?.canEditProperties;
+            return isEditableDatasetNameEnabled && entityData?.privileges?.canEditProperties;
         default:
             return false;
     }
@@ -99,9 +100,13 @@ export const EntityHeader = ({ headerDropdownItems, headerActionItems, isNameEdi
 
     const isEditableDatasetNameEnabled = useIsEditableDatasetNameEnabled();
     const canEditName =
-        isEditableDatasetNameEnabled &&
         isNameEditable &&
-        getCanEditName(entityType, entityData, me?.platformPrivileges as PlatformPrivileges);
+        getCanEditName(
+            entityType,
+            entityData,
+            isEditableDatasetNameEnabled,
+            me?.platformPrivileges as PlatformPrivileges,
+        );
     const entityRegistry = useEntityRegistry();
 
     return (


### PR DESCRIPTION
We don't want a feature flag for editing dataset names to be affecting the ability to edit other entity names (like glossary terms, domains, etc.). This should only affect editing dataset names.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
