### PR TITLE
fix(propagation): show last modified propagated documentation

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/getFieldDescriptionDetails.ts
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/getFieldDescriptionDetails.ts
@@ -7,19 +7,29 @@ interface Props {
 }
 
 export function getFieldDescriptionDetails({ schemaFieldEntity, editableFieldInfo, defaultDescription }: Props) {
-    const documentation = schemaFieldEntity?.documentation?.documentations?.[0];
-    const isUsingDocumentationAspect = !editableFieldInfo?.description && !!documentation;
+    const documentations = schemaFieldEntity?.documentation?.documentations;
+    let latestDocumentation: typeof documentations[0] | undefined;
+
+    if (documentations && documentations.length > 0) {
+        latestDocumentation = documentations.reduce((latest, current) => {
+            const latestTime = latest.attribution?.time || 0;
+            const currentTime = current.attribution?.time || 0;
+            return currentTime > latestTime ? current : latest;
+        });
+    }
+
+    const isUsingDocumentationAspect = !editableFieldInfo?.description && !!latestDocumentation;
     const isPropagated =
         isUsingDocumentationAspect &&
-        !!documentation?.attribution?.sourceDetail?.find(
+        !!latestDocumentation?.attribution?.sourceDetail?.find(
             (mapEntry) => mapEntry.key === 'propagated' && mapEntry.value === 'true',
         );
 
     const displayedDescription =
-        editableFieldInfo?.description || documentation?.documentation || defaultDescription || '';
+        editableFieldInfo?.description || latestDocumentation?.documentation || defaultDescription || '';
 
-    const sourceDetail = documentation?.attribution?.sourceDetail;
-    const propagatedDescription = documentation?.documentation;
+    const sourceDetail = latestDocumentation?.attribution?.sourceDetail;
+    const propagatedDescription = latestDocumentation?.documentation;
 
     return { displayedDescription, isPropagated, sourceDetail, propagatedDescription };
 }


### PR DESCRIPTION
Current description UI deterministically chooses the first entry in the propagated array.
This PR changes that to always pick the latest propagated entry (by time). 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
