### PR TITLE
Feature/custom highlight on search 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
@@ -65,9 +65,6 @@ public class SearchFlagsInputMapper
                           .map(c -> GroupingCriterionInputMapper.map(context, c))
                           .collect(Collectors.toList()))));
     }
-    if (searchFlags.getCustomHighlighting() != null) {
-      result.setCustomHighlighting(searchFlags.getCustomHighlighting());
-    }
     if (searchFlags.getCustomHighlightingFields() != null) {
       result.setCustomHighlightingFields(new StringArray(searchFlags.getCustomHighlightingFields()));
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.query.GroupingSpec;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import com.linkedin.data.template.StringArray;
 
 /**
  * Maps GraphQL SearchFlags to Pegasus
@@ -63,6 +64,12 @@ public class SearchFlagsInputMapper
                       searchFlags.getGroupingSpec().getGroupingCriteria().stream()
                           .map(c -> GroupingCriterionInputMapper.map(context, c))
                           .collect(Collectors.toList()))));
+    }
+    if (searchFlags.getCustomHighlighting() != null) {
+      result.setCustomHighlighting(searchFlags.getCustomHighlighting());
+    }
+    if (searchFlags.getCustomHighlightingFields() != null) {
+      result.setCustomHighlightingFields(new StringArray(searchFlags.getCustomHighlightingFields()));
     }
     return result;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/SearchFlagsInputMapper.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.types.common.mappers;
 
+import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.SearchFlags;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
@@ -8,7 +9,6 @@ import com.linkedin.metadata.query.GroupingSpec;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import com.linkedin.data.template.StringArray;
 
 /**
  * Maps GraphQL SearchFlags to Pegasus
@@ -66,7 +66,8 @@ public class SearchFlagsInputMapper
                           .collect(Collectors.toList()))));
     }
     if (searchFlags.getCustomHighlightingFields() != null) {
-      result.setCustomHighlightingFields(new StringArray(searchFlags.getCustomHighlightingFields()));
+      result.setCustomHighlightingFields(
+          new StringArray(searchFlags.getCustomHighlightingFields()));
     }
     return result;
   }

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -162,6 +162,16 @@ input  SearchFlags {
   Whether to include restricted entities
   """
   includeRestricted: Boolean
+
+  """
+  Whether to enable custom highlighting
+  """
+  customHighlighting: Boolean
+
+  """
+  fields to include for custom Highlighting
+  """
+  customHighlightingFields: [String!]
 }
 
 """

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -164,11 +164,6 @@ input  SearchFlags {
   includeRestricted: Boolean
 
   """
-  Whether to enable custom highlighting
-  """
-  customHighlighting: Boolean
-
-  """
   fields to include for custom Highlighting
   """
   customHighlightingFields: [String!]

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -213,6 +213,20 @@ public class SearchRequestHandler {
     if (Boolean.FALSE.equals(searchFlags.isSkipHighlighting())) {
       searchSourceBuilder.highlighter(highlights);
     }
+    if (Boolean.TRUE.equals(finalSearchFlags.isCustomHighlighting())) {
+      HighlightBuilder highlightBuilder = new HighlightBuilder();
+
+      // Don't set tags to get the original field value
+      highlightBuilder.preTags("");
+      highlightBuilder.postTags("");
+
+      // Check for each field name and any subfields
+      finalSearchFlags.getCustomHighlightingFields().stream()
+              .flatMap(fieldName -> Stream.of(fieldName, fieldName + ".*")).distinct()
+              .forEach(highlightBuilder::field);
+
+      searchSourceBuilder.highlighter(highlightBuilder);
+    }
     ESUtils.buildSortOrder(searchSourceBuilder, sortCriteria, entitySpecs);
 
     if (Boolean.TRUE.equals(searchFlags.isGetSuggestions())) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -213,7 +213,8 @@ public class SearchRequestHandler {
     }
     if (Boolean.FALSE.equals(searchFlags.isSkipHighlighting())) {
       if (CollectionUtils.isNotEmpty(searchFlags.getCustomHighlightingFields())) {
-        searchSourceBuilder.highlighter(getValidatedHighlighter(searchFlags.getCustomHighlightingFields()));
+        searchSourceBuilder.highlighter(
+            getValidatedHighlighter(searchFlags.getCustomHighlightingFields()));
       } else {
         searchSourceBuilder.highlighter(highlights);
       }
@@ -568,9 +569,10 @@ public class SearchRequestHandler {
     highlightBuilder.preTags("");
     highlightBuilder.postTags("");
     fieldsToHighlight.stream()
-            .filter(defaultQueryFieldNames::contains)
-            .flatMap(fieldName -> Stream.of(fieldName, fieldName + ".*")).distinct()
-            .forEach(highlightBuilder::field);
+        .filter(defaultQueryFieldNames::contains)
+        .flatMap(fieldName -> Stream.of(fieldName, fieldName + ".*"))
+        .distinct()
+        .forEach(highlightBuilder::field);
     return highlightBuilder;
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -56,8 +56,13 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
 
   public static SearchConfiguration testQueryConfig;
   public static List<String> validHighlightingFields = List.of("urn", "foreignKey");
-  public static StringArray customHighlightFields = new StringArray(
-          List.of(validHighlightingFields.get(0), validHighlightingFields.get(1), "notExistingField", ""));
+  public static StringArray customHighlightFields =
+      new StringArray(
+          List.of(
+              validHighlightingFields.get(0),
+              validHighlightingFields.get(1),
+              "notExistingField",
+              ""));
 
   static {
     testQueryConfig = new SearchConfiguration();
@@ -109,22 +114,23 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
   public void testCustomHighlights() {
     EntitySpec entitySpec = operationContext.getEntityRegistry().getEntitySpec("dataset");
     SearchRequestHandler requestHandler =
-            SearchRequestHandler.getBuilder(TestEntitySpecBuilder.getSpec(), testQueryConfig, null);
+        SearchRequestHandler.getBuilder(TestEntitySpecBuilder.getSpec(), testQueryConfig, null);
     SearchRequest searchRequest =
-            requestHandler.getSearchRequest(
-                    operationContext.withSearchFlags(
-                            flags -> flags.setFulltext(false).setCustomHighlightingFields(customHighlightFields)),
-                    "testQuery",
-                    null,
-                    null,
-                    0,
-                    10,
-                    null);
+        requestHandler.getSearchRequest(
+            operationContext.withSearchFlags(
+                flags ->
+                    flags.setFulltext(false).setCustomHighlightingFields(customHighlightFields)),
+            "testQuery",
+            null,
+            null,
+            0,
+            10,
+            null);
     SearchSourceBuilder sourceBuilder = searchRequest.source();
     assertNotNull(sourceBuilder.highlighter());
     assertEquals(4, sourceBuilder.highlighter().fields().size());
-    assertTrue(sourceBuilder.highlighter().fields()
-            .stream()
+    assertTrue(
+        sourceBuilder.highlighter().fields().stream()
             .map(HighlightBuilder.Field::name)
             .toList()
             .containsAll(validHighlightingFields));

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/SearchRequestHandlerTest.java
@@ -55,6 +55,9 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
   private OperationContext operationContext;
 
   public static SearchConfiguration testQueryConfig;
+  public static List<String> validHighlightingFields = List.of("urn", "foreignKey");
+  public static StringArray customHighlightFields = new StringArray(
+          List.of(validHighlightingFields.get(0), validHighlightingFields.get(1), "notExistingField", ""));
 
   static {
     testQueryConfig = new SearchConfiguration();
@@ -100,6 +103,31 @@ public class SearchRequestHandlerTest extends AbstractTestNGSpringContextTests {
             .noneMatch(
                 fieldName -> fieldName.contains("upstream") || fieldName.contains("downstream")),
         "unexpected lineage fields in highlights: " + highlightFields);
+  }
+
+  @Test
+  public void testCustomHighlights() {
+    EntitySpec entitySpec = operationContext.getEntityRegistry().getEntitySpec("dataset");
+    SearchRequestHandler requestHandler =
+            SearchRequestHandler.getBuilder(TestEntitySpecBuilder.getSpec(), testQueryConfig, null);
+    SearchRequest searchRequest =
+            requestHandler.getSearchRequest(
+                    operationContext.withSearchFlags(
+                            flags -> flags.setFulltext(false).setCustomHighlightingFields(customHighlightFields)),
+                    "testQuery",
+                    null,
+                    null,
+                    0,
+                    10,
+                    null);
+    SearchSourceBuilder sourceBuilder = searchRequest.source();
+    assertNotNull(sourceBuilder.highlighter());
+    assertEquals(4, sourceBuilder.highlighter().fields().size());
+    assertTrue(sourceBuilder.highlighter().fields()
+            .stream()
+            .map(HighlightBuilder.Field::name)
+            .toList()
+            .containsAll(validHighlightingFields));
   }
 
   @Test

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -48,4 +48,14 @@ record SearchFlags {
    * include restricted entities in results (default is to filter)
    */
    includeRestricted:optional boolean = false
+  
+  /**
+   * Whether to enable custom highlighting
+   */
+   customHighlighting:optional boolean = false
+
+  /**
+   * include mentioned fields inside elastich highlighting query
+   */
+   customHighlightingFields:optional array[string]
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/query/SearchFlags.pdl
@@ -48,14 +48,9 @@ record SearchFlags {
    * include restricted entities in results (default is to filter)
    */
    includeRestricted:optional boolean = false
-  
-  /**
-   * Whether to enable custom highlighting
-   */
-   customHighlighting:optional boolean = false
 
   /**
-   * include mentioned fields inside elastich highlighting query
+   * Include mentioned fields inside elastic highlighting query
    */
    customHighlightingFields:optional array[string]
 }

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -3180,7 +3180,7 @@
             }, {
               "name" : "isPartitioningKey",
               "type" : "boolean",
-              "doc" : "For Datasets which are partitioned, this determines the partitioning key.",
+              "doc" : "For Datasets which are partitioned, this determines the partitioning key.\nNote that multiple columns can be part of a partitioning key, but currently we do not support\nrendering the ordered partitioning key.",
               "optional" : true
             }, {
               "name" : "jsonProps",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -3572,7 +3572,7 @@
                         }, {
                           "name" : "isPartitioningKey",
                           "type" : "boolean",
-                          "doc" : "For Datasets which are partitioned, this determines the partitioning key.",
+                          "doc" : "For Datasets which are partitioned, this determines the partitioning key.\nNote that multiple columns can be part of a partitioning key, but currently we do not support\nrendering the ordered partitioning key.",
                           "optional" : true
                         }, {
                           "name" : "jsonProps",
@@ -6031,6 +6031,14 @@
       "type" : "boolean",
       "doc" : "include restricted entities in results (default is to filter)",
       "default" : false,
+      "optional" : true
+    }, {
+      "name" : "customHighlightingFields",
+      "type" : {
+        "type" : "array",
+        "items" : "string"
+      },
+      "doc" : "Include mentioned fields inside elastic highlighting query",
       "optional" : true
     } ]
   }, {

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -2908,7 +2908,7 @@
             }, {
               "name" : "isPartitioningKey",
               "type" : "boolean",
-              "doc" : "For Datasets which are partitioned, this determines the partitioning key.",
+              "doc" : "For Datasets which are partitioned, this determines the partitioning key.\nNote that multiple columns can be part of a partitioning key, but currently we do not support\nrendering the ordered partitioning key.",
               "optional" : true
             }, {
               "name" : "jsonProps",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.operations.operations.snapshot.json
@@ -2902,7 +2902,7 @@
             }, {
               "name" : "isPartitioningKey",
               "type" : "boolean",
-              "doc" : "For Datasets which are partitioned, this determines the partitioning key.",
+              "doc" : "For Datasets which are partitioned, this determines the partitioning key.\nNote that multiple columns can be part of a partitioning key, but currently we do not support\nrendering the ordered partitioning key.",
               "optional" : true
             }, {
               "name" : "jsonProps",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.platform.platform.snapshot.json
@@ -3566,7 +3566,7 @@
                         }, {
                           "name" : "isPartitioningKey",
                           "type" : "boolean",
-                          "doc" : "For Datasets which are partitioned, this determines the partitioning key.",
+                          "doc" : "For Datasets which are partitioned, this determines the partitioning key.\nNote that multiple columns can be part of a partitioning key, but currently we do not support\nrendering the ordered partitioning key.",
                           "optional" : true
                         }, {
                           "name" : "jsonProps",


### PR DESCRIPTION
This PR aims to introduce a new feature to enable custom highlighting while searching via Datahub native graphql queries .
By default , Datahub graphql engine adds all searchable fields inside elastic search highlighter which adds  huge overhead if the search universe is large and have enriched description on column level . Because for each field mentioned in the highlighter , Elastic search reruns another in memory indexing per entity .

We have introduced a new field called **customHighlightingFields** where user can pass the fields which they want to highlight , we then only take these fields in to account for search highlighting . This features enables faster retrieval of data and offers customization . 


Please refer below on the usage -
**Highlight with Valid Field **

![custom_highlighting_with_valid_field](https://github.com/user-attachments/assets/3458b45e-030b-4d77-9f6e-e79b5ddbe3bc)

**Custom Highlight when highlighting disabled**

![custom_highlighting_with_highlighting_disabled](https://github.com/user-attachments/assets/c72c8d32-0abd-4ba5-bdc8-567b02291a28)

**Custom Highlight  with empty fields array** ( It default backs to original highlighting in case of empty array or invalid items)

![custom_highlighting_with_empty_fields_array](https://github.com/user-attachments/assets/a10beb6f-4213-4a15-a6d1-209faeea529a)




