### PR TITLE
fix(ui) Add backwards compatibility to the UI for old policy filters

### DIFF
--- a/datahub-web-react/src/app/permissions/policy/PolicyDetailsModal.tsx
+++ b/datahub-web-react/src/app/permissions/policy/PolicyDetailsModal.tsx
@@ -12,6 +12,7 @@ import {
     mapResourceTypeToDisplayName,
 } from './policyUtils';
 import AvatarsGroup from '../AvatarsGroup';
+import { RESOURCE_TYPE, RESOURCE_URN, TYPE, URN } from './constants';
 
 type PrivilegeOptionType = {
     type?: string;
@@ -72,10 +73,11 @@ export default function PolicyDetailsModal({ policy, open, onClose, privileges }
     const isMetadataPolicy = policy?.type === PolicyType.Metadata;
 
     const resources = convertLegacyResourceFilter(policy?.resources);
-    const resourceTypes = getFieldValues(resources?.filter, 'TYPE') || [];
+    const resourceTypes = getFieldValues(resources?.filter, TYPE, RESOURCE_TYPE) || [];
     const dataPlatformInstances = getFieldValues(resources?.filter, 'DATA_PLATFORM_INSTANCE') || [];
-    const resourceEntities = getFieldValues(resources?.filter, 'URN') || [];
-    const resourceFilterCondition = getFieldCondition(resources?.filter, 'URN') || PolicyMatchCondition.Equals;
+    const resourceEntities = getFieldValues(resources?.filter, URN, RESOURCE_URN) || [];
+    const resourceFilterCondition =
+        getFieldCondition(resources?.filter, URN, RESOURCE_URN) || PolicyMatchCondition.Equals;
     const domains = getFieldValues(resources?.filter, 'DOMAIN') || [];
 
     const {

--- a/datahub-web-react/src/app/permissions/policy/PolicyPrivilegeForm.tsx
+++ b/datahub-web-react/src/app/permissions/policy/PolicyPrivilegeForm.tsx
@@ -28,6 +28,7 @@ import ClickOutside from '../../shared/ClickOutside';
 import { TagTermLabel } from '../../shared/tags/TagTermLabel';
 import { ENTER_KEY_CODE } from '../../shared/constants';
 import { useGetRecommendations } from '../../shared/recommendation';
+import { RESOURCE_TYPE, RESOURCE_URN, TYPE, URN } from './constants';
 
 type Props = {
     policyType: PolicyType;
@@ -102,8 +103,9 @@ export default function PolicyPrivilegeForm({
     } = useAppConfig();
 
     const resources: ResourceFilter = convertLegacyResourceFilter(maybeResources) || EMPTY_POLICY.resources;
-    const resourceTypes = getFieldValues(resources.filter, 'TYPE') || [];
-    const resourceEntities = getFieldValues(resources.filter, 'URN') || [];
+    // RESOURCE_TYPE and RESOURCE_URN are deprecated, but need to get them for backwards compatibility
+    const resourceTypes = getFieldValues(resources.filter, TYPE, RESOURCE_TYPE) || [];
+    const resourceEntities = getFieldValues(resources.filter, URN, RESOURCE_URN) || [];
 
     const getDisplayName = (entity) => {
         if (!entity) {
@@ -178,9 +180,14 @@ export default function PolicyPrivilegeForm({
         const filter = resources.filter || {
             criteria: [],
         };
+        // remove the deprecated RESOURCE_TYPE field and replace with TYPE field
+        const filterWithoutDeprecatedField = setFieldValues(filter, RESOURCE_TYPE, []);
         setResources({
             ...resources,
-            filter: setFieldValues(filter, 'TYPE', [...resourceTypes, createCriterionValue(selectedResourceType)]),
+            filter: setFieldValues(filterWithoutDeprecatedField, TYPE, [
+                ...resourceTypes,
+                createCriterionValue(selectedResourceType),
+            ]),
         });
     };
 
@@ -188,11 +195,13 @@ export default function PolicyPrivilegeForm({
         const filter = resources.filter || {
             criteria: [],
         };
+        // remove the deprecated RESOURCE_TYPE field and replace with TYPE field
+        const filterWithoutDeprecatedField = setFieldValues(filter, RESOURCE_TYPE, []);
         setResources({
             ...resources,
             filter: setFieldValues(
-                filter,
-                'TYPE',
+                filterWithoutDeprecatedField,
+                TYPE,
                 resourceTypes?.filter((criterionValue) => criterionValue.value !== deselectedResourceType),
             ),
         });
@@ -203,9 +212,11 @@ export default function PolicyPrivilegeForm({
         const filter = resources.filter || {
             criteria: [],
         };
+        // remove the deprecated RESOURCE_URN field and replace with URN field
+        const filterWithoutDeprecatedField = setFieldValues(filter, RESOURCE_URN, []);
         setResources({
             ...resources,
-            filter: setFieldValues(filter, 'URN', [
+            filter: setFieldValues(filterWithoutDeprecatedField, URN, [
                 ...resourceEntities,
                 createCriterionValueWithEntity(
                     resource,
@@ -220,11 +231,13 @@ export default function PolicyPrivilegeForm({
         const filter = resources.filter || {
             criteria: [],
         };
+        // remove the deprecated RESOURCE_URN field and replace with URN field
+        const filterWithoutDeprecatedField = setFieldValues(filter, RESOURCE_URN, []);
         setResources({
             ...resources,
             filter: setFieldValues(
-                filter,
-                'URN',
+                filterWithoutDeprecatedField,
+                URN,
                 resourceEntities?.filter((criterionValue) => criterionValue.value !== resource),
             ),
         });

--- a/datahub-web-react/src/app/permissions/policy/_tests_/policyUtils.test.tsx
+++ b/datahub-web-react/src/app/permissions/policy/_tests_/policyUtils.test.tsx
@@ -1,4 +1,4 @@
-import { PolicyMatchCondition } from '@src/types.generated';
+import { PolicyMatchCondition } from '../../../../types.generated';
 import {
     addOrUpdatePoliciesInList,
     updateListPoliciesCache,

--- a/datahub-web-react/src/app/permissions/policy/_tests_/policyUtils.test.tsx
+++ b/datahub-web-react/src/app/permissions/policy/_tests_/policyUtils.test.tsx
@@ -5,6 +5,7 @@ import {
     removeFromListPoliciesCache,
     getFieldValues,
     getFieldCondition,
+    setFieldValues,
 } from '../policyUtils';
 
 // Mock the Apollo Client readQuery and writeQuery methods
@@ -214,5 +215,49 @@ describe('getFieldCondition', () => {
 
         // should only return values from main field
         expect(getFieldCondition(filter, 'TYPE', 'RESOURCE_TYPE')).toBe(PolicyMatchCondition.Equals);
+    });
+});
+describe('setFieldValues', () => {
+    it('should remove a field if you pass in an empty array', () => {
+        const filter = {
+            criteria: [
+                {
+                    condition: PolicyMatchCondition.Equals,
+                    field: 'RESOURCE_TYPE',
+                    values: [{ value: 'dataset' }],
+                },
+                {
+                    condition: PolicyMatchCondition.Equals,
+                    field: 'TYPE',
+                    values: [{ value: 'dataJob' }],
+                },
+            ],
+        };
+
+        expect(setFieldValues(filter, 'RESOURCE_TYPE', [])).toMatchObject({
+            criteria: [
+                {
+                    condition: PolicyMatchCondition.Equals,
+                    field: 'TYPE',
+                    values: [{ value: 'dataJob' }],
+                },
+            ],
+        });
+    });
+
+    it('should set values for a field properly', () => {
+        const filter = {
+            criteria: [],
+        };
+
+        expect(setFieldValues(filter, 'TYPE', [{ value: 'dataFlow' }])).toMatchObject({
+            criteria: [
+                {
+                    condition: PolicyMatchCondition.Equals,
+                    field: 'TYPE',
+                    values: [{ value: 'dataFlow' }],
+                },
+            ],
+        });
     });
 });

--- a/datahub-web-react/src/app/permissions/policy/constants.ts
+++ b/datahub-web-react/src/app/permissions/policy/constants.ts
@@ -1,0 +1,4 @@
+export const TYPE = 'TYPE';
+export const RESOURCE_TYPE = 'RESOURCE_TYPE';
+export const URN = 'URN';
+export const RESOURCE_URN = 'RESOURCE_URN';

--- a/datahub-web-react/src/app/permissions/policy/policyUtils.ts
+++ b/datahub-web-react/src/app/permissions/policy/policyUtils.ts
@@ -114,12 +114,28 @@ export const convertLegacyResourceFilter = (resourceFilter: Maybe<ResourceFilter
     };
 };
 
-export const getFieldValues = (filter: Maybe<PolicyMatchFilter> | undefined, resourceFieldType: string) => {
-    return filter?.criteria?.find((criterion) => criterion.field === resourceFieldType)?.values || [];
+export const getFieldValues = (
+    filter: Maybe<PolicyMatchFilter> | undefined,
+    resourceFieldType: string,
+    alternateResourceFieldType?: string,
+) => {
+    return (
+        filter?.criteria?.find((criterion) => criterion.field === resourceFieldType)?.values ||
+        filter?.criteria?.find((criterion) => criterion.field === alternateResourceFieldType)?.values ||
+        []
+    );
 };
 
-export const getFieldCondition = (filter: Maybe<PolicyMatchFilter> | undefined, resourceFieldType: string) => {
-    return filter?.criteria?.find((criterion) => criterion.field === resourceFieldType)?.condition || null;
+export const getFieldCondition = (
+    filter: Maybe<PolicyMatchFilter> | undefined,
+    resourceFieldType: string,
+    alternateResourceFieldType?: string,
+) => {
+    return (
+        filter?.criteria?.find((criterion) => criterion.field === resourceFieldType)?.condition ||
+        filter?.criteria?.find((criterion) => criterion.field === alternateResourceFieldType)?.condition ||
+        null
+    );
 };
 
 export const getFieldValuesOfTags = (filter: Maybe<PolicyMatchFilter> | undefined, resourceFieldType: string) => {


### PR DESCRIPTION
We discovered a bug where old policies with the `RESOURCE_TYPE` or `RESOURCE_URN` filters applied to them were not being rendered in the UI. These are still supported on the backend, but the UI was saying "All" since it didn't think there was a filter for the types or assets fields.

This PR adds that backwards compatibility to the UI by fetching those fields if they exist to display, and when editing these fields we remove the deprecated fields and only use the newer ones going forward.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
