### PR TITLE
fix(changeGenerator): fix logic around descriptions and make execution more efficient

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -4,6 +4,7 @@ import static com.linkedin.metadata.timeline.eventgenerator.ChangeEventGenerator
 
 import com.datahub.util.RecordUtils;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.common.urn.Urn;
@@ -54,7 +55,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       AuditStamp auditStamp) {
     String baseDescription = (baseField != null) ? baseField.getDescription() : null;
     String targetDescription = (targetField != null) ? targetField.getDescription() : null;
-    if (baseDescription == null && targetDescription != null) {
+    if (baseField != null && baseDescription == null && targetDescription != null) {
       // Description got added.
       return ChangeEvent.builder()
           .operation(ChangeOperation.ADD)
@@ -173,7 +174,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       SchemaField baseField,
       SchemaField targetField,
       Urn datasetUrn,
-      ChangeCategory changeCategory,
+      Set<ChangeCategory> changeCategories,
       AuditStamp auditStamp) {
     List<ChangeEvent> propChangeEvents = new ArrayList<>();
     String datasetFieldUrn;
@@ -184,7 +185,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     }
 
     // Description Change.
-    if (ChangeCategory.DOCUMENTATION.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.DOCUMENTATION)) {
       ChangeEvent descriptionChangeEvent =
           getDescriptionChange(baseField, targetField, datasetFieldUrn, auditStamp);
       if (descriptionChangeEvent != null) {
@@ -193,14 +194,14 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
     }
 
     // Global Tags
-    if (ChangeCategory.TAG.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.TAG)) {
       propChangeEvents.addAll(
           getGlobalTagChangeEvents(
               baseField, targetField, datasetUrn.toString(), datasetFieldUrn, auditStamp));
     }
 
     // Glossary terms.
-    if (ChangeCategory.GLOSSARY_TERM.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.GLOSSARY_TERM)) {
       propChangeEvents.addAll(
           getGlossaryTermsChangeEvents(
               baseField, targetField, datasetUrn.toString(), datasetFieldUrn, auditStamp));
@@ -213,7 +214,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       SchemaMetadata baseSchema,
       SchemaMetadata targetSchema,
       Urn datasetUrn,
-      ChangeCategory changeCategory,
+      Set<ChangeCategory> changeCategories,
       AuditStamp auditStamp) {
     // Sort the fields by their field path. This aligns both sets of fields based on field paths for
     // comparisons.
@@ -247,11 +248,11 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
         // This is the same field. Check for change events from property changes.
         if (!curBaseField.getNativeDataType().equals(curTargetField.getNativeDataType())) {
           processNativeTypeChange(
-              changeCategory, changeEvents, datasetUrn, curBaseField, curTargetField, auditStamp);
+              changeCategories, changeEvents, datasetUrn, curBaseField, curTargetField, auditStamp);
         }
         List<ChangeEvent> propChangeEvents =
             getFieldPropertyChangeEvents(
-                curBaseField, curTargetField, datasetUrn, changeCategory, auditStamp);
+                curBaseField, curTargetField, datasetUrn, changeCategories, auditStamp);
         changeEvents.addAll(propChangeEvents);
         ++baseFieldIdx;
         ++targetFieldIdx;
@@ -268,16 +269,17 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
                 targetFields.subList(targetFieldIdx, targetFields.size()),
                 renamedFields);
         if (renamedField == null) {
-          processRemoval(changeCategory, changeEvents, datasetUrn, curBaseField, auditStamp);
+          processRemoval(changeCategories, changeEvents, datasetUrn, curBaseField, auditStamp);
           ++baseFieldIdx;
         } else {
-          if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+          if (changeCategories != null
+              && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
             changeEvents.add(
                 generateRenameEvent(datasetUrn, curBaseField, renamedField, auditStamp));
           }
           List<ChangeEvent> propChangeEvents =
               getFieldPropertyChangeEvents(
-                  curBaseField, curTargetField, datasetUrn, changeCategory, auditStamp);
+                  curBaseField, renamedField, datasetUrn, changeCategories, auditStamp);
           changeEvents.addAll(propChangeEvents);
           ++baseFieldIdx;
           renamedFields.add(renamedField);
