### PR TITLE
fix(bigquery): followups on bigquery queries v2 integration

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_config.py
@@ -467,6 +467,7 @@ class BigQueryV2Config(
         default=True,
         description="Option to enable/disable lineage generation. Is enabled by default.",
     )
+
     max_query_duration: timedelta = Field(
         default=timedelta(minutes=15),
         description="Correction to pad start_time and end_time with. For handling the case where the read happens within our time range but the query completion event is delayed and happens after the configured end time.",
@@ -520,6 +521,30 @@ class BigQueryV2Config(
         description="Number of worker threads to use to parallelize BigQuery Dataset Metadata Extraction."
         " Set to 1 to disable.",
     )
+
+    # include_view_lineage and include_view_column_lineage are inherited from SQLCommonConfig
+    # but not used in bigquery so we hide them from docs.
+    include_view_lineage: bool = Field(default=True, hidden_from_docs=True)
+
+    include_view_column_lineage: bool = Field(default=True, hidden_from_docs=True)
+
+    @root_validator(pre=True)
+    def set_include_schema_metadata(cls, values: Dict) -> Dict:
+        # Historically this is used to disable schema ingestion
+        if (
+            "include_tables" in values
+            and "include_views" in values
+            and not values["include_tables"]
+            and not values["include_views"]
+        ):
+            values["include_schema_metadata"] = False
+            values["include_table_snapshots"] = False
+            logger.info(
+                "include_tables and include_views are both set to False."
+                " Disabling schema metadata ingestion for tables, views, and snapshots."
+            )
+
+        return values
 
     @root_validator(skip_on_failure=True)
     def profile_default_settings(cls, values: Dict) -> Dict:

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import lru_cache
-from typing import Any, Dict, Iterable, Iterator, List, Optional
+from typing import Any, Dict, FrozenSet, Iterable, Iterator, List, Optional
 
 from google.api_core import retry
 from google.cloud import bigquery, datacatalog_v1, resourcemanager_v3
@@ -225,7 +225,7 @@ class BigQuerySchemaApi:
         return projects
 
     @lru_cache(maxsize=1)
-    def get_projects_with_labels(self, labels: frozenset[str]) -> List[BigqueryProject]:
+    def get_projects_with_labels(self, labels: FrozenSet[str]) -> List[BigqueryProject]:
         with self.report.list_projects_with_labels_timer:
             try:
                 projects = []
@@ -679,7 +679,7 @@ def query_project_list_from_labels(
     filters: BigQueryFilter,
 ) -> Iterable[BigqueryProject]:
     projects = schema_api.get_projects_with_labels(
-        frozenset(filters.filter_config.project_labels)
+        FrozenSet(filters.filter_config.project_labels)
     )
 
     if not projects:  # Report failure on exception and if empty list is returned

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -679,7 +679,7 @@ def query_project_list_from_labels(
     filters: BigQueryFilter,
 ) -> Iterable[BigqueryProject]:
     projects = schema_api.get_projects_with_labels(
-        FrozenSet(filters.filter_config.project_labels)
+        frozenset(filters.filter_config.project_labels)
     )
 
     if not projects:  # Report failure on exception and if empty list is returned

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 from typing import Any, Dict, Iterable, Iterator, List, Optional
 
 from google.api_core import retry
@@ -175,6 +176,7 @@ class BigQuerySchemaApi:
         )
         return resp.result()
 
