### PR TITLE
fix the bug: duplicate key exception

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/hooks/StructuredPropertiesSoftDelete.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/structuredproperties/hooks/StructuredPropertiesSoftDelete.java
@@ -30,7 +30,7 @@ public class StructuredPropertiesSoftDelete extends MutationHook {
         items.stream()
             .filter(i -> i.getRecordTemplate() != null)
             .map(i -> Pair.of(i.getUrn(), i.getAspect(StructuredProperties.class)))
-            .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+            .collect(Collectors.toMap(Pair::getKey, Pair::getValue, (a, b) -> a)));
 
     // Apply filter
     Map<Urn, Boolean> mutatedEntityStructuredPropertiesMap =


### PR DESCRIPTION
The exception is thrown during rest call /v3/entity/dataset/{urn}/structuredProperties for version != 0


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
