### PR TITLE
fix(ui) Fix merging siblings schema with mix of v1 & v2 fields

### DIFF
--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -5,6 +5,7 @@ import * as QueryString from 'query-string';
 import { Dataset, Entity, Maybe, SiblingProperties } from '../../../types.generated';
 import { GenericEntityProperties } from './types';
 import { useIsShowSeparateSiblingsEnabled } from '../../useAppConfig';
+import { downgradeV2FieldPath } from '../dataset/profile/schema/utils/utils';
 
 export function stripSiblingsFromEntity(entity: any) {
     return {
@@ -55,16 +56,35 @@ const combineMerge = (target, source, options) => {
     return destination;
 };
 
-function convertObjectKeysToLowercase(object: Record<string, unknown>) {
-    return Object.fromEntries(Object.entries(object).map(([key, value]) => [key.toLowerCase(), value]));
+// this function is responsible for normalizing object keys to make sure merging on key matches keys appropriately
+function normalizeObjectKeys(object: Record<string, unknown>, isSchemaField: boolean = false) {
+    return Object.fromEntries(
+        Object.entries(object).map(([key, value]) => {
+            let normalizedKey = key.toLowerCase();
+            if (isSchemaField) {
+                normalizedKey = downgradeV2FieldPath(key) || key;
+            }
+            return [normalizedKey, value];
+        }),
+    );
 }
 
 // use when you want to merge an array of objects by key in the object as opposed to by index of array
-const mergeArrayOfObjectsByKey = (destinationArray: any[], sourceArray: any[], key: string) => {
-    const destination = convertObjectKeysToLowercase(keyBy(destinationArray, key));
-    const source = convertObjectKeysToLowercase(keyBy(sourceArray, key));
+const mergeArrayOfObjectsByKey = (
+    destinationArray: any[],
+    sourceArray: any[],
+    key: string,
+    isSchemaField: boolean = false,
+) => {
+    const destination = normalizeObjectKeys(keyBy(destinationArray, key), isSchemaField);
+    const source = normalizeObjectKeys(keyBy(sourceArray, key), isSchemaField);
 
-    return values(merge(destination, source));
+    return values(
+        merge(destination, source, {
+            arrayMerge: combineMerge,
+            customMerge,
+        }),
+    );
 };
 
 const mergeTags = (destinationArray, sourceArray, _options) => {
@@ -88,7 +108,7 @@ const mergeOwners = (destinationArray, sourceArray, _options) => {
 };
 
 const mergeFields = (destinationArray, sourceArray, _options) => {
-    return mergeArrayOfObjectsByKey(destinationArray, sourceArray, 'fieldPath');
+    return mergeArrayOfObjectsByKey(destinationArray, sourceArray, 'fieldPath', true);
 };
 
 function getArrayMergeFunction(key) {

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -62,7 +62,7 @@ function normalizeObjectKeys(object: Record<string, unknown>, isSchemaField = fa
         Object.entries(object).map(([key, value]) => {
             let normalizedKey = key.toLowerCase();
             if (isSchemaField) {
-                normalizedKey = downgradeV2FieldPath(key) || key;
+                normalizedKey = downgradeV2FieldPath(normalizedKey) || normalizedKey;
             }
             return [normalizedKey, value];
         }),

--- a/datahub-web-react/src/app/entity/shared/siblingUtils.ts
+++ b/datahub-web-react/src/app/entity/shared/siblingUtils.ts
@@ -57,7 +57,7 @@ const combineMerge = (target, source, options) => {
 };
 
 // this function is responsible for normalizing object keys to make sure merging on key matches keys appropriately
-function normalizeObjectKeys(object: Record<string, unknown>, isSchemaField: boolean = false) {
+function normalizeObjectKeys(object: Record<string, unknown>, isSchemaField = false) {
     return Object.fromEntries(
         Object.entries(object).map(([key, value]) => {
             let normalizedKey = key.toLowerCase();
@@ -70,12 +70,7 @@ function normalizeObjectKeys(object: Record<string, unknown>, isSchemaField: boo
 }
 
 // use when you want to merge an array of objects by key in the object as opposed to by index of array
-const mergeArrayOfObjectsByKey = (
-    destinationArray: any[],
-    sourceArray: any[],
-    key: string,
-    isSchemaField: boolean = false,
-) => {
+const mergeArrayOfObjectsByKey = (destinationArray: any[], sourceArray: any[], key: string, isSchemaField = false) => {
     const destination = normalizeObjectKeys(keyBy(destinationArray, key), isSchemaField);
     const source = normalizeObjectKeys(keyBy(sourceArray, key), isSchemaField);
 
@@ -132,7 +127,7 @@ function getArrayMergeFunction(key) {
     }
 }
 
-const customMerge = (isPrimary, key) => {
+function customMerge(isPrimary, key) {
     if (key === 'upstream' || key === 'downstream') {
         return (_secondary, primary) => primary;
     }
@@ -165,7 +160,7 @@ const customMerge = (isPrimary, key) => {
             customMerge: customMerge.bind({}, isPrimary),
         });
     };
-};
+}
 
 export const getEntitySiblingData = <T>(baseEntity: T): Maybe<SiblingProperties> => {
     if (!baseEntity) {


### PR DESCRIPTION
We had a bug when merging schemas between entities where there was a mix of v1 and v2 schema field names - they wouldn't match as keys so the field would show up twice. Now, normalize these keys so we can merge properly by downgrading everything.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
