### PR TITLE
fix(ingest): override setdefault in file-backed dict

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -350,6 +350,13 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
             self[key] = default
             return default
 
+    def setdefault(self, key: str, default: _VT) -> _VT:
+        # In almost all cases where setdefault is used, we want to always mark the
+        # value as dirty, even if the key already exists. While `for_mutation` is
+        # preferred, it's easy to accidentally use the default `setdefault`
+        # implementation in a subtly unsafe way, so we override it here.
+        return self.for_mutation(key, default=default)
+
     def __delitem__(self, key: str) -> None:
         in_cache = False
         if key in self._active_object_cache:


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
