### PR TITLE
feat(ui): support all entities with display names in browse paths v2

### DIFF
--- a/datahub-web-react/src/graphql/browseV2.graphql
+++ b/datahub-web-react/src/graphql/browseV2.graphql
@@ -7,30 +7,7 @@ query getBrowseResultsV2($input: BrowseV2Input!) {
             entity {
                 urn
                 type
-                ... on Container {
-                    properties {
-                        name
-                    }
-                }
-                ... on DataFlow {
-                    properties {
-                        name
-                    }
-                }
-                ... on DataPlatformInstance {
-                    platform {
-                        name
-                        properties {
-                            displayName
-                        }
-                    }
-                    instanceId
-                }
-                ... on Dataset {
-                    properties {
-                        name
-                    }
-                }
+                ...entityDisplayNameFields
             }
         }
         start

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1098,30 +1098,7 @@ fragment browsePathV2Fields on BrowsePathV2 {
         entity {
             urn
             type
-            ... on Container {
-                properties {
-                    name
-                }
-            }
-            ... on DataFlow {
-                properties {
-                    name
-                }
-            }
-            ... on DataPlatformInstance {
-                platform {
-                    name
-                    properties {
-                        displayName
-                    }
-                }
-                instanceId
-            }
-            ... on Dataset {
-                properties {
-                    name
-                }
-            }
+            ...entityDisplayNameFields
         }
     }
 }


### PR DESCRIPTION
As it is now supported that dashboards can contain other dashboards (#11529) it would also make sense to represent this in the browse path v2 in case a dashboard is only included in a single dashboard (same as for the charts).

Question: Shouldn't we just support all entities as part of the browse path v2 to avoid having to update the query and fragment in the future? I think technically urns of all entity types could be used as part of the browse path v2?

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
