### PR TITLE
fix(siblings) Combine siblings in embedded search results

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -10,6 +10,8 @@ import { SearchFiltersSection } from '../../../../../search/SearchFiltersSection
 import { EntitySearchResults, EntityActionProps } from './EntitySearchResults';
 import MatchingViewsLabel from './MatchingViewsLabel';
 import { ANTD_GRAY } from '../../../constants';
+import { useIsShowSeparateSiblingsEnabled } from '../../../../../useAppConfig';
+import { combineSiblingsInSearchResults } from '../../../../../search/utils/combineSiblingsInSearchResults';
 
 const SearchBody = styled.div`
     height: 100%;
@@ -129,6 +131,12 @@ export const EmbeddedListSearchResults = ({
     onLineageClick,
     isLineageTab = false,
 }: Props) => {
+    const showSeparateSiblings = useIsShowSeparateSiblingsEnabled();
+    const combinedSiblingSearchResults = combineSiblingsInSearchResults(
+        showSeparateSiblings,
+        searchResponse?.searchResults,
+    );
+
     const pageStart = searchResponse?.start || 0;
     const pageSize = searchResponse?.count || 0;
     const totalResults = searchResponse?.total || 0;
@@ -169,9 +177,9 @@ export const EmbeddedListSearchResults = ({
                     )}
                     {!loading && !isServerOverloadError && (
                         <EntitySearchResults
-                            searchResults={searchResponse?.searchResults || []}
+                            searchResults={combinedSiblingSearchResults || []}
                             additionalPropertiesList={
-                                searchResponse?.searchResults?.map((searchResult) => ({
+                                combinedSiblingSearchResults?.map((searchResult) => ({
                                     // when we add impact analysis, we will want to pipe the path to each element to the result this
                                     // eslint-disable-next-line @typescript-eslint/dot-notation
                                     degree: searchResult['degree'],


### PR DESCRIPTION
We combine siblings in our main search results when the combine siblings flag is on, we should do the same to be consistent in our embedded list search results as well.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
