### PR TITLE
fix(ingest/redshift): avoid asserts in redshift schemas

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift_schema.py
@@ -313,23 +313,19 @@ class RedshiftDataDictionary:
         size_in_bytes: Optional[int] = None
         rows_count: Optional[int] = None
         if schema in enriched_tables and table_name in enriched_tables[schema]:
-            if enriched_tables[schema][table_name].last_accessed is not None:
-                # Mypy seems to be not clever enough to understand the above check
-                last_accessed = enriched_tables[schema][table_name].last_accessed
-                assert last_accessed
+            if (
+                last_accessed := enriched_tables[schema][table_name].last_accessed
+            ) is not None:
                 last_altered = last_accessed.replace(tzinfo=timezone.utc)
             elif creation_time:
                 last_altered = creation_time
 
-            if enriched_tables[schema][table_name].size is not None:
-                # Mypy seems to be not clever enough to understand the above check
-                size = enriched_tables[schema][table_name].size
-                if size:
-                    size_in_bytes = size * 1024 * 1024
+            if (size := enriched_tables[schema][table_name].size) is not None:
+                size_in_bytes = size * 1024 * 1024
 
-            if enriched_tables[schema][table_name].estimated_visible_rows is not None:
-                rows = enriched_tables[schema][table_name].estimated_visible_rows
-                assert rows
+            if (
+                rows := enriched_tables[schema][table_name].estimated_visible_rows
+            ) is not None:
                 rows_count = int(rows)
         else:
             # The object was not found in the enriched data.


### PR DESCRIPTION
The `assert rows` lines would previously fail if rows=0.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
