### PR TITLE
fix(ingest/elasticsearch): detect sub-properties in 'nested' type mapping

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -138,20 +138,7 @@ class ElasticToSchemaFieldConverter:
         for columnName, column in elastic_schema_dict.items():
             elastic_type: Optional[str] = column.get("type")
             nested_props: Optional[Dict[str, Any]] = column.get(PROPERTIES)
-            if elastic_type is not None and elastic_type != "nested":
-                self._prefix_name_stack.append(f"[type={elastic_type}].{columnName}")
-                schema_field_data_type = self.get_column_type(elastic_type)
-                schema_field = SchemaField(
-                    fieldPath=self._get_cur_field_path(),
-                    nativeDataType=elastic_type,
-                    type=schema_field_data_type,
-                    description=None,
-                    nullable=True,
-                    recursive=False,
-                )
-                yield schema_field
-                self._prefix_name_stack.pop()
-            elif nested_props:
+            if nested_props:
                 self._prefix_name_stack.append(f"[type={PROPERTIES}].{columnName}")
                 schema_field = SchemaField(
                     fieldPath=self._get_cur_field_path(),
@@ -163,6 +150,19 @@ class ElasticToSchemaFieldConverter:
                 )
                 yield schema_field
                 yield from self._get_schema_fields(nested_props)
+                self._prefix_name_stack.pop()
+            elif elastic_type is not None:
+                self._prefix_name_stack.append(f"[type={elastic_type}].{columnName}")
+                schema_field_data_type = self.get_column_type(elastic_type)
+                schema_field = SchemaField(
+                    fieldPath=self._get_cur_field_path(),
+                    nativeDataType=elastic_type,
+                    type=schema_field_data_type,
+                    description=None,
+                    nullable=True,
+                    recursive=False,
+                )
+                yield schema_field
                 self._prefix_name_stack.pop()
             else:
                 # Unexpected! Log a warning.

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -138,7 +138,7 @@ class ElasticToSchemaFieldConverter:
         for columnName, column in elastic_schema_dict.items():
             elastic_type: Optional[str] = column.get("type")
             nested_props: Optional[Dict[str, Any]] = column.get(PROPERTIES)
-            if elastic_type is not None:
+            if elastic_type is not None and elastic_type != "nested":
                 self._prefix_name_stack.append(f"[type={elastic_type}].{columnName}")
                 schema_field_data_type = self.get_column_type(elastic_type)
                 schema_field = SchemaField(


### PR DESCRIPTION
…mapping

fix issue where sub-properties in 'nested' type mappings are not detected during Elasticsearch ingestion, resulting in incomplete ingestion of data. Prior to this fix, only top-level properties were recognized, missing critical sub-fields.

Fixes: https://github.com/datahub-project/datahub/issues/10911


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