+    @lru_cache(maxsize=1)
     def get_projects(self, max_results_per_page: int = 100) -> List[BigqueryProject]:
         def _should_retry(exc: BaseException) -> bool:
             logger.debug(
@@ -222,7 +224,8 @@ class BigQuerySchemaApi:
                     return []
         return projects
 
-    def get_projects_with_labels(self, labels: List[str]) -> List[BigqueryProject]:
+    @lru_cache(maxsize=1)
+    def get_projects_with_labels(self, labels: frozenset[str]) -> List[BigqueryProject]:
         with self.report.list_projects_with_labels_timer:
             try:
                 projects = []
@@ -675,7 +678,9 @@ def query_project_list_from_labels(
     report: SourceReport,
     filters: BigQueryFilter,
 ) -> Iterable[BigqueryProject]:
-    projects = schema_api.get_projects_with_labels(filters.filter_config.project_labels)
+    projects = schema_api.get_projects_with_labels(
+        frozenset(filters.filter_config.project_labels)
+    )
 
     if not projects:  # Report failure on exception and if empty list is returned
         report.report_failure(

--- a/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/bigquery_v2/bigquery_schema_gen.py
@@ -188,7 +188,11 @@ class BigQuerySchemaGenerator:
 
     @property
     def store_table_refs(self):
-        return self.config.include_table_lineage or self.config.include_usage_statistics
+        return (
+            self.config.include_table_lineage
+            or self.config.include_usage_statistics
+            or self.config.use_queries_v2
+        )
 
     def get_project_workunits(
         self, project: BigqueryProject
@@ -312,7 +316,8 @@ class BigQuerySchemaGenerator:
                     f"Excluded project '{project_id}' since no datasets were found. {action_message}"
                 )
             else:
-                yield from self.gen_project_id_containers(project_id)
+                if self.config.include_schema_metadata:
+                    yield from self.gen_project_id_containers(project_id)
                 self.report.warning(
                     title="No datasets found in project",
                     message=action_message,
@@ -320,7 +325,8 @@ class BigQuerySchemaGenerator:
                 )
             return
 
-        yield from self.gen_project_id_containers(project_id)
+        if self.config.include_schema_metadata:
+            yield from self.gen_project_id_containers(project_id)
 
         self.report.num_project_datasets_to_scan[project_id] = len(
             bigquery_project.datasets
@@ -392,9 +398,10 @@ class BigQuerySchemaGenerator:
     ) -> Iterable[MetadataWorkUnit]:
         dataset_name = bigquery_dataset.name
 
-        yield from self.gen_dataset_containers(
-            dataset_name, project_id, bigquery_dataset.labels
-        )
+        if self.config.include_schema_metadata:
+            yield from self.gen_dataset_containers(
+                dataset_name, project_id, bigquery_dataset.labels
+            )
 
         columns = None
 
@@ -404,11 +411,7 @@ class BigQuerySchemaGenerator:
                 max_calls=self.config.requests_per_min, period=60
             )
 
-        if (
-            self.config.include_tables
-            or self.config.include_views
-            or self.config.include_table_snapshots
-        ):
+        if self.config.include_schema_metadata:
             columns = self.schema_api.get_columns_for_dataset(
                 project_id=project_id,
                 dataset_name=dataset_name,
@@ -418,6 +421,27 @@ class BigQuerySchemaGenerator:
                 report=self.report,
                 rate_limiter=rate_limiter,
             )
+        elif self.store_table_refs:
+            # Need table_refs to calculate lineage and usage
+            for table_item in self.schema_api.list_tables(dataset_name, project_id):
+                identifier = BigqueryTableIdentifier(
+                    project_id=project_id,
+                    dataset=dataset_name,
+                    table=table_item.table_id,
+                )
+                if not self.config.table_pattern.allowed(identifier.raw_table_name()):
+                    self.report.report_dropped(identifier.raw_table_name())
+                    continue
+                try:
+                    self.table_refs.add(
+                        str(BigQueryTableRef(identifier).get_sanitized_table_ref())
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Could not create table ref for {table_item.path}: {e}"
+                    )
+            yield from []
+            return
 
         if self.config.include_tables:
             db_tables[dataset_name] = list(
@@ -447,25 +471,6 @@ class BigQuerySchemaGenerator:
                         )
                     ),
                 )
