### PR TITLE
fix(search): reduce minimum length filter from 3 to 2 characters

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
@@ -225,7 +225,7 @@ public class SettingsBuilder {
 
     filters.put(
         MIN_LENGTH,
-        ImmutableMap.<String, Object>builder().put(TYPE, "length").put("min", "3").build());
+        ImmutableMap.<String, Object>builder().put(TYPE, "length").put("min", "2").build());
 
     Resource stemOverride =
         resourceResolver.getResource("classpath:elasticsearch/stem_override.txt");


### PR DESCRIPTION
# Modify elasticsearch filter settings for shorter search terms

Change min length parameter from 3 to 2 in SettingsBuilder.java to allow shorter search terms.

## Changes
- Modified min_length parameter in elasticsearch filter settings from 3 to 2
- This change improves search functionality for multilingual environments

issue #11721 

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
