### PR TITLE
fic(ingestion/glue): manage table names from resource_links from nearest catalog correctly

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -678,12 +678,19 @@ class GlueSource(StatefulIngestionSourceBase):
         else:
             paginator_response = paginator.paginate()
 
-        for page in paginator_response:
-            yield from page["DatabaseList"]
+        pattern = "DatabaseList"
+        if self.source_config.ignore_resource_links:
+            # exclude records that contain TargetDatabase struct key to ignore resource links
+            pattern += "[?!TargetDatabase]"
 
-    def get_tables_from_database(self, database_name: str) -> Iterable[Dict]:
+        for database in paginator_response.search(pattern):
+            if self.source_config.database_pattern.allowed(database["Name"]):
+                yield database
+
+    def get_tables_from_database(self, database: Mapping[str, Any]) -> Iterable[Dict]:
         # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue/paginator/GetTables.html
         paginator = self.glue_client.get_paginator("get_tables")
+        database_name = database["Name"]
 
         if self.source_config.catalog_id:
             paginator_response = paginator.paginate(
@@ -692,34 +699,25 @@ class GlueSource(StatefulIngestionSourceBase):
         else:
             paginator_response = paginator.paginate(DatabaseName=database_name)
 
-        for page in paginator_response:
-            yield from page["TableList"]
+        yield from paginator_response.search("TableList")
+        # for table in paginator_response.search("TableList"):
+        # if resource links are detected, re-use database name from the outermost catalog
+        # otherwise, you will use external names instead of new aliased ones when creating full table names
+        # Note: we use an explicit source_config check but it is useless actually (filtering has been done)
+        # if not self.source_config.ignore_resource_links and "TargetDatabase" in database:
+        #   table["DatabaseName"] = database["Name"]
+        #   yield table
 
     def get_all_databases_and_tables(
         self,
     ) -> Tuple[Dict, List[Dict]]:
-        all_databases = self.get_all_databases()
-
-        if self.source_config.ignore_resource_links:
-            all_databases = [
-                database
-                for database in all_databases
-                if "TargetDatabase" not in database
-            ]
-
-        allowed_databases = {
-            database["Name"]: database
-            for database in all_databases
-            if self.source_config.database_pattern.allowed(database["Name"])
-        }
-
+        all_databases = [*self.get_all_databases()]
         all_tables = [
-            table
-            for database_name in allowed_databases
-            for table in self.get_tables_from_database(database_name)
+            tables
+            for database in all_databases
+            for tables in self.get_tables_from_database(database)
         ]
-
-        return allowed_databases, all_tables
+        return all_databases, all_tables
 
     def get_lineage_if_enabled(
         self, mce: MetadataChangeEventClass
@@ -1039,7 +1037,7 @@ class GlueSource(StatefulIngestionSourceBase):
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         databases, tables = self.get_all_databases_and_tables()
 
-        for database in databases.values():
+        for database in databases:
             yield from self.gen_database_containers(database)
 
         for table in tables:

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -712,7 +712,7 @@ class GlueSource(StatefulIngestionSourceBase):
 
     def get_all_databases_and_tables(
         self,
-    ) -> Tuple[Dict, List[Dict]]:
+    ) -> Tuple[List[Mapping[str, Any]], List[Dict]]:
         all_databases = [*self.get_all_databases()]
         all_tables = [
             tables

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -680,7 +680,7 @@ class GlueSource(StatefulIngestionSourceBase):
 
         pattern = "DatabaseList"
         if self.source_config.ignore_resource_links:
-            # exclude records that contain TargetDatabase struct key to ignore resource links
+            # exclude resource links by using a JMESPath conditional query against the TargetDatabase struct key
             pattern += "[?!TargetDatabase]"
 
         for database in paginator_response.search(pattern):
@@ -701,8 +701,9 @@ class GlueSource(StatefulIngestionSourceBase):
 
         for table in paginator_response.search("TableList"):
             # if resource links are detected, re-use database names from the current catalog
-            # otherwise, external names are used instead of aliased ones when creating full table names later
-            # Note: use an explicit source_config check but it is useless actually (filtering has been done)
+            # otherwise external resource names are picked out instead of aliased ones
+            # This will cause an incoherent situation when creating full table names later
+            # Note: use an explicit source_config check but it is useless actually (filtering has already been done)
             if (
                 not self.source_config.ignore_resource_links
                 and "TargetDatabase" in database

--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -699,14 +699,16 @@ class GlueSource(StatefulIngestionSourceBase):
         else:
             paginator_response = paginator.paginate(DatabaseName=database_name)
 
-        yield from paginator_response.search("TableList")
-        # for table in paginator_response.search("TableList"):
-        # if resource links are detected, re-use database name from the outermost catalog
-        # otherwise, you will use external names instead of new aliased ones when creating full table names
-        # Note: we use an explicit source_config check but it is useless actually (filtering has been done)
-        # if not self.source_config.ignore_resource_links and "TargetDatabase" in database:
-        #   table["DatabaseName"] = database["Name"]
-        #   yield table
+        for table in paginator_response.search("TableList"):
+            # if resource links are detected, re-use database names from the current catalog
+            # otherwise, external names are used instead of aliased ones when creating full table names later
+            # Note: use an explicit source_config check but it is useless actually (filtering has been done)
+            if (
+                not self.source_config.ignore_resource_links
+                and "TargetDatabase" in database
+            ):
+                table["DatabaseName"] = database["Name"]
+            yield table
 
     def get_all_databases_and_tables(
         self,

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -266,8 +266,8 @@ def test_platform_config():
 @pytest.mark.parametrize(
     "ignore_resource_links, all_databases_and_tables_result",
     [
-        (True, ({}, [])),
-        (False, ({"test-database": resource_link_database}, target_database_tables)),
+        (True, ([], [])),
+        (False, ([resource_link_database], target_database_tables)),
     ],
 )
 def test_ignore_resource_links(ignore_resource_links, all_databases_and_tables_result):

--- a/metadata-ingestion/tests/unit/test_glue_source_stubs.py
+++ b/metadata-ingestion/tests/unit/test_glue_source_stubs.py
@@ -92,10 +92,8 @@ get_databases_response = {
         },
     ]
 }
-databases_1 = {
-    "flights-database": {"Name": "flights-database", "CatalogId": "123412341234"}
-}
-databases_2 = {"test-database": {"Name": "test-database", "CatalogId": "123412341234"}}
+databases_1 = [{"Name": "flights-database", "CatalogId": "123412341234"}]
+databases_2 = [{"Name": "test-database", "CatalogId": "123412341234"}]
 tables_1 = [
     {
         "Name": "avro",


### PR DESCRIPTION
## Checklist

- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

## Details

Changes:

If resource links are detected, re-use database names from the current/nearest catalog.
Otherwise external resource names are picked out instead of the aliased ones.
This will cause an incoherent situation when creating full table names later in DataHub.

Refactoring:
- database filtering is move to an upper step in `get_databases()` using JMESPath notation
- `get_tables_from_database()` signature changed to support database aliases
- use an explicit source_config check but it is useless actually (filtering has already been done)