### PR TITLE
fix(restli): fix restli startup order

### DIFF
--- a/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
@@ -6,6 +6,7 @@ import com.linkedin.restli.server.RestliHandlerServlet;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.HttpRequestHandler;
 
@@ -13,6 +14,9 @@ import org.springframework.web.HttpRequestHandler;
 @PropertySource(value = "classpath:/application.yaml", factory = YamlPropertySourceFactory.class)
 @Configuration
 public class RestliServletConfig {
+
+  // ensure ordering by depending on required service
+  @DependsOn("entityService")
   @Bean("restliRequestHandler")
   public HttpRequestHandler restliHandlerServlet(final RAPJakartaServlet r2Servlet) {
     return new RestliHandlerServlet(r2Servlet);

--- a/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
@@ -1,12 +1,13 @@
 package com.linkedin.gms.servlet;
 
+import com.linkedin.metadata.entity.AspectDao;
 import com.linkedin.metadata.spring.YamlPropertySourceFactory;
 import com.linkedin.r2.transport.http.server.RAPJakartaServlet;
 import com.linkedin.restli.server.RestliHandlerServlet;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.HttpRequestHandler;
 
@@ -15,10 +16,10 @@ import org.springframework.web.HttpRequestHandler;
 @Configuration
 public class RestliServletConfig {
 
-  // ensure ordering by depending on required service
-  @DependsOn("entityService")
+  // ensure ordering by depending on required entityAspectDao
   @Bean("restliRequestHandler")
-  public HttpRequestHandler restliHandlerServlet(final RAPJakartaServlet r2Servlet) {
+  public HttpRequestHandler restliHandlerServlet(
+      final RAPJakartaServlet r2Servlet, @Qualifier("entityAspectDao") final AspectDao aspectDao) {
     return new RestliHandlerServlet(r2Servlet);
   }
 }


### PR DESCRIPTION
Ensure restli service is initialized only after entityService is ready.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
