### PR TITLE
feat(structuredProps) Add created and lastModified timestamps to structured prop entity

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1034,6 +1034,7 @@ public class GmsGraphQLEngine {
                 .dataFetcher("assertion", getResolver(assertionType))
                 .dataFetcher("form", getResolver(formType))
                 .dataFetcher("view", getResolver(dataHubViewType))
+                .dataFetcher("structuredProperty", getResolver(structuredPropertyType))
                 .dataFetcher("listPolicies", new ListPoliciesResolver(this.entityClient))
                 .dataFetcher("getGrantedPrivileges", new GetGrantedPrivilegesResolver())
                 .dataFetcher("listUsers", new ListUsersResolver(this.entityClient))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/CreateStructuredPropertyResolver.java
@@ -83,6 +83,8 @@ public class CreateStructuredPropertyResolver
               builder.setCardinality(
                   PropertyCardinality.valueOf(input.getCardinality().toString()));
             }
+            builder.setCreated(context.getOperationContext().getAuditStamp());
+            builder.setLastModified(context.getOperationContext().getAuditStamp());
 
             MetadataChangeProposal mcp = builder.build();
             _entityClient.ingestProposal(context.getOperationContext(), mcp, false);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
@@ -76,6 +76,7 @@ public class UpdateStructuredPropertyResolver
             if (input.getNewEntityTypes() != null) {
               input.getNewEntityTypes().forEach(builder::addEntityType);
             }
+            builder.setLastModified(context.getOperationContext().getAuditStamp());
 
             MetadataChangeProposal mcp = builder.build();
             _entityClient.ingestProposal(context.getOperationContext(), mcp, false);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/MapperUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/MapperUtils.java
@@ -3,15 +3,18 @@ package com.linkedin.datahub.graphql.types.mappers;
 import static com.linkedin.datahub.graphql.util.SearchInsightsUtil.*;
 import static com.linkedin.metadata.utils.SearchUtil.*;
 
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AggregationMetadata;
+import com.linkedin.datahub.graphql.generated.CorpUser;
 import com.linkedin.datahub.graphql.generated.EntityPath;
 import com.linkedin.datahub.graphql.generated.ExtraProperty;
 import com.linkedin.datahub.graphql.generated.FacetMetadata;
 import com.linkedin.datahub.graphql.generated.MatchedField;
+import com.linkedin.datahub.graphql.generated.ResolvedAuditStamp;
 import com.linkedin.datahub.graphql.generated.SearchResult;
 import com.linkedin.datahub.graphql.generated.SearchSuggestion;
 import com.linkedin.datahub.graphql.types.common.mappers.UrnToEntityMapper;
@@ -131,5 +134,14 @@ public class MapperUtils {
     entityPath.setPath(
         path.stream().map(p -> UrnToEntityMapper.map(context, p)).collect(Collectors.toList()));
     return entityPath;
+  }
+
+  public static ResolvedAuditStamp createResolvedAuditStamp(AuditStamp auditStamp) {
+    final ResolvedAuditStamp resolvedAuditStamp = new ResolvedAuditStamp();
+    final CorpUser emptyCreatedUser = new CorpUser();
+    emptyCreatedUser.setUrn(auditStamp.getActor().toString());
+    resolvedAuditStamp.setActor(emptyCreatedUser);
+    resolvedAuditStamp.setTime(auditStamp.getTime());
+    return resolvedAuditStamp;
   }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/structuredproperty/StructuredPropertyMapper.java
@@ -17,6 +17,7 @@ import com.linkedin.datahub.graphql.generated.StructuredPropertyDefinition;
 import com.linkedin.datahub.graphql.generated.StructuredPropertyEntity;
 import com.linkedin.datahub.graphql.generated.TypeQualifier;
 import com.linkedin.datahub.graphql.types.common.mappers.util.MappingHelper;
+import com.linkedin.datahub.graphql.types.mappers.MapperUtils;
 import com.linkedin.datahub.graphql.types.mappers.ModelMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspectMap;