@@ -289,16 +291,17 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
             findRenamedField(
                 curTargetField, baseFields.subList(baseFieldIdx, baseFields.size()), renamedFields);
         if (renamedField == null) {
-          processAdd(changeCategory, changeEvents, datasetUrn, curTargetField, auditStamp);
+          processAdd(changeCategories, changeEvents, datasetUrn, curTargetField, auditStamp);
           ++targetFieldIdx;
         } else {
-          if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+          if (changeCategories != null
+              && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
             changeEvents.add(
                 generateRenameEvent(datasetUrn, renamedField, curTargetField, auditStamp));
           }
           List<ChangeEvent> propChangeEvents =
               getFieldPropertyChangeEvents(
-                  curBaseField, curTargetField, datasetUrn, changeCategory, auditStamp);
+                  renamedField, curTargetField, datasetUrn, changeCategories, auditStamp);
           changeEvents.addAll(propChangeEvents);
           ++targetFieldIdx;
           renamedFields.add(renamedField);
@@ -309,7 +312,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       // Handle removed fields. Non-backward compatible change + major version bump
       SchemaField baseField = baseFields.get(baseFieldIdx);
       if (!renamedFields.contains(baseField)) {
-        processRemoval(changeCategory, changeEvents, datasetUrn, baseField, auditStamp);
+        processRemoval(changeCategories, changeEvents, datasetUrn, baseField, auditStamp);
       }
       ++baseFieldIdx;
     }
@@ -317,14 +320,15 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       // Newly added fields. Forwards & backwards compatible change + minor version bump.
       SchemaField targetField = targetFields.get(targetFieldIdx);
       if (!renamedFields.contains(targetField)) {
-        processAdd(changeCategory, changeEvents, datasetUrn, targetField, auditStamp);
+        processAdd(changeCategories, changeEvents, datasetUrn, targetField, auditStamp);
       }
       ++targetFieldIdx;
     }
 
     // Handle primary key constraint change events.
     List<ChangeEvent> primaryKeyChangeEvents =
-        getPrimaryKeyChangeEvents(changeCategory, baseSchema, targetSchema, datasetUrn, auditStamp);
+        getPrimaryKeyChangeEvents(
+            changeCategories, baseSchema, targetSchema, datasetUrn, auditStamp);
     changeEvents.addAll(primaryKeyChangeEvents);
 
     // Handle foreign key constraint change events, currently no-op due to field not being utilized.
@@ -375,12 +379,12 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
   }
 
   private static void processRemoval(
-      ChangeCategory changeCategory,
+      Set<ChangeCategory> changeCategories,
       List<ChangeEvent> changeEvents,
       Urn datasetUrn,
       SchemaField baseField,
       AuditStamp auditStamp) {
-    if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       changeEvents.add(
           DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
               .modifier(getSchemaFieldUrn(datasetUrn, baseField).toString())
@@ -401,17 +405,17 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .build());
     }
     List<ChangeEvent> propChangeEvents =
-        getFieldPropertyChangeEvents(baseField, null, datasetUrn, changeCategory, auditStamp);
+        getFieldPropertyChangeEvents(baseField, null, datasetUrn, changeCategories, auditStamp);
     changeEvents.addAll(propChangeEvents);
   }
 
   private static void processAdd(
-      ChangeCategory changeCategory,
+      Set<ChangeCategory> changeCategories,
       List<ChangeEvent> changeEvents,
       Urn datasetUrn,
       SchemaField targetField,
       AuditStamp auditStamp) {
-    if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       changeEvents.add(
           DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
               .modifier(getSchemaFieldUrn(datasetUrn, targetField).toString())
@@ -431,19 +435,19 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .build());
     }
     List<ChangeEvent> propChangeEvents =
