### PR TITLE
fix(ingest/azure_ad): support v2 (Entra ID) endpoints

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
@@ -72,7 +72,7 @@ class AzureADConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin):
         description="The authority (https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-client-application-configuration) is a URL that indicates a directory that MSAL can request tokens from."
     )
     token_url: str = Field(
-        description="The token URL that acquires a token from Azure AD for authorizing requests.  This source will only work with v1.0 endpoint."
+        description="The token URL that acquires a token from Azure AD for authorizing requests."
     )
     # Optional: URLs for redirect and hitting the Graph API
     redirect: str = Field(
@@ -83,6 +83,12 @@ class AzureADConfig(StatefulIngestionConfigBase, DatasetSourceConfigMixin):
     graph_url: str = Field(
         "https://graph.microsoft.com/v1.0",
         description="[Microsoft Graph API endpoint](https://docs.microsoft.com/en-us/graph/use-the-api)",
+    )
+
+    # Optional: Specify the version of Azure AD endpoint
+    endpoint_version: str = Field(
+        "v1",
+        description="[Azure AD endpoint version (v1 for Azure AD, v2 for Entra ID)](https://stackoverflow.com/questions/45987516/how-do-i-check-to-see-if-my-azuread-version-is-v1-or-v2)",
     )
 
     # Optional: Customize the mapping to DataHub Username from an attribute in the REST API response
@@ -282,9 +288,11 @@ class AzureADSource(StatefulIngestionSourceBase):
             "client_id": self.config.client_id,
             "tenant_id": self.config.tenant_id,
             "client_secret": self.config.client_secret,
-            "resource": "https://graph.microsoft.com",
-            "scope": "https://graph.microsoft.com/.default",
         }
+        if self.config.endpoint_version == "v2":
+            self.token_data["scope"] = "https://graph.microsoft.com/.default"
+        else:
+            self.token_data["resource"] = "https://graph.microsoft.com"
         self.token = self.get_token()
         self.selected_azure_ad_groups: list = []
         self.azure_ad_groups_users: list = []


### PR DESCRIPTION
This allows Azure AD ingestion source to fetch data from v2 endpoints (Entra ID), instead of failing with 400 error due to `resource` field not being supported by v2 API.

I've decided to add an optional field `endpoint_version`, and send either `resource` or `scope` token field depending on its value. Could be a boolean (or be extracted from `authority`/`token_url`), but this is simpler and clearer.

Apologies in advance for linking to stackoverflow, but I couldn't find a better resource on Microsoft's side.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
