### PR TITLE
feat(py-sdk): add cli version to ingestion headers

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -10,6 +10,7 @@ from deprecated import deprecated
 from requests.adapters import HTTPAdapter, Retry
 from requests.exceptions import HTTPError, RequestException
 
+from datahub import nice_version_name
 from datahub.cli import config_utils
 from datahub.cli.cli_utils import ensure_has_system_metadata, fixup_gms_url
 from datahub.configuration.common import ConfigurationError, OperationalError
@@ -91,6 +92,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         self._session.headers.update(
             {
                 "X-RestLi-Protocol-Version": "2.0.0",
+                "X-Datahub-Cli-Version": nice_version_name(),
                 "Content-Type": "application/json",
             }
         )

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -92,7 +92,7 @@ class DataHubRestEmitter(Closeable, Emitter):
         self._session.headers.update(
             {
                 "X-RestLi-Protocol-Version": "2.0.0",
-                "X-Datahub-Cli-Version": nice_version_name(),
+                "X-DataHub-Py-Cli-Version": nice_version_name(),
                 "Content-Type": "application/json",
             }
         )


### PR DESCRIPTION
This PR aims to add the CLI version to the http headers when ingesting.
We run a distributed setup for ingesting various data sources. To keep an eye on our ecosystem, we would like to correlate ingestion-users and their current cli versions, to inform them to update when we roll out a new version of datahub.

Let me know if this makes sense to you, or if we should find an alternative solution :-) Thanks!

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
