### PR TITLE
fix(misc): misc fixes

### DIFF
--- a/datahub-frontend/app/auth/AuthModule.java
+++ b/datahub-frontend/app/auth/AuthModule.java
@@ -21,6 +21,7 @@ import com.linkedin.parseq.retry.backoff.ExponentialBackoff;
 import com.linkedin.util.Configuration;
 import config.ConfigurationProvider;
 import controllers.SsoCallbackController;
+import io.datahubproject.metadata.context.ValidationContext;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
@@ -187,6 +188,7 @@ public class AuthModule extends AbstractModule {
             .authorizationContext(AuthorizationContext.builder().authorizer(Authorizer.EMPTY).build())
             .searchContext(SearchContext.EMPTY)
             .entityRegistryContext(EntityRegistryContext.builder().build(EmptyEntityRegistry.EMPTY))
+            .validationContext(ValidationContext.builder().alternateValidation(false).build())
             .build(systemAuthentication);
   }
 

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/SystemUpdateConfig.java
@@ -29,6 +29,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
+import io.datahubproject.metadata.context.ValidationContext;
 import io.datahubproject.metadata.services.RestrictedService;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -161,7 +162,8 @@ public class SystemUpdateConfig {
       @Nonnull final GraphService graphService,
       @Nonnull final SearchService searchService,
       @Qualifier("baseElasticSearchComponents")
-          BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components) {
+          BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components,
+      @Nonnull final ConfigurationProvider configurationProvider) {
 
     EntityServiceAspectRetriever entityServiceAspectRetriever =
         EntityServiceAspectRetriever.builder()
@@ -186,6 +188,10 @@ public class SystemUpdateConfig {
                 .aspectRetriever(entityServiceAspectRetriever)
                 .graphRetriever(systemGraphRetriever)
                 .searchRetriever(searchServiceSearchRetriever)
+                .build(),
+            ValidationContext.builder()
+                .alternateValidation(
+                    configurationProvider.getFeatureFlags().isAlternateMCPValidation())
                 .build());
 
     entityServiceAspectRetriever.setSystemOperationContext(systemOperationContext);

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -101,6 +101,7 @@ x-datahub-gms-service: &datahub-gms-service
   environment: &datahub-gms-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env]
     ELASTICSEARCH_QUERY_CUSTOM_CONFIG_FILE: ${ELASTICSEARCH_QUERY_CUSTOM_CONFIG_FILE:-search_config.yaml}
+    ALTERNATE_MCP_VALIDATION: ${ALTERNATE_MCP_VALIDATION:-true}
   healthcheck:
     test: curl -sS --fail http://datahub-gms:${DATAHUB_GMS_PORT:-8080}/health
     start_period: 90s
@@ -182,6 +183,7 @@ x-datahub-mce-consumer-service: &datahub-mce-consumer-service
     - ${DATAHUB_LOCAL_MCE_ENV:-empty2.env}
   environment: &datahub-mce-consumer-env
     <<: [*primary-datastore-mysql-env, *graph-datastore-search-env, *search-datastore-env, *datahub-quickstart-telemetry-env, *kafka-env]
+    ALTERNATE_MCP_VALIDATION: ${ALTERNATE_MCP_VALIDATION:-true}
 
 x-datahub-mce-consumer-service-dev: &datahub-mce-consumer-service-dev
   <<: *datahub-mce-consumer-service

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/plugins/PluginSpec.java
@@ -12,7 +12,7 @@ import lombok.EqualsAndHashCode;
 @AllArgsConstructor
 @EqualsAndHashCode
 public abstract class PluginSpec {
-  protected static String ENTITY_WILDCARD = "*";
+  protected static String WILDCARD = "*";
 
   @Nonnull
   public abstract AspectPluginConfig getConfig();
@@ -50,7 +50,7 @@ public abstract class PluginSpec {
     return (getConfig().getSupportedEntityAspectNames().stream()
             .anyMatch(
                 supported ->
-                    ENTITY_WILDCARD.equals(supported.getEntityName())
+                    WILDCARD.equals(supported.getEntityName())
                         || supported.getEntityName().equals(entityName)))
         && isAspectSupported(aspectName);
   }
@@ -59,13 +59,16 @@ public abstract class PluginSpec {
     return getConfig().getSupportedEntityAspectNames().stream()
         .anyMatch(
             supported ->
-                ENTITY_WILDCARD.equals(supported.getAspectName())
+                WILDCARD.equals(supported.getAspectName())
                     || supported.getAspectName().equals(aspectName));
   }
 
   protected boolean isChangeTypeSupported(@Nullable ChangeType changeType) {
     return (changeType == null && getConfig().getSupportedOperations().isEmpty())
         || getConfig().getSupportedOperations().stream()
-            .anyMatch(supported -> supported.equalsIgnoreCase(String.valueOf(changeType)));
+            .anyMatch(
+                supported ->
+                    WILDCARD.equals(supported)
+                        || supported.equalsIgnoreCase(String.valueOf(changeType)));
   }
 }

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/EntityAspect.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/EntityAspect.java
@@ -9,6 +9,7 @@ import com.linkedin.entity.EnvelopedAspect;
 import com.linkedin.metadata.aspect.SystemAspect;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.SystemMetadata;
 import java.sql.Timestamp;
 import javax.annotation.Nonnull;