-        getFieldPropertyChangeEvents(null, targetField, datasetUrn, changeCategory, auditStamp);
+        getFieldPropertyChangeEvents(null, targetField, datasetUrn, changeCategories, auditStamp);
     changeEvents.addAll(propChangeEvents);
   }
 
   private static void processNativeTypeChange(
-      ChangeCategory changeCategory,
+      Set<ChangeCategory> changeCategories,
       List<ChangeEvent> changeEvents,
       Urn datasetUrn,
       SchemaField curBaseField,
       SchemaField curTargetField,
       AuditStamp auditStamp) {
     // Non-backward compatible change + Major version bump
-    if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       changeEvents.add(
           DatasetSchemaFieldChangeEvent.schemaFieldChangeEventBuilder()
               .category(ChangeCategory.TECHNICAL_SCHEMA)
@@ -505,12 +509,12 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
   }
 
   private static List<ChangeEvent> getPrimaryKeyChangeEvents(
-      ChangeCategory changeCategory,
+      Set<ChangeCategory> changeCategories,
       SchemaMetadata baseSchema,
       SchemaMetadata targetSchema,
       Urn datasetUrn,
       AuditStamp auditStamp) {
-    if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+    if (changeCategories != null && changeCategories.contains(ChangeCategory.TECHNICAL_SCHEMA)) {
       List<ChangeEvent> primaryKeyChangeEvents = new ArrayList<>();
       Set<String> basePrimaryKeys =
           (baseSchema != null && baseSchema.getPrimaryKeys() != null)
@@ -598,7 +602,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
                   baseSchema,
                   targetSchema,
                   DatasetUrn.createFromString(currentValue.getUrn()),
-                  changeCategory,
+                  Collections.singleton(changeCategory),
                   null));
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Malformed DatasetUrn " + currentValue.getUrn());
@@ -632,18 +636,16 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       @Nonnull Aspect<SchemaMetadata> from,
       @Nonnull Aspect<SchemaMetadata> to,
       @Nonnull AuditStamp auditStamp) {
-    final List<ChangeEvent> changeEvents = new ArrayList<>();
-    changeEvents.addAll(
+    return new ArrayList<>(
         computeDiffs(
-            from.getValue(), to.getValue(), urn, ChangeCategory.DOCUMENTATION, auditStamp));
-    changeEvents.addAll(
-        computeDiffs(from.getValue(), to.getValue(), urn, ChangeCategory.TAG, auditStamp));
-    changeEvents.addAll(
-        computeDiffs(
-            from.getValue(), to.getValue(), urn, ChangeCategory.TECHNICAL_SCHEMA, auditStamp));
-    changeEvents.addAll(
-        computeDiffs(
-            from.getValue(), to.getValue(), urn, ChangeCategory.GLOSSARY_TERM, auditStamp));
-    return changeEvents;
+            from.getValue(),
+            to.getValue(),
+            urn,
+            ImmutableSet.of(
+                ChangeCategory.DOCUMENTATION,
+                ChangeCategory.TAG,
+                ChangeCategory.TECHNICAL_SCHEMA,
+                ChangeCategory.GLOSSARY_TERM),
+            auditStamp));
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGenerator.java
@@ -55,7 +55,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
       AuditStamp auditStamp) {
     String baseDescription = (baseField != null) ? baseField.getDescription() : null;
     String targetDescription = (targetField != null) ? targetField.getDescription() : null;
-    if (baseField != null && baseDescription == null && targetDescription != null) {
+    if (baseDescription == null && targetDescription != null) {
       // Description got added.
       return ChangeEvent.builder()
           .operation(ChangeOperation.ADD)
@@ -432,6 +432,7 @@ public class SchemaMetadataChangeEventGenerator extends EntityChangeEventGenerat
               .fieldUrn(getSchemaFieldUrn(datasetUrn, targetField))
               .nullable(targetField.isNullable())
               .auditStamp(auditStamp)
+              .modificationCategory(SchemaFieldModificationCategory.OTHER)
               .build());
     }
     List<ChangeEvent> propChangeEvents =

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/eventgenerator/SchemaMetadataChangeEventGeneratorTest.java
@@ -41,7 +41,7 @@ public class SchemaMetadataChangeEventGeneratorTest extends AbstractTestNGSpring
         changeEvent -> {
           actualDescriptions.add(changeEvent.getDescription());
         });
