### PR TITLE
feat(snowflake): adding oauth token bypass to snowflake

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -150,6 +150,11 @@ class SnowflakeConnectionConfig(ConfigModel):
                 )
         elif v == "OAUTH_AUTHENTICATOR":
             cls._check_oauth_config(values.get("oauth_config"))
+        elif v == "OAUTH_AUTHENTICATOR_TOKEN":
+            if values.get("token") is None:
+                raise ValueError(
+                    "token is required when using OAUTH_AUTHENTICATOR_TOKEN authentication"
+                )
         logger.info(f"using authenticator type '{v}'")
         return v
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_connection.py
@@ -150,22 +150,19 @@ class SnowflakeConnectionConfig(ConfigModel):
                 )
         elif v == "OAUTH_AUTHENTICATOR":
             cls._check_oauth_config(values.get("oauth_config"))
-        elif v == "OAUTH_AUTHENTICATOR_TOKEN":
-            if values.get("token") is None:
-                raise ValueError(
-                    "token is required when using OAUTH_AUTHENTICATOR_TOKEN authentication"
-                )
         logger.info(f"using authenticator type '{v}'")
         return v
 
-    @pydantic.validator("token")
+    @pydantic.validator("token", always=True)
     def validate_token_oauth_config(cls, v, values):
-        if v is not None:
-            # First check auth type
-            if values.get("authentication_type") != "OAUTH_AUTHENTICATOR_TOKEN":
-                raise ValueError(
-                    "Token can only be provided when using OAUTH_AUTHENTICATOR. Token bypasses authenticating with the OAuth server."
-                )
+        auth_type = values.get("authentication_type")
+        if auth_type == "OAUTH_AUTHENTICATOR_TOKEN":
+            if not v:
+                raise ValueError("Token required for OAUTH_AUTHENTICATOR_TOKEN.")
+        elif v is not None:
+            raise ValueError(
+                "Token can only be provided when using OAUTH_AUTHENTICATOR_TOKEN"
+            )
         return v
 
     @staticmethod

--- a/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/snowflake/test_snowflake_source.py
@@ -130,6 +130,60 @@ def test_snowflake_oauth_happy_paths():
     )
 
 
+def test_snowflake_oauth_token_happy_path():
+    assert SnowflakeV2Config.parse_obj(
+        {
+            "account_id": "test",
+            "authentication_type": "OAUTH_AUTHENTICATOR_TOKEN",
+            "token": "valid-token",
+            "username": "test-user",
+            "oauth_config": None,
+        }
+    )
+
+
+def test_snowflake_oauth_token_without_token():
+    with pytest.raises(
+        ValidationError, match="Token required for OAUTH_AUTHENTICATOR_TOKEN."
+    ):
+        SnowflakeV2Config.parse_obj(
+            {
+                "account_id": "test",
+                "authentication_type": "OAUTH_AUTHENTICATOR_TOKEN",
+                "username": "test-user",
+            }
+        )
+
+
+def test_snowflake_oauth_token_with_wrong_auth_type():
+    with pytest.raises(
+        ValueError,
+        match="Token can only be provided when using OAUTH_AUTHENTICATOR_TOKEN.",
+    ):
+        SnowflakeV2Config.parse_obj(
+            {
+                "account_id": "test",
+                "authentication_type": "OAUTH_AUTHENTICATOR",
+                "token": "some-token",
+                "username": "test-user",
+            }
+        )
+
+
+def test_snowflake_oauth_token_with_empty_token():
+    with pytest.raises(
+        ValidationError, match="Token required for OAUTH_AUTHENTICATOR_TOKEN."
+    ):
+        SnowflakeV2Config.parse_obj(
+            {
+                "account_id": "test",
+                "authentication_type": "OAUTH_AUTHENTICATOR_TOKEN",
+                "token": "",
+                "username": "test-user",
+            }
+        )
+
+
 default_config_dict: Dict[str, Any] = {
     "username": "user",
     "password": "password",


### PR DESCRIPTION
This enables a user to create a token outside of the ingestion flow and supply it. This has some risks, including not being able to refresh the token once expired, so a warning is added here.

Snowflake docs that were referenced: https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#connecting-with-oauth

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