@@ -65,7 +66,7 @@ public class EntityAspect {
     @Nullable private final RecordTemplate recordTemplate;
 
     @Nonnull private final EntitySpec entitySpec;
-    @Nonnull private final AspectSpec aspectSpec;
+    @Nullable private final AspectSpec aspectSpec;
 
     @Nonnull
     public String getUrnRaw() {
@@ -151,7 +152,7 @@ public class EntityAspect {
 
       public EntityAspect.EntitySystemAspect build(
           @Nonnull EntitySpec entitySpec,
-          @Nonnull AspectSpec aspectSpec,
+          @Nullable AspectSpec aspectSpec,
           @Nonnull EntityAspect entityAspect) {
         this.entityAspect = entityAspect;
         this.urn = UrnUtils.getUrn(entityAspect.getUrn());
@@ -159,7 +160,11 @@ public class EntityAspect {
         if (entityAspect.getMetadata() != null) {
           this.recordTemplate =
               RecordUtils.toRecordTemplate(
-                  aspectSpec.getDataTemplateClass(), entityAspect.getMetadata());
+                  (Class<? extends RecordTemplate>)
+                      (aspectSpec == null
+                          ? GenericAspect.class
+                          : aspectSpec.getDataTemplateClass()),
+                  entityAspect.getMetadata());
         }
 
         return new EntitySystemAspect(entityAspect, urn, recordTemplate, entitySpec, aspectSpec);

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/AspectsBatchImpl.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/AspectsBatchImpl.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.entity.ebean.batch;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.SystemAspect;
 import com.linkedin.metadata.aspect.batch.AspectsBatch;
@@ -11,6 +12,7 @@ import com.linkedin.metadata.aspect.batch.ChangeMCP;
 import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
 import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
+import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.util.Pair;
 import java.util.Collection;
@@ -114,19 +116,7 @@ public class AspectsBatchImpl implements AspectsBatch {
                                     proposedItem.getChangeType(),
                                     proposedItem.getUrn(),
                                     proposedItem.getAspectName())))
-            .map(
-                mcpItem -> {
-                  if (ChangeType.PATCH.equals(mcpItem.getChangeType())) {
-                    return PatchItemImpl.PatchItemImplBuilder.build(
-                        mcpItem.getMetadataChangeProposal(),
-                        mcpItem.getAuditStamp(),
-                        retrieverContext.getAspectRetriever().getEntityRegistry());
-                  }
-                  return ChangeItemImpl.ChangeItemImplBuilder.build(
-                      mcpItem.getMetadataChangeProposal(),
-                      mcpItem.getAuditStamp(),
-                      retrieverContext.getAspectRetriever());
-                });
+            .map(mcpItem -> patchDiscriminator(mcpItem, retrieverContext.getAspectRetriever()));
     List<MCPItem> mutatedItems =
         applyProposalMutationHooks(proposedItems, retrieverContext).collect(Collectors.toList());
     Stream<? extends BatchItem> proposedItemsToChangeItems =
@@ -134,17 +124,23 @@ public class AspectsBatchImpl implements AspectsBatch {
             .filter(mcpItem -> mcpItem.getMetadataChangeProposal() != null)
             // Filter on proposed items again to avoid applying builder to Patch Item side effects
             .filter(mcpItem -> mcpItem instanceof ProposedItem)
-            .map(
-                mcpItem ->
-                    ChangeItemImpl.ChangeItemImplBuilder.build(
-                        mcpItem.getMetadataChangeProposal(),
-                        mcpItem.getAuditStamp(),
-                        retrieverContext.getAspectRetriever()));
+            .map(mcpItem -> patchDiscriminator(mcpItem, retrieverContext.getAspectRetriever()));
     Stream<? extends BatchItem> sideEffectItems =
         mutatedItems.stream().filter(mcpItem -> !(mcpItem instanceof ProposedItem));
     Stream<? extends BatchItem> combinedChangeItems =
         Stream.concat(proposedItemsToChangeItems, unmutatedItems);
     return Stream.concat(combinedChangeItems, sideEffectItems);
+  }
+
+  private static BatchItem patchDiscriminator(MCPItem mcpItem, AspectRetriever aspectRetriever) {
+    if (ChangeType.PATCH.equals(mcpItem.getChangeType())) {
+      return PatchItemImpl.PatchItemImplBuilder.build(
+          mcpItem.getMetadataChangeProposal(),
+          mcpItem.getAuditStamp(),
+          aspectRetriever.getEntityRegistry());
+    }
+    return ChangeItemImpl.ChangeItemImplBuilder.build(
+        mcpItem.getMetadataChangeProposal(), mcpItem.getAuditStamp(), aspectRetriever);
   }
 
   public static class AspectsBatchImplBuilder {
@@ -164,6 +160,14 @@ public class AspectsBatchImpl implements AspectsBatch {
         Collection<MetadataChangeProposal> mcps,
         AuditStamp auditStamp,
         RetrieverContext retrieverContext) {
+      return mcps(mcps, auditStamp, retrieverContext, false);
+    }
+
+    public AspectsBatchImplBuilder mcps(
+        Collection<MetadataChangeProposal> mcps,
+        AuditStamp auditStamp,
+        RetrieverContext retrieverContext,
+        boolean alternateMCPValidation) {
 
       retrieverContext(retrieverContext);
       items(
@@ -171,6 +175,18 @@ public class AspectsBatchImpl implements AspectsBatch {
               .map(
                   mcp -> {
                     try {
+                      if (alternateMCPValidation) {
+                        EntitySpec entitySpec =
+                            retrieverContext
+                                .getAspectRetriever()
+                                .getEntityRegistry()
+                                .getEntitySpec(mcp.getEntityType());
+                        return ProposedItem.builder()
+                            .metadataChangeProposal(mcp)
+                            .entitySpec(entitySpec)
+                            .auditStamp(auditStamp)
+                            .build();
+                      }
                       if (mcp.getChangeType().equals(ChangeType.PATCH)) {
                         return PatchItemImpl.PatchItemImplBuilder.build(
                             mcp,

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImpl.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImpl.java
@@ -203,7 +203,7 @@ public class PatchItemImpl implements PatchMCP {
           .build(entityRegistry);
     }
 
-    private static JsonPatch convertToJsonPatch(MetadataChangeProposal mcp) {
+    public static JsonPatch convertToJsonPatch(MetadataChangeProposal mcp) {
       JsonNode json;
       try {
         return Json.createPatch(

--- a/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/ProposedItem.java
+++ b/metadata-io/metadata-io-api/src/main/java/com/linkedin/metadata/entity/ebean/batch/ProposedItem.java
@@ -9,8 +9,10 @@ import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.SystemMetadataUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.Builder;
@@ -82,5 +84,19 @@ public class ProposedItem implements MCPItem {
   @Override
   public ChangeType getChangeType() {
     return metadataChangeProposal.getChangeType();
+  }
+
+  public static class ProposedItemBuilder {
+    public ProposedItem build() {
+      // Ensure systemMetadata
+      return new ProposedItem(
+          Objects.requireNonNull(this.metadataChangeProposal)
+              .setSystemMetadata(
+                  SystemMetadataUtils.generateSystemMetadataIfEmpty(
+                      this.metadataChangeProposal.getSystemMetadata())),
+          this.auditStamp,
+          this.entitySpec,
+          this.aspectSpec);
+    }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutator.java
@@ -1,8 +1,14 @@
 package com.linkedin.metadata.aspect.hooks;
 
+import static com.linkedin.events.metadata.ChangeType.CREATE;
+import static com.linkedin.events.metadata.ChangeType.CREATE_ENTITY;
+import static com.linkedin.events.metadata.ChangeType.UPDATE;
+import static com.linkedin.events.metadata.ChangeType.UPSERT;
+
 import com.datahub.util.exception.ModelConversionException;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.transform.filter.request.MaskTree;
+import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.RetrieverContext;
 import com.linkedin.metadata.aspect.batch.MCPItem;
 import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
@@ -14,6 +20,7 @@ import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.mxe.GenericAspect;
 import com.linkedin.restli.internal.server.util.RestUtils;
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import lombok.Getter;
@@ -27,6 +34,11 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @Accessors(chain = true)
 public class IgnoreUnknownMutator extends MutationHook {
+  private static final Set<String> SUPPORTED_MIME_TYPES =
+      Set.of("application/json", "application/json-patch+json");
+  private static final Set<ChangeType> MUTATION_TYPES =
+      Set.of(CREATE, CREATE_ENTITY, UPSERT, UPDATE);
+
   @Nonnull private AspectPluginConfig config;
 
   @Override
@@ -42,8 +54,8 @@ public class IgnoreUnknownMutator extends MutationHook {
                     item.getAspectSpec().getName());
                 return false;
               }
-              if (!"application/json"
-                  .equals(item.getMetadataChangeProposal().getAspect().getContentType())) {
+              if (!SUPPORTED_MIME_TYPES.contains(
+                  item.getMetadataChangeProposal().getAspect().getContentType())) {
                 log.warn(
                     "Dropping unknown content type {} for aspect {} on entity {}",
                     item.getMetadataChangeProposal().getAspect().getContentType(),
@@ -55,25 +67,27 @@ public class IgnoreUnknownMutator extends MutationHook {
             })
         .peek(
             item -> {
-              try {
-                AspectSpec aspectSpec = item.getEntitySpec().getAspectSpec(item.getAspectName());
-                GenericAspect aspect = item.getMetadataChangeProposal().getAspect();
-                RecordTemplate recordTemplate =
-                    GenericRecordUtils.deserializeAspect(
-                        aspect.getValue(), aspect.getContentType(), aspectSpec);
+              if (MUTATION_TYPES.contains(item.getChangeType())) {
                 try {
-                  ValidationApiUtils.validateOrThrow(recordTemplate);
-                } catch (ValidationException | ModelConversionException e) {
-                  log.warn(
-                      "Failed to validate aspect. Coercing aspect {} on entity {}",
-                      item.getAspectName(),
-                      item.getEntitySpec().getName());
-                  RestUtils.trimRecordTemplate(recordTemplate, new MaskTree(), false);
-                  item.getMetadataChangeProposal()
-                      .setAspect(GenericRecordUtils.serializeAspect(recordTemplate));
+                  AspectSpec aspectSpec = item.getEntitySpec().getAspectSpec(item.getAspectName());
+                  GenericAspect aspect = item.getMetadataChangeProposal().getAspect();
+                  RecordTemplate recordTemplate =
+                      GenericRecordUtils.deserializeAspect(
+                          aspect.getValue(), aspect.getContentType(), aspectSpec);
+                  try {
+                    ValidationApiUtils.validateOrThrow(recordTemplate);
+                  } catch (ValidationException | ModelConversionException e) {
+                    log.warn(
+                        "Failed to validate aspect. Coercing aspect {} on entity {}",
+                        item.getAspectName(),
+                        item.getEntitySpec().getName());
+                    RestUtils.trimRecordTemplate(recordTemplate, new MaskTree(), false);
+                    item.getMetadataChangeProposal()
+                        .setAspect(GenericRecordUtils.serializeAspect(recordTemplate));
+                  }
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
                 }
-              } catch (Exception e) {
-                throw new RuntimeException(e);
               }
             });
   }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -1173,15 +1173,15 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
    * @return an {@link IngestResult} containing the results
    */
   @Override
-  public Set<IngestResult> ingestProposal(
+  public List<IngestResult> ingestProposal(
       @Nonnull OperationContext opContext, AspectsBatch aspectsBatch, final boolean async) {
     Stream<IngestResult> timeseriesIngestResults =
         ingestTimeseriesProposal(opContext, aspectsBatch, async);
     Stream<IngestResult> nonTimeseriesIngestResults =
         async ? ingestProposalAsync(aspectsBatch) : ingestProposalSync(opContext, aspectsBatch);
 
-    return Stream.concat(timeseriesIngestResults, nonTimeseriesIngestResults)
-        .collect(Collectors.toSet());
+    return Stream.concat(nonTimeseriesIngestResults, timeseriesIngestResults)
+        .collect(Collectors.toList());
   }
 
   /**
@@ -1192,11 +1192,13 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
    */
   private Stream<IngestResult> ingestTimeseriesProposal(
       @Nonnull OperationContext opContext, AspectsBatch aspectsBatch, final boolean async) {
+
     List<? extends BatchItem> unsupported =
         aspectsBatch.getItems().stream()
             .filter(
                 item ->
-                    item.getAspectSpec().isTimeseries()
+                    item.getAspectSpec() != null
+                        && item.getAspectSpec().isTimeseries()
                         && item.getChangeType() != ChangeType.UPSERT)
             .collect(Collectors.toList());
     if (!unsupported.isEmpty()) {
@@ -1212,7 +1214,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
       // Create default non-timeseries aspects for timeseries aspects
       List<MCPItem> timeseriesKeyAspects =
           aspectsBatch.getMCPItems().stream()
-              .filter(item -> item.getAspectSpec().isTimeseries())
+              .filter(item -> item.getAspectSpec() != null && item.getAspectSpec().isTimeseries())
               .map(
                   item ->
                       ChangeItemImpl.builder()
@@ -1238,10 +1240,10 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     }
 
     // Emit timeseries MCLs
-    List<Pair<ChangeItemImpl, Optional<Pair<Future<?>, Boolean>>>> timeseriesResults =
+    List<Pair<MCPItem, Optional<Pair<Future<?>, Boolean>>>> timeseriesResults =
         aspectsBatch.getItems().stream()
-            .filter(item -> item.getAspectSpec().isTimeseries())
-            .map(item -> (ChangeItemImpl) item)
+            .filter(item -> item.getAspectSpec() != null && item.getAspectSpec().isTimeseries())
+            .map(item -> (MCPItem) item)
             .map(
                 item ->
                     Pair.of(
@@ -1272,7 +1274,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     }
                   });
 
-              ChangeItemImpl request = result.getFirst();
+              MCPItem request = result.getFirst();
               return IngestResult.builder()
                   .urn(request.getUrn())
                   .request(request)
@@ -1292,7 +1294,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
   private Stream<IngestResult> ingestProposalAsync(AspectsBatch aspectsBatch) {
     List<? extends MCPItem> nonTimeseries =
         aspectsBatch.getMCPItems().stream()
-            .filter(item -> !item.getAspectSpec().isTimeseries())
+            .filter(item -> item.getAspectSpec() == null || !item.getAspectSpec().isTimeseries())
             .collect(Collectors.toList());
 
     List<Future<?>> futures =
@@ -1328,6 +1330,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
 
   private Stream<IngestResult> ingestProposalSync(
       @Nonnull OperationContext opContext, AspectsBatch aspectsBatch) {
+
     AspectsBatchImpl nonTimeseries =
         AspectsBatchImpl.builder()
             .retrieverContext(aspectsBatch.getRetrieverContext())

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/BaseQueryFilterRewriter.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/filter/BaseQueryFilterRewriter.java
@@ -110,11 +110,8 @@ public abstract class BaseQueryFilterRewriter implements QueryFilterRewriter {
     mustNotQueryBuilders.forEach(expandedQueryBuilder::mustNot);
     expandedQueryBuilder.queryName(boolQueryBuilder.queryName());
     expandedQueryBuilder.adjustPureNegative(boolQueryBuilder.adjustPureNegative());
+    expandedQueryBuilder.minimumShouldMatch(boolQueryBuilder.minimumShouldMatch());
     expandedQueryBuilder.boost(boolQueryBuilder.boost());
-
-    if (!expandedQueryBuilder.should().isEmpty()) {
-      expandedQueryBuilder.minimumShouldMatch(1);
-    }
 
     return expandedQueryBuilder;
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/client/JavaEntityClientTest.java
@@ -5,9 +5,22 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import com.codahale.metrics.Counter;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Status;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.data.template.RequiredFieldNotPresentException;
+import com.linkedin.domain.Domains;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.aspect.batch.AspectsBatch;
 import com.linkedin.metadata.entity.DeleteEntityService;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.IngestResult;
+import com.linkedin.metadata.entity.UpdateAspectResult;
+import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
+import com.linkedin.metadata.entity.ebean.batch.ProposedItem;
 import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.search.LineageSearchService;
@@ -15,8 +28,14 @@ import com.linkedin.metadata.search.SearchService;
 import com.linkedin.metadata.search.client.CachingEntitySearchService;
 import com.linkedin.metadata.service.RollbackService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.metadata.utils.AuditStampUtils;
+import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.r2.RemoteInvocationException;
 import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import java.util.List;
 import java.util.function.Supplier;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterMethod;
@@ -25,7 +44,7 @@ import org.testng.annotations.Test;
 
 public class JavaEntityClientTest {
 
-  private EntityService _entityService;
+  private EntityService<?> _entityService;
   private DeleteEntityService _deleteEntityService;
   private EntitySearchService _entitySearchService;
   private CachingEntitySearchService _cachingEntitySearchService;
@@ -52,7 +71,7 @@ public class JavaEntityClientTest {
     _metricUtils = mockStatic(MetricUtils.class);
     _counter = mock(Counter.class);
     when(MetricUtils.counter(any(), any())).thenReturn(_counter);
-    opContext = mock(OperationContext.class);
+    opContext = TestOperationContexts.systemContextNoSearchAuthorization();
   }
 
   @AfterMethod
@@ -130,5 +149,98 @@ public class JavaEntityClientTest {
     _metricUtils.verify(
         () -> MetricUtils.counter(client.getClass(), "exception_" + e.getClass().getName()),
         times(1));
+  }
+
+  @Test
+  void tesIngestOrderingWithProposedItem() throws RemoteInvocationException {
+    JavaEntityClient client = getJavaEntityClient();
+    Urn testUrn = UrnUtils.getUrn("urn:li:container:orderingTest");
+    AuditStamp auditStamp = AuditStampUtils.createDefaultAuditStamp();
+    MetadataChangeProposal mcp =
+        new MetadataChangeProposal()
+            .setEntityUrn(testUrn)
+            .setAspectName("status")
+            .setEntityType("container")
+            .setChangeType(ChangeType.UPSERT)
+            .setAspect(GenericRecordUtils.serializeAspect(new Status().setRemoved(true)));
+
+    when(_entityService.ingestProposal(
+            any(OperationContext.class), any(AspectsBatch.class), eq(false)))
+        .thenReturn(
+            List.<IngestResult>of(
+                // Misc - unrelated urn
+                IngestResult.builder()
+                    .urn(UrnUtils.getUrn("urn:li:container:domains"))
+                    .request(
+                        ChangeItemImpl.builder()
+                            .entitySpec(
+                                opContext
+                                    .getEntityRegistry()
+                                    .getEntitySpec(Constants.CONTAINER_ENTITY_NAME))
+                            .aspectSpec(
+                                opContext
+                                    .getEntityRegistry()
+                                    .getEntitySpec(Constants.CONTAINER_ENTITY_NAME)
+                                    .getAspectSpec(Constants.DOMAINS_ASPECT_NAME))
+                            .changeType(ChangeType.UPSERT)
+                            .urn(UrnUtils.getUrn("urn:li:container:domains"))
+                            .aspectName("domains")
+                            .recordTemplate(new Domains().setDomains(new UrnArray()))
+                            .auditStamp(auditStamp)
+                            .build(opContext.getAspectRetriever()))
+                    .isUpdate(true)
+                    .publishedMCL(true)
+                    .sqlCommitted(true)
+                    .build(),
+                // Side effect - unrelated urn
+                IngestResult.builder()
+                    .urn(UrnUtils.getUrn("urn:li:container:sideEffect"))
+                    .request(
+                        ChangeItemImpl.builder()
+                            .entitySpec(
+                                opContext
+                                    .getEntityRegistry()
+                                    .getEntitySpec(Constants.CONTAINER_ENTITY_NAME))
+                            .aspectSpec(
+                                opContext
+                                    .getEntityRegistry()
+                                    .getEntitySpec(Constants.CONTAINER_ENTITY_NAME)
+                                    .getAspectSpec(Constants.STATUS_ASPECT_NAME))
+                            .changeType(ChangeType.UPSERT)
+                            .urn(UrnUtils.getUrn("urn:li:container:sideEffect"))
+                            .aspectName("status")
+                            .recordTemplate(new Status().setRemoved(false))
+                            .auditStamp(auditStamp)
+                            .build(opContext.getAspectRetriever()))
+                    .isUpdate(true)
+                    .publishedMCL(true)
+                    .sqlCommitted(true)
+                    .build(),
+                // Expected response
+                IngestResult.builder()
+                    .urn(testUrn)
+                    .request(
+                        ProposedItem.builder()
+                            .metadataChangeProposal(mcp)
+                            .entitySpec(
+                                opContext
+                                    .getEntityRegistry()
+                                    .getEntitySpec(Constants.CONTAINER_ENTITY_NAME))
+                            .aspectSpec(
+                                opContext
+                                    .getEntityRegistry()
+                                    .getEntitySpec(Constants.CONTAINER_ENTITY_NAME)
+                                    .getAspectSpec(Constants.STATUS_ASPECT_NAME))
+                            .auditStamp(auditStamp)
+                            .build())
+                    .result(UpdateAspectResult.builder().mcp(mcp).urn(testUrn).build())
+                    .isUpdate(true)
+                    .publishedMCL(true)
+                    .sqlCommitted(true)
+                    .build()));
+
+    String urnStr = client.ingestProposal(opContext, mcp, false);
+
+    assertEquals(urnStr, "urn:li:container:orderingTest");
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
@@ -104,7 +104,8 @@ public class EbeanEntityServiceTest
             null,
             opContext ->
                 ((EntityServiceAspectRetriever) opContext.getAspectRetrieverOpt().get())
-                    .setSystemOperationContext(opContext));
+                    .setSystemOperationContext(opContext),
+            null);
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/cassandra/CassandraEntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/cassandra/CassandraEntityServiceTest.java
@@ -99,7 +99,8 @@ public class CassandraEntityServiceTest
             null,
             opContext ->
                 ((EntityServiceAspectRetriever) opContext.getAspectRetrieverOpt().get())
-                    .setSystemOperationContext(opContext));
+                    .setSystemOperationContext(opContext),
+            null);
   }
 
   /**

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/BaseQueryFilterRewriterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/BaseQueryFilterRewriterTest.java
@@ -1,0 +1,75 @@
+package com.linkedin.metadata.search.query.filter;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.search.elasticsearch.query.filter.BaseQueryFilterRewriter;
+import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriteChain;
+import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterContext;
+import com.linkedin.metadata.search.elasticsearch.query.filter.QueryFilterRewriterSearchType;
+import io.datahubproject.metadata.context.OperationContext;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.testng.annotations.Test;
+
+public abstract class BaseQueryFilterRewriterTest<T extends BaseQueryFilterRewriter> {
+
+  abstract OperationContext getOpContext();
+
+  abstract T getTestRewriter();
+
+  abstract String getTargetField();
+
+  abstract String getTargetFieldValue();
+
+  abstract Condition getTargetCondition();
+
+  @Test
+  public void testPreservedMinimumMatchRewrite() {
+    BaseQueryFilterRewriter test = getTestRewriter();
+
+    // Setup nested container
+    BoolQueryBuilder testQuery = QueryBuilders.boolQuery().minimumShouldMatch(99);
+    testQuery.filter(
+        QueryBuilders.boolQuery()
+            .filter(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()))));
+    testQuery.filter(QueryBuilders.existsQuery("someField"));
+    testQuery.should(
+        QueryBuilders.boolQuery()
+            .minimumShouldMatch(100)
+            .should(
+                QueryBuilders.boolQuery()
+                    .minimumShouldMatch(101)
+                    .should(QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()))));
+
+    BoolQueryBuilder expectedRewrite = QueryBuilders.boolQuery().minimumShouldMatch(99);
+    expectedRewrite.filter(
+        QueryBuilders.boolQuery()
+            .filter(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()))));
+    expectedRewrite.filter(QueryBuilders.existsQuery("someField"));
+    expectedRewrite.should(
+        QueryBuilders.boolQuery()
+            .minimumShouldMatch(100)
+            .should(
+                QueryBuilders.boolQuery()
+                    .minimumShouldMatch(101)
+                    .should(QueryBuilders.termsQuery(getTargetField(), getTargetFieldValue()))));
+
+    assertEquals(
+        test.rewrite(
+            getOpContext(),
+            QueryFilterRewriterContext.builder()
+                .condition(getTargetCondition())
+                .searchType(QueryFilterRewriterSearchType.FULLTEXT_SEARCH)
+                .queryFilterRewriteChain(mock(QueryFilterRewriteChain.class))
+                .build(false),
+            testQuery),
+        expectedRewrite,
+        "Expected preservation of minimumShouldMatch");
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/ContainerExpansionRewriterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/ContainerExpansionRewriterTest.java
@@ -39,7 +39,8 @@ import org.opensearch.index.query.TermsQueryBuilder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class ContainerExpansionRewriterTest {
+public class ContainerExpansionRewriterTest
+    extends BaseQueryFilterRewriterTest<ContainerExpansionRewriter> {
   private static final String FIELD_NAME = "container.keyword";
   private final String grandParentUrn = "urn:li:container:grand";
   private final String parentUrn = "urn:li:container:foo";
@@ -74,15 +75,40 @@ public class ContainerExpansionRewriterTest {
                     .searchRetriever(TestOperationContexts.emptySearchRetriever)
                     .build(),
             null,
+            null,
             null);
+  }
+
+  @Override
+  OperationContext getOpContext() {
+    return opContext;
+  }
+
+  @Override
+  ContainerExpansionRewriter getTestRewriter() {
+    return ContainerExpansionRewriter.builder()
+        .config(QueryFilterRewriterConfiguration.ExpansionRewriterConfiguration.DEFAULT)
+        .build();
+  }
+
+  @Override
+  String getTargetField() {
+    return FIELD_NAME;
+  }
+
+  @Override
+  String getTargetFieldValue() {
+    return childUrn;
+  }
+
+  @Override
+  Condition getTargetCondition() {
+    return Condition.ANCESTORS_INCL;
   }
 
   @Test
   public void testTermsQueryRewrite() {
-    ContainerExpansionRewriter test =
-        ContainerExpansionRewriter.builder()
-            .config(QueryFilterRewriterConfiguration.ExpansionRewriterConfiguration.DEFAULT)
-            .build();
+    ContainerExpansionRewriter test = getTestRewriter();
 
     TermsQueryBuilder notTheFieldQuery = QueryBuilders.termsQuery("notTheField", childUrn);
     assertEquals(

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/DomainExpansionRewriterTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/filter/DomainExpansionRewriterTest.java
@@ -39,7 +39,8 @@ import org.opensearch.index.query.TermsQueryBuilder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class DomainExpansionRewriterTest {
+public class DomainExpansionRewriterTest
+    extends BaseQueryFilterRewriterTest<DomainExpansionRewriter> {
   private static final String FIELD_NAME = "domains.keyword";
   private final String grandParentUrn = "urn:li:domain:grand";
   private final String parentUrn = "urn:li:domain:foo";
@@ -74,15 +75,40 @@ public class DomainExpansionRewriterTest {
                     .searchRetriever(TestOperationContexts.emptySearchRetriever)
                     .build(),
             null,
+            null,
             null);
+  }
+
+  @Override
+  OperationContext getOpContext() {
+    return opContext;
+  }
+
+  @Override
+  DomainExpansionRewriter getTestRewriter() {
+    return DomainExpansionRewriter.builder()
+        .config(QueryFilterRewriterConfiguration.ExpansionRewriterConfiguration.DEFAULT)
+        .build();
+  }
+
+  @Override
+  String getTargetField() {
+    return FIELD_NAME;
+  }
+
+  @Override
+  String getTargetFieldValue() {
+    return parentUrn;
+  }
+
+  @Override
+  Condition getTargetCondition() {
+    return Condition.DESCENDANTS_INCL;
   }
 
   @Test
   public void testTermsQueryRewrite() {
-    DomainExpansionRewriter test =
-        DomainExpansionRewriter.builder()
-            .config(QueryFilterRewriterConfiguration.ExpansionRewriterConfiguration.DEFAULT)
-            .build();
+    DomainExpansionRewriter test = getTestRewriter();
 
     TermsQueryBuilder notTheFieldQuery = QueryBuilders.termsQuery("notTheField", parentUrn);
     assertEquals(

--- a/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
+++ b/metadata-jobs/mae-consumer/src/test/java/com/linkedin/metadata/kafka/hook/spring/MCLSpringCommonTestConfiguration.java
@@ -21,6 +21,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
+import io.datahubproject.metadata.context.ValidationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import org.apache.avro.generic.GenericRecord;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -88,7 +89,8 @@ public class MCLSpringCommonTestConfiguration {
         entityRegistry,
         mock(ServicesRegistryContext.class),
         indexConvention,
-        mock(RetrieverContext.class));
+        mock(RetrieverContext.class),
+        mock(ValidationContext.class));
   }
 
   @MockBean SpringStandardPluginConfiguration springStandardPluginConfiguration;

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/OperationContext.java
@@ -71,6 +71,7 @@ public class OperationContext implements AuthorizationSession {
                 .build())
         .authorizationContext(AuthorizationContext.builder().authorizer(authorizer).build())
         .requestContext(requestContext)
+        .validationContext(systemOperationContext.getValidationContext())
         .build(sessionAuthentication);
   }
 
@@ -122,7 +123,8 @@ public class OperationContext implements AuthorizationSession {
       @Nonnull EntityRegistry entityRegistry,
       @Nullable ServicesRegistryContext servicesRegistryContext,
       @Nullable IndexConvention indexConvention,
-      @Nullable RetrieverContext retrieverContext) {
+      @Nullable RetrieverContext retrieverContext,
+      @Nonnull ValidationContext validationContext) {
     return asSystem(
         config,
         systemAuthentication,
@@ -130,6 +132,7 @@ public class OperationContext implements AuthorizationSession {
         servicesRegistryContext,
         indexConvention,
         retrieverContext,
+        validationContext,
         ObjectMapperContext.DEFAULT);
   }
 
@@ -140,6 +143,7 @@ public class OperationContext implements AuthorizationSession {
       @Nullable ServicesRegistryContext servicesRegistryContext,
       @Nullable IndexConvention indexConvention,
       @Nullable RetrieverContext retrieverContext,
+      @Nonnull ValidationContext validationContext,
       @Nonnull ObjectMapperContext objectMapperContext) {
 
     ActorContext systemActorContext =
@@ -161,6 +165,7 @@ public class OperationContext implements AuthorizationSession {
         .authorizationContext(AuthorizationContext.builder().authorizer(Authorizer.EMPTY).build())
         .retrieverContext(retrieverContext)
         .objectMapperContext(objectMapperContext)
+        .validationContext(validationContext)
         .build(systemAuthentication);
   }
 
@@ -174,6 +179,7 @@ public class OperationContext implements AuthorizationSession {
   @Nullable private final RequestContext requestContext;
   @Nullable private final RetrieverContext retrieverContext;
   @Nonnull private final ObjectMapperContext objectMapperContext;
+  @Nonnull private final ValidationContext validationContext;
 
   public OperationContext withSearchFlags(
       @Nonnull Function<SearchFlags, SearchFlags> flagDefaults) {
@@ -460,9 +466,8 @@ public class OperationContext implements AuthorizationSession {
           this.servicesRegistryContext,
           this.requestContext,
           this.retrieverContext,
-          this.objectMapperContext != null
-              ? this.objectMapperContext
-              : ObjectMapperContext.DEFAULT);
+          this.objectMapperContext != null ? this.objectMapperContext : ObjectMapperContext.DEFAULT,
+          this.validationContext);
     }
 
     private OperationContext build() {

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ValidationContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/ValidationContext.java
@@ -1,0 +1,18 @@
+package io.datahubproject.metadata.context;
+
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+
+/** Context holder for environment variables relevant to operations */
+@Builder
+@Getter
+public class ValidationContext implements ContextInterface {
+  // Uses alternate validation flow for MCP ingestion
+  private final boolean alternateValidation;
+
+  @Override
+  public Optional<Integer> getCacheKeyComponent() {
+    return Optional.of(alternateValidation ? 1 : 0);
+  }
+}

--- a/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
+++ b/metadata-operation-context/src/test/java/io/datahubproject/metadata/context/OperationContextTest.java
@@ -25,7 +25,8 @@ public class OperationContextTest {
             mock(EntityRegistry.class),
             mock(ServicesRegistryContext.class),
             null,
-            mock(RetrieverContext.class));
+            mock(RetrieverContext.class),
+            mock(ValidationContext.class));
 
     OperationContext opContext =
         systemOpContext.asSession(RequestContext.TEST, Authorizer.EMPTY, userAuth);

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authorization/DataHubAuthorizerTest.java
@@ -54,6 +54,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
+import io.datahubproject.metadata.context.ValidationContext;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -318,7 +319,8 @@ public class DataHubAuthorizerTest {
             mock(EntityRegistry.class),
             mock(ServicesRegistryContext.class),
             mock(IndexConvention.class),
-            mock(RetrieverContext.class));
+            mock(RetrieverContext.class),
+            mock(ValidationContext.class));
 
     _dataHubAuthorizer =
         new DataHubAuthorizer(
@@ -598,7 +600,6 @@ public class DataHubAuthorizerTest {
     dataHubPolicyInfo.setDisplayName("My Test Display");
     dataHubPolicyInfo.setDescription("My test display!");
     dataHubPolicyInfo.setEditable(true);
-
     dataHubPolicyInfo.setActors(actorFilter);
 
     final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -23,4 +23,5 @@ public class FeatureFlags {
   private boolean dataContractsEnabled = false;
   private boolean editableDatasetNameEnabled = false;
   private boolean showSeparateSiblings = false;
+  private boolean alternateMCPValidation = false;
 }

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MCPValidationConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MCPValidationConfig.java
@@ -1,0 +1,9 @@
+package com.linkedin.metadata.config;
+
+import com.linkedin.metadata.config.structuredProperties.extensions.ModelExtensionValidationConfiguration;
+import lombok.Data;
+
+@Data
+public class MCPValidationConfig {
+  private ModelExtensionValidationConfiguration extensions;
+}

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MetadataChangeProposalConfig.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/MetadataChangeProposalConfig.java
@@ -8,6 +8,7 @@ import lombok.experimental.Accessors;
 public class MetadataChangeProposalConfig {
 
   ThrottlesConfig throttle;
+  MCPValidationConfig validation;
   SideEffectsConfig sideEffects;
 
   @Data

--- a/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/structuredProperties/extensions/ModelExtensionValidationConfiguration.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/metadata/config/structuredProperties/extensions/ModelExtensionValidationConfiguration.java
@@ -1,0 +1,10 @@
+package com.linkedin.metadata.config.structuredProperties.extensions;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Slf4j
+public class ModelExtensionValidationConfiguration {
+  private boolean enabled;
+}

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -435,6 +435,7 @@ featureFlags:
   schemaFieldEntityFetchEnabled: ${SCHEMA_FIELD_ENTITY_FETCH_ENABLED:true} # Enables fetching for schema field entities from the database when we hydrate them on schema fields
   businessAttributeEntityEnabled: ${BUSINESS_ATTRIBUTE_ENTITY_ENABLED:false} # Enables business attribute entity which can be associated with field of dataset
   dataContractsEnabled: ${DATA_CONTRACTS_ENABLED:true} # Enables the Data Contracts feature (Tab) in the UI
+  alternateMCPValidation: ${ALTERNATE_MCP_VALIDATION:false} # Enables alternate MCP validation flow
   showSeparateSiblings: ${SHOW_SEPARATE_SIBLINGS:false} # If turned on, all siblings will be separated with no way to get to a "combined" sibling view
   editableDatasetNameEnabled: ${EDITABLE_DATASET_NAME_ENABLED:false} # Enables the ability to edit the dataset name in the UI
 
@@ -539,6 +540,8 @@ businessAttribute:
 metadataChangeProposal:
   validation:
     ignoreUnknown: ${MCP_VALIDATION_IGNORE_UNKNOWN:true}
+    extensions:
+      enabled: ${MCP_VALIDATION_EXTENSIONS_ENABLED:false}
   sideEffects:
     schemaField:
       enabled: ${MCP_SIDE_EFFECTS_SCHEMA_FIELD_ENABLED:false}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/CacheConfig.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/CacheConfig.java
@@ -48,7 +48,7 @@ public class CacheConfig {
     return Caffeine.newBuilder()
         .initialCapacity(100)
         .maximumSize(cacheMaxSize)
-        .expireAfterAccess(cacheTtlSeconds, TimeUnit.SECONDS)
+        .expireAfterWrite(cacheTtlSeconds, TimeUnit.SECONDS)
         .recordStats();
   }
 
@@ -86,10 +86,7 @@ public class CacheConfig {
   @Bean
   @ConditionalOnProperty(name = "searchService.cacheImplementation", havingValue = "hazelcast")
   public MapConfig defaultMapConfig() {
-    // TODO: This setting is equivalent to expireAfterAccess, refreshes timer after a get, put,
-    // containsKey etc.
-    //       is this behavior what we actually desire? Should we change it now?
-    MapConfig mapConfig = new MapConfig().setMaxIdleSeconds(cacheTtlSeconds);
+    MapConfig mapConfig = new MapConfig().setTimeToLiveSeconds(cacheTtlSeconds);
 
     EvictionConfig evictionConfig =
         new EvictionConfig()

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/context/SystemOperationContextFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/context/SystemOperationContextFactory.java
@@ -16,6 +16,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.OperationContextConfig;
 import io.datahubproject.metadata.context.RetrieverContext;
 import io.datahubproject.metadata.context.ServicesRegistryContext;
+import io.datahubproject.metadata.context.ValidationContext;
 import io.datahubproject.metadata.services.RestrictedService;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -43,7 +44,8 @@ public class SystemOperationContextFactory {
       @Nonnull final GraphService graphService,
       @Nonnull final SearchService searchService,
       @Qualifier("baseElasticSearchComponents")
-          BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components) {
+          BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components,
+      @Nonnull final ConfigurationProvider configurationProvider) {
 
     EntityServiceAspectRetriever entityServiceAspectRetriever =
         EntityServiceAspectRetriever.builder()
@@ -68,6 +70,10 @@ public class SystemOperationContextFactory {
                 .aspectRetriever(entityServiceAspectRetriever)
                 .graphRetriever(systemGraphRetriever)
                 .searchRetriever(searchServiceSearchRetriever)
+                .build(),
+            ValidationContext.builder()
+                .alternateValidation(
+                    configurationProvider.getFeatureFlags().isAlternateMCPValidation())
                 .build());
 
     entityServiceAspectRetriever.setSystemOperationContext(systemOperationContext);
@@ -95,7 +101,8 @@ public class SystemOperationContextFactory {
       @Nonnull final GraphService graphService,
       @Nonnull final SearchService searchService,
       @Qualifier("baseElasticSearchComponents")
-          BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components) {
+          BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components,
+      @Nonnull final ConfigurationProvider configurationProvider) {
 
     EntityClientAspectRetriever entityServiceAspectRetriever =
         EntityClientAspectRetriever.builder().entityClient(systemEntityClient).build();
@@ -117,6 +124,10 @@ public class SystemOperationContextFactory {
                 .aspectRetriever(entityServiceAspectRetriever)
                 .graphRetriever(systemGraphRetriever)
                 .searchRetriever(searchServiceSearchRetriever)
+                .build(),
+            ValidationContext.builder()
+                .alternateValidation(
+                    configurationProvider.getFeatureFlags().isAlternateMCPValidation())
                 .build());
 
     entityServiceAspectRetriever.setSystemOperationContext(systemOperationContext);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -45,7 +45,7 @@ public class SpringStandardPluginConfiguration {
             AspectPluginConfig.builder()
                 .className(IgnoreUnknownMutator.class.getName())
                 .enabled(ignoreUnknownEnabled && !extensionsEnabled)
-                .supportedOperations(List.of("CREATE", "CREATE_ENTITY", "UPSERT"))
+                .supportedOperations(List.of("*"))
                 .supportedEntityAspectNames(
                     List.of(
                         AspectPluginConfig.EntityAspectName.builder()

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v3/models/GenericEntityV3.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v3/models/GenericEntityV3.java
@@ -29,6 +29,10 @@ public class GenericEntityV3 extends LinkedHashMap<String, Object>
     super(m);
   }
 
+  public String getUrn() {
+    return (String) get("urn");
+  }
+
   @Override
   public Map<String, GenericAspectV3> getAspects() {
     return this.entrySet().stream()
@@ -40,17 +44,31 @@ public class GenericEntityV3 extends LinkedHashMap<String, Object>
 
     public GenericEntityV3 build(
         ObjectMapper objectMapper, @Nonnull Urn urn, Map<String, AspectItem> aspects) {
+      return build(objectMapper, urn, aspects, false);
+    }
+
+    public GenericEntityV3 build(
+        ObjectMapper objectMapper,
+        @Nonnull Urn urn,
+        Map<String, AspectItem> aspects,
+        boolean isAsyncAlternateValidation) {
       Map<String, GenericAspectV3> jsonObjectMap =
           aspects.entrySet().stream()
               .map(
                   entry -> {
                     try {
                       String aspectName = entry.getKey();
-                      Map<String, Object> aspectValue =
+                      Map<String, Object> aspectValueMap =
                           objectMapper.readValue(
                               RecordUtils.toJsonString(entry.getValue().getAspect())
                                   .getBytes(StandardCharsets.UTF_8),
                               new TypeReference<>() {});
+
+                      Map<String, Object> aspectValue =
+                          isAsyncAlternateValidation
+                              ? (Map<String, Object>) aspectValueMap.get("value")
+                              : aspectValueMap;
+
                       Map<String, Object> systemMetadata =
                           entry.getValue().getSystemMetadata() != null
                               ? objectMapper.convertValue(

--- a/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client-api/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -36,6 +36,7 @@ import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nonnull;
@@ -523,12 +524,16 @@ public interface EntityClient {
    *
    * @return the urn string ingested
    */
+  @Nullable
   default String ingestProposal(
       @Nonnull OperationContext opContext,
       @Nonnull final MetadataChangeProposal metadataChangeProposal,
       final boolean async)
       throws RemoteInvocationException {
-    return batchIngestProposals(opContext, List.of(metadataChangeProposal), async).get(0);
+    return batchIngestProposals(opContext, List.of(metadataChangeProposal), async).stream()
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
   }
 
   @Deprecated

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -33,6 +33,7 @@ import com.linkedin.metadata.resources.operations.Utils;
 import com.linkedin.metadata.resources.restli.RestliUtils;
 import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
+import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.parseq.Task;
@@ -51,6 +52,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
@@ -61,6 +63,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 /** Single unified resource for fetching, updating, searching, & browsing DataHub entities */
 @Slf4j
@@ -84,6 +87,8 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
   private static final String UNSET = "unset";
 
   private final Clock _clock = Clock.systemUTC();
+
+  private static final int MAX_LOG_WIDTH = 512;
 
   @Inject
   @Named("entityService")
@@ -238,16 +243,20 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       @ActionParam(PARAM_PROPOSAL) @Nonnull MetadataChangeProposal metadataChangeProposal,
       @ActionParam(PARAM_ASYNC) @Optional(UNSET) String async)
       throws URISyntaxException {
-      log.info("INGEST PROPOSAL proposal: {}", metadataChangeProposal);
 
-      final boolean asyncBool;
-      if (UNSET.equals(async)) {
-          asyncBool = Boolean.parseBoolean(System.getenv(ASYNC_INGEST_DEFAULT_NAME));
-      } else {
-          asyncBool = Boolean.parseBoolean(async);
-      }
+      String urn = metadataChangeProposal.getEntityUrn() != null ? metadataChangeProposal.getEntityUrn().toString() :
+        java.util.Optional.ofNullable(metadataChangeProposal.getEntityKeyAspect()).orElse(new GenericAspect())
+            .getValue().asString(StandardCharsets.UTF_8);
+    String proposedValue = java.util.Optional.ofNullable(metadataChangeProposal.getAspect()).orElse(new GenericAspect())
+        .getValue().asString(StandardCharsets.UTF_8);
 
-      return ingestProposals(List.of(metadataChangeProposal), asyncBool);
+    final boolean asyncBool;
+    if (UNSET.equals(async)) {
+      asyncBool = Boolean.parseBoolean(System.getenv(ASYNC_INGEST_DEFAULT_NAME));
+    } else {
+      asyncBool = Boolean.parseBoolean(async);
+    }
+    return ingestProposals(List.of(metadataChangeProposal), asyncBool);
   }
 
   @Action(name = ACTION_INGEST_PROPOSAL_BATCH)
@@ -303,10 +312,21 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       log.debug("Proposals: {}", metadataChangeProposals);
       try {
         final AspectsBatch batch = AspectsBatchImpl.builder()
-                .mcps(metadataChangeProposals, auditStamp, opContext.getRetrieverContext().get())
+                .mcps(metadataChangeProposals, auditStamp, opContext.getRetrieverContext().get(),
+                    opContext.getValidationContext().isAlternateValidation())
                 .build();
 
-        Set<IngestResult> results =
+        batch.getMCPItems().forEach(item ->
+            log.info(
+                    "INGEST PROPOSAL content: urn: {}, async: {}, value: {}",
+                    item.getUrn(),
+                    asyncBool,
+                    StringUtils.abbreviate(java.util.Optional.ofNullable(item.getMetadataChangeProposal())
+                            .map(MetadataChangeProposal::getAspect)
+                            .orElse(new GenericAspect())
+                            .getValue().asString(StandardCharsets.UTF_8), MAX_LOG_WIDTH)));
+
+        List<IngestResult> results =
                 _entityService.ingestProposal(opContext, batch, asyncBool);
 
             for (IngestResult result : results) {

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -927,7 +927,7 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
                   opContext.getEntityRegistry(), urn.getEntityType());
           if (aspectName != null && !timeseriesAspectNames.contains(aspectName)) {
             throw new UnsupportedOperationException(
-                String.format("Not supported for non-timeseries aspect '{}'.", aspectName));
+                String.format("Not supported for non-timeseries aspect %s.", aspectName));
           }
           List<String> timeseriesAspectsToDelete =
               (aspectName == null) ? timeseriesAspectNames : ImmutableList.of(aspectName);

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -487,7 +487,7 @@ public interface EntityService<U extends ChangeMCP> {
       Map<String, String> conditions,
       boolean hardDelete);
 
-  Set<IngestResult> ingestProposal(
+  List<IngestResult> ingestProposal(
       @Nonnull OperationContext opContext, AspectsBatch aspectsBatch, final boolean async);
 
   /**

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/GenericRecordUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/GenericRecordUtils.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.utils;
 
 import com.datahub.util.RecordUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.ByteString;
 import com.linkedin.data.template.RecordTemplate;
@@ -66,6 +67,14 @@ public class GenericRecordUtils {
   public static GenericAspect serializeAspect(@Nonnull String str) {
     GenericAspect genericAspect = new GenericAspect();
     genericAspect.setValue(ByteString.unsafeWrap(str.getBytes(StandardCharsets.UTF_8)));
+    genericAspect.setContentType(GenericRecordUtils.JSON);
+    return genericAspect;
+  }
+
+  @Nonnull
+  public static GenericAspect serializeAspect(@Nonnull JsonNode json) {
+    GenericAspect genericAspect = new GenericAspect();
+    genericAspect.setValue(ByteString.unsafeWrap(json.toString().getBytes(StandardCharsets.UTF_8)));
     genericAspect.setContentType(GenericRecordUtils.JSON);
     return genericAspect;
   }

--- a/smoke-test/conftest.py
+++ b/smoke-test/conftest.py
@@ -15,16 +15,19 @@ from tests.utils import (
 os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 
 
+def build_auth_session():
+    wait_for_healthcheck_util(requests)
+    return TestSessionWrapper(get_frontend_session())
+
+
 @pytest.fixture(scope="session")
 def auth_session():
-    wait_for_healthcheck_util(requests)
-    auth_session = TestSessionWrapper(get_frontend_session())
+    auth_session = build_auth_session()
     yield auth_session
     auth_session.destroy()
 
 
-@pytest.fixture(scope="session")
-def graph_client(auth_session) -> DataHubGraph:
+def build_graph_client(auth_session):
     print(auth_session.cookies)
     graph: DataHubGraph = DataHubGraph(
         config=DatahubClientConfig(
@@ -32,6 +35,11 @@ def graph_client(auth_session) -> DataHubGraph:
         )
     )
     return graph
+
+
+@pytest.fixture(scope="session")
+def graph_client(auth_session) -> DataHubGraph:
+    return build_graph_client(auth_session)
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/smoke-test/cypress-dev.sh
+++ b/smoke-test/cypress-dev.sh
@@ -16,7 +16,16 @@ set -x
 # set environment variables for the test
 source ./set-test-env-vars.sh
 
-python -c 'from tests.cypress.integration_test import ingest_data; ingest_data()'
+LOAD_DATA=$(cat <<EOF
+from conftest import build_auth_session, build_graph_client
+from tests.cypress.integration_test import ingest_data
+
+auth_session = build_auth_session()
+ingest_data(auth_session, build_graph_client(auth_session))
+EOF
+)
+
+echo -e "$LOAD_DATA" | python
 
 cd tests/cypress
 yarn install

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -26,9 +26,7 @@ from tests.utils import (
 )
 
 bootstrap_sample_data = "../metadata-ingestion/examples/mce_files/bootstrap_mce.json"
-usage_sample_data = (
-    "./test_resources/bigquery_usages_golden.json"
-)
+usage_sample_data = "./test_resources/bigquery_usages_golden.json"
 bq_sample_data = "./sample_bq_data.json"
 restli_default_headers = {
     "X-RestLi-Protocol-Version": "2.0.0",

--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -3,10 +3,9 @@ import os
 import subprocess
 import time
 
-_ELASTIC_BUFFER_WRITES_TIME_IN_SEC: int = 1
 USE_STATIC_SLEEP: bool = bool(os.getenv("USE_STATIC_SLEEP", False))
 ELASTICSEARCH_REFRESH_INTERVAL_SECONDS: int = int(
-    os.getenv("ELASTICSEARCH_REFRESH_INTERVAL_SECONDS", 5)
+    os.getenv("ELASTICSEARCH_REFRESH_INTERVAL_SECONDS", 1)
 )
 KAFKA_BOOTSTRAP_SERVER: str = str(os.getenv("KAFKA_BOOTSTRAP_SERVER", "broker:29092"))
 
@@ -71,4 +70,4 @@ def wait_for_writes_to_sync(max_timeout_in_sec: int = 120) -> None:
         )
     else:
         # we want to sleep for an additional period of time for Elastic writes buffer to clear
-        time.sleep(_ELASTIC_BUFFER_WRITES_TIME_IN_SEC)
+        time.sleep(ELASTICSEARCH_REFRESH_INTERVAL_SECONDS)

--- a/smoke-test/tests/lineage/test_lineage.py
+++ b/smoke-test/tests/lineage/test_lineage.py
@@ -796,7 +796,7 @@ class Scenario(BaseModel):
                             expectation.impacted_entities[impacted_entity]
                         ), f"Expected impacted entity paths to be {expectation.impacted_entities[impacted_entity]}, found {impacted_entity_paths}"
                     except Exception:
-                        breakpoint()
+                        # breakpoint()
                         raise
                     # for i in range(len(impacted_entity_paths)):
                     #     assert impacted_entity_paths[i].path == expectation.impacted_entities[impacted_entity][i].path, f"Expected impacted entity paths to be {expectation.impacted_entities[impacted_entity][i].path}, found {impacted_entity_paths[i].path}"

--- a/smoke-test/tests/platform_resources/test_platform_resource.py
+++ b/smoke-test/tests/platform_resources/test_platform_resource.py
@@ -9,15 +9,9 @@ from datahub.api.entities.platformresource.platform_resource import (
     PlatformResourceKey,
 )
 
-from tests.utils import wait_for_healthcheck_util, wait_for_writes_to_sync
+from tests.utils import wait_for_writes_to_sync
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="module")
-def wait_for_healthchecks(auth_session):
-    wait_for_healthcheck_util(auth_session)
-    yield
 
 
 def generate_random_id(length=8):

--- a/smoke-test/tests/restli/restli_test.py
+++ b/smoke-test/tests/restli/restli_test.py
@@ -1,0 +1,98 @@
+import dataclasses
+import json
+import time
+from typing import List
+
+import pytest
+from datahub.emitter.aspect import JSON_CONTENT_TYPE
+from datahub.emitter.mce_builder import make_dashboard_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.emitter.serialization_helper import pre_json_transform
+from datahub.metadata.schema_classes import (
+    AuditStampClass,
+    ChangeAuditStampsClass,
+    DashboardInfoClass,
+    GenericAspectClass,
+    MetadataChangeProposalClass,
+)
+from datahub.utilities.urns.urn import guess_entity_type
+
+from tests.utils import delete_urns
+
+generated_urns: List[str] = []
+
+
+@dataclasses.dataclass
+class MetadataChangeProposalInvalidWrapper(MetadataChangeProposalWrapper):
+    @staticmethod
+    def _make_generic_aspect(dict) -> GenericAspectClass:
+        serialized = json.dumps(pre_json_transform(dict))
+        return GenericAspectClass(
+            value=serialized.encode(),
+            contentType=JSON_CONTENT_TYPE,
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __post_init__(self) -> None:
+        if self.entityUrn:
+            self.entityType = guess_entity_type(self.entityUrn)
+
+    def make_mcp(self) -> MetadataChangeProposalClass:
+        serializedAspect = None
+        if self.aspect is not None:
+            serializedAspect = (
+                MetadataChangeProposalInvalidWrapper._make_generic_aspect(self.aspect)
+            )
+
+        mcp = self._make_mcp_without_aspects()
+        mcp.aspect = serializedAspect
+        return mcp
+
+
+@pytest.fixture(scope="module")
+def ingest_cleanup_data(auth_session, graph_client, request):
+    yield
+    delete_urns(graph_client, generated_urns)
+
+
+def test_gms_ignore_unknown_dashboard_info(graph_client):
+    dashboard_urn = make_dashboard_urn(platform="looker", name="test-ignore-unknown")
+    generated_urns.extend([dashboard_urn])
+
+    audit_stamp = pre_json_transform(
+        ChangeAuditStampsClass(
+            created=AuditStampClass(
+                time=int(time.time() * 1000),
+                actor="urn:li:corpuser:datahub",
+            )
+        ).to_obj()
+    )
+
+    invalid_dashboard_info = {
+        "title": "Ignore Unknown Title",
+        "description": "Ignore Unknown Description",
+        "lastModified": audit_stamp,
+        "notAValidField": "invalid field value",
+    }
+    mcpw = MetadataChangeProposalInvalidWrapper(
+        entityUrn=dashboard_urn,
+        aspectName="dashboardInfo",
+        aspect=invalid_dashboard_info,
+    )
+
+    mcp = mcpw.make_mcp()
+    assert "notAValidField" in str(mcp)
+    assert "invalid field value" in str(mcp)
+
+    graph_client.emit_mcp(mcpw, async_flag=False)
+
+    dashboard_info = graph_client.get_aspect(
+        entity_urn=dashboard_urn,
+        aspect_type=DashboardInfoClass,
+    )
+
+    assert dashboard_info
+    assert dashboard_info.title == invalid_dashboard_info["title"]
+    assert dashboard_info.description == invalid_dashboard_info["description"]

--- a/smoke-test/tests/tests/data.json
+++ b/smoke-test/tests/tests/data.json
@@ -148,7 +148,7 @@
     "changeType": "UPSERT",
     "aspectName": "testInfo",
     "aspect": {
-      "value": "{\"name\": \"Sample Test 1\", \"category\": \"Examples\", \"description\": \"An example of Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{\\\"on\\\":{\\\"dataset\\\":[{\\\"query\\\":\\\"dataPlatformInstance.platform\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:dataPlatform:bigQuery\\\"]}]},\\\"rules\\\":{\\\"or\\\":[{\\\"query\\\":\\\"glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]},{\\\"query\\\":\\\"container.container.glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]}]}}\"} }",
+      "value": "{\"name\": \"Sample Test 1\", \"category\": \"Examples\", \"description\": \"An example of Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{\\\"on\\\":{\\\"types\\\":[\\\"dataset\\\"],\\\"dataset\\\":[{\\\"query\\\":\\\"dataPlatformInstance.platform\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:dataPlatform:bigQuery\\\"]}]},\\\"rules\\\":{\\\"or\\\":[{\\\"query\\\":\\\"glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]},{\\\"query\\\":\\\"container.container.glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]}]}}\"} }",
       "contentType": "application/json"
     },
     "systemMetadata": null
@@ -161,7 +161,7 @@
     "changeType": "UPSERT",
     "aspectName": "testInfo",
     "aspect": {
-      "value": "{\"name\": \"Sample Test 2\", \"category\": \"Examples\", \"description\": \"An example of another Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{\\\"on\\\":{\\\"dataset\\\":[{\\\"query\\\":\\\"dataPlatformInstance.platform\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:dataPlatform:bigQuery\\\"]}]},\\\"rules\\\":{\\\"or\\\":[{\\\"query\\\":\\\"glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]},{\\\"query\\\":\\\"container.container.glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]}]}}\"} }",
+      "value": "{\"name\": \"Sample Test 2\", \"category\": \"Examples\", \"description\": \"An example of another Metadata Test\", \"definition\": { \"type\": \"JSON\", \"json\": \"{\\\"on\\\":{\\\"types\\\":[\\\"dataset\\\"],\\\"dataset\\\":[{\\\"query\\\":\\\"dataPlatformInstance.platform\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:dataPlatform:bigQuery\\\"]}]},\\\"rules\\\":{\\\"or\\\":[{\\\"query\\\":\\\"glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]},{\\\"query\\\":\\\"container.container.glossaryTerms.terms.glossaryTermInfo.parentNode\\\",\\\"condition\\\":\\\"EQUALS\\\",\\\"values\\\":[\\\"urn:li:glossaryNode:Category\\\"]}]}}\"} }",
       "contentType": "application/json"
     },
     "systemMetadata": null

--- a/smoke-test/tests/tokens/revokable_access_token_test.py
+++ b/smoke-test/tests/tokens/revokable_access_token_test.py
@@ -17,11 +17,6 @@ os.environ["DATAHUB_TELEMETRY_ENABLED"] = "false"
 (admin_user, admin_pass) = get_admin_credentials()
 
 
-@pytest.fixture(autouse=True)
-def setup(auth_session):
-    wait_for_writes_to_sync()
-
-
 @pytest.fixture()
 def auth_exclude_filter():
     return {


### PR DESCRIPTION
## [IgnoreUnknownMutator](https://github.com/datahub-project/datahub/blob/master/metadata-io/src/main/java/com/linkedin/metadata/aspect/hooks/IgnoreUnknownMutator.java)
Allows ignoring unknown fields to allow newer clients to execute against older servers. This is disabled by default for now, however will be enabled in the future for better client/server compatibility.
* Enable in docker profile for smoke-tests
* Added smoke-test using rest.li
* Bug fix & unit test for JavaEntityClient ingestProposal when used in combination with this feature
* Bug fix patch support using rest.li

## [BaseQueryFilterRewriter.java](https://github.com/datahub-project/datahub/pull/11678/files#diff-620a35153ed0c39c86bc8cf828898093bd01d78759f8d0495aa9399dc65ad9ac)
* Bug fix & unit test to make sure the minimum should match is preserved

## View Restriction - `STARTS_WITH` Resource Policy
* Added unit test for policies which include a STARTS_WITH resource match

## Search Cache Configuration
* Both caching implementations (caffeine/hazelcast) were using `expireAfterAccess` instead of the expected `expireAfterWrite`

## Cypress Development
* Update `cypress-dev.sh` to support authentication by default



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