-    assertEquals(expectedDescriptions, actualDescriptions);
+    assertEquals(actualDescriptions, expectedDescriptions);
   }
 
   private static void compareModificationCategories(
@@ -52,7 +52,7 @@ public class SchemaMetadataChangeEventGeneratorTest extends AbstractTestNGSpring
           actualModificationCategories.add(
               changeEvent.getParameters().get("modificationCategory").toString());
         });
-    assertEquals(expectedCategories, actualModificationCategories);
+    assertEquals(actualModificationCategories, expectedCategories);
   }
 
   private static Aspect<SchemaMetadata> getSchemaMetadata(List<SchemaField> schemaFieldList) {
@@ -234,6 +234,97 @@ public class SchemaMetadataChangeEventGeneratorTest extends AbstractTestNGSpring
     List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to, auditStamp);
 
     assertEquals(14, actual.size());
+  }
+
+  @Test
+  public void testSchemaFieldPrimaryKeyChangeRenameAdd() throws Exception {
+    // When a rename cannot be detected, treated as drop -> add
+    SchemaMetadataChangeEventGenerator test = new SchemaMetadataChangeEventGenerator();
+
+    Urn urn = getTestUrn();
+    String entity = "dataset";
+    String aspect = "schemaMetadata";
+    AuditStamp auditStamp = getTestAuditStamp();
+
+    Aspect<SchemaMetadata> from =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("ID")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Description"),
+                new SchemaField()
+                    .setFieldPath("ID2")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Other Description")));
+    from.getValue().setPrimaryKeys(new StringArray(List.of("ID")));
+    Aspect<SchemaMetadata> to3 =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("ID")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Description"),
+                new SchemaField()
+                    .setFieldPath("ID2")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Other Description")));
+    to3.getValue().setPrimaryKeys(new StringArray(List.of("ID2")));
+    List<ChangeEvent> actual = test.getChangeEvents(urn, entity, aspect, from, to3, auditStamp);
+    compareDescriptions(
+        Set.of(
+            "A backwards incompatible change due to a primary key constraint change. "
+                + "The following fields were removed: 'ID'. The following fields were added: 'ID2'."),
+        actual);
+    assertEquals(1, actual.size());
+    compareModificationCategories(Set.of(SchemaFieldModificationCategory.OTHER.toString()), actual);
+
+    Aspect<SchemaMetadata> to4 =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("IDZ")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Description"),
+                new SchemaField()
+                    .setFieldPath("ID2")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Other Description")));
+    to4.getValue().setPrimaryKeys(new StringArray(List.of("ID2")));
+
+    List<ChangeEvent> actual2 = test.getChangeEvents(urn, entity, aspect, to3, to4, auditStamp);
+    compareDescriptions(
+        Set.of(
+            "A forwards & backwards compatible change due to renaming of the field 'ID to IDZ'."),
+        actual2);
+    assertEquals(1, actual2.size());
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.RENAME.toString()), actual2);
+
+    Aspect<SchemaMetadata> to5 =
+        getSchemaMetadata(
+            List.of(
+                new SchemaField()
+                    .setFieldPath("IDZ")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Description"),
+                new SchemaField()
+                    .setFieldPath("ID1")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Third Description"),
+                new SchemaField()
+                    .setFieldPath("ID2")
+                    .setNativeDataType("NUMBER(16,1)")
+                    .setDescription("My Other Description")));
+    to5.getValue().setPrimaryKeys(new StringArray(List.of("ID2")));
+
+    List<ChangeEvent> actual3 = test.getChangeEvents(urn, entity, aspect, to4, to5, auditStamp);
+    compareDescriptions(
+        Set.of("A forwards & backwards compatible change due to the newly added field 'ID1'."),
+        actual3);
+    assertEquals(actual3.size(), 1);
+    compareModificationCategories(
+        Set.of(SchemaFieldModificationCategory.OTHER.toString()), actual3);
   }
 
   // CHECKSTYLE:OFF


### PR DESCRIPTION
Fixes some issues around determination of description changes and pushes down ChangeCategory set behavior to reduce repeated execution.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
