### PR TITLE
fix(ingest): include platform instance in looker usage urns

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -13,7 +13,6 @@ from typing import (
     Set,
     Tuple,
     Union,
-    cast,
 )
 
 from looker_sdk.error import SDKError
@@ -163,28 +162,6 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
         # (model, explore) -> list of charts/looks/dashboards that reference this explore
         # The list values are used purely for debugging purposes.
         self.reachable_explores: Dict[Tuple[str, str], List[str]] = {}
-
-        # Keep stat generators to generate entity stat aspect later
-        stat_generator_config: looker_usage.StatGeneratorConfig = (
-            looker_usage.StatGeneratorConfig(
-                looker_api_wrapper=self.looker_api,
-                looker_user_registry=self.user_registry,
-                interval=self.source_config.extract_usage_history_for_interval,
-                strip_user_ids_from_email=self.source_config.strip_user_ids_from_email,
-                platform_name=self.source_config.platform_name,
-                max_threads=self.source_config.max_threads,
-            )
-        )
-
-        self.dashboard_stat_generator = looker_usage.create_stat_entity_generator(
-            looker_usage.SupportedStatEntity.DASHBOARD,
-            config=stat_generator_config,
-        )
-
-        self.chart_stat_generator = looker_usage.create_stat_entity_generator(
-            looker_usage.SupportedStatEntity.CHART,
-            config=stat_generator_config,
-        )
 
         # To keep track of folders (containers) which have already been ingested
         # Required, as we do not ingest all folders but only those that have dashboards/looks
@@ -648,9 +625,7 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
         )
 
     def _make_chart_urn(self, element_id: str) -> str:
-
         platform_instance: Optional[str] = None
-
         if self.source_config.include_platform_instance_in_urns:
             platform_instance = self.source_config.platform_instance
 
@@ -871,18 +846,21 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             )
 
         return proposals
-
-    def make_dashboard_urn(self, looker_dashboard: LookerDashboard) -> str:
+    
+    def _make_dashboard_urn(self, looker_dashboard_name_part: str) -> str:
+        # Note that `looker_dashboard_name_part` will like be `dashboard.1234`.
         platform_instance: Optional[str] = None
-
         if self.source_config.include_platform_instance_in_urns:
             platform_instance = self.source_config.platform_instance
 
         return builder.make_dashboard_urn(
-            name=looker_dashboard.get_urn_dashboard_id(),
+            name=looker_dashboard_name_part,
             platform=self.source_config.platform_name,
             platform_instance=platform_instance,
         )
+
+    def make_dashboard_urn(self, looker_dashboard: LookerDashboard) -> str:
+        return self._make_dashboard_urn(looker_dashboard.get_urn_dashboard_id())
 
     def _make_explore_metadata_events(
         self,
@@ -1397,7 +1375,6 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
     def extract_usage_stat(
         self, looker_dashboards: List[looker_usage.LookerDashboardForUsage]
     ) -> List[MetadataChangeProposalWrapper]:
-        mcps: List[MetadataChangeProposalWrapper] = []
         looks: List[looker_usage.LookerChartForUsage] = []
         # filter out look from all dashboard
         for dashboard in looker_dashboards:
@@ -1408,16 +1385,33 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
         # dedup looks
         looks = list({str(look.id): look for look in looks}.values())
 
-        usage_stat_generators = [
-            self.dashboard_stat_generator(
-                cast(List[looker_usage.ModelForUsage], looker_dashboards), self.reporter
-            ),
-            self.chart_stat_generator(
-                cast(List[looker_usage.ModelForUsage], looks), self.reporter
-            ),
-        ]
+        # Keep stat generators to generate entity stat aspect later
+        stat_generator_config: looker_usage.StatGeneratorConfig = (
+            looker_usage.StatGeneratorConfig(
+                looker_api_wrapper=self.looker_api,
+                looker_user_registry=self.user_registry,
+                interval=self.source_config.extract_usage_history_for_interval,
+                strip_user_ids_from_email=self.source_config.strip_user_ids_from_email,
+                max_threads=self.source_config.max_threads,
+            )
+        )
 
-        for usage_stat_generator in usage_stat_generators:
+        dashboard_usage_generator = looker_usage.create_dashboard_stat_generator(
+            stat_generator_config,
+            self.reporter,
+            self._make_dashboard_urn,
+            looker_dashboards,
+        )
+
+        chart_usage_generator = looker_usage.create_chart_stat_generator(
+            stat_generator_config,
+            self.reporter,
+            self._make_chart_urn,
+            looks,
+        )
+
+        mcps: List[MetadataChangeProposalWrapper] = []
+        for usage_stat_generator in [dashboard_usage_generator, chart_usage_generator]:
             for mcp in usage_stat_generator.generate_usage_stat_mcps():
                 mcps.append(mcp)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_source.py
@@ -846,7 +846,7 @@ class LookerDashboardSource(TestableSource, StatefulIngestionSourceBase):
             )
 
         return proposals
-    
+
     def _make_dashboard_urn(self, looker_dashboard_name_part: str) -> str:
         # Note that `looker_dashboard_name_part` will like be `dashboard.1234`.
         platform_instance: Optional[str] = None

--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_usage.py
@@ -10,12 +10,10 @@ import datetime
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import Enum
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, cast
 
 from looker_sdk.sdk.api40.models import Dashboard, LookWithQuery
 
-import datahub.emitter.mce_builder as builder
 from datahub.emitter.mce_builder import Aspect, AspectAbstract
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.source.looker import looker_common
@@ -97,7 +95,6 @@ class StatGeneratorConfig:
     looker_user_registry: LookerUserRegistry
     strip_user_ids_from_email: bool
     interval: str
-    platform_name: str
     max_threads: int = 1
 
 
