### PR TITLE
Block http trace method on mce and mce consumers 

### DIFF
--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/CustomDispatcherServlet.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/CustomDispatcherServlet.java
@@ -1,0 +1,18 @@
+package com.linkedin.metadata.kafka;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.DispatcherServlet;
+
+@Component("dispatcherServlet")
+public class CustomDispatcherServlet extends DispatcherServlet {
+
+  @Override
+  protected void doTrace(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+  }
+}

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/CustomDispatcherServlet.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/CustomDispatcherServlet.java
@@ -1,0 +1,18 @@
+package com.linkedin.metadata.kafka;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.DispatcherServlet;
+
+@Component("dispatcherServlet")
+public class CustomDispatcherServlet extends DispatcherServlet {
+
+  @Override
+  protected void doTrace(HttpServletRequest request, HttpServletResponse response)
+      throws ServletException, IOException {
+    response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+  }
+}


### PR DESCRIPTION
This PR adds two classes under mae-consumer and mce-consumer. These classes will take care of blocking HTTP TRACE method on both components. This is required because mae and mce makes use of embedded jetty which provided 200 response to http trace calls by default. This change will return proper method not allowed response with http code 405. 