### PR TITLE
Introducing DataHub Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ HOSTED_DOCS_ONLY-->
 [![YouTube](https://img.shields.io/youtube/channel/subscribers/UC3qFQC5IiwR5fvWEqi_tJ5w?style=social)](https://www.youtube.com/channel/UC3qFQC5IiwR5fvWEqi_tJ5w)
 [![Medium](https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white)](https://medium.com/datahub-project)
 [![Follow](https://img.shields.io/twitter/follow/datahubproject?label=Follow&style=social)](https://twitter.com/datahubproject)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20DataHub%20Guru-006BFF)](https://gurubase.io/g/datahub)
 ### 🏠 Hosted DataHub Docs (Courtesy of Acryl Data): [datahubproject.io](https://datahubproject.io/docs)
 
 ---


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DataHub Guru](https://gurubase.io/g/datahub) to Gurubase. DataHub Guru uses the data from this repo and data from the [docs](https://datahubproject.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "DataHub Guru", which highlights that DataHub now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DataHub Guru in Gurubase, just let me know that's totally fine.
