### PR TITLE
fix(ingest/sac): handle descriptions which are None correctly

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sac/sac.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sac/sac.py
@@ -329,7 +329,9 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
             entityUrn=dashboard_urn,
             aspect=DashboardInfoClass(
                 title=resource.name,
-                description=resource.description,
+                description=resource.description
+                if resource.description is not None
+                else "",
                 lastModified=ChangeAuditStampsClass(
                     created=AuditStampClass(
                         time=round(resource.created_time.timestamp() * 1000),
@@ -559,7 +561,7 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
 
         retries = 3
         backoff_factor = 10
-        status_forcelist = (500,)
+        status_forcelist = (400, 500, 503)
 
         retry = Retry(
             total=retries,
@@ -611,7 +613,9 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
         entity: pyodata.v2.service.EntityProxy
         for entity in entities:
             resource_id: str = entity.resourceId
-            name: str = entity.name.strip()
+            name: str = (
+                entity.name.strip() if entity.name is not None else entity.resourceId
+            )
 
             if not self.config.resource_id_pattern.allowed(
                 resource_id
@@ -655,8 +659,12 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
                     ResourceModel(
                         namespace=namespace,
                         model_id=model_id,
-                        name=nav_entity.name.strip(),
-                        description=nav_entity.description.strip(),
+                        name=nav_entity.name.strip()
+                        if nav_entity.name is not None
+                        else f"{namespace}:{model_id}",
+                        description=nav_entity.description.strip()
+                        if nav_entity.description is not None
+                        else None,
                         system_type=nav_entity.systemType,  # BW or HANA
                         connection_id=nav_entity.connectionId,
                         external_id=nav_entity.externalId,  # query:[][][query] or view:[schema][schema.namespace][view]
@@ -678,7 +686,9 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
                 resource_subtype=entity.resourceSubtype,
                 story_id=entity.storyId,
                 name=name,
-                description=entity.description.strip(),
+                description=entity.description.strip()
+                if entity.description is not None
+                else None,
                 created_time=entity.createdTime,
                 created_by=created_by,
                 modified_time=entity.modifiedTime,
@@ -715,7 +725,12 @@ class SACSource(StatefulIngestionSourceBase, TestableSource):
             columns.append(
                 ImportDataModelColumn(
                     name=column["columnName"].strip(),
-                    description=column["descriptionName"].strip(),
+                    description=(
+                        column["descriptionName"].strip()
+                        if "descriptionName" in column
+                        and column["descriptionName"] is not None
+                        else None
+                    ),
                     property_type=column["propertyType"],
                     data_type=column["columnDataType"],
                     max_length=column.get("maxLength"),

--- a/metadata-ingestion/src/datahub/ingestion/source/sac/sac_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sac/sac_common.py
@@ -8,7 +8,7 @@ class ResourceModel:
     namespace: str
     model_id: str
     name: str
-    description: str
+    description: Optional[str]
     system_type: Optional[str]
     connection_id: Optional[str]
     external_id: Optional[str]
@@ -22,7 +22,7 @@ class Resource:
     resource_subtype: str
     story_id: str
     name: str
-    description: str
+    description: Optional[str]
     created_time: datetime
     created_by: Optional[str]
     modified_time: datetime
@@ -36,7 +36,7 @@ class Resource:
 @dataclass(frozen=True)
 class ImportDataModelColumn:
     name: str
-    description: str
+    description: Optional[str]
     property_type: str
     data_type: str
     max_length: Optional[int]


### PR DESCRIPTION
It is technically possible that the descriptions for Stories, Models and columns of Import Data models are None...this PR fixes the handling of such cases.

Additionally some more HTTP statuses will be retried (400 and 503) - unfortunately the Import Data API is a bit unstable and returns these HTTP status codes from time to time, although everything else is working.

FYI @hsheth2 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
