### PR TITLE
fix(ingest/sigma): handle members api paginated response

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sigma/sigma_api.py
@@ -141,12 +141,19 @@ class SigmaAPI:
         logger.debug("Fetching all accessible users metadata.")
         try:
             users: Dict[str, str] = {}
-            response = self._get_api_call(f"{self.config.api_url}/members")
-            response.raise_for_status()
-            for user_dict in response.json():
-                users[
-                    user_dict[Constant.MEMBERID]
-                ] = f"{user_dict[Constant.FIRSTNAME]}_{user_dict[Constant.LASTNAME]}"
+            members_url = url = f"{self.config.api_url}/members?limit=50"
+            while True:
+                response = self._get_api_call(url)
+                response.raise_for_status()
+                response_dict = response.json()
+                for user_dict in response_dict[Constant.ENTRIES]:
+                    users[
+                        user_dict[Constant.MEMBERID]
+                    ] = f"{user_dict[Constant.FIRSTNAME]}_{user_dict[Constant.LASTNAME]}"
+                if response_dict[Constant.NEXTPAGE]:
+                    url = f"{members_url}&page={response_dict[Constant.NEXTPAGE]}"
+                else:
+                    break
             return users
         except Exception as e:
             self._log_http_error(

--- a/metadata-ingestion/tests/integration/sigma/test_sigma.py
+++ b/metadata-ingestion/tests/integration/sigma/test_sigma.py
@@ -381,25 +381,29 @@ def register_mock_api(request_mock: Any, override_data: dict = {}) -> None:
         "https://aws-api.sigmacomputing.com/v2/members": {
             "method": "GET",
             "status_code": 200,
-            "json": [
-                {
-                    "organizationId": "b94da709-176c-4242-bea6-6760f34c9228",
-                    "memberId": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
-                    "memberType": "admin",
-                    "firstName": "Shubham",
-                    "lastName": "Jagtap",
-                    "email": "john.doe@example.com",
-                    "profileImgUrl": None,
-                    "createdBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
-                    "updatedBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
-                    "createdAt": "2023-11-28T10:59:20.957Z",
-                    "updatedAt": "2024-03-12T21:21:17.996Z",
-                    "homeFolderId": "9bb94df1-e8af-49eb-9c37-2bd40b0efb2e",
-                    "userKind": "internal",
-                    "isArchived": False,
-                    "isInactive": False,
-                },
-            ],
+            "json": {
+                "entries": [
+                    {
+                        "organizationId": "b94da709-176c-4242-bea6-6760f34c9228",
+                        "memberId": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+                        "memberType": "admin",
+                        "firstName": "Shubham",
+                        "lastName": "Jagtap",
+                        "email": "john.doe@example.com",
+                        "profileImgUrl": None,
+                        "createdBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+                        "updatedBy": "CPbEdA26GNQ2cM2Ra2BeO0fa5Awz1",
+                        "createdAt": "2023-11-28T10:59:20.957Z",
+                        "updatedAt": "2024-03-12T21:21:17.996Z",
+                        "homeFolderId": "9bb94df1-e8af-49eb-9c37-2bd40b0efb2e",
+                        "userKind": "internal",
+                        "isArchived": False,
+                        "isInactive": False,
+                    },
+                ],
+                "total": 1,
+                "nextPage": None,
+            },
         },
     }
 


### PR DESCRIPTION
Sigma introduced a breaking change in list members api about a month ago. - https://help.sigmacomputing.com/changelog#pagination-required-for-list-endpoints-breaking-change

This has started affecting instances recently.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
