### PR TITLE
fix(ingest/gc): add limit, add actual loop for iterating over batches

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
@@ -158,14 +158,19 @@ class SoftDeletedEntitiesCleanup:
             self.report.num_soft_deleted_entity_removed
             <= self.config.limit_entities_delete
         ):
-            urns = self.ctx.graph.get_urns_by_filter(
-                entity_types=self.config.entity_types,
-                platform=self.config.platform,
-                env=self.config.env,
-                query=self.config.query,
-                status=RemovedStatusFilter.ONLY_SOFT_DELETED,
-                batch_size=self.config.batch_size,
+            urns = list(
+                self.ctx.graph.get_urns_by_filter(
+                    entity_types=self.config.entity_types,
+                    platform=self.config.platform,
+                    env=self.config.env,
+                    query=self.config.query,
+                    status=RemovedStatusFilter.ONLY_SOFT_DELETED,
+                    batch_size=self.config.batch_size,
+                )
             )
+            if len(urns) == 0:
+                logger.info("No more urns found")
+                return
 
             futures = {}
             with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
@@ -182,7 +182,10 @@ class SoftDeletedEntitiesCleanup:
                         f"Limit of {self.config.limit_entities_delete} entities reached. Stopping"
                     )
                     break
-                if time.time() - start_time > self.config.runtime_limit_seconds:
+                if (
+                    self.config.runtime_limit_seconds
+                    and time.time() - start_time > self.config.runtime_limit_seconds
+                ):
                     logger.info(
                         f"Runtime limit of {self.config.runtime_limit_seconds} seconds reached. Stopping"
                     )


### PR DESCRIPTION
- there was no actual loop iterating over batches, added that
- references were not being deleted, added that
- added a limit of number of entities to be deleted so a single run doesn't go endlessly for ever risking multiple runs starting concurrently

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
