### PR TITLE
feat(ingest/dbt): produce multiple assertions for multi-table dbt tests

### DIFF
--- a/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_events_golden.json
@@ -1886,6 +1886,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.accepted_values_orders_status__placed__shipped__completed__return_pending__returned.be6b5b5ec3",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -1939,8 +1941,8 @@
             },
             "assertionUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -1974,6 +1976,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.accepted_values_stg_orders_status__placed__shipped__completed__return_pending__returned.080fb20aad",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2027,8 +2031,8 @@
             },
             "assertionUrn": "urn:li:assertion:da743330013b7e3e3707ac6e526ab408",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2062,6 +2066,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.accepted_values_stg_payments_payment_method__credit_card__coupon__bank_transfer__gift_card.3c3820f278",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2115,8 +2121,8 @@
             },
             "assertionUrn": "urn:li:assertion:2887b9c826e0be6296a37833bdc380bd",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2150,6 +2156,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.assert_total_payment_amount_is_positive",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2191,8 +2199,8 @@
             },
             "assertionUrn": "urn:li:assertion:591d8dc8939e0cf9bf0fd03264ad1a0e",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2226,6 +2234,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_be_between_customers_customer_id__2000000__0__customer_id_is_not_null__False.e67667298f",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2293,6 +2303,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_be_in_set_customers_customer_id__customer_id_is_not_null__0__1__2.81450cfcd8",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2349,8 +2361,8 @@
             },
             "assertionUrn": "urn:li:assertion:bf7fd2b46d2c32ee9bb036acd1559782",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2384,6 +2396,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.dbt_expectations_expect_column_values_to_not_be_in_set_orders_credit_card_amount__credit_card_amount_is_not_null__0.888b06036c",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2435,8 +2449,8 @@
             },
             "assertionUrn": "urn:li:assertion:1c217b7587a0cad47a07a09bfe154055",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2470,6 +2484,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_customers_customer_id.5c9bf9911d",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2516,8 +2532,8 @@
             },
             "assertionUrn": "urn:li:assertion:44519aa345bf3ea896179f9f352ae946",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2551,6 +2567,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_amount.106140f9fd",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2597,8 +2615,8 @@
             },
             "assertionUrn": "urn:li:assertion:bbd78a070092f54313153abec49f6f31",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2632,6 +2650,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_bank_transfer_amount.7743500c49",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2678,8 +2698,8 @@
             },
             "assertionUrn": "urn:li:assertion:52d06197762e3608d94609e96f03a0a7",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2713,6 +2733,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_coupon_amount.ab90c90625",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2759,8 +2781,8 @@
             },
             "assertionUrn": "urn:li:assertion:ca065a99637630468f688717590beeab",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2794,6 +2816,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_credit_card_amount.d3ca593b59",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2840,8 +2864,8 @@
             },
             "assertionUrn": "urn:li:assertion:7a305acc5fc049dc9bbd141b814461d0",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2875,6 +2899,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_customer_id.c5f02694af",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -2921,8 +2947,8 @@
             },
             "assertionUrn": "urn:li:assertion:11087a3d7ae178df22c42922ac8ef8ad",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -2956,6 +2982,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_gift_card_amount.413a0d2d7a",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3002,8 +3030,8 @@
             },
             "assertionUrn": "urn:li:assertion:b301bb47cc4ebce4e78a194b3de11f25",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3037,6 +3065,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_orders_order_id.cf6c17daed",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3083,8 +3113,8 @@
             },
             "assertionUrn": "urn:li:assertion:2e9117138dcc9facda66f1efd55a8cd7",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3118,6 +3148,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_stg_customers_customer_id.e2cfb1f9aa",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3164,8 +3196,8 @@
             },
             "assertionUrn": "urn:li:assertion:25ebf4faa9b1654ef54c46d975ca0a81",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3199,6 +3231,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_stg_orders_order_id.81cfe2fe64",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3245,8 +3279,8 @@
             },
             "assertionUrn": "urn:li:assertion:b03abcc447aac70bbebb22a8a9d7dbbe",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3280,6 +3314,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.not_null_stg_payments_payment_id.c19cc50075",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3326,8 +3362,8 @@
             },
             "assertionUrn": "urn:li:assertion:c1eebc71f36690e4523adca30314e927",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3339,7 +3375,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -3355,12 +3391,14 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3401,7 +3439,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3414,10 +3452,10 @@
                 "type": "SUCCESS",
                 "nativeResults": {}
             },
