### PR TITLE
fix(restoreIndices): fix bug in urn paginated restoreIndices exit code

### DIFF
--- a/datahub-upgrade/build.gradle
+++ b/datahub-upgrade/build.gradle
@@ -121,6 +121,34 @@ task run(type: Exec) {
           "-Dserver.port=8083", bootJar.getArchiveFile().get(), "-u", "SystemUpdate"
 }
 
+/**
+ * Runs RestoreIndices on locally running system. The batchSize are set to
+ * test the process with pagination and not designed for optimal performance.
+ */
+task runRestoreIndices(type: Exec) {
+  dependsOn bootJar
+  group = "Execution"
+  description = "Run the restore indices process locally."
+  environment "ENTITY_REGISTRY_CONFIG_PATH", "../metadata-models/src/main/resources/entity-registry.yml"
+  commandLine "java", "-agentlib:jdwp=transport=dt_socket,address=5003,server=y,suspend=n",
+          "-jar",
+          "-Dkafka.schemaRegistry.url=http://localhost:8080/schema-registry/api",
+          "-Dserver.port=8083",
+          bootJar.getArchiveFile().get(), "-u", "RestoreIndices", "-a", "batchSize=100"
+}
+
+task runRestoreIndicesUrn(type: Exec) {
+  dependsOn bootJar
+  group = "Execution"
+  description = "Run the restore indices process locally."
+  environment "ENTITY_REGISTRY_CONFIG_PATH", "../metadata-models/src/main/resources/entity-registry.yml"
+  commandLine "java", "-agentlib:jdwp=transport=dt_socket,address=5003,server=y,suspend=n",
+          "-jar",
+          "-Dkafka.schemaRegistry.url=http://localhost:8080/schema-registry/api",
+          "-Dserver.port=8083",
+          bootJar.getArchiveFile().get(), "-u", "RestoreIndices", "-a", "batchSize=100", "-a", "urnBasedPagination=true"
+}
+
 docker {
   name "${docker_registry}/${docker_repo}:v${version}"
   version "v${version}"

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -16,6 +16,7 @@ import io.ebean.ExpressionList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -189,7 +190,12 @@ public class SendMAEStep implements UpgradeStep {
             context.report().addLine(String.format("Rows processed this loop %d", rowsProcessed));
             start += args.batchSize;
           } catch (InterruptedException | ExecutionException e) {
-            return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+            if (e.getCause() instanceof NoSuchElementException) {
+              context.report().addLine("End of data.");
+              break;
+            } else {
+              return new DefaultUpgradeStepResult(id(), DataHubUpgradeState.FAILED);
+            }
           }
         }
       } else {


### PR DESCRIPTION
When using restoreIndices with Urn pagination enabled, the natural control loop throws an exception. This exception should not be raised.

See https://github.com/datahub-project/datahub/issues/11305

```
2024-09-20 09:23:16,117 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Successfully sent MAEs for 1186/1186 rows (100.00% of total). 0 rows ignored (0.00% of total)
2024-09-20 09:23:16,117 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - 0.16 mins taken. 0.00 est. mins to completion. Total mins est. = 0.16.
2024-09-20 09:23:16,117 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Rows processed this loop 86
2024-09-20 09:23:16,117 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Getting next batch of urns + aspects, starting with urn:li:tag:Cypress2 - tagProperties
2024-09-20 09:23:16,117 [pool-16-thread-1] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Args are RestoreIndicesArgs(start=1200, batchSize=100, limit=100, numThreads=1, batchDelayMs=250, gePitEpochMs=0, lePitEpochMs=0, aspectName=null, aspectNames=[], urn=null, urnLike=null, urnBasedPagination=true, lastUrn=urn:li:tag:Cypress2, lastAspect=tagProperties)
2024-09-20 09:23:16,117 [pool-16-thread-1] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Reading rows 1200 through 1300 (0 == infinite) in batches of 100 from the aspects table started.
2024-09-20 09:23:16,121 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - End of data.
2024-09-20 09:23:16,122 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Completed Step 4/4: SendMAEStep successfully.
2024-09-20 09:23:16,122 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Success! Completed upgrade with id RestoreIndices successfully.
2024-09-20 09:23:16,122 [main] INFO  c.l.d.u.impl.DefaultUpgradeReport:15 - Upgrade RestoreIndices completed with result SUCCEEDED. Exiting...
2024-09-20 09:23:16,129 [EbeanHook] INFO  io.ebean.datasource:122 - DataSource [gmsEbeanDatabaseConfig] shutdown min[2] max[50] free[2] busy[0] waiting[0] highWaterMark[2] waitCount[0] hitCount[1203] meanAcquireNanos[1335] maxAcquireMicros[15]  psc[hit:2,368 miss:6 put:2,374 rem:0]
2024-09-20 09:23:16,129 [SpringApplicationShutdownHook] INFO  c.l.r.t.h.c.c.AbstractNettyClient:249 - Shutdown requested
2024-09-20 09:23:16,129 [SpringApplicationShutdownHook] INFO  c.l.r.t.h.c.c.AbstractNettyClient:252 - Shutting down

```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
