### PR TITLE
build(coverage): rename python coverage reports

### DIFF
--- a/gradle/coverage/python-coverage.gradle
+++ b/gradle/coverage/python-coverage.gradle
@@ -1,7 +1,7 @@
 //coverage related args to be passed to pytest
 ext.get_coverage_args = { test_name = "" ->
 
-  def coverage_file_name = "pycov-${project.name}${test_name}.xml"
+  def coverage_file_name = "coverage-${project.name}${test_name}.xml"
 
   /*
   Tools that aggregate and analyse coverage tools search for the coverage result files. Keeping them under one folder


### PR DESCRIPTION
codecov requires the word coverage to be present in the coverage report file name


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