-            "assertionUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+            "assertionUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3429,12 +3467,30 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3475,7 +3531,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -3488,10 +3544,10 @@
                 "type": "SUCCESS",
                 "nativeResults": {}
             },
-            "assertionUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
+            "assertionUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3525,6 +3581,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.unique_customers_customer_id.c5af1ff4b1",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3577,8 +3635,8 @@
             },
             "assertionUrn": "urn:li:assertion:c51ca9c4b5a1f964bef748f0b8968e71",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3612,6 +3670,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.unique_orders_order_id.fed79b3a6e",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3664,8 +3724,8 @@
             },
             "assertionUrn": "urn:li:assertion:caa9b8060e214cecab88a92dc39c2e60",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3699,6 +3759,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.unique_stg_customers_customer_id.c7614daada",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_customers",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3751,8 +3813,8 @@
             },
             "assertionUrn": "urn:li:assertion:54bac90e6785bdefd8685ebf8814c429",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3786,6 +3848,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.unique_stg_orders_order_id.e3b841c71a",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_orders",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3838,8 +3902,8 @@
             },
             "assertionUrn": "urn:li:assertion:815963e1332b46a203504ba46ebfab24",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -3873,6 +3937,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.jaffle_shop.unique_stg_payments_payment_id.3744510712",
+                "dbt_test_upstream_unique_id": "model.jaffle_shop.stg_payments",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v5.json",
                 "manifest_version": "1.1.0",
                 "manifest_adapter": "bigquery",
