### PR TITLE
feat(structuredProps) Add delete structured props endpoint and handle null props

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -293,6 +293,7 @@ import com.linkedin.datahub.graphql.resolvers.settings.view.UpdateGlobalViewsSet
 import com.linkedin.datahub.graphql.resolvers.step.BatchGetStepStatesResolver;
 import com.linkedin.datahub.graphql.resolvers.step.BatchUpdateStepStatesResolver;
 import com.linkedin.datahub.graphql.resolvers.structuredproperties.CreateStructuredPropertyResolver;
+import com.linkedin.datahub.graphql.resolvers.structuredproperties.DeleteStructuredPropertyResolver;
 import com.linkedin.datahub.graphql.resolvers.structuredproperties.RemoveStructuredPropertiesResolver;
 import com.linkedin.datahub.graphql.resolvers.structuredproperties.UpdateStructuredPropertyResolver;
 import com.linkedin.datahub.graphql.resolvers.structuredproperties.UpsertStructuredPropertiesResolver;
@@ -1343,6 +1344,9 @@ public class GmsGraphQLEngine {
               .dataFetcher(
                   "updateStructuredProperty",
                   new UpdateStructuredPropertyResolver(this.entityClient))
+              .dataFetcher(
+                  "deleteStructuredProperty",
+                  new DeleteStructuredPropertyResolver(this.entityClient))
               .dataFetcher("raiseIncident", new RaiseIncidentResolver(this.entityClient))
               .dataFetcher(
                   "updateIncidentStatus",
@@ -2116,6 +2120,9 @@ public class GmsGraphQLEngine {
                             .getAllowedTypes().stream()
                                 .map(entityTypeType.getKeyProvider())
                                 .collect(Collectors.toList()))));
+    builder.type(
+        "StructuredPropertyEntity",
+        typeWiring -> typeWiring.dataFetcher("exists", new EntityExistsResolver(entityService)));
   }
 
   /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/DeleteStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/DeleteStructuredPropertyResolver.java
@@ -1,0 +1,52 @@
+package com.linkedin.datahub.graphql.resolvers.structuredproperties;
+
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.generated.DeleteStructuredPropertyInput;
+import com.linkedin.entity.client.EntityClient;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DeleteStructuredPropertyResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityClient _entityClient;
+
+  public DeleteStructuredPropertyResolver(@Nonnull final EntityClient entityClient) {
+    _entityClient = Objects.requireNonNull(entityClient, "entityClient must not be null");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment)
+      throws Exception {
+    final QueryContext context = environment.getContext();
+
+    final DeleteStructuredPropertyInput input =
+        bindArgument(environment.getArgument("input"), DeleteStructuredPropertyInput.class);
+    final Urn propertyUrn = UrnUtils.getUrn(input.getUrn());
+
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            if (!AuthorizationUtils.canManageStructuredProperties(context)) {
+              throw new AuthorizationException(
+                  "Unable to delete structured property. Please contact your admin.");
+            }
+            _entityClient.deleteEntity(context.getOperationContext(), propertyUrn);
+            return true;
+          } catch (Exception e) {
+            throw new RuntimeException(
+                String.format("Failed to perform update against input %s", input), e);
+          }
+        });
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java
@@ -2,7 +2,9 @@ package com.linkedin.datahub.graphql.types.structuredproperty;
 
 import static com.linkedin.metadata.Constants.*;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.StringArrayMap;
 import com.linkedin.datahub.graphql.QueryContext;
@@ -45,6 +47,9 @@ public class StructuredPropertyMapper
     final StructuredPropertyEntity result = new StructuredPropertyEntity();
     result.setUrn(entityResponse.getUrn().toString());
     result.setType(EntityType.STRUCTURED_PROPERTY);
+    // set the default required values for a structured property in case references are still being
+    // cleaned up
+    setDefaultProperty(result);
     EnvelopedAspectMap aspectMap = entityResponse.getAspects();
     MappingHelper<StructuredPropertyEntity> mappingHelper = new MappingHelper<>(aspectMap, result);
     mappingHelper.mapToResult(
@@ -125,5 +130,23 @@ public class StructuredPropertyMapper
     entityType.setUrn(entityTypeUrnStr);
     entityType.setType(EntityType.ENTITY_TYPE);
     return entityType;
+  }
+
+  /*
+   * In the case that a property is deleted and the references haven't been cleaned up yet (this process is async)
+   * set a default property to prevent APIs breaking. The UI queries for whether the entity exists and it will
+   * be filtered out.
+   */
+  private void setDefaultProperty(final StructuredPropertyEntity result) {
+    StructuredPropertyDefinition definition = new StructuredPropertyDefinition();
+    definition.setQualifiedName("");
+    definition.setCardinality(PropertyCardinality.SINGLE);
+    definition.setImmutable(true);
+    definition.setValueType(
+        createDataTypeEntity(UrnUtils.getUrn("urn:li:dataType:datahub.string")));
+    definition.setEntityTypes(
+        ImmutableList.of(
+            createEntityTypeEntity(UrnUtils.getUrn("urn:li:entityType:datahub.dataset"))));
+    result.setDefinition(definition);
   }
 }

