### PR TITLE
fix(ingestion/oracle): display database name when using service name in recipe

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/oracle.py
@@ -597,21 +597,30 @@ class OracleSource(SQLAlchemySource):
     def create(cls, config_dict, ctx):
         config = OracleConfig.parse_obj(config_dict)
         return cls(config, ctx)
-
+  
     def get_db_name(self, inspector: Inspector) -> str:
         """
+
         This overwrites the default implementation, which only tries to read
         database name from Connection URL, which does not work when using
         service instead of database.
         In that case, it tries to retrieve the database name by sending a query to the DB.
+
         """
 
         # call default implementation first
         db_name = super().get_db_name(inspector)
-
-        if db_name == "" and isinstance(inspector, OracleInspectorObjectWrapper):
-            db_name = inspector.get_db_name()
-
+        if not db_name:
+            try:
+                with inspector.engine.connect() as connection:
+                    db_name_result = connection.execute(
+                        sql.text("SELECT sys_context('USERENV','DB_NAME') FROM dual")
+                    ).scalar()
+                db_name = str(db_name_result) if db_name_result else ""
+            except Exception as e:
+                logger.error(f"Error retrieving database name: {e}")
+                db_name = ""
+        logger.info(f'db_name: "{db_name}".')
         return db_name
 
     def get_inspectors(self) -> Iterable[Inspector]:


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


## Motivation 

The database name was not displayed correctly in the dropdown menu if the service name was used in the ingestion recipe.