### PR TITLE
fix(ui): show structured report context in pre

### DIFF
--- a/datahub-web-react/src/app/ingest/source/executions/reporting/StructuredReportItemContext.tsx
+++ b/datahub-web-react/src/app/ingest/source/executions/reporting/StructuredReportItemContext.tsx
@@ -17,7 +17,7 @@ const Title = styled.div`
     font-weight: bold;
 `;
 
-const Item = styled.div`
+const Item = styled.pre`
     padding: 6px;
     font-size: 12px;
     border-radius: 2px;


### PR DESCRIPTION
This way it's monospaced and newlines come through properly.

<img width="361" alt="image" src="https://github.com/user-attachments/assets/652199a1-e00f-4df4-8b88-6d803668f420">


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
