### PR TITLE
fix(ingest/partitionExecutor): Fetch ready items for non-empty batch when _pending is empty

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/partition_executor.py
+++ b/metadata-ingestion/src/datahub/utilities/partition_executor.py
@@ -324,9 +324,6 @@ class BatchPartitionExecutor(Closeable):
                     item.done_callback(future)
 
         def _find_ready_items(max_to_add: int) -> List[_BatchPartitionWorkItem]:
-            if not max_to_add:
-                return []
-
             with clearinghouse_state_lock:
                 # First, update the keys in flight.
                 for key in keys_no_longer_in_flight:
@@ -393,7 +390,6 @@ class BatchPartitionExecutor(Closeable):
             return next_batch
 
         def _submit_batch(next_batch: List[_BatchPartitionWorkItem]) -> None:
-            print("SUBMITTING BATCH", next_batch)
             with clearinghouse_state_lock:
                 for item in next_batch:
                     keys_in_flight.add(item.key)

--- a/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
+++ b/metadata-ingestion/tests/unit/utilities/test_partition_executor.py
@@ -133,9 +133,9 @@ def test_batch_partition_executor_sequential_key_execution():
     }
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(5)
 def test_batch_partition_executor_max_batch_size():
-    n = 20  # Exceed max_pending to test for deadlocks when max_pending exceeded
+    n = 5
     batches_processed = []
 
     def process_batch(batch):
@@ -147,8 +147,8 @@ def test_batch_partition_executor_max_batch_size():
         max_pending=10,
         process_batch=process_batch,
         max_per_batch=2,
-        min_process_interval=timedelta(seconds=1),
-        read_from_pending_interval=timedelta(seconds=1),
+        min_process_interval=timedelta(seconds=0.1),
+        read_from_pending_interval=timedelta(seconds=0.1),
     ) as executor:
         # Submit more tasks than the max_per_batch to test batching limits.
         for i in range(n):
@@ -159,6 +159,34 @@ def test_batch_partition_executor_max_batch_size():
     assert len(batches_processed) == math.ceil(n / 2), "Incorrect number of batches"
     for batch in batches_processed:
         assert len(batch) <= 2, "Batch size exceeded max_per_batch limit"
+
+
+@pytest.mark.timeout(10)
+def test_batch_partition_executor_deadlock():
+    n = 20  # Exceed max_pending to test for deadlocks when max_pending exceeded
+    batch_size = 2
+    batches_processed = []
+
+    def process_batch(batch):
+        batches_processed.append(batch)
+        time.sleep(0.1)  # Simulate batch processing time
+
+    with BatchPartitionExecutor(
+        max_workers=5,
+        max_pending=2,
+        process_batch=process_batch,
+        max_per_batch=batch_size,
+        min_process_interval=timedelta(seconds=30),
+        read_from_pending_interval=timedelta(seconds=0.01),
+    ) as executor:
+        # Submit more tasks than the max_per_batch to test batching limits.
+        executor.submit("key3", "key3", "task0")
+        executor.submit("key3", "key3", "task1")
+        executor.submit("key1", "key1", "task1")  # Populates second batch
+        for i in range(3, n):
+            executor.submit("key3", "key3", f"task{i}")
+
+    assert sum(len(batch) for batch in batches_processed) == n
 
 
 def test_empty_batch_partition_executor():


### PR DESCRIPTION
Previously, the batch partition executor could stall for `min_process_interval` (default 30s) if the batch was not empty, but `_pending` was cleared out into `pending_key_completion`. This changes the logic to re-calculate the batch if we can't ready from `_pending`, i.e. if it's been cleared out and the main ingestion process is blocked.

Reverts the old test so it's only testing batching behavior; adds new deadlock test that tests both the old deadlock failure + this new 30s wait failure. Before the change is made, the test times out after 10 seconds, now it passes in ~1s.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
