### PR TITLE
fix(XServiceProvider): fix ebean framework race condition

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -990,7 +990,7 @@ jobs:
           DATAHUB_VERSION: ${{ needs.setup.outputs.unique_tag }}
           DATAHUB_ACTIONS_IMAGE: ${{ env.DATAHUB_INGESTION_IMAGE }}
           ACTIONS_VERSION: ${{ needs.datahub_ingestion_slim_build.outputs.tag || 'head-slim' }}
-          ACTIONS_EXTRA_PACKAGES: "acryl-datahub-actions[executor]==0.0.13 acryl-datahub-actions==0.0.13 acryl-datahub==0.10.5"
+          ACTIONS_EXTRA_PACKAGES: "acryl-datahub-actions[executor] acryl-datahub-actions"
           ACTIONS_CONFIG: "https://raw.githubusercontent.com/acryldata/datahub-actions/main/docker/config/executor.yaml"
         run: |
           ./smoke-test/run-quickstart.sh

--- a/docker/datahub-ingestion-base/Dockerfile
+++ b/docker/datahub-ingestion-base/Dockerfile
@@ -43,7 +43,9 @@ RUN apt-get update && apt-get upgrade -y \
     krb5-user \
     krb5-config \
     libkrb5-dev \
+    librdkafka-dev \
     wget \
+    curl \
     zip \
     unzip \
     ldap-utils \

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/restli/RestliServletConfig.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/restli/RestliServletConfig.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.restli;
 
 import com.datahub.auth.authentication.filter.AuthenticationFilter;
 import com.linkedin.gms.factory.auth.SystemAuthenticationFactory;
+import com.linkedin.r2.transport.http.server.RAPJakartaServlet;
 import com.linkedin.restli.server.RestliHandlerServlet;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,8 +37,8 @@ public class RestliServletConfig {
   }
 
   @Bean("restliHandlerServlet")
-  public RestliHandlerServlet restliHandlerServlet() {
-    return new RestliHandlerServlet();
+  public RestliHandlerServlet restliHandlerServlet(final RAPJakartaServlet r2Servlet) {
+    return new RestliHandlerServlet(r2Servlet);
   }
 
   @Bean

--- a/metadata-service/auth-filter/src/main/java/com/datahub/auth/authentication/filter/AuthenticationFilter.java
+++ b/metadata-service/auth-filter/src/main/java/com/datahub/auth/authentication/filter/AuthenticationFilter.java
@@ -77,6 +77,7 @@ public class AuthenticationFilter implements Filter {
   public void init(FilterConfig filterConfig) throws ServletException {
     SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
     buildAuthenticatorChain();
+    log.info("AuthenticationFilter initialized.");
   }
 
   @Override

--- a/metadata-service/factories/src/main/java/com/linkedin/restli/server/RAPServletFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/restli/server/RAPServletFactory.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,8 +30,10 @@ public class RAPServletFactory {
   private int maxSerializedStringLength;
 
   @Bean(name = "restliSpringInjectResourceFactory")
-  public SpringInjectResourceFactory springInjectResourceFactory() {
-    return new SpringInjectResourceFactory();
+  public SpringInjectResourceFactory springInjectResourceFactory(final ApplicationContext ctx) {
+    SpringInjectResourceFactory springInjectResourceFactory = new SpringInjectResourceFactory();
+    springInjectResourceFactory.setApplicationContext(ctx);
+    return springInjectResourceFactory;
   }
 
   @Bean("parseqEngineThreads")

--- a/metadata-service/factories/src/main/java/com/linkedin/restli/server/RestliHandlerServlet.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/restli/server/RestliHandlerServlet.java
@@ -1,22 +1,28 @@
 package com.linkedin.restli.server;
 
 import com.linkedin.r2.transport.http.server.RAPJakartaServlet;
+import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.context.support.HttpRequestHandlerServlet;
 
+@Slf4j
 @AllArgsConstructor
-@NoArgsConstructor
-@Component
 public class RestliHandlerServlet extends HttpRequestHandlerServlet implements HttpRequestHandler {
   @Autowired private RAPJakartaServlet _r2Servlet;
+
+  @Override
+  public void init(ServletConfig config) throws ServletException {
+    log.info("Initializing RestliHandlerServlet");
+    this._r2Servlet.init(config);
+    log.info("Initialized RestliHandlerServlet");
+  }
 
   @Override
   public void service(HttpServletRequest req, HttpServletResponse res)

--- a/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/servlet/RestliServletConfig.java
@@ -7,14 +7,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.web.HttpRequestHandler;
+import org.springframework.web.context.support.HttpRequestHandlerServlet;
 
 @ComponentScan(basePackages = {"com.linkedin.restli.server"})
 @PropertySource(value = "classpath:/application.yaml", factory = YamlPropertySourceFactory.class)
 @Configuration
 public class RestliServletConfig {
   @Bean("restliRequestHandler")
-  public HttpRequestHandler restliHandlerServlet(final RAPJakartaServlet r2Servlet) {
+  public HttpRequestHandlerServlet restliHandlerServlet(final RAPJakartaServlet r2Servlet) {
     return new RestliHandlerServlet(r2Servlet);
   }
 }


### PR DESCRIPTION
While updating to the latest executor code in actions, a GMS startup race condition is triggered by incomplete
initialization of the ebean framework during integration/smoke-tests.

This PR fixes the race condition by loading the class prior to starting the wait/bootstrap process during GMS startup. This allows AuthenticationFilter to handle requests which require interaction with SQL via the ebean library as the application is loading.

Notes:

In production environments running kubernetes the pod would not be expected to receive traffic before the health check is healthy and would avoid this condition.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
