### PR TITLE
fix(structuredProps) Fix adding new allowed types in updateStructuredProp endpoint

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
@@ -1,7 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
-import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTIES_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_ENTITY_NAME;
 
@@ -23,7 +22,6 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.structured.PrimitivePropertyValue;
 import com.linkedin.structured.PropertyCardinality;
 import com.linkedin.structured.PropertyValue;
-import com.linkedin.structured.StructuredProperties;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
@@ -59,7 +57,8 @@ public class UpdateStructuredPropertyResolver
                   "Unable to update structured property. Please contact your admin.");
             }
             final Urn propertyUrn = UrnUtils.getUrn(input.getUrn());
-            StructuredPropertyDefinition existingDefinition = getExistingStructuredProperty(context, propertyUrn);
+            StructuredPropertyDefinition existingDefinition =
+                getExistingStructuredProperty(context, propertyUrn);
             StructuredPropertyDefinitionPatchBuilder builder =
                 new StructuredPropertyDefinitionPatchBuilder().urn(propertyUrn);
 
@@ -73,7 +72,7 @@ public class UpdateStructuredPropertyResolver
               builder.setImmutable(input.getImmutable());
             }
             if (input.getTypeQualifier() != null) {
-              buildTypeQualifier(input, builder);
+              buildTypeQualifier(input, builder, existingDefinition);
             }
             if (input.getNewAllowedValues() != null) {
               buildAllowedValues(input, builder);
@@ -109,7 +108,9 @@ public class UpdateStructuredPropertyResolver
     if (input.getTypeQualifier().getNewAllowedTypes() != null) {
       final StringArrayMap typeQualifier = new StringArrayMap();
       StringArray allowedTypes = new StringArray();
-      if (existingDefinition != null && existingDefinition.getTypeQualifier() != null && existingDefinition.getTypeQualifier().get(ALLOWED_TYPES) != null) {
+      if (existingDefinition != null
+          && existingDefinition.getTypeQualifier() != null
+          && existingDefinition.getTypeQualifier().get(ALLOWED_TYPES) != null) {
         allowedTypes.addAll(existingDefinition.getTypeQualifier().get(ALLOWED_TYPES));
       }
       allowedTypes.addAll(input.getTypeQualifier().getNewAllowedTypes());
@@ -140,18 +141,15 @@ public class UpdateStructuredPropertyResolver
   }
 
   private StructuredPropertyDefinition getExistingStructuredProperty(
-      @Nonnull final QueryContext context,
-      @Nonnull final Urn propertyUrn) throws Exception {
+      @Nonnull final QueryContext context, @Nonnull final Urn propertyUrn) throws Exception {
     EntityResponse response =
         _entityClient.getV2(
-            context.getOperationContext(),
-            STRUCTURED_PROPERTY_ENTITY_NAME,
-            propertyUrn,
-            null);
+            context.getOperationContext(), STRUCTURED_PROPERTY_ENTITY_NAME, propertyUrn, null);
 
-    if (response != null && response.getAspects().containsKey(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME)) {
+    if (response != null
+        && response.getAspects().containsKey(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME)) {
       return new StructuredPropertyDefinition(
-              response.getAspects().get(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME).getValue().data());
+          response.getAspects().get(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME).getValue().data());
     }
     return null;
   }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolver.java
@@ -1,6 +1,8 @@
 package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTIES_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_ENTITY_NAME;
 
 import com.linkedin.common.urn.Urn;
@@ -21,16 +23,21 @@ import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.structured.PrimitivePropertyValue;
 import com.linkedin.structured.PropertyCardinality;
 import com.linkedin.structured.PropertyValue;
+import com.linkedin.structured.StructuredProperties;
+import com.linkedin.structured.StructuredPropertyDefinition;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class UpdateStructuredPropertyResolver
     implements DataFetcher<CompletableFuture<StructuredPropertyEntity>> {
 
   private final EntityClient _entityClient;
+
+  private static final String ALLOWED_TYPES = "allowedTypes";
 
   public UpdateStructuredPropertyResolver(@Nonnull final EntityClient entityClient) {
     _entityClient = Objects.requireNonNull(entityClient, "entityClient must not be null");
@@ -52,6 +59,7 @@ public class UpdateStructuredPropertyResolver
                   "Unable to update structured property. Please contact your admin.");
             }
             final Urn propertyUrn = UrnUtils.getUrn(input.getUrn());
+            StructuredPropertyDefinition existingDefinition = getExistingStructuredProperty(context, propertyUrn);
             StructuredPropertyDefinitionPatchBuilder builder =
                 new StructuredPropertyDefinitionPatchBuilder().urn(propertyUrn);
 
@@ -96,10 +104,14 @@ public class UpdateStructuredPropertyResolver
 
   private void buildTypeQualifier(
       @Nonnull final UpdateStructuredPropertyInput input,
-      @Nonnull final StructuredPropertyDefinitionPatchBuilder builder) {
+      @Nonnull final StructuredPropertyDefinitionPatchBuilder builder,
+      @Nullable final StructuredPropertyDefinition existingDefinition) {
     if (input.getTypeQualifier().getNewAllowedTypes() != null) {
       final StringArrayMap typeQualifier = new StringArrayMap();
       StringArray allowedTypes = new StringArray();
+      if (existingDefinition != null && existingDefinition.getTypeQualifier() != null && existingDefinition.getTypeQualifier().get(ALLOWED_TYPES) != null) {
+        allowedTypes.addAll(existingDefinition.getTypeQualifier().get(ALLOWED_TYPES));
+      }
       allowedTypes.addAll(input.getTypeQualifier().getNewAllowedTypes());
       typeQualifier.put("allowedTypes", allowedTypes);
       builder.setTypeQualifier(typeQualifier);
@@ -125,5 +137,22 @@ public class UpdateStructuredPropertyResolver
               value.setDescription(allowedValueInput.getDescription(), SetMode.IGNORE_NULL);
               builder.addAllowedValue(value);
             });
+  }
+
+  private StructuredPropertyDefinition getExistingStructuredProperty(
+      @Nonnull final QueryContext context,
+      @Nonnull final Urn propertyUrn) throws Exception {
+    EntityResponse response =
+        _entityClient.getV2(
+            context.getOperationContext(),
+            STRUCTURED_PROPERTY_ENTITY_NAME,
+            propertyUrn,
+            null);
+
+    if (response != null && response.getAspects().containsKey(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME)) {
+      return new StructuredPropertyDefinition(
+              response.getAspects().get(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME).getValue().data());
+    }
+    return null;
   }
 }

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpdateStructuredPropertyResolverTest.java
@@ -89,8 +89,8 @@ public class UpdateStructuredPropertyResolverTest {
 
     assertThrows(CompletionException.class, () -> resolver.get(mockEnv).join());
 
-    // Validate that ingest was called, but that caused a failure
-    Mockito.verify(mockEntityClient, Mockito.times(1))
+    // Validate that ingest was not called since there was a get failure before ingesting
+    Mockito.verify(mockEntityClient, Mockito.times(0))
         .ingestProposal(any(), any(MetadataChangeProposal.class), Mockito.eq(false));
   }
 


### PR DESCRIPTION
Fixes a bug where we were overwriting the allowed types value on a structured props type qualifier when providing `newAllowedTypes`. This breaks backwards compatibility as we should only be adding new types, never removing them.

This PR fixes that by fetching the existing allowed types if they exist and appending to them with what's provided in the update API.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
