### PR TITLE
feat(spark):OpenLineage 1.25.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ buildscript {
   ext.hazelcastVersion = '5.3.6'
   ext.ebeanVersion = '15.5.2'
   ext.googleJavaFormatVersion = '1.18.1'
-  ext.openLineageVersion = '1.24.2'
+  ext.openLineageVersion = '1.25.0'
   ext.logbackClassicJava8 = '1.2.12'
 
   ext.docker_registry = 'acryldata'


### PR DESCRIPTION
# Context
We are trying to use the Datahub project to ingest metadata of our Delta tables.
Recently we upgraded to a newer Delta version and this broke the integration.
This was fixed in https://github.com/OpenLineage/OpenLineage/pull/3253.
Given they just released https://github.com/OpenLineage/OpenLineage/releases/tag/1.25.0, it would be nice to use this version in Datahub as well.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
