### PR TITLE
build(metadata-events): fix shell interpreter mismatch in build script

### DIFF
--- a/metadata-events/mxe-schemas/build.gradle
+++ b/metadata-events/mxe-schemas/build.gradle
@@ -25,7 +25,7 @@ task copyOriginalAvsc(type: Copy, dependsOn: generateAvroSchema) {
 }
 
 task renameNamespace(type: Exec, dependsOn: copyOriginalAvsc) {
-  commandLine 'sh', './rename-namespace.sh'
+  commandLine 'bash', './rename-namespace.sh'
 }
 
 build.dependsOn renameNamespace


### PR DESCRIPTION
Script was expected to run with bash, but build script launched with sh (overriding the shebang) . While this mismatch didn't cause problems on osx and the ci envs, this did fail on ubuntu24.04 dev envs.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