@@ -3925,9 +3991,25 @@
             },
             "assertionUrn": "urn:li:assertion:fac27f352406b941125292413afa8096",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:0331fa8a77015ca1a48d3a2fc90948fb",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
         }
     },
     "systemMetadata": {
@@ -4019,6 +4101,22 @@
 {
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:2ff754df689ea951ed2e12cbe356708f",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-2022_02_03-07_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:3191c2851901165afc07c3bd7f5f590a",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -4147,22 +4245,6 @@
 {
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:b052a324c05327985f3b579a19ad7579",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-2022_02_03-07_00_00",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:b210dbd31c2ee4efc0c24a9e4cf125ef",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_prefer_sql_parser_lineage_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_prefer_sql_parser_lineage_golden.json
@@ -4498,6 +4498,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.assert_source_actor_last_update_is_recent",
+                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -4574,6 +4576,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.is_email_monthly_billing_with_cust_email.57a935ce99",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -4656,6 +4660,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_billing_month.19ce54289b",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -4737,6 +4743,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_email.d405c2cc13",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -4796,7 +4804,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -4812,86 +4820,14 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
         "json": {
             "customProperties": {
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
-                    }
-                },
-                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "field": "customer_id",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
-                    "to": "ref('customer_details')"
-                },
-                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-prefer-sql-parser-lineage",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.customer_details",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -4932,7 +4868,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -4945,7 +4881,99 @@
                 "type": "SUCCESS",
                 "nativeResults": {}
             },
-            "assertionUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+            "assertionUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3"
+            },
+            "type": "DATASET",
+            "datasetAssertion": {
+                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "scope": "DATASET_COLUMN",
+                "fields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                ],
+                "aggregation": "IDENTITY",
+                "operator": "_NATIVE_",
+                "parameters": {
+                    "value": {
+                        "value": "null",
+                        "type": "SET"
+                    }
+                },
+                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
+                "nativeParameters": {
+                    "column_name": "customer_id",
+                    "field": "customer_id",
+                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
+                    "to": "ref('customer_details')"
+                },
+                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1663355198239,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {}
+            },
+            "assertionUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4982,6 +5010,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.source_not_null_pagila_actor_actor_id.ad63829d3e",
+                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5063,6 +5093,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.source_unique_pagila_actor_actor_id.76aff1935a",
+                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5128,7 +5160,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -5144,7 +5176,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -5193,6 +5225,22 @@
 {
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-prefer-sql-parser-lineage",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/dbt/dbt_test_test_model_performance_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_test_test_model_performance_golden.json
@@ -638,8 +638,8 @@
         "json": {
             "timestampMillis": 1663355198240,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "STARTED"
         }
@@ -659,8 +659,8 @@
         "json": {
             "timestampMillis": 1663355198242,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "COMPLETE",
             "result": {
@@ -1097,8 +1097,8 @@
         "json": {
             "timestampMillis": 1663355198240,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "STARTED"
         }
@@ -1118,8 +1118,8 @@
         "json": {
             "timestampMillis": 1663355198242,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "COMPLETE",
             "result": {
@@ -1420,8 +1420,8 @@
         "json": {
             "timestampMillis": 1663355198240,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "STARTED"
         }
@@ -1441,8 +1441,8 @@
         "json": {
             "timestampMillis": 1663355198242,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "COMPLETE",
             "result": {
@@ -1944,8 +1944,8 @@
         "json": {
             "timestampMillis": 1663355198240,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "STARTED"
         }
@@ -1965,8 +1965,8 @@
         "json": {
             "timestampMillis": 1663355198242,
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             },
             "status": "COMPLETE",
             "result": {
@@ -5270,6 +5270,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.assert_source_actor_last_update_is_recent",
+                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5311,8 +5313,8 @@
             },
             "assertionUrn": "urn:li:assertion:ba2c6ba830d407d539452f4cf46c92a6",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5346,6 +5348,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.is_email_monthly_billing_with_cust_email.57a935ce99",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5393,8 +5397,8 @@
             },
             "assertionUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5428,6 +5432,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_billing_month.19ce54289b",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5474,8 +5480,8 @@
             },
             "assertionUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5509,6 +5515,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.not_null_monthly_billing_with_cust_email.d405c2cc13",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5555,8 +5563,8 @@
             },
             "assertionUrn": "urn:li:assertion:f812b73477d81e6af283d918cb59e7bf",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5568,7 +5576,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -5584,86 +5592,14 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "assertionInfo",
     "aspect": {
         "json": {
             "customProperties": {
-                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
-                "manifest_version": "1.7.3",
-                "manifest_adapter": "postgres",
-                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
-                "catalog_version": "1.7.3"
-            },
-            "type": "DATASET",
-            "datasetAssertion": {
-                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-                "scope": "DATASET_COLUMN",
-                "fields": [
-                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
-                ],
-                "aggregation": "IDENTITY",
-                "operator": "_NATIVE_",
-                "parameters": {
-                    "value": {
-                        "value": "null",
-                        "type": "SET"
-                    }
-                },
-                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
-                "nativeParameters": {
-                    "column_name": "customer_id",
-                    "field": "customer_id",
-                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
-                    "to": "ref('customer_details')"
-                },
-                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionRunEvent",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1663355198239,
-            "runId": "just-some-random-id",
-            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
-            "status": "COMPLETE",
-            "result": {
-                "type": "SUCCESS",
-                "nativeResults": {}
-            },
-            "assertionUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
-            "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
-            }
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1643871600000,
-        "runId": "dbt-model-performance",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
-    "changeType": "UPSERT",
-    "aspectName": "assertionInfo",
-    "aspect": {
-        "json": {
-            "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.customer_details",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5704,7 +5640,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "assertionRunEvent",
     "aspect": {
@@ -5717,10 +5653,102 @@
                 "type": "SUCCESS",
                 "nativeResults": {}
             },
-            "assertionUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+            "assertionUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:dbt"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_.653e08a90b",
+                "dbt_test_upstream_unique_id": "model.sample_dbt.monthly_billing_with_cust",
+                "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
+                "manifest_version": "1.7.3",
+                "manifest_adapter": "postgres",
+                "catalog_schema": "https://schemas.getdbt.com/dbt/catalog/v1.json",
+                "catalog_version": "1.7.3"
+            },
+            "type": "DATASET",
+            "datasetAssertion": {
+                "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+                "scope": "DATASET_COLUMN",
+                "fields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD),customer_id)"
+                ],
+                "aggregation": "IDENTITY",
+                "operator": "_NATIVE_",
+                "parameters": {
+                    "value": {
+                        "value": "null",
+                        "type": "SET"
+                    }
+                },
+                "nativeType": "relationships_monthly_billing_with_cust_customer_id__customer_id__ref_customer_details_",
+                "nativeParameters": {
+                    "column_name": "customer_id",
+                    "field": "customer_id",
+                    "model": "{{ get_where_subquery(ref('monthly_billing_with_cust')) }}",
+                    "to": "ref('customer_details')"
+                },
+                "logic": "monthly_billing_with_cust.customer_id referential integrity to customer_details.customer_id"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1663355198239,
+            "runId": "just-some-random-id",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.an-aliased-view-for-monthly-billing,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "nativeResults": {}
+            },
+            "assertionUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5754,6 +5782,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.source_not_null_pagila_actor_actor_id.ad63829d3e",
+                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5800,8 +5830,8 @@
             },
             "assertionUrn": "urn:li:assertion:f6a1fde3ab4919abcc04bdee93144958",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5835,6 +5865,8 @@
     "aspect": {
         "json": {
             "customProperties": {
+                "dbt_unique_id": "test.sample_dbt.source_unique_pagila_actor_actor_id.76aff1935a",
+                "dbt_test_upstream_unique_id": "source.sample_dbt.pagila.actor",
                 "manifest_schema": "https://schemas.getdbt.com/dbt/manifest/v11.json",
                 "manifest_version": "1.7.3",
                 "manifest_adapter": "postgres",
@@ -5887,8 +5919,8 @@
             },
             "assertionUrn": "urn:li:assertion:60ce4aad7ff6dbff7004da0f2258c9df",
             "partitionSpec": {
-                "type": "FULL_TABLE",
-                "partition": "FULL_TABLE_SNAPSHOT"
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
             }
         }
     },
@@ -5900,7 +5932,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:08c35a6481d3c37c93eaf9e424faa6d5",
+    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -5916,7 +5948,7 @@
 },
 {
     "entityType": "assertion",
-    "entityUrn": "urn:li:assertion:10f2a119dedcaab43afc47ff13d9cb5b",
+    "entityUrn": "urn:li:assertion:1f37cbfd95ea2a1d46b8e94828805eb1",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {
@@ -5965,6 +5997,22 @@
 {
     "entityType": "assertion",
     "entityUrn": "urn:li:assertion:c456eccf6440c6e3388c584689a74d91",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1643871600000,
+        "runId": "dbt-model-performance",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:f3a0dbf71b6cbf7112ff44925f475ff5",
     "changeType": "UPSERT",
     "aspectName": "status",
     "aspect": {

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -465,7 +465,7 @@ def test_dbt_tests_only_assertions(
         )
         > 20
     )
-    number_of_valid_assertions_in_test_results = 23
+    number_of_valid_assertions_in_test_results = 24
     assert (
         mce_helpers.assert_entity_urn_like(
             entity_type="assertion", regex_pattern="urn:li:assertion:", file=output_file
@@ -542,7 +542,7 @@ def test_dbt_only_test_definitions_and_results(
         )
         > 20
     )
-    number_of_assertions = 24
+    number_of_assertions = 25
     assert (
         mce_helpers.assert_entity_urn_like(
             entity_type="assertion", regex_pattern="urn:li:assertion:", file=output_file


### PR DESCRIPTION
Stacked on https://github.com/datahub-project/datahub/pull/11450

For dbt tests that depend on multiple underlying models (e.g. relationship tests), we previously would only produce one datahub assertion. The dataset that this assertion was associated with was not consistently defined (it used to be whatever model was last when alphabetically ordered - not sure why). This changes it so we produce multiple dataset assertions for the dbt test, one per dataset. While it's not strictly correct, the end user experience will make more sense. The assertions produced will have custom properties in case they need to be linked in the future.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
