### PR TITLE
fix(structuredProps) Allow upserting structured props on schema fields that don't exist

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpsertStructuredPropertiesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/structuredproperties/UpsertStructuredPropertiesResolver.java
@@ -1,6 +1,7 @@
 package com.linkedin.datahub.graphql.resolvers.structuredproperties;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
+import static com.linkedin.metadata.Constants.SCHEMA_FIELD_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTIES_ASPECT_NAME;
 
 import com.datahub.authentication.Authentication;
@@ -74,7 +75,9 @@ public class UpsertStructuredPropertiesResolver
             final AuditStamp auditStamp =
                 AuditStampUtils.createAuditStamp(authentication.getActor().toUrnStr());
 
-            if (!_entityClient.exists(context.getOperationContext(), assetUrn)) {
+            // schemaField entities often don't exist, create it if upserting on a schema field
+            if (!assetUrn.getEntityType().equals(SCHEMA_FIELD_ENTITY_NAME)
+                && !_entityClient.exists(context.getOperationContext(), assetUrn)) {
               throw new RuntimeException(
                   String.format("Asset with provided urn %s does not exist", assetUrn));
             }


### PR DESCRIPTION
Most schema fields don't have their own urns yet in the database and structured properties are the first main aspect we're storing on them. This PR edits the `upsertStructuredProperties` endpoint to allow users to add a property to a schema field urn that doesn't exist yet. This way users will be able to add/remove properties on schema fields even if they weren't minted by some other way yet (other than forms or API, there is no other way as far as I know).

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