--- a/datahub-graphql-core/src/main/resources/properties.graphql
+++ b/datahub-graphql-core/src/main/resources/properties.graphql
@@ -18,6 +18,11 @@ extend type Mutation {
     Update an existing structured property
     """
     updateStructuredProperty(input: UpdateStructuredPropertyInput!): StructuredPropertyEntity!
+
+    """
+    Delete an existing structured property
+    """
+    deleteStructuredProperty(input: DeleteStructuredPropertyInput!): Boolean!
 }
 
 """
@@ -33,6 +38,11 @@ type StructuredPropertyEntity implements Entity {
     A standard Entity Type
     """
     type: EntityType!
+
+    """
+    Whether or not this entity exists on DataHub
+    """
+    exists: Boolean
 
     """
     Definition of this structured property including its name
@@ -446,4 +456,14 @@ input UpdateTypeQualifierInput {
     For backwards compatibility, this is append only.
     """
     newAllowedTypes: [String!]
+}
+
+"""
+Input for deleting a form
+"""
+input DeleteStructuredPropertyInput {
+    """
+    The urn of the structured properties that is being deleted
+    """
+    urn: String!
 }

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
@@ -79,7 +79,10 @@ export const SchemaTab = ({ properties }: { properties?: any }) => {
     const hasProperties = useMemo(
         () =>
             entityWithSchema?.schemaMetadata?.fields?.some(
-                (schemaField) => !!schemaField.schemaFieldEntity?.structuredProperties?.properties?.length,
+                (schemaField) =>
+                    !!schemaField.schemaFieldEntity?.structuredProperties?.properties?.filter(
+                        (prop) => prop.structuredProperty.exists,
+                    )?.length,
             ),
         [entityWithSchema],
     );

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldProperties.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/FieldProperties.tsx
@@ -34,14 +34,16 @@ interface Props {
 export default function FieldProperties({ expandedField }: Props) {
     const { schemaFieldEntity } = expandedField;
     const { refetch } = useGetEntityWithSchema(true);
+    const properties =
+        schemaFieldEntity?.structuredProperties?.properties?.filter((prop) => prop.structuredProperty.exists) || [];
 
-    if (!schemaFieldEntity?.structuredProperties?.properties?.length) return null;
+    if (!schemaFieldEntity || !properties.length) return null;
 
     return (
         <>
             <SectionHeader>Properties</SectionHeader>
             <PropertiesWrapper>
-                {schemaFieldEntity.structuredProperties.properties.map((structuredProp) => {
+                {properties.map((structuredProp) => {
                     const isRichText =
                         structuredProp.structuredProperty.definition.valueType?.info.type === StdDataType.RichText;
                     const valuesData = mapStructuredPropertyValues(structuredProp);

--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/useStructuredProperties.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/useStructuredProperties.tsx
@@ -27,23 +27,26 @@ export function mapStructuredPropertyValues(structuredPropertiesEntry: Structure
 function getStructuredPropertyRows(entityData?: GenericEntityProperties | null) {
     const structuredPropertyRows: PropertyRow[] = [];
 
-    entityData?.structuredProperties?.properties?.forEach((structuredPropertiesEntry) => {
-        const { displayName, qualifiedName } = structuredPropertiesEntry.structuredProperty.definition;
-        structuredPropertyRows.push({
-            displayName: displayName || qualifiedName,
-            qualifiedName,
-            values: mapStructuredPropertyValues(structuredPropertiesEntry),
-            dataType: structuredPropertiesEntry.structuredProperty.definition.valueType,
-            structuredProperty: structuredPropertiesEntry.structuredProperty,
-            type:
-                structuredPropertiesEntry.values[0] && structuredPropertiesEntry.values[0].__typename
-                    ? {
-                          type: typeNameToType[structuredPropertiesEntry.values[0].__typename].type,
-                          nativeDataType: typeNameToType[structuredPropertiesEntry.values[0].__typename].nativeDataType,
-                      }
-                    : undefined,
+    entityData?.structuredProperties?.properties
+        ?.filter((prop) => prop.structuredProperty.exists)
+        .forEach((structuredPropertiesEntry) => {
+            const { displayName, qualifiedName } = structuredPropertiesEntry.structuredProperty.definition;
+            structuredPropertyRows.push({
+                displayName: displayName || qualifiedName,
+                qualifiedName,
+                values: mapStructuredPropertyValues(structuredPropertiesEntry),
+                dataType: structuredPropertiesEntry.structuredProperty.definition.valueType,
+                structuredProperty: structuredPropertiesEntry.structuredProperty,
+                type:
+                    structuredPropertiesEntry.values[0] && structuredPropertiesEntry.values[0].__typename
+                        ? {
+                              type: typeNameToType[structuredPropertiesEntry.values[0].__typename].type,
+                              nativeDataType:
+                                  typeNameToType[structuredPropertiesEntry.values[0].__typename].nativeDataType,
+                          }
+                        : undefined,
+            });
         });
-    });
 
     return structuredPropertyRows;
 }

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1314,6 +1314,7 @@ fragment structuredPropertyFields on StructuredPropertyEntity {
 
 fragment structuredPropertiesFields on StructuredPropertiesEntry {
     structuredProperty {
+        exists
         ...structuredPropertyFields
     }
     values {


### PR DESCRIPTION
This PR adds a new graphql endpoint that allows users to delete structured properties if they have the manage structured props platform privilege. This is pretty standard stuff here.

However, cleaning up references once a structured prop is deleted is async so I added some handling on the graphql and frontend side to return a default structured prop in case it doesn't exist so we don't break the API and cause error screens on the UI. I added an `exists` check for structured props and filter them out in the UI as well.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