-        elif self.store_table_refs:
-            # Need table_refs to calculate lineage and usage
-            for table_item in self.schema_api.list_tables(dataset_name, project_id):
-                identifier = BigqueryTableIdentifier(
-                    project_id=project_id,
-                    dataset=dataset_name,
-                    table=table_item.table_id,
-                )
-                if not self.config.table_pattern.allowed(identifier.raw_table_name()):
-                    self.report.report_dropped(identifier.raw_table_name())
-                    continue
-                try:
-                    self.table_refs.add(
-                        str(BigQueryTableRef(identifier).get_sanitized_table_ref())
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"Could not create table ref for {table_item.path}: {e}"
-                    )
 
         if self.config.include_views:
             db_views[dataset_name] = list(

--- a/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_golden.json
+++ b/metadata-ingestion/tests/integration/bigquery_v2/bigquery_mcp_golden.json
@@ -403,6 +403,129 @@
 },
 {
     "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "project-id-1.bigquery-dataset-1.view-1",
+            "platform": "urn:li:dataPlatform:bigquery",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.MySqlDDL": {
+                    "tableSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "age",
+                    "nullable": false,
+                    "description": "comment",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "INT",
+                    "recursive": false,
+                    "globalTags": {
+                        "tags": [
+                            {
+                                "tag": "urn:li:tag:Test Policy Tag"
+                            }
+                        ]
+                    },
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "email",
+                    "nullable": false,
+                    "description": "comment",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "STRING",
+                    "recursive": false,
+                    "globalTags": {
+                        "tags": []
+                    },
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "externalUrl": "https://console.cloud.google.com/bigquery?project=project-id-1&ws=!1m5!1m4!4m3!1sproject-id-1!2sbigquery-dataset-1!3sview-1",
+            "name": "view-1",
+            "qualifiedName": "project-id-1.bigquery-dataset-1.view-1",
+            "description": "",
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:8df46c5e3ded05a3122b0015822c0ef0"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.snapshot-table-1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "status",
@@ -425,6 +548,24 @@
     "aspect": {
         "json": {
             "name": "Age"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "View"
+            ]
         }
     },
     "systemMetadata": {
@@ -525,6 +666,66 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:bigquery,project-id-1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "viewProperties",
+    "aspect": {
+        "json": {
+            "materialized": false,
+            "viewLogic": "create view `bigquery-dataset-1.view-1` as select email from `bigquery-dataset-1.table-1`",
+            "viewLanguage": "SQL"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:068bd9323110994a40019fcf6cfc60d3",
+                    "urn": "urn:li:container:068bd9323110994a40019fcf6cfc60d3"
+                },
+                {
+                    "id": "urn:li:container:8df46c5e3ded05a3122b0015822c0ef0",
+                    "urn": "urn:li:container:8df46c5e3ded05a3122b0015822c0ef0"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "glossaryTerm",
     "entityUrn": "urn:li:glossaryTerm:Email_Address",
     "changeType": "UPSERT",
@@ -608,6 +809,34 @@
     }
 },
 {
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Abigquery%2Cproject-id-1.bigquery-dataset-1.view-1%2CPROD%29",
+    "changeType": "UPSERT",
+    "aspectName": "queryProperties",
+    "aspect": {
+        "json": {
+            "statement": {
+                "value": "CREATE VIEW `bigquery-dataset-1.view-1` AS\nSELECT\n  email\nFROM `bigquery-dataset-1.table-1`",
+                "language": "SQL"
+            },
+            "source": "SYSTEM",
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:_ingestion"
+            },
+            "lastModified": {
+                "time": 1643871600000,
+                "actor": "urn:li:corpuser:_ingestion"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.snapshot-table-1,PROD)",
     "changeType": "UPSERT",
@@ -622,6 +851,35 @@
                 {
                     "id": "urn:li:container:8df46c5e3ded05a3122b0015822c0ef0",
                     "urn": "urn:li:container:8df46c5e3ded05a3122b0015822c0ef0"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Abigquery%2Cproject-id-1.bigquery-dataset-1.view-1%2CPROD%29",
+    "changeType": "UPSERT",
+    "aspectName": "querySubjects",
+    "aspect": {
+        "json": {
+            "subjects": [
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD),email)"
+                },
+                {
+                    "entity": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)"
+                },
+                {
+                    "entity": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD),email)"
                 }
             ]
         }
@@ -675,6 +933,82 @@
                         "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.snapshot-table-1,PROD),email)"
                     ],
                     "confidenceScore": 1.0
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Abigquery%2Cproject-id-1.bigquery-dataset-1.view-1%2CPROD%29",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:bigquery"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "query",
+    "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Abigquery%2Cproject-id-1.bigquery-dataset-1.view-1%2CPROD%29",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "bigquery-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+        "json": {
+            "upstreams": [
+                {
+                    "auditStamp": {
+                        "time": 1643871600000,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "created": {
+                        "time": 0,
+                        "actor": "urn:li:corpuser:_ingestion"
+                    },
+                    "dataset": "urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD)",
+                    "type": "VIEW",
+                    "query": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Abigquery%2Cproject-id-1.bigquery-dataset-1.view-1%2CPROD%29"
+                }
+            ],
+            "fineGrainedLineages": [
+                {
+                    "upstreamType": "FIELD_SET",
+                    "upstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.table-1,PROD),email)"
+                    ],
+                    "downstreamType": "FIELD",
+                    "downstreams": [
+                        "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:bigquery,project-id-1.bigquery-dataset-1.view-1,PROD),email)"
+                    ],
+                    "confidenceScore": 0.9,
+                    "query": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Abigquery%2Cproject-id-1.bigquery-dataset-1.view-1%2CPROD%29"
                 }
             ]
         }