@@ -73,6 +74,13 @@ public class StructuredPropertyMapper
     }
     if (gmsDefinition.hasTypeQualifier()) {
       definition.setTypeQualifier(mapTypeQualifier(gmsDefinition.getTypeQualifier()));
+    }
+    if (gmsDefinition.getCreated() != null) {
+      definition.setCreated(MapperUtils.createResolvedAuditStamp(gmsDefinition.getCreated()));
+    }
+    if (gmsDefinition.getLastModified() != null) {
+      definition.setLastModified(
+          MapperUtils.createResolvedAuditStamp(gmsDefinition.getLastModified()));
     }
     definition.setEntityTypes(
         gmsDefinition.getEntityTypes().stream()

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -85,6 +85,11 @@ type Query {
     role(urn: String!): Role
 
     """
+    Fetch a Structured Property by primary key (urn)
+    """
+    structuredProperty(urn: String!): StructuredPropertyEntity
+
+    """
     Fetch a ERModelRelationship by primary key (urn)
     """
     erModelRelationship(urn: String!): ERModelRelationship

--- a/datahub-graphql-core/src/main/resources/properties.graphql
+++ b/datahub-graphql-core/src/main/resources/properties.graphql
@@ -95,6 +95,16 @@ type StructuredPropertyDefinition {
     Whether or not this structured property is immutable
     """
     immutable: Boolean!
+
+    """
+    Audit stamp for when this structured property was created
+    """
+    created: ResolvedAuditStamp
+
+    """
+    Audit stamp for when this structured property was last modified
+    """
+    lastModified: ResolvedAuditStamp
 }
 
 """

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilder.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/builder/StructuredPropertyDefinitionPatchBuilder.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.data.template.StringArrayMap;
 import com.linkedin.metadata.aspect.patch.PatchOperationType;
 import com.linkedin.structured.PropertyCardinality;
@@ -29,6 +30,10 @@ public class StructuredPropertyDefinitionPatchBuilder
   public static final String ENTITY_TYPES_FIELD = "entityTypes";
   public static final String DESCRIPTION_FIELD = "description";
   public static final String IMMUTABLE_FIELD = "immutable";
+  private static final String LAST_MODIFIED_KEY = "lastModified";
+  private static final String CREATED_KEY = "created";
+  private static final String TIME_KEY = "time";
+  private static final String ACTOR_KEY = "actor";
 
   // can only be used when creating a new structured property
   public StructuredPropertyDefinitionPatchBuilder setQualifiedName(@Nonnull String name) {
@@ -131,6 +136,30 @@ public class StructuredPropertyDefinitionPatchBuilder
             PatchOperationType.ADD.getValue(),
             PATH_DELIM + IMMUTABLE_FIELD,
             instance.booleanNode(immutable)));
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setLastModified(
+      @Nonnull AuditStamp lastModified) {
+    ObjectNode lastModifiedValue = instance.objectNode();
+    lastModifiedValue.put(TIME_KEY, lastModified.getTime());
+    lastModifiedValue.put(ACTOR_KEY, lastModified.getActor().toString());
+
+    pathValues.add(
+        ImmutableTriple.of(
+            PatchOperationType.ADD.getValue(), "/" + LAST_MODIFIED_KEY, lastModifiedValue));
+
+    return this;
+  }
+
+  public StructuredPropertyDefinitionPatchBuilder setCreated(@Nonnull AuditStamp created) {
+    ObjectNode createdValue = instance.objectNode();
+    createdValue.put(TIME_KEY, created.getTime());
+    createdValue.put(ACTOR_KEY, created.getActor().toString());
+
+    pathValues.add(
+        ImmutableTriple.of(PatchOperationType.ADD.getValue(), "/" + CREATED_KEY, createdValue));
+
     return this;
   }
 

--- a/metadata-models/src/main/pegasus/com/linkedin/structured/StructuredPropertyDefinition.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/structured/StructuredPropertyDefinition.pdl
@@ -1,5 +1,6 @@
 namespace com.linkedin.structured
 
+import com.linkedin.common.AuditStamp
 import com.linkedin.common.Urn
 import com.linkedin.datahub.DataHubSearchConfig
 
@@ -86,5 +87,27 @@ record StructuredPropertyDefinition {
      *                                   20240610, 20240611
      */
     version: optional string
+
+    /**
+         * Created Audit stamp
+         */
+        @Searchable = {
+          "/time": {
+           "fieldName": "createdTime",
+           "fieldType": "DATETIME"
+          }
+        }
+        created: optional AuditStamp
+
+        /**
+         * Created Audit stamp
+         */
+        @Searchable = {
+          "/time": {
+           "fieldName": "lastModified",
+           "fieldType": "DATETIME"
+          }
+        }
+        lastModified: optional AuditStamp
 }
 


### PR DESCRIPTION
This adds the `created` and `lastModified` timestamps to the structured props definition aspect to track when this entity was created and last modified. Also, it adds a new graphql endpoint to explicitly get a structured property by urn.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
