### PR TITLE
fix(cli/delete): change filter to include env

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/graph/filters.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/filters.py
@@ -110,6 +110,10 @@ def _get_env_filters(env: str) -> List[SearchFilterRule]:
             "field": "customProperties",
             "value": f"instance={env}",
         },
+        {
+            "field": "env",
+            "value": env,
+        }
         # Note that not all entity types have an env (e.g. dashboards / charts).
         # If the env filter is specified, these will be excluded.
     ]


### PR DESCRIPTION
After this https://github.com/datahub-project/datahub/pull/10814 for data flows and data jobs we have `env` stored which needed to be filtered for otherwise dataflows and datajobs won't come up when doing deletes. This fixes that problem.

The below gave zero results without this while UI was working due to lack of this filter
```
datahub delete by-filter --platform airflow --env PROD --dry-run
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
