### PR TITLE
fix(schematron): fix for jdk8

### DIFF
--- a/metadata-integration/java/datahub-schematron/lib/src/main/java/io/datahubproject/schematron/converters/avro/AvroSchemaConverter.java
+++ b/metadata-integration/java/datahub-schematron/lib/src/main/java/io/datahubproject/schematron/converters/avro/AvroSchemaConverter.java
@@ -345,7 +345,8 @@ public class AvroSchemaConverter implements SchemaConverter<Schema> {
       log.debug("Array Field Path before expand: {}", fieldPath.asString());
       fieldPath = fieldPath.popLast();
       fieldPath =
-          fieldPath.clonePlus(new FieldElement(List.of("array"), new ArrayList<>(), null, null));
+          fieldPath.clonePlus(
+              new FieldElement(Collections.singletonList("array"), new ArrayList<>(), null, null));
       Schema.Field elementField =
           new Schema.Field(
               field.name(),
@@ -400,7 +401,9 @@ public class AvroSchemaConverter implements SchemaConverter<Schema> {
       FieldPath valueFieldPath =
           fieldPath
               .popLast()
-              .clonePlus(new FieldElement(List.of("map"), new ArrayList<>(), null, null));
+              .clonePlus(
+                  new FieldElement(
+                      Collections.singletonList("map"), new ArrayList<>(), null, null));
       processField(valueField, valueFieldPath, defaultNullable, fields, isNullable, mapDataHubType);
     } else {
       SchemaField mapField =
@@ -434,7 +437,7 @@ public class AvroSchemaConverter implements SchemaConverter<Schema> {
           unionTypes.stream()
               .filter(s -> s.getType() != Schema.Type.NULL)
               .findFirst()
-              .orElseThrow();
+              .orElseThrow(NoSuchElementException::new);
 
       processField(
           new Schema.Field(field.name(), nonNullSchema, field.doc()),
@@ -476,7 +479,8 @@ public class AvroSchemaConverter implements SchemaConverter<Schema> {
         FieldPath indexedFieldPath = fieldPath.popLast();
         indexedFieldPath =
             indexedFieldPath.clonePlus(
-                new FieldElement(List.of("union"), new ArrayList<>(), null, null));
+                new FieldElement(
+                    Collections.singletonList("union"), new ArrayList<>(), null, null));
         log.debug("TypeIndex: {}, Indexed Field path : {}", typeIndex, indexedFieldPath.asString());
         // FieldPath unionFieldPath =
         // fieldPath.expandType(getDiscriminatedType(unionSchema),

--- a/metadata-integration/java/datahub-schematron/lib/src/main/java/io/datahubproject/schematron/models/FieldPath.java
+++ b/metadata-integration/java/datahub-schematron/lib/src/main/java/io/datahubproject/schematron/models/FieldPath.java
@@ -2,6 +2,7 @@ package io.datahubproject.schematron.models;
 
 import com.linkedin.schema.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -117,8 +118,8 @@ public class FieldPath {
           .getPath()
           .add(
               new FieldElement(
-                  new ArrayList<>(List.of(type)),
-                  new ArrayList<>(List.of(typeSchema.toString())),
+                  new ArrayList<>(Collections.singletonList(type)),
+                  new ArrayList<>(Collections.singletonList(typeSchema.toString())),
                   null,
                   null));
     }


### PR DESCRIPTION
For components used in the Spark plugin (i.e. datahub client) we still need to support jdk8 for old versions of spark.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
