### PR TITLE
feat(cli): added cli option for ingestion source

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,7 @@ The `docker` command allows you to start up a local DataHub instance using `data
 
 The `ingest` command allows you to ingest metadata from your sources using ingestion configuration files, which we call recipes.
 Source specific crawlers are provided by plugins and might sometimes need additional extras to be installed. See [installing plugins](#installing-plugins) for more information.
-[Removing Metadata from DataHub](./how/delete-metadata.md) contains detailed instructions about how you can use the ingest command to perform operations like rolling-back previously ingested metadata through the `rollback` sub-command and listing all runs that happened through `list-run-ids` sub-command.
+[Removing Metadata from DataHub](./how/delete-metadata.md) contains detailed instructions about how you can use the ingest command to perform operations like rolling-back previously ingested metadata through the `rollback` sub-command and listing all runs that happened through `list-runs` sub-command.
 
 ```console
 Usage: datahub [datahub-options] ingest [command-options]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -88,7 +88,7 @@ The `docker` command allows you to start up a local DataHub instance using `data
 
 The `ingest` command allows you to ingest metadata from your sources using ingestion configuration files, which we call recipes.
 Source specific crawlers are provided by plugins and might sometimes need additional extras to be installed. See [installing plugins](#installing-plugins) for more information.
-[Removing Metadata from DataHub](./how/delete-metadata.md) contains detailed instructions about how you can use the ingest command to perform operations like rolling-back previously ingested metadata through the `rollback` sub-command and listing all runs that happened through `list-runs` sub-command.
+[Removing Metadata from DataHub](./how/delete-metadata.md) contains detailed instructions about how you can use the ingest command to perform operations like rolling-back previously ingested metadata through the `rollback` sub-command and listing all runs that happened through `list-run-ids` sub-command.
 
 ```console
 Usage: datahub [datahub-options] ingest [command-options]
@@ -113,6 +113,19 @@ ingestion recipe is producing the desired metadata events before ingesting them 
 datahub ingest -c ./examples/recipes/example_to_datahub_rest.dhub.yaml --dry-run
 # Short-form
 datahub ingest -c ./examples/recipes/example_to_datahub_rest.dhub.yaml -n
+```
+
+#### ingest --list-source-runs
+
+The `--list-source-runs` option of the `ingest` command lists the previous runs, displaying their run ID, source name, 
+start time, status, and source URN. This command allows you to filter results using the --urn option for URN-based 
+filtering or the --source option to filter by source name (partial or complete matches are supported).
+
+```shell
+# List all ingestion runs
+datahub ingest --list-source-runs
+# Filter runs by a source name containing "demo"
+datahub ingest --list-source-runs --source "demo"
 ```
 
 #### ingest --preview

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -4,7 +4,7 @@
 To follow this guide, you'll need the [DataHub CLI](../cli.md).
 :::
 
-There are a two ways to delete metadata from DataHub:
+There are two ways to delete metadata from DataHub:
 
 1. Delete metadata attached to entities by providing a specific urn or filters that identify a set of urns (delete CLI).
 2. Delete metadata created by a single ingestion run (rollback).
@@ -230,7 +230,7 @@ The second way to delete metadata is to identify entities (and the aspects affec
 To view the ids of the most recent set of ingestion batches, execute
 
 ```shell
-datahub ingest list-runs
+datahub ingest list-run-ids
 ```
 
 That will print out a table of all the runs. Once you have an idea of which run you want to roll back, run

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -230,10 +230,16 @@ The second way to delete metadata is to identify entities (and the aspects affec
 To view the ids of the most recent set of ingestion batches, execute
 
 ```shell
-datahub ingest list-run-ids
+datahub ingest list-runs
 ```
 
-That will print out a table of all the runs. Once you have an idea of which run you want to roll back, run
+That will print out a table of all the runs. To see run statuses or to filter runs by URN/source run
+
+```shell
+datahub ingest list-source-runs
+```
+
+Once you have an idea of which run you want to roll back, run
 
 ```shell
 datahub ingest show --run-id <run-id>

--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -558,7 +558,7 @@ def list_source_runs(page_offset: int, page_size: int, urn: str, source: str) ->
 )
 @upgrade.check_upgrade
 @telemetry.with_telemetry()
-def list_run_ids(page_offset: int, page_size: int, include_soft_deletes: bool) -> None:
+def list_runs(page_offset: int, page_size: int, include_soft_deletes: bool) -> None:
     """List recent ingestion runs to datahub"""
 
     client = get_default_graph()

--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -515,17 +515,17 @@ def list_source_runs(page_offset: int, page_size: int, urn: str, source: str) ->
         click.echo("No matching ingestion sources found. Please check your filters.")
         return
 
-    sources = data["data"]["listIngestionSources"]["ingestionSources"]
-    if not sources:
+    ingestion_sources = data["data"]["listIngestionSources"]["ingestionSources"]
+    if not ingestion_sources:
         click.echo("No ingestion sources or executions found.")
         return
 
     rows = []
-    for source in sources:
-        urn = source.get("urn", "N/A")
-        name = source.get("name", "N/A")
+    for ingestion_source in ingestion_sources:
+        urn = ingestion_source.get("urn", "N/A")
+        name = ingestion_source.get("name", "N/A")
 
-        executions = source.get("executions", {}).get("executionRequests", [])
+        executions = ingestion_source.get("executions", {}).get("executionRequests", [])
         for execution in executions:
             execution_id = execution.get("id", "N/A")
             start_time = execution.get("result", {}).get("startTimeMs", "N/A")

--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -459,12 +459,7 @@ def list_sources(page_offset: int, page_size: int) -> None:
     }
     """
 
-    variables = {
-        "input": {
-            "start": page_offset,
-            "count": page_size
-        }
-    }
+    variables = {"input": {"start": page_offset, "count": page_size}}
 
     client = get_default_graph()
     session = client._session
@@ -485,7 +480,11 @@ def list_sources(page_offset: int, page_size: int) -> None:
             total = executions.get("total", 0)
             rows.append([urn, name, total])
 
-    click.echo(tabulate(rows, headers=["URN", "Name", "Total Executions"], tablefmt="grid") if rows else "No ingestion sources found.")
+    click.echo(
+        tabulate(rows, headers=["URN", "Name", "Total Executions"], tablefmt="grid")
+        if rows
+        else "No ingestion sources found."
+    )
 
 
 @ingest.command()


### PR DESCRIPTION
I'm adding a new CLI command called "datahub ingest list-source-runs" (name pending) that will give this result 
![image](https://github.com/user-attachments/assets/4958dc61-14e1-489f-91c0-a2ec932aa852)

Can also filter by URN and/or source name:
![image](https://github.com/user-attachments/assets/1f29a1a8-41d2-43fb-aca5-cecb83e67237)

Do we like the resulting columns? Are there any we should add or get rid of?

I attempted to filter by platform but it seems like platform is always null in the graphql response.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
