### PR TITLE
feat(ingest/fivetran): support filtering on destination ids

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/config.py
@@ -161,6 +161,10 @@ class FivetranSourceConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin
         default=AllowDenyPattern.allow_all(),
         description="Regex patterns for connectors to filter in ingestion.",
     )
+    destination_patterns: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex patterns for destinations to filter in ingestion.",
+    )
     include_column_lineage: bool = Field(
         default=True,
         description="Populates table->table column lineage.",

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran.py
@@ -283,6 +283,7 @@ class FivetranSource(StatefulIngestionSourceBase):
         logger.info("Fivetran plugin execution is started")
         connectors = self.audit_log.get_allowed_connectors_list(
             self.config.connector_patterns,
+            self.config.destination_patterns,
             self.report,
             self.config.history_sync_lookback_period,
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/fivetran/fivetran_log_api.py
@@ -251,6 +251,7 @@ class FivetranLogAPI:
     def get_allowed_connectors_list(
         self,
         connector_patterns: AllowDenyPattern,
+        destination_patterns: AllowDenyPattern,
         report: FivetranSourceReport,
         syncs_interval: int,
     ) -> List[Connector]:
@@ -259,6 +260,9 @@ class FivetranLogAPI:
             connector_list = self._query(self.fivetran_log_query.get_connectors_query())
             for connector in connector_list:
                 if not connector_patterns.allowed(connector[Constant.CONNECTOR_NAME]):
+                    report.report_connectors_dropped(connector[Constant.CONNECTOR_NAME])
+                    continue
+                if not destination_patterns.allowed(connector[Constant.DESTINATION_ID]):
                     report.report_connectors_dropped(connector[Constant.CONNECTOR_NAME])
                     continue
                 connectors.append(

--- a/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
+++ b/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
@@ -205,6 +205,11 @@ def test_fivetran_with_snowflake_dest(pytestconfig, tmp_path):
                                 "postgres",
                             ]
                         },
+                        "destination_patterns": {
+                            "allow": [
+                                "interval_unconstitutional"
+                            ]
+                        },
                         "sources_to_database": {
                             "calendar_elected": "postgres_db",
                         },
@@ -289,6 +294,11 @@ def test_fivetran_with_snowflake_dest_and_null_connector_user(pytestconfig, tmp_
                         "connector_patterns": {
                             "allow": [
                                 "postgres",
+                            ]
+                        },
+                        "destination_patterns": {
+                            "allow": [
+                                "interval_unconstitutional"
                             ]
                         },
                         "sources_to_database": {

--- a/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
+++ b/metadata-ingestion/tests/integration/fivetran/test_fivetran.py
@@ -207,7 +207,7 @@ def test_fivetran_with_snowflake_dest(pytestconfig, tmp_path):
                         },
                         "destination_patterns": {
                             "allow": [
-                                "interval_unconstitutional"
+                                "interval_unconstitutional",
                             ]
                         },
                         "sources_to_database": {
@@ -298,7 +298,7 @@ def test_fivetran_with_snowflake_dest_and_null_connector_user(pytestconfig, tmp_
                         },
                         "destination_patterns": {
                             "allow": [
-                                "interval_unconstitutional"
+                                "interval_unconstitutional",
                             ]
                         },
                         "sources_to_database": {


### PR DESCRIPTION
Add ability for users to filter to only include specific destination IDs. This would let us exclude non-prod environments in our PROD DataHub deployment and speed up the ingestion (as its pretty slow given the 100s of connectors we have).

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
