### PR TITLE
feat(graphql): add origin aspect to CorpUser GraphQL entity

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/OriginMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/common/mappers/OriginMapper.java
@@ -1,0 +1,37 @@
+package com.linkedin.datahub.graphql.types.common.mappers;
+
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.Origin;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Maps Pegasus {@link RecordTemplate} objects to objects conforming to the GQL schema.
+ *
+ * <p>To be replaced by auto-generated mappers implementations
+ */
+public class OriginMapper {
+
+  public static final OriginMapper INSTANCE = new OriginMapper();
+
+  public static Origin map(
+      @Nullable QueryContext context, @Nonnull final com.linkedin.common.Origin origin) {
+    return INSTANCE.apply(context, origin);
+  }
+
+  public Origin apply(
+      @Nullable QueryContext context, @Nonnull final com.linkedin.common.Origin origin) {
+    final Origin result = new Origin();
+    if (origin.hasType()) {
+      result.setType(
+          com.linkedin.datahub.graphql.generated.OriginType.valueOf(origin.getType().toString()));
+    } else {
+      result.setType(com.linkedin.datahub.graphql.generated.OriginType.UNKNOWN);
+    }
+    if (origin.hasExternalType()) {
+      result.setExternalType(origin.getExternalType());
+    }
+    return result;
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpgroup/mappers/CorpGroupMapper.java
@@ -7,9 +7,11 @@ import com.linkedin.common.Origin;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.CorpGroup;
 import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.types.common.mappers.OriginMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.datahub.graphql.types.form.FormsMapper;
@@ -66,7 +68,10 @@ public class CorpGroupMapper implements ModelMapper<EntityResponse, CorpGroup> {
         ((entity, dataMap) ->
             entity.setForms(FormsMapper.map(new Forms(dataMap), entityUrn.toString()))));
     if (aspectMap.containsKey(ORIGIN_ASPECT_NAME)) {
-      mappingHelper.mapToResult(ORIGIN_ASPECT_NAME, this::mapEntityOriginType);
+      mappingHelper.mapToResult(
+          ORIGIN_ASPECT_NAME,
+          (corpUser, dataMap) ->
+              corpUser.setOrigin(OriginMapper.map(context, new Origin(dataMap))));
     } else {
       com.linkedin.datahub.graphql.generated.Origin mappedGroupOrigin =
           new com.linkedin.datahub.graphql.generated.Origin();
@@ -100,22 +105,5 @@ public class CorpGroupMapper implements ModelMapper<EntityResponse, CorpGroup> {
       @Nonnull DataMap dataMap,
       @Nonnull Urn entityUrn) {
     corpGroup.setOwnership(OwnershipMapper.map(context, new Ownership(dataMap), entityUrn));
-  }
-
-  private void mapEntityOriginType(@Nonnull CorpGroup corpGroup, @Nonnull DataMap dataMap) {
-    Origin groupOrigin = new Origin(dataMap);
-    com.linkedin.datahub.graphql.generated.Origin mappedGroupOrigin =
-        new com.linkedin.datahub.graphql.generated.Origin();
-    if (groupOrigin.hasType()) {
-      mappedGroupOrigin.setType(
-          com.linkedin.datahub.graphql.generated.OriginType.valueOf(
-              groupOrigin.getType().toString()));
-    } else {
-      mappedGroupOrigin.setType(com.linkedin.datahub.graphql.generated.OriginType.UNKNOWN);
-    }
-    if (groupOrigin.hasExternalType()) {
-      mappedGroupOrigin.setExternalType(groupOrigin.getExternalType());
-    }
-    corpGroup.setOrigin(mappedGroupOrigin);
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserMapper.java
@@ -17,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.CorpUserViewsSettings;
 import com.linkedin.datahub.graphql.generated.DataHubView;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.types.common.mappers.CustomPropertiesMapper;
+import com.linkedin.datahub.graphql.types.common.mappers.OriginMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
 import com.linkedin.datahub.graphql.types.form.FormsMapper;
 import com.linkedin.datahub.graphql.types.structuredproperty.StructuredPropertiesMapper;
@@ -96,7 +97,10 @@ public class CorpUserMapper {
         ((entity, dataMap) ->
             entity.setForms(FormsMapper.map(new Forms(dataMap), entityUrn.toString()))));
     if (aspectMap.containsKey(ORIGIN_ASPECT_NAME)) {
-      mappingHelper.mapToResult(ORIGIN_ASPECT_NAME, this::mapEntityOriginType);
+      mappingHelper.mapToResult(
+          ORIGIN_ASPECT_NAME,
+          (corpUser, dataMap) ->
+              corpUser.setOrigin(OriginMapper.map(context, new Origin(dataMap))));
     } else {
       com.linkedin.datahub.graphql.generated.Origin mappedUserOrigin =
           new com.linkedin.datahub.graphql.generated.Origin();
@@ -190,22 +194,5 @@ public class CorpUserMapper {
             && corpUserCredentials.hasSalt()
             && corpUserCredentials.hasHashedPassword();
     corpUser.setIsNativeUser(isNativeUser);
-  }
-
-  private void mapEntityOriginType(@Nonnull CorpUser corpUser, @Nonnull DataMap dataMap) {
-    Origin userOrigin = new Origin(dataMap);
-    com.linkedin.datahub.graphql.generated.Origin mappedUserOrigin =
-        new com.linkedin.datahub.graphql.generated.Origin();
-    if (userOrigin.hasType()) {
-      mappedUserOrigin.setType(
-          com.linkedin.datahub.graphql.generated.OriginType.valueOf(
-              userOrigin.getType().toString()));
-    } else {
-      mappedUserOrigin.setType(com.linkedin.datahub.graphql.generated.OriginType.UNKNOWN);
-    }
-    if (userOrigin.hasExternalType()) {
-      mappedUserOrigin.setExternalType(userOrigin.getExternalType());
-    }
-    corpUser.setOrigin(mappedUserOrigin);
   }
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -4003,6 +4003,11 @@ type CorpUser implements Entity {
     relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
     """
+    Origin info about this user.
+    """
+    origin: Origin
+
+    """
     Whether or not this user is a native DataHub user
     """
     isNativeUser: Boolean

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Origin.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Origin.pdl
@@ -10,10 +10,20 @@ record Origin {
   /**
    * Where an entity originated from. Either NATIVE or EXTERNAL.
    */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "fieldName": "originType"
+    "queryByDefault": false
+  }
   type: OriginType
 
   /**
    * Only populated if type is EXTERNAL. The externalType of the entity, such as the name of the identity provider.
    */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "fieldName": "originExternalType"
+    "queryByDefault": false
+  }
   externalType: optional string
 }


### PR DESCRIPTION
This PR adds the origin aspect to the CorpUser GraphQL entity (it is already present for the CorpGroup entity). Additionally the two fields type and externalType of the aspect will be made searchable, to have no name conflicts the searchfields will be named originType and originExternalType.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
