### PR TITLE
fix(ingest): add typeUrn in glossary sync source

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
@@ -40,6 +40,7 @@ GlossaryNodeInterface = TypeVar(
 
 class Owners(ConfigModel):
     type: str = models.OwnershipTypeClass.DEVELOPER
+    typeUrn: Optional[str] = None
     users: Optional[List[str]] = None
     groups: Optional[List[str]] = None
 
@@ -154,6 +155,8 @@ def make_glossary_term_urn(
 
 def get_owners(owners: Owners) -> models.OwnershipClass:
     ownership_type, ownership_type_urn = validate_ownership_type(owners.type)
+    if owners.typeUrn is not None:
+        ownership_type_urn = owners.typeUrn
     owners_meta: List[models.OwnerClass] = []
     if owners.users is not None:
         owners_meta = owners_meta + [


### PR DESCRIPTION
Without this doing a sync was removing any custom ownership type set in glossary

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
