### PR TITLE
fix(looker): Pin cattrs dependency

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -172,6 +172,8 @@ looker_common = {
     # LookML files with spaces between an item and the following comma.
     # See https://github.com/joshtemple/lkml/issues/73.
     "lkml>=1.3.4",
+    # Fixes https://github.com/looker-open-source/sdk-codegen/issues/1410
+    "cattrs==23.1.2",
     *sqlglot_lib,
     "GitPython>2",
     "python-liquid",


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/sdk-codegen/issues/1410 that directly affects Looker ingestions erroring out with:
```
'looker_sdk.rtl.serialize.DeserializeError'>: Bad json Unterminated string starting at: line 1 column 7721467 "
```


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
