### PR TITLE
docs[Teradata]: Fix privileges and query logging scripts

### DIFF
--- a/metadata-ingestion/docs/sources/teradata/teradata_pre.md
+++ b/metadata-ingestion/docs/sources/teradata/teradata_pre.md
@@ -5,24 +5,26 @@
     ```
 2. Create a user with the following privileges:
     ```sql
-    GRANT SELECT ON dbc.columns TO datahub;
-    GRANT SELECT ON dbc.databases TO datahub;
-    GRANT SELECT ON dbc.tables TO datahub;
-    GRANT SELECT ON DBC.All_RI_ChildrenV TO datahub;
-    GRANT SELECT ON DBC.ColumnsV TO datahub;
-    GRANT SELECT ON DBC.IndicesV TO datahub;
-    GRANT SELECT ON dbc.TableTextV TO datahub;
-    GRANT SELECT ON dbc.TablesV TO datahub;
-    GRANT SELECT ON dbc.dbqlogtbl TO datahub; -- if lineage or usage extraction is enabled
+GRANT SELECT ON DBC.DatabasesV TO datahub;
+GRANT SELECT ON DBC.TablesV TO datahub;
+GRANT SELECT ON DBC.ColumnsV TO datahub;
+GRANT SELECT ON DBC.IndicesV TO datahub;
+GRANT SELECT ON dbc.TableTextV TO datahub;
+GRANT SELECT ON DBC.All_RI_ChildrenV TO datahub;
+
+-- if lineage or usage extraction is enabled
+GRANT SELECT ON dbc.dbqlogtbl TO datahub; 
+GRANT SELECT ON dbc.QryLogV TO datahub;
+GRANT SELECT ON dbc.QryLogSqlV TO datahub;
     ```
    
     If you want to run profiling, you need to grant select permission on all the tables you want to profile.
 
 3. If lineage or usage extraction is enabled, please, check if query logging is enabled and it is set to size which
 will fit for your queries (the default query text size Teradata captures is max 200 chars)
-   An example how you can set it for all users:
+   An example how you can set it for all users and capture the SQL:
     ```sql
-    REPLACE QUERY LOGGING LIMIT SQLTEXT=2000 ON ALL;
+    REPLACE QUERY LOGGING WITH SQL LIMIT SQLTEXT=2000 ON ALL;
     ```
    See more here about query logging:
       [https://docs.teradata.com/r/Teradata-VantageCloud-Lake/Database-Reference/Database-Administration/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs](https://docs.teradata.com/r/Teradata-VantageCloud-Lake/Database-Reference/Database-Administration/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs)


### PR DESCRIPTION
Cleaned up privileges and added QryLogSQLv access so that SQL lineage can be read from dictionary. Also changing query logging statement to ensure SQL is logged


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
