### PR TITLE
fix(ingest/superset): parse postgres platform correctly

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -243,6 +243,8 @@ class SupersetSource(StatefulIngestionSourceBase):
             return "athena"
         if platform_name == "clickhousedb":
             return "clickhouse"
+        if platform_name == "postgresql":
+            return "postgres"
         return platform_name
 
     @lru_cache(maxsize=None)


### PR DESCRIPTION
parse postgres platform as postgres rather than postgresql when ingesting superset charts


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
