### PR TITLE
fix(browseDAO): Handle null browse path from ES in BrowseDAO

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESBrowseDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESBrowseDAO.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -425,7 +426,10 @@ public class ESBrowseDAO {
     if (!sourceMap.containsKey(BROWSE_PATH)) {
       return Collections.emptyList();
     }
-    return (List<String>) sourceMap.get(BROWSE_PATH);
+    List<String> browsePaths =
+        ((List<String>) sourceMap.get(BROWSE_PATH))
+            .stream().filter(Objects::nonNull).collect(Collectors.toList());
+    return browsePaths;
   }
 
   public BrowseResultV2 browseV2(

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
@@ -18,7 +18,6 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.datahubproject.test.search.config.SearchCommonTestConfiguration;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -106,7 +105,7 @@ public class BrowseDAOTest extends AbstractTestNGSpringContextTests {
     assertEquals(browsePaths.get(0), "foo");
 
     // Test the case of null browsePaths field
-    sourceMap.put("browsePaths", new ArrayList<>(null));
+    sourceMap.put("browsePaths", Collections.singletonList(null));
     when(mockSearchHit.getSourceAsMap()).thenReturn(sourceMap);
     when(mockSearchHits.getHits()).thenReturn(new SearchHit[] {mockSearchHit});
     when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
@@ -18,6 +18,7 @@ import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import io.datahubproject.test.search.config.SearchCommonTestConfiguration;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -105,7 +106,7 @@ public class BrowseDAOTest extends AbstractTestNGSpringContextTests {
     assertEquals(browsePaths.get(0), "foo");
 
     // Test the case of null browsePaths field
-    sourceMap.put("browsePaths", null);
+    sourceMap.put("browsePaths", new ArrayList<>(null));
     when(mockSearchHit.getSourceAsMap()).thenReturn(sourceMap);
     when(mockSearchHits.getHits()).thenReturn(new SearchHit[] {mockSearchHit});
     when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.search.query;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -102,5 +103,15 @@ public class BrowseDAOTest extends AbstractTestNGSpringContextTests {
     List<String> browsePaths = browseDAO.getBrowsePaths(opContext, "dataset", dummyUrn);
     assertEquals(browsePaths.size(), 1);
     assertEquals(browsePaths.get(0), "foo");
+
+    // Test the case of null browsePaths field
+    sourceMap.put("browsePaths", null);
+    when(mockSearchHit.getSourceAsMap()).thenReturn(sourceMap);
+    when(mockSearchHits.getHits()).thenReturn(new SearchHit[] {mockSearchHit});
+    when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);
+    when(mockClient.search(any(), eq(RequestOptions.DEFAULT))).thenReturn(mockSearchResponse);
+    List<String> nullBrowsePaths = browseDAO.getBrowsePaths(opContext, "dataset", dummyUrn);
+    assertEquals(nullBrowsePaths.size(), 1);
+    assertTrue(nullBrowsePaths.get(0).isEmpty());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/BrowseDAOTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.search.query;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -111,7 +110,6 @@ public class BrowseDAOTest extends AbstractTestNGSpringContextTests {
     when(mockSearchResponse.getHits()).thenReturn(mockSearchHits);
     when(mockClient.search(any(), eq(RequestOptions.DEFAULT))).thenReturn(mockSearchResponse);
     List<String> nullBrowsePaths = browseDAO.getBrowsePaths(opContext, "dataset", dummyUrn);
-    assertEquals(nullBrowsePaths.size(), 1);
-    assertTrue(nullBrowsePaths.get(0).isEmpty());
+    assertEquals(nullBrowsePaths.size(), 0);
   }
 }


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


## Background:
In PR: https://github.com/datahub-project/datahub/pull/11514/files, empty strings were considered as null for ES indexing.

### In Kibana:
<img width="179" alt="image" src="https://github.com/user-attachments/assets/4429c881-bfd7-4426-a628-5c28a686c84c">

### From DB (aspect):
<img width="316" alt="image" src="https://github.com/user-attachments/assets/42a35d73-6cbc-48b0-a3ae-bf8a21ec2e3f">

## Issue:
This is causing null pointer exception for entities, where browse path is empty string.

Which is emulated in the below test:

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/3f52f235-cbff-4415-b5fb-4354ca709dab">

---

Have added test for the changes as well.

