### PR TITLE
fix(filters) Fix issues with structured properties filters

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/models/StructuredPropertyUtils.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/StructuredPropertyUtils.java
@@ -178,7 +178,7 @@ public class StructuredPropertyUtils {
   /**
    * Return an elasticsearch type from structured property type
    *
-   * @param fieldName filter or facet field name
+   * @param fieldName filter or facet field name - must match actual FQN of structured prop
    * @param aspectRetriever aspect retriever
    * @return elasticsearch type
    */

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -448,9 +448,20 @@ public class ESUtils {
                             urnDefinition.getFirst(), urnDefinition.getSecond()))
             .orElse(filterField);
 
+    return replaceSuffix(fieldName);
+  }
+
+  /**
+   * Strip subfields from filter field
+   *
+   * @param fieldName name of the field
+   * @return normalized field name without subfields
+   */
+  @Nonnull
+  public static String replaceSuffix(@Nonnull final String fieldName) {
     for (String subfield : SUBFIELDS) {
       String SUFFIX = "." + subfield;
-      if (filterField.endsWith(SUFFIX)) {
+      if (fieldName.endsWith(SUFFIX)) {
         return fieldName.replace(SUFFIX, "");
       }
     }
@@ -710,7 +721,8 @@ public class ESUtils {
       final Map<String, Set<SearchableAnnotation.FieldType>> searchableFieldTypes,
       @Nonnull AspectRetriever aspectRetriever,
       boolean enableCaseInsensitiveSearch) {
-    Set<String> fieldTypes = getFieldTypes(searchableFieldTypes, fieldName, aspectRetriever);
+    Set<String> fieldTypes =
+        getFieldTypes(searchableFieldTypes, fieldName, criterion, aspectRetriever);
     if (fieldTypes.size() > 1) {
       log.warn(
           "Multiple field types for field name {}, determining best fit for set: {}",
@@ -753,12 +765,16 @@ public class ESUtils {
   private static Set<String> getFieldTypes(
       Map<String, Set<SearchableAnnotation.FieldType>> searchableFields,
       String fieldName,
+      @Nonnull final Criterion criterion,
       @Nullable AspectRetriever aspectRetriever) {
 
     final Set<String> finalFieldTypes;
     if (fieldName.startsWith(STRUCTURED_PROPERTY_MAPPING_FIELD_PREFIX)) {
+      // use criterion field here for structured props since fieldName has dots replaced with
+      // underscores
       finalFieldTypes =
-          StructuredPropertyUtils.toElasticsearchFieldType(fieldName, aspectRetriever);
+          StructuredPropertyUtils.toElasticsearchFieldType(
+              replaceSuffix(criterion.getField()), aspectRetriever);
     } else {
       Set<SearchableAnnotation.FieldType> fieldTypes =
           searchableFields.getOrDefault(fieldName.split("\\.")[0], Collections.emptySet());
@@ -782,7 +798,8 @@ public class ESUtils {
       Condition condition,
       boolean isTimeseries,
       AspectRetriever aspectRetriever) {
-    Set<String> fieldTypes = getFieldTypes(searchableFieldTypes, fieldName, aspectRetriever);
+    Set<String> fieldTypes =
+        getFieldTypes(searchableFieldTypes, fieldName, criterion, aspectRetriever);
 
     // Determine criterion value, range query only accepts single value so take first value in
     // values if multiple

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/AggregationQueryBuilderTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/query/request/AggregationQueryBuilderTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.search.query.request;
 import static com.linkedin.metadata.Constants.DATA_TYPE_URN_PREFIX;
 import static com.linkedin.metadata.Constants.STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME;
 import static com.linkedin.metadata.utils.SearchUtil.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -12,23 +13,36 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.template.LongMap;
 import com.linkedin.data.template.SetMode;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.Aspect;
 import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.config.search.SearchConfiguration;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.search.AggregationMetadata;
+import com.linkedin.metadata.search.FilterValue;
+import com.linkedin.metadata.search.FilterValueArray;
 import com.linkedin.metadata.search.elasticsearch.query.request.AggregationQueryBuilder;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.structured.StructuredPropertyDefinition;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.mockito.Mockito;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.testng.Assert;
@@ -597,5 +611,95 @@ public class AggregationQueryBuilderTest {
                     agg.getName()
                         .equals(
                             MISSING_SPECIAL_TYPE + AGGREGATION_SPECIAL_TYPE_DELIMITER + "test")));
+  }
+
+  @Test
+  public void testAddFiltersToMetadataWithStructuredPropsNoResults() {
+    final Urn propertyUrn = UrnUtils.getUrn("urn:li:structuredProperty:test_me.one");
+
+    SearchConfiguration config = new SearchConfiguration();
+    config.setMaxTermBucketSize(25);
+
+    AggregationQueryBuilder builder =
+        new AggregationQueryBuilder(
+            config, ImmutableMap.of(mock(EntitySpec.class), ImmutableList.of()));
+
+    Criterion criterion =
+        new Criterion()
+            .setField("structuredProperties.test_me.one")
+            .setValues(new StringArray("test123"))
+            .setCondition(Condition.EQUAL);
+
+    AspectRetriever mockAspectRetriever = getMockAspectRetriever(propertyUrn);
+
+    final List<AggregationMetadata> aggregationMetadataList = new ArrayList<>();
+    builder.addCriterionFiltersToAggregationMetadata(
+        criterion, aggregationMetadataList, mockAspectRetriever);
+
+    // ensure we add the correct structured prop aggregation here
+    Assert.assertEquals(aggregationMetadataList.size(), 1);
+    //    Assert.assertEquals(aggregationMetadataList.get(0).getEntity(), propertyUrn);
+    Assert.assertEquals(
+        aggregationMetadataList.get(0).getName(), "structuredProperties.test_me.one");
+    Assert.assertEquals(aggregationMetadataList.get(0).getAggregations().size(), 1);
+    Assert.assertEquals(aggregationMetadataList.get(0).getAggregations().get("test123"), 0);
+  }
+
+  @Test
+  public void testAddFiltersToMetadataWithStructuredPropsWithAggregations() {
+    final Urn propertyUrn = UrnUtils.getUrn("urn:li:structuredProperty:test_me.one");
+
+    final AggregationMetadata aggregationMetadata = new AggregationMetadata();
+    aggregationMetadata.setName("structuredProperties.test_me.one");
+    FilterValue filterValue =
+        new FilterValue().setValue("test123").setFiltered(false).setFacetCount(1);
+    aggregationMetadata.setFilterValues(new FilterValueArray(filterValue));
+    LongMap aggregations = new LongMap();
+    aggregations.put("test123", 1L);
+    aggregationMetadata.setAggregations(aggregations);
+
+    SearchConfiguration config = new SearchConfiguration();
+    config.setMaxTermBucketSize(25);
+
+    AggregationQueryBuilder builder =
+        new AggregationQueryBuilder(
+            config, ImmutableMap.of(mock(EntitySpec.class), ImmutableList.of()));
+
+    Criterion criterion =
+        new Criterion()
+            .setField("structuredProperties.test_me.one")
+            .setValues(new StringArray("test123"))
+            .setCondition(Condition.EQUAL);
+
+    AspectRetriever mockAspectRetriever = getMockAspectRetriever(propertyUrn);
+
+    final List<AggregationMetadata> aggregationMetadataList = new ArrayList<>();
+    aggregationMetadataList.add(aggregationMetadata);
+    builder.addCriterionFiltersToAggregationMetadata(
+        criterion, aggregationMetadataList, mockAspectRetriever);
+
+    Assert.assertEquals(aggregationMetadataList.size(), 1);
+    Assert.assertEquals(
+        aggregationMetadataList.get(0).getName(), "structuredProperties.test_me.one");
+    Assert.assertEquals(aggregationMetadataList.get(0).getAggregations().size(), 1);
+    Assert.assertEquals(aggregationMetadataList.get(0).getAggregations().get("test123"), 1);
+  }
+
+  private AspectRetriever getMockAspectRetriever(Urn propertyUrn) {
+    AspectRetriever mockAspectRetriever = Mockito.mock(AspectRetriever.class);
+    Map<Urn, Map<String, Aspect>> mockResult = new HashMap<>();
+    Map<String, Aspect> aspectMap = new HashMap<>();
+    DataMap definition = new DataMap();
+    definition.put("qualifiedName", "test_me.one");
+    definition.put("valueType", "urn:li:dataType:datahub.string");
+    Aspect definitionAspect = new Aspect(definition);
+    aspectMap.put(STRUCTURED_PROPERTY_DEFINITION_ASPECT_NAME, definitionAspect);
+    mockResult.put(propertyUrn, aspectMap);
+    Set<Urn> urns = new HashSet<>();
+    urns.add(propertyUrn);
+    Mockito.when(mockAspectRetriever.getLatestAspectObjects(eq(urns), any()))
+        .thenReturn(mockResult);
+
+    return mockAspectRetriever;
   }
 }


### PR DESCRIPTION
Fix a few issues we were seeing with structured properties that have dots in their IDs:
- we were passing in the converted field name for structured props into `toElasticsearchFieldType` which would not match with a structured property entity definition since the field name strips dots and replaces them with underscores. Therefore we were always defaulting to `STRING` - now use the `criterion` field which doesn't have dots removed.
- When there were no matches, we were just returning the converted elastic field name back to the UI which we could not resolve to a structured property entity if there were dots in it. In this case, return the criterion field instead.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