--- a/metadata-ingestion/tests/integration/bigquery_v2/test_bigquery.py
+++ b/metadata-ingestion/tests/integration/bigquery_v2/test_bigquery.py
@@ -20,6 +20,7 @@ from datahub.ingestion.source.bigquery_v2.bigquery_schema import (
     BigQuerySchemaApi,
     BigqueryTable,
     BigqueryTableSnapshot,
+    BigqueryView,
 )
 from datahub.ingestion.source.bigquery_v2.bigquery_schema_gen import (
     BigQuerySchemaGenerator,
@@ -63,6 +64,7 @@ def recipe(mcp_output_path: str, override: dict = {}) -> dict:
                     ],
                     max_workers=1,
                 ).dict(),
+                **override,
             },
         },
         "sink": {"type": "file", "config": {"filename": mcp_output_path}},
@@ -71,6 +73,7 @@ def recipe(mcp_output_path: str, override: dict = {}) -> dict:
 
 @freeze_time(FROZEN_TIME)
 @patch.object(BigQuerySchemaApi, "get_snapshots_for_dataset")
+@patch.object(BigQuerySchemaApi, "get_views_for_dataset")
 @patch.object(BigQuerySchemaApi, "get_tables_for_dataset")
 @patch.object(BigQuerySchemaGenerator, "get_core_table_details")
 @patch.object(BigQuerySchemaApi, "get_datasets_for_project_id")
