### PR TITLE
fix(openlineage): fix jar conflict

### DIFF
--- a/metadata-integration/java/openlineage-converter/build.gradle
+++ b/metadata-integration/java/openlineage-converter/build.gradle
@@ -47,6 +47,10 @@ shadowJar {
     exclude('log4j2.*', 'log4j.*')
 }
 
+jar {
+    archiveClassifier = 'lib'
+}
+
 //task sourcesJar(type: Jar) {
 //    classifier 'sources'
 //    from sourceSets.main.allJava


### PR DESCRIPTION
Since the shadow jar doesn't have a classifier, specify one for the non-shadowJar. This prevents compilation errors in the project.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
