### PR TITLE
fix(tests): Bump databricks-sdk dependency to `>=0.30.0`

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -298,7 +298,7 @@ slack = {"slack-sdk==3.18.1"}
 
 databricks = {
     # 0.1.11 appears to have authentication issues with azure databricks
-    "databricks-sdk>=0.9.0",
+    "databricks-sdk>=0.30.0",
     "pyspark~=3.3.0",
     "requests",
     # Version 2.4.0 includes sqlalchemy dialect, 2.8.0 includes some bug fixes


### PR DESCRIPTION
`StatementResponse` class imported by one of the tests was introduced to `databricks.sdk.service.sql` in `0.30.0`.
