### PR TITLE
docs(structured props): fix a typo in structured property docs

### DIFF
--- a/docs/api/tutorials/structured-properties.md
+++ b/docs/api/tutorials/structured-properties.md
@@ -66,7 +66,7 @@ mutation createStructuredProperty {
       qualifiedName:"retentionTime",
       displayName: "Retention Time",
       description: "Retention Time is used to figure out how long to retain records in a dataset",
-      valueType: "urn:li:dataType:number",
+      valueType: "urn:li:dataType:datahub.number",
       allowedValues: [
         {numberValue: 30, description: "30 days, usually reserved for datasets that are ephemeral and contain pii"},
         {numberValue: 90, description:"description: Use this for datasets that drive monthly reporting but contain pii"},


### PR DESCRIPTION
## Checklist

```
 datahub get --urn "urn:li:dataType:number"                                                                      
{
  "dataTypeKey": {
    "id": "number"
  }
}
```

```
datahub get --urn "urn:li:dataType:datahub.number"                                                                 
{
  "dataTypeInfo": {
    "description": "An integer or decimal number.",
    "displayName": "Number",
    "qualifiedName": "datahub.number"
  },
  "dataTypeKey": {
    "id": "datahub.number"
  }
}
```

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
