### PR TITLE
fix(datahub-client): prevent unneeded classes in datahub-client jar

### DIFF
--- a/entity-registry/build.gradle
+++ b/entity-registry/build.gradle
@@ -8,7 +8,7 @@ apply from: "../gradle/coverage/java-coverage.gradle"
 
 dependencies {
   implementation spec.product.pegasus.data
-  implementation spec.product.pegasus.generator
+  compileOnly spec.product.pegasus.generator
   api project(path: ':metadata-models')
   api project(path: ':metadata-models', configuration: "dataTemplate")
   api externalDependency.classGraph

--- a/metadata-integration/java/datahub-event/build.gradle
+++ b/metadata-integration/java/datahub-event/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   implementation externalDependency.jacksonDataBind
   runtimeOnly externalDependency.jna
 
+  compileOnly externalDependency.swaggerAnnotations
   compileOnly externalDependency.lombok
   annotationProcessor externalDependency.lombok
   // VisibleForTesting

--- a/metadata-models/build.gradle
+++ b/metadata-models/build.gradle
@@ -9,12 +9,15 @@ plugins {
 apply from: '../gradle/coverage/java-coverage.gradle'
 
 dependencies {
-  api spec.product.pegasus.data
-    constraints {
-      implementation('org.apache.commons:commons-text:1.10.0') {
-        because 'Vulnerability Issue'
-      }
+  constraints {
+    implementation('org.apache.commons:commons-text:1.10.0') {
+      because 'Vulnerability Issue'
     }
+  }
+
+  api(spec.product.pegasus.data) {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
   api project(':li-utils')
   api project(path: ':li-utils', configuration: "dataTemplate")
   dataModel project(':li-utils')
@@ -26,7 +29,7 @@ dependencies {
 
   compileOnly externalDependency.lombok
   annotationProcessor externalDependency.lombok
-  api externalDependency.swaggerAnnotations
+  compileOnly externalDependency.swaggerAnnotations
   compileOnly externalDependency.jacksonCore
   compileOnly externalDependency.jacksonDataBind
 

--- a/metadata-service/openapi-servlet/models/build.gradle
+++ b/metadata-service/openapi-servlet/models/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation externalDependency.jacksonDataBind
   implementation externalDependency.httpClient
 
+  compileOnly externalDependency.swaggerAnnotations
   compileOnly externalDependency.lombok
 
   annotationProcessor externalDependency.lombok


### PR DESCRIPTION
* remove javax.servlet from datahub-client jar
* remove swagger classes from datahub-client jar


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