@@ -166,7 +163,7 @@ class BaseStatGenerator(ABC):
     def __init__(
         self,
         config: StatGeneratorConfig,
-        looker_models: List[ModelForUsage],
+        looker_models: Sequence[ModelForUsage],
         report: LookerDashboardSourceReport,
     ):
         self.config = config
@@ -411,14 +408,16 @@ class DashboardStatGenerator(BaseStatGenerator):
     def __init__(
         self,
         config: StatGeneratorConfig,
-        looker_dashboards: List[LookerDashboardForUsage],
+        looker_dashboards: Sequence[LookerDashboardForUsage],
         report: LookerDashboardSourceReport,
+        urn_builder: Callable[[str], str],
     ):
         super().__init__(
             config,
-            looker_models=cast(List[ModelForUsage], looker_dashboards),
+            looker_models=looker_dashboards,
             report=report,
         )
+        self.urn_builder = urn_builder
         self.report = report
         self.report.report_dashboards_scanned_for_usage(len(looker_dashboards))
 
@@ -457,10 +456,7 @@ class DashboardStatGenerator(BaseStatGenerator):
         assert isinstance(model, LookerDashboardForUsage)
         assert model.id is not None
 
-        return builder.make_dashboard_urn(
-            self.config.platform_name,
-            looker_common.get_urn_looker_dashboard_id(model.id),
-        )
+        return self.urn_builder(looker_common.get_urn_looker_dashboard_id(model.id))
 
     def to_entity_absolute_stat_aspect(
         self, looker_object: ModelForUsage
@@ -528,14 +524,16 @@ class LookStatGenerator(BaseStatGenerator):
     def __init__(
         self,
         config: StatGeneratorConfig,
-        looker_looks: List[LookerChartForUsage],
+        looker_looks: Sequence[LookerChartForUsage],
         report: LookerDashboardSourceReport,
+        urn_builder: Callable[[str], str],
     ):
         super().__init__(
             config,
-            looker_models=cast(List[ModelForUsage], looker_looks),
+            looker_models=looker_looks,
             report=report,
         )
+        self.urn_builder = urn_builder
         self.report = report
         report.report_charts_scanned_for_usage(len(looker_looks))
 
@@ -570,10 +568,7 @@ class LookStatGenerator(BaseStatGenerator):
         assert isinstance(model, LookerChartForUsage)
         assert model.id is not None
 
-        return builder.make_chart_urn(
-            self.config.platform_name,
-            looker_common.get_urn_looker_element_id(str(model.id)),
-        )
+        return self.urn_builder(looker_common.get_urn_looker_element_id(str(model.id)))
 
     def to_entity_absolute_stat_aspect(
         self, looker_object: ModelForUsage
@@ -629,45 +624,34 @@ class LookStatGenerator(BaseStatGenerator):
         )
 
 
-class SupportedStatEntity(Enum):
-    DASHBOARD = "dashboard"
-    CHART = "chart"
-
-
-# type_ is because of type is builtin identifier
-def create_stat_entity_generator(
-    type_: SupportedStatEntity, config: StatGeneratorConfig
-) -> Callable[[List[ModelForUsage], LookerDashboardSourceReport], BaseStatGenerator]:
-    # Wrapper function to defer creation of actual entities
-    # config is generally available at the startup, however entities may get created later during processing
-    def create_dashboard_stat_generator(
-        looker_dashboards: List[LookerDashboardForUsage],
-        report: LookerDashboardSourceReport,
-    ) -> BaseStatGenerator:
-        logger.debug(
-            "Number of dashboard received for stat processing = {}".format(
-                len(looker_dashboards)
-            )
+def create_dashboard_stat_generator(
+    config: StatGeneratorConfig,
+    report: LookerDashboardSourceReport,
+    urn_builder: Callable[[str], str],
+    looker_dashboards: Sequence[LookerDashboardForUsage],
+) -> DashboardStatGenerator:
+    logger.debug(
+        "Number of dashboard received for stat processing = {}".format(
+            len(looker_dashboards)
         )
-        return DashboardStatGenerator(
-            config=config, looker_dashboards=looker_dashboards, report=report
-        )
+    )
+    return DashboardStatGenerator(
+        config=config,
+        looker_dashboards=looker_dashboards,
+        report=report,
+        urn_builder=urn_builder,
+    )
 
-    def create_chart_stat_generator(
-        looker_looks: List[LookerChartForUsage], report: LookerDashboardSourceReport
-    ) -> BaseStatGenerator:
-        logger.debug(
-            "Number of looks received for stat processing = {}".format(
-                len(looker_looks)
-            )
-        )
-        return LookStatGenerator(
-            config=config, looker_looks=looker_looks, report=report
-        )
 
-    stat_entities_generator = {
-        SupportedStatEntity.DASHBOARD: create_dashboard_stat_generator,
-        SupportedStatEntity.CHART: create_chart_stat_generator,
-    }
-
-    return stat_entities_generator[type_]  # type: ignore
+def create_chart_stat_generator(
+    config: StatGeneratorConfig,
+    report: LookerDashboardSourceReport,
+    urn_builder: Callable[[str], str],
+    looker_looks: Sequence[LookerChartForUsage],
+) -> LookStatGenerator:
+    logger.debug(
+        "Number of looks received for stat processing = {}".format(len(looker_looks))
+    )
+    return LookStatGenerator(
+        config=config, looker_looks=looker_looks, report=report, urn_builder=urn_builder
+    )


### PR DESCRIPTION
Follow up on https://github.com/datahub-project/datahub/issues/10771

That PR updated most looker urns to use the platform instance when configured, but missed updating the usage code. This finishes the job by passing the urn builder function in as a parameter, so the urn construction logic only lives in one place.

It also refactors the Looker usage code to remove `cast` calls and overall be more readable.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
