### PR TITLE
fix(ingest/redshift): fix serverless redshift temp table lineage

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/query.py
@@ -994,7 +994,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                                     query_text,
                                     REGEXP_REPLACE(REGEXP_SUBSTR(REGEXP_REPLACE(query_text,'\\\\n','\\n'), '(CREATE(?:[\\n\\s\\t]+(?:temp|temporary))?(?:[\\n\\s\\t]+)table(?:[\\n\\s\\t]+)[^\\n\\s\\t()-]+)', 0, 1, 'ipe'),'[\\n\\s\\t]+',' ',1,'p') AS create_command,
                                     ROW_NUMBER() OVER (
-                                    PARTITION BY session_id, query_text
+                                    PARTITION BY session_id, query_text, query_id
                                     ORDER BY start_time DESC
                                     ) rn
                             FROM
@@ -1004,6 +1004,7 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                                             qh.transaction_id AS transaction_id,
                                             qh.start_time AS start_time,
                                             qh.user_id AS userid,
+                                            qh.query_id as query_id,
                                             LISTAGG(qt."text") WITHIN GROUP (ORDER BY sequence) AS query_text
                                     FROM
                                             SYS_QUERY_HISTORY qh
@@ -1013,8 +1014,8 @@ class RedshiftServerlessQuery(RedshiftCommonQuery):
                                             AND qh.start_time >= '{start_time_str}'
                                             AND qh.start_time < '{end_time_str}'
                                             AND qt.sequence < 16
-                                    GROUP BY qh.start_time, qh.session_id, qh.transaction_id, qh.user_id
-                                    ORDER BY qh.start_time, qh.session_id, qh.transaction_id, qh.user_id ASC
+                                    GROUP BY qh.start_time, qh.session_id, qh.transaction_id, qh.user_id, qh.query_id
+                                    ORDER BY qh.start_time, qh.session_id, qh.transaction_id, qh.user_id, qh.query_id ASC
                             )
                             WHERE
                                     (


### PR DESCRIPTION
A session can consist of multiple query_id. If multiple SQL commands are used to create several temp tables in a session, only one temp table lineage will be generated. This is wrong.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
