### PR TITLE
fix(ci): fix cassandra test flake

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/cassandra/CassandraEntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/cassandra/CassandraEntityServiceTest.java
@@ -1,4 +1,4 @@
-package com.linkedin.metadata.entity;
+package com.linkedin.metadata.entity.cassandra;
 
 import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
@@ -11,8 +11,10 @@ import com.linkedin.metadata.AspectGenerationUtils;
 import com.linkedin.metadata.AspectIngestionUtils;
 import com.linkedin.metadata.CassandraTestUtils;
 import com.linkedin.metadata.config.PreProcessHooks;
-import com.linkedin.metadata.entity.cassandra.CassandraAspectDao;
-import com.linkedin.metadata.entity.cassandra.CassandraRetentionService;
+import com.linkedin.metadata.entity.EntityServiceAspectRetriever;
+import com.linkedin.metadata.entity.EntityServiceImpl;
+import com.linkedin.metadata.entity.EntityServiceTest;
+import com.linkedin.metadata.entity.ListResult;
 import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.key.CorpUserKey;
 import com.linkedin.metadata.models.registry.EntityRegistryException;

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeline/cassandra/CassandraTimelineServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeline/cassandra/CassandraTimelineServiceTest.java
@@ -1,15 +1,16 @@
-package com.linkedin.metadata.entity;
+package com.linkedin.metadata.timeline.cassandra;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.linkedin.metadata.CassandraTestUtils;
 import com.linkedin.metadata.config.PreProcessHooks;
+import com.linkedin.metadata.entity.EntityServiceImpl;
 import com.linkedin.metadata.entity.cassandra.CassandraAspectDao;
-import com.linkedin.metadata.entity.cassandra.CassandraRetentionService;
 import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.models.registry.EntityRegistryException;
-import com.linkedin.metadata.service.UpdateIndicesService;
+import com.linkedin.metadata.timeline.TimelineServiceImpl;
+import com.linkedin.metadata.timeline.TimelineServiceTest;
 import org.testcontainers.containers.CassandraContainer;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -17,11 +18,19 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class CassandraAspectMigrationsDaoTest extends AspectMigrationsDaoTest<CassandraAspectDao> {
+/**
+ * A class that knows how to configure {@link TimelineServiceTest} to run integration tests against
+ * a Cassandra database.
+ *
+ * <p>This class also contains all the test methods where realities of an underlying storage leak
+ * into the {@link TimelineServiceImpl} in the form of subtle behavior differences. Ideally that
+ * should never happen, and it'd be great to address captured differences.
+ */
+public class CassandraTimelineServiceTest extends TimelineServiceTest<CassandraAspectDao> {
 
   private CassandraContainer _cassandraContainer;
 
-  public CassandraAspectMigrationsDaoTest() throws EntityRegistryException {}
+  public CassandraTimelineServiceTest() throws EntityRegistryException {}
 
   @BeforeClass
   public void setupContainer() {
@@ -41,18 +50,15 @@ public class CassandraAspectMigrationsDaoTest extends AspectMigrationsDaoTest<Ca
 
   private void configureComponents() {
     CqlSession session = CassandraTestUtils.createTestSession(_cassandraContainer);
-    CassandraAspectDao dao = new CassandraAspectDao(session);
-    dao.setConnectionValidated(true);
+    _aspectDao = new CassandraAspectDao(session);
+    _aspectDao.setConnectionValidated(true);
+    _entityTimelineService = new TimelineServiceImpl(_aspectDao, _testEntityRegistry);
     _mockProducer = mock(EventProducer.class);
-    _mockUpdateIndicesService = mock(UpdateIndicesService.class);
     PreProcessHooks preProcessHooks = new PreProcessHooks();
     preProcessHooks.setUiEnabled(true);
-    _entityServiceImpl = new EntityServiceImpl(dao, _mockProducer, true, preProcessHooks, true);
+    _entityServiceImpl =
+        new EntityServiceImpl(_aspectDao, _mockProducer, true, preProcessHooks, true);
     _entityServiceImpl.setUpdateIndicesService(_mockUpdateIndicesService);
-    _retentionService = new CassandraRetentionService(_entityServiceImpl, session, 1000);
-    _entityServiceImpl.setRetentionService(_retentionService);
-
-    _migrationsDao = dao;
   }
 
   /**
@@ -61,7 +67,7 @@ public class CassandraAspectMigrationsDaoTest extends AspectMigrationsDaoTest<Ca
    * test to make sure this class will always be discovered.
    */
   @Test
-  public void obligatoryTest() throws AssertionError {
+  public void obligatoryTest() throws Exception {
     Assert.assertTrue(true);
   }
 }

--- a/metadata-io/src/test/resources/testng-cassandra.xml
+++ b/metadata-io/src/test/resources/testng-cassandra.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="metadata-io-cassandra" parallel="tests" thread-count="1">
+    <test name="cassandra-testcontainers">
+        <packages>
+            <package name="com.linkedin.metadata.entity.cassandra.*" />
+            <package name="com.linkedin.metadata.timeline.cassandra.*"/>
+        </packages>
+    </test>
+</suite>

--- a/metadata-io/src/test/resources/testng-other.xml
+++ b/metadata-io/src/test/resources/testng-other.xml
@@ -8,6 +8,8 @@
                 <exclude name="com.linkedin.metadata.search.elasticsearch"/>
                 <exclude name="com.linkedin.metadata.graph.search.opensearch" />
                 <exclude name="com.linkedin.metadata.search.opensearch"/>
+                <exclude name="com.linkedin.metadata.entity.cassandra.*" />
+                <exclude name="com.linkedin.metadata.timeline.cassandra.*"/>
             </package>
         </packages>
     </test>

--- a/metadata-io/src/test/resources/testng.xml
+++ b/metadata-io/src/test/resources/testng.xml
@@ -9,6 +9,7 @@ parallel followed by everything else.
 <suite name="metadata-io-testcontainers">
 <suite-files>
     <suite-file path="testng-search.xml"/>
+    <suite-file path="testng-cassandra.xml"/>
     <suite-file path="testng-other.xml"/>
 </suite-files>
 </suite>


### PR DESCRIPTION
Cassandra tests truncates data before each method which can cause issues when the test classes using Cassandra execute on different threads. This ensures the cassandra tests execute on a single thread.

```
metadata-io > nonsearch > com.linkedin.metadata.entity.CassandraEntityServiceTest > setupTest FAILED
    java.lang.AssertionError: expected [0] but found [1]
        at org.testng.Assert.fail(Assert.java:111)
        at org.testng.Assert.failNotEquals(Assert.java:1578)
        at org.testng.Assert.assertEqualsImpl(Assert.java:150)
        at org.testng.Assert.assertEquals(Assert.java:132)
        at org.testng.Assert.assertEquals(Assert.java:1419)
        at org.testng.Assert.assertEquals(Assert.java:1383)
        at org.testng.Assert.assertEquals(Assert.java:1429)
        at com.linkedin.metadata.CassandraTestUtils.purgeData(CassandraTestUtils.java:128)
        at com.linkedin.metadata.entity.CassandraEntityServiceTest.setupTest(CassandraEntityServiceTest.java:63)
```

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
