### PR TITLE
feat(frontend): default schema tab to raw schema if only raw schema is available

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTab.tsx
@@ -44,13 +44,23 @@ const LoadingWrapper = styled.div`
 export const SchemaTab = ({ properties }: { properties?: any }) => {
     const entityRegistry = useEntityRegistry();
     const baseEntity = useBaseEntity<GetDatasetQuery>();
+    const [showRaw, setShowRaw] = useState(false);
     // Dynamically load the schema + editable schema information.
-    const { entityWithSchema, loading, refetch } = useGetEntityWithSchema();
+    const { entityWithSchema, loading, refetch } = useGetEntityWithSchema(undefined, (data) => {
+        const schemaMetadata = data?.dataset?.schemaMetadata;
+        if (
+            schemaMetadata?.fields?.length === 0 &&
+            schemaMetadata?.platformSchema?.__typename === 'TableSchema' &&
+            schemaMetadata?.platformSchema?.schema?.length > 0
+        ) {
+            // default to raw schema if only raw schema is available
+            setShowRaw(true);
+        }
+    });
     let schemaMetadata: any = entityWithSchema?.schemaMetadata || undefined;
     let editableSchemaMetadata: any = entityWithSchema?.editableSchemaMetadata || undefined;
     const datasetUrn: string = baseEntity?.dataset?.urn || '';
     const usageStats = baseEntity?.dataset?.usageStats;
-    const [showRaw, setShowRaw] = useState(false);
     const location = useLocation();
     const schemaFilter = getSchemaFilterFromQueryString(location);
     const [filterText, setFilterText] = useState(schemaFilter);

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/useGetEntitySchema.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/useGetEntitySchema.tsx
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import { EntityType } from '../../../../../../types.generated';
 import { useEntityData } from '../../../EntityContext';
-import { useGetDatasetSchemaQuery } from '../../../../../../graphql/dataset.generated';
+import { GetDatasetSchemaQuery, useGetDatasetSchemaQuery } from '../../../../../../graphql/dataset.generated';
 import { combineEntityDataWithSiblings, useIsSeparateSiblingsMode } from '../../../siblingUtils';
 
 // Whether to dynamically load the schema from the backend.
@@ -9,7 +9,10 @@ const shouldLoadSchema = (entityType, entityData) => {
     return entityType === EntityType.Dataset && !entityData?.schemaMetadata;
 };
 
-export const useGetEntityWithSchema = (skip?: boolean) => {
+export const useGetEntityWithSchema = (
+    skip?: boolean,
+    onCompleted?: ((data: GetDatasetSchemaQuery) => void) | undefined,
+) => {
     const { urn, entityData, entityType } = useEntityData();
     // Load the dataset schema lazily.
     const {
@@ -22,6 +25,7 @@ export const useGetEntityWithSchema = (skip?: boolean) => {
         },
         skip: skip || !shouldLoadSchema(entityType, entityData),
         fetchPolicy: 'cache-first',
+        onCompleted,
     });
     const isHideSiblingMode = useIsSeparateSiblingsMode();
     // Merge with sibling information as required.


### PR DESCRIPTION
We have cases with Kafka topics were we don't have the tabular schema available but only the raw schema. With this change, we fallback to the raw schema if only the raw schema is available on the schema tab.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
