### PR TITLE
fix(ui): use correct docs link for csv enricher

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/sources.json
+++ b/datahub-web-react/src/app/ingest/source/builder/sources.json
@@ -284,7 +284,7 @@
         "name": "csv-enricher",
         "displayName": "CSV",
         "description": "Import metadata from a formatted CSV.",
-        "docsUrl": "https://datahubproject.io/docs/generated/ingestion/sources/csv'",
+        "docsUrl": "https://datahubproject.io/docs/generated/ingestion/sources/csv-enricher",
         "recipe": "source: \n    type: csv-enricher \n    config: \n        # URL of your csv file to ingest \n        filename: \n        array_delimiter: '|' \n        delimiter: ',' \n        write_semantics: PATCH"
     },
     {

--- a/datahub-web-react/src/app/ingest/source/conf/csv/csv.ts
+++ b/datahub-web-react/src/app/ingest/source/conf/csv/csv.ts
@@ -15,7 +15,7 @@ const csvConfig: SourceConfig = {
     type: 'csv-enricher',
     placeholderRecipe,
     displayName: 'CSV',
-    docsUrl: 'https://datahubproject.io/docs/generated/ingestion/sources/csv',
+    docsUrl: 'https://datahubproject.io/docs/generated/ingestion/sources/csv-enricher',
     logoUrl: csvLogo,
 };
 


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

## Description

Use the correct link for the [csv enricher](https://datahubproject.io/docs/generated/ingestion/sources/csv-enricher) source, i.e. the one used in the Managed Ingest UI dialogue box.

![grafik](https://github.com/user-attachments/assets/3981146f-4d9a-4fae-9476-38ed0297c791)

