### PR TITLE
Add ownership to Ingestion Source resolvers

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/IngestionResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/IngestionResolverUtils.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.graphql.resolvers.ingest;
 
+import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.ExecutionRequest;
@@ -8,6 +9,7 @@ import com.linkedin.datahub.graphql.generated.IngestionSchedule;
 import com.linkedin.datahub.graphql.generated.IngestionSource;
 import com.linkedin.datahub.graphql.generated.StringMapEntry;
 import com.linkedin.datahub.graphql.generated.StructuredReport;
+import com.linkedin.datahub.graphql.types.common.mappers.OwnershipMapper;
 import com.linkedin.datahub.graphql.types.common.mappers.StringMapMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.EnvelopedAspect;
@@ -88,6 +90,10 @@ public class IngestionResolverUtils {
     final com.linkedin.datahub.graphql.generated.ExecutionRequestSource result =
         new com.linkedin.datahub.graphql.generated.ExecutionRequestSource();
     result.setType(execRequestSource.getType());
+    if (execRequestSource.hasIngestionSource()) {
+      result.setIngestionSource(execRequestSource.getIngestionSource().toString());
+    }
+
     return result;
   }
 
@@ -115,11 +121,11 @@ public class IngestionResolverUtils {
   }
 
   public static List<IngestionSource> mapIngestionSources(
-      final Collection<EntityResponse> entities) {
+      @Nullable final QueryContext context, final Collection<EntityResponse> entities) {
     final List<IngestionSource> results = new ArrayList<>();
     for (EntityResponse response : entities) {
       try {
-        results.add(mapIngestionSource(response));
+        results.add(mapIngestionSource(context, response));
       } catch (IllegalStateException e) {
         log.error("Unable to map ingestion source, continuing to other sources.", e);
       }
@@ -127,7 +133,8 @@ public class IngestionResolverUtils {
     return results;
   }
 
-  public static IngestionSource mapIngestionSource(final EntityResponse ingestionSource) {
+  public static IngestionSource mapIngestionSource(
+      @Nullable final QueryContext context, final EntityResponse ingestionSource) {
     final Urn entityUrn = ingestionSource.getUrn();
     final EnvelopedAspectMap aspects = ingestionSource.getAspects();
 
@@ -143,7 +150,16 @@ public class IngestionResolverUtils {
     final DataHubIngestionSourceInfo ingestionSourceInfo =
         new DataHubIngestionSourceInfo(envelopedInfo.getValue().data());
 
-    return mapIngestionSourceInfo(entityUrn, ingestionSourceInfo);
+    IngestionSource result = mapIngestionSourceInfo(entityUrn, ingestionSourceInfo);
+
+    final EnvelopedAspect envelopedOwnership = aspects.get(Constants.OWNERSHIP_ASPECT_NAME);
+    if (envelopedOwnership != null) {
+      result.setOwnership(
+          OwnershipMapper.map(
+              context, new Ownership(envelopedOwnership.getValue().data()), entityUrn));
+    }
+
+    return result;
   }
 
   public static IngestionSource mapIngestionSourceInfo(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/GetIngestionSourceResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/GetIngestionSourceResolver.java
@@ -47,7 +47,8 @@ public class GetIngestionSourceResolver implements DataFetcher<CompletableFuture
                       context.getOperationContext(),
                       Constants.INGESTION_SOURCE_ENTITY_NAME,
                       new HashSet<>(ImmutableSet.of(urn)),
-                      ImmutableSet.of(Constants.INGESTION_INFO_ASPECT_NAME));
+                      ImmutableSet.of(
+                          Constants.INGESTION_INFO_ASPECT_NAME, Constants.ORIGIN_ASPECT_NAME));
               if (!entities.containsKey(urn)) {
                 // No ingestion source found
                 throw new DataHubGraphQLException(
@@ -55,7 +56,7 @@ public class GetIngestionSourceResolver implements DataFetcher<CompletableFuture
                     DataHubGraphQLErrorCode.NOT_FOUND);
               }
               // Ingestion source found
-              return IngestionResolverUtils.mapIngestionSource(entities.get(urn));
+              return IngestionResolverUtils.mapIngestionSource(context, entities.get(urn));
             } catch (Exception e) {
               throw new RuntimeException("Failed to retrieve ingestion source", e);
             }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ingest/source/ListIngestionSourcesResolver.java
@@ -101,7 +101,8 @@ public class ListIngestionSourcesResolver
                       new HashSet<>(entitiesUrnList),
                       ImmutableSet.of(
                           Constants.INGESTION_INFO_ASPECT_NAME,
-                          Constants.INGESTION_SOURCE_KEY_ASPECT_NAME));
+                          Constants.INGESTION_SOURCE_KEY_ASPECT_NAME,
+                          Constants.OWNERSHIP_ASPECT_NAME));
 
               final List<EntityResponse> entitiesOrdered =
                   entitiesUrnList.stream().map(entities::get).filter(Objects::nonNull).toList();
@@ -112,7 +113,7 @@ public class ListIngestionSourcesResolver
               result.setCount(gmsResult.getPageSize());
               result.setTotal(gmsResult.getNumEntities());
               result.setIngestionSources(
-                  IngestionResolverUtils.mapIngestionSources(entitiesOrdered));
+                  IngestionResolverUtils.mapIngestionSources(context, entitiesOrdered));
               return result;
 
             } catch (Exception e) {

--- a/datahub-graphql-core/src/main/resources/ingestion.graphql
+++ b/datahub-graphql-core/src/main/resources/ingestion.graphql
@@ -92,6 +92,11 @@ type ExecutionRequestSource {
   The type of the source, e.g. SCHEDULED_INGESTION_SOURCE
   """
   type: String
+
+  """
+  The urn of the ingestion source
+  """
+  ingestionSource: String
 }
 
 """
@@ -176,7 +181,7 @@ type StructuredReport {
 """
 Retrieve an ingestion execution request
 """
-type ExecutionRequest {
+type ExecutionRequest implements Entity  {
   """
   Urn of the execution request
   """
@@ -196,7 +201,22 @@ type ExecutionRequest {
   Result of the execution request
   """
   result: ExecutionRequestResult
+  
+  """  
+  Ownership metadata of the IngestionSource
+  """
+  ownership: Ownership
+  
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
+  """
+  List of relationships between the source Entity and some destination entities with a given types
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  
 }
 
 """
@@ -413,6 +433,11 @@ type IngestionSource {
   The data platform associated with this ingestion source
   """
   platform: DataPlatform
+
+  """
+  Ownership metadata of the IngestionSource
+  """
+  ownership: Ownership
 
   """
   An type-specific set of configurations for the ingestion source


### PR DESCRIPTION
Add "ownership" aspect with the entity "DatahubExecutionRequest" so that we could filter jobs by the owner's corp id
and will be able to send notification to the owners of the DatahubExecutionRequest
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