@@ -88,6 +91,7 @@ def test_bigquery_v2_ingest(
     get_datasets_for_project_id,
     get_core_table_details,
     get_tables_for_dataset,
+    get_views_for_dataset,
     get_snapshots_for_dataset,
     pytestconfig,
     tmp_path,
@@ -96,15 +100,15 @@ def test_bigquery_v2_ingest(
     mcp_golden_path = f"{test_resources_dir}/bigquery_mcp_golden.json"
     mcp_output_path = "{}/{}".format(tmp_path, "bigquery_mcp_output.json")
 
-    get_datasets_for_project_id.return_value = [
-        BigqueryDataset(name="bigquery-dataset-1")
-    ]
+    dataset_name = "bigquery-dataset-1"
+    get_datasets_for_project_id.return_value = [BigqueryDataset(name=dataset_name)]
 
     table_list_item = TableListItem(
         {"tableReference": {"projectId": "", "datasetId": "", "tableId": ""}}
     )
     table_name = "table-1"
     snapshot_table_name = "snapshot-table-1"
+    view_name = "view-1"
     get_core_table_details.return_value = {table_name: table_list_item}
     columns = [
         BigqueryColumn(
@@ -133,6 +137,7 @@ def test_bigquery_v2_ingest(
     get_columns_for_dataset.return_value = {
         table_name: columns,
         snapshot_table_name: columns,
+        view_name: columns,
     }
     get_sample_data_for_table.return_value = {
         "age": [random.randint(1, 80) for i in range(20)],
@@ -162,6 +167,19 @@ def test_bigquery_v2_ingest(
         ),
     )
     get_snapshots_for_dataset.return_value = iter([snapshot_table])
+
+    bigquery_view = BigqueryView(
+        name=view_name,
+        comment=None,
+        created=None,
+        view_definition=f"create view `{dataset_name}.view-1` as select email from `{dataset_name}.table-1`",
+        last_altered=None,
+        size_in_bytes=None,
+        rows_count=None,
+        materialized=False,
+    )
+
+    get_views_for_dataset.return_value = iter([bigquery_view])
 
     pipeline_config_dict: Dict[str, Any] = recipe(mcp_output_path=mcp_output_path)
 
@@ -261,6 +279,132 @@ def test_bigquery_v2_project_labels_ingest(
     pipeline_config_dict["source"]["config"]["project_labels"] = [
         "environment:development"
     ]
+
+    run_and_get_pipeline(pipeline_config_dict)
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=mcp_output_path,
+        golden_path=mcp_golden_path,
+    )
+
+
+@freeze_time(FROZEN_TIME)
+@patch.object(BigQuerySchemaApi, "get_snapshots_for_dataset")
+@patch.object(BigQuerySchemaApi, "get_views_for_dataset")
+@patch.object(BigQuerySchemaApi, "get_tables_for_dataset")
+@patch.object(BigQuerySchemaGenerator, "get_core_table_details")
+@patch.object(BigQuerySchemaApi, "get_datasets_for_project_id")
+@patch.object(BigQuerySchemaApi, "get_columns_for_dataset")
+@patch.object(BigQueryDataReader, "get_sample_data_for_table")
+@patch("google.cloud.bigquery.Client")
+@patch("google.cloud.datacatalog_v1.PolicyTagManagerClient")
+@patch("google.cloud.resourcemanager_v3.ProjectsClient")
+def test_bigquery_queries_v2_ingest(
+    client,
+    policy_tag_manager_client,
+    projects_client,
+    get_sample_data_for_table,
+    get_columns_for_dataset,
+    get_datasets_for_project_id,
+    get_core_table_details,
+    get_tables_for_dataset,
+    get_views_for_dataset,
+    get_snapshots_for_dataset,
+    pytestconfig,
+    tmp_path,
+):
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/bigquery_v2"
+    mcp_golden_path = f"{test_resources_dir}/bigquery_mcp_golden.json"
+    mcp_output_path = "{}/{}".format(tmp_path, "bigquery_mcp_output.json")
+
+    dataset_name = "bigquery-dataset-1"
+    get_datasets_for_project_id.return_value = [BigqueryDataset(name=dataset_name)]
+
+    table_list_item = TableListItem(
+        {"tableReference": {"projectId": "", "datasetId": "", "tableId": ""}}
+    )
+    table_name = "table-1"
+    snapshot_table_name = "snapshot-table-1"
+    view_name = "view-1"
+    get_core_table_details.return_value = {table_name: table_list_item}
+    columns = [
+        BigqueryColumn(
+            name="age",
+            ordinal_position=1,
+            is_nullable=False,
+            field_path="col_1",
+            data_type="INT",
+            comment="comment",
+            is_partition_column=False,
+            cluster_column_position=None,
+            policy_tags=["Test Policy Tag"],
+        ),
+        BigqueryColumn(
+            name="email",
+            ordinal_position=1,
+            is_nullable=False,
+            field_path="col_2",
+            data_type="STRING",
+            comment="comment",
+            is_partition_column=False,
+            cluster_column_position=None,
+        ),
+    ]
+
+    get_columns_for_dataset.return_value = {
+        table_name: columns,
+        snapshot_table_name: columns,
+        view_name: columns,
+    }
+    get_sample_data_for_table.return_value = {
+        "age": [random.randint(1, 80) for i in range(20)],
+        "email": [random_email() for i in range(20)],
+    }
+
+    bigquery_table = BigqueryTable(
+        name=table_name,
+        comment=None,
+        created=None,
+        last_altered=None,
+        size_in_bytes=None,
+        rows_count=None,
+    )
+    get_tables_for_dataset.return_value = iter([bigquery_table])
+
+    bigquery_view = BigqueryView(
+        name=view_name,
+        comment=None,
+        created=None,
+        view_definition=f"create view `{dataset_name}.view-1` as select email from `{dataset_name}.table-1`",
+        last_altered=None,
+        size_in_bytes=None,
+        rows_count=None,
+        materialized=False,
+    )
+
+    get_views_for_dataset.return_value = iter([bigquery_view])
+    snapshot_table = BigqueryTableSnapshot(
+        name=snapshot_table_name,
+        comment=None,
+        created=None,
+        last_altered=None,
+        size_in_bytes=None,
+        rows_count=None,
+        base_table_identifier=BigqueryTableIdentifier(
+            project_id="project-id-1",
+            dataset="bigquery-dataset-1",
+            table="table-1",
+        ),
+    )
+    get_snapshots_for_dataset.return_value = iter([snapshot_table])
+
+    # Even if `include_table_lineage` is disabled, we still ingest view and snapshot lineage
+    # if use_queries_v2 is set.
+    pipeline_config_dict: Dict[str, Any] = recipe(
+        mcp_output_path=mcp_output_path,
+        override={"use_queries_v2": True, "include_table_lineage": False},
+    )
 
     run_and_get_pipeline(pipeline_config_dict)
 


### PR DESCRIPTION
- avoid calling list projects multiple times using cachine at schema api perf level
- fix arg to set schema api perf report
- fix usage of `include_schema_metadata`
- add tests for use_queries_v2 schema ingestion

Pending:
- add tests for use_queries_v2 lineage and usage ingestion


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
