### PR TITLE
fix(views): fix environment filter for views

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -100,7 +100,7 @@ public class ESUtils {
   // top-level properties
   // to field level properties
   public static final Map<String, List<String>> FIELDS_TO_EXPANDED_FIELDS_LIST =
-      new HashMap<String, List<String>>() {
+      new HashMap<>() {
         {
           put("tags", ImmutableList.of("tags", "fieldTags", "editedFieldTags"));
           put(
@@ -117,6 +117,8 @@ public class ESUtils {
           put(
               "businessAttribute",
               ImmutableList.of("businessAttributeRef", "businessAttributeRef.urn"));
+          put("origin", ImmutableList.of("origin", "env"));
+          put("env", ImmutableList.of("env", "origin"));
         }
       };
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/utils/ESUtilsTest.java
@@ -707,6 +707,86 @@ public class ESUtilsTest {
             + "  }\n"
             + "}";
     Assert.assertEquals(result.toString(), expected);
+
+    final Criterion originCriterion = buildCriterion("origin", Condition.EQUAL, "PROD");
+
+    // Ensure that the query is expanded!
+    QueryBuilder originExpanded =
+        ESUtils.getQueryBuilderFromCriterion(
+            originCriterion,
+            false,
+            new HashMap<>(),
+            mock(OperationContext.class),
+            QueryFilterRewriteChain.EMPTY);
+    String originExpected =
+        "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"should\" : [\n"
+            + "      {\n"
+            + "        \"terms\" : {\n"
+            + "          \"origin.keyword\" : [\n"
+            + "            \"PROD\"\n"
+            + "          ],\n"
+            + "          \"boost\" : 1.0,\n"
+            + "          \"_name\" : \"origin\"\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"terms\" : {\n"
+            + "          \"env.keyword\" : [\n"
+            + "            \"PROD\"\n"
+            + "          ],\n"
+            + "          \"boost\" : 1.0,\n"
+            + "          \"_name\" : \"env\"\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"minimum_should_match\" : \"1\",\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+    Assert.assertEquals(originExpanded.toString(), originExpected);
+
+    final Criterion envCriterion = buildCriterion("env", Condition.EQUAL, "PROD");
+
+    // Ensure that the query is expanded!
+    QueryBuilder envExpanded =
+        ESUtils.getQueryBuilderFromCriterion(
+            envCriterion,
+            false,
+            new HashMap<>(),
+            mock(OperationContext.class),
+            QueryFilterRewriteChain.EMPTY);
+    String envExpected =
+        "{\n"
+            + "  \"bool\" : {\n"
+            + "    \"should\" : [\n"
+            + "      {\n"
+            + "        \"terms\" : {\n"
+            + "          \"env.keyword\" : [\n"
+            + "            \"PROD\"\n"
+            + "          ],\n"
+            + "          \"boost\" : 1.0,\n"
+            + "          \"_name\" : \"env\"\n"
+            + "        }\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"terms\" : {\n"
+            + "          \"origin.keyword\" : [\n"
+            + "            \"PROD\"\n"
+            + "          ],\n"
+            + "          \"boost\" : 1.0,\n"
+            + "          \"_name\" : \"origin\"\n"
+            + "        }\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"adjust_pure_negative\" : true,\n"
+            + "    \"minimum_should_match\" : \"1\",\n"
+            + "    \"boost\" : 1.0\n"
+            + "  }\n"
+            + "}";
+    Assert.assertEquals(envExpanded.toString(), envExpected);
   }
 
   @Test


### PR DESCRIPTION
Fixes the environment filter for views by expanding origin to include env fields on entities that use env instead. Also adds the reverse expansion.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
