### PR TITLE
fix(ingest): cache sql is_profiling_enabled method

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -122,6 +122,10 @@ dbt_common = {
     "more_itertools",
 }
 
+cachetools_lib = {
+    "cachetools",
+}
+
 sql_common = (
     {
         # Required for all SQL sources.
@@ -138,6 +142,7 @@ sql_common = (
         # https://github.com/ipython/traitlets/issues/741
         "traitlets<5.2.2",
         "greenlet",
+        *cachetools_lib,
     }
     | usage_common
     | sqlglot_lib
@@ -213,7 +218,7 @@ snowflake_common = {
     "pandas",
     "cryptography",
     "msal",
-    "cachetools",
+    *cachetools_lib,
 } | classification_lib
 
 trino = {
@@ -457,7 +462,7 @@ plugins: Dict[str, Set[str]] = {
     | sqlglot_lib
     | classification_lib
     | {"db-dtypes"}  # Pandas extension data types
-    | {"cachetools"},
+    | cachetools_lib,
     "s3": {*s3_base, *data_lake_profiling},
     "gcs": {*s3_base, *data_lake_profiling},
     "abs": {*abs_base, *data_lake_profiling},

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_config.py
@@ -29,6 +29,7 @@ from datahub.ingestion.source.state.stateful_ingestion_base import (
     StatefulIngestionConfigBase,
 )
 from datahub.ingestion.source_config.operation_config import is_profiling_enabled
+from datahub.utilities.cachetools_keys import self_methodkey
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -122,7 +123,7 @@ class SQLCommonConfig(
     # TODO: This decorator should be moved to the is_profiling_enabled(operation_config) method.
     @cachetools.cached(
         cache=cachetools.LRUCache(maxsize=1),
-        key=cachetools.keys.methodkey,
+        key=self_methodkey,
     )
     def is_profiling_enabled(self) -> bool:
         return self.profiling.enabled and is_profiling_enabled(

--- a/metadata-ingestion/src/datahub/utilities/cachetools_keys.py
+++ b/metadata-ingestion/src/datahub/utilities/cachetools_keys.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+import cachetools.keys
+
+
+def self_methodkey(self: Any, *args: Any, **kwargs: Any) -> Any:
+    # Keeps the id of self around
+    return cachetools.keys.hashkey(id(self), *args, **kwargs)


### PR DESCRIPTION
Fixes a bug with operation_config where the profiling enabled value could change partway through ingestion.

Was added in a broken state here https://github.com/datahub-project/datahub/pull/8489

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
