### PR TITLE
fix(docs): fix layout in documentation after #11380

### DIFF
--- a/docs/how/restore-indices.md
+++ b/docs/how/restore-indices.md
@@ -21,6 +21,7 @@ datahub docker quickstart --restore-indices
 
 :::info
 Using the `datahub` CLI to restore the indices when using the quickstart images will also clear the search and graph indices before restoring.
+:::
 
 See [this section](../quickstart.md#restore-datahub) for more information. 
 
@@ -34,6 +35,7 @@ If you are on a custom docker-compose deployment, run the following command (you
 
 :::info
 By default this command will not clear the search and graph indices before restoring, thous potentially leading to inconsistencies between the local database and the indices, in case aspects were previously deleted in the local database but were not removed from the correponding index.
+:::
 
 If you need to clear the search and graph indices before restoring, add `-a clean` to the end of the command. Please take note that the search and graph services might not be fully functional during reindexing when the indices are cleared.
 
@@ -67,6 +69,7 @@ Once the job completes, your indices will have been restored.
 
 :::info
 By default the restore indices job template will not clear the search and graph indices before restoring, thous potentially leading to inconsistencies between the local database and the indices, in case aspects were previously deleted in the local database but were not removed from the correponding index.
+:::
 
 If you need to clear the search and graph indices before restoring, modify the `values.yaml` for your deployment and overwrite the default arguments of the restore indices job template to include the `-a clean` argument. Please take note that the search and graph services might not be fully functional during reindexing when the indices are cleared.
 


### PR DESCRIPTION
I have just checked the documentation after my previous PR #11380 was merged...unfortunately I broke the layout (see: https://docs-website-1dvlu3ird-acryldata.vercel.app/docs/how/restore-indices/) , because I have forgot the closing colons in the Markdown...this PR is fixing this.

(I have not expected the previous PR to be merged that fast...I wanted to check the layout this morning to make sure everything is right...sorry! 😁)

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
