### PR TITLE
fix(spark-lineage): exclude log4j.xml and log4j2.xml from openlineage…

### DIFF
--- a/metadata-integration/java/openlineage-converter/build.gradle
+++ b/metadata-integration/java/openlineage-converter/build.gradle
@@ -41,6 +41,11 @@ test {
     useJUnit()
     finalizedBy jacocoTestReport
 }
+shadowJar {
+    zip64 = true
+    archiveClassifier = ''
+    exclude('log4j2.*', 'log4j.*')
+}
 
 //task sourcesJar(type: Jar) {
 //    classifier 'sources'


### PR DESCRIPTION
acryl-spark-lineage fat jar contains log4j2.xml and log4j.xml and they are controlling/overriding the spark application logging configuration.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
