### PR TITLE
fix(cli): don't use /api in gms url

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -327,6 +327,8 @@ def _ensure_valid_gms_url_acryl_cloud(url: str) -> str:
         url = f"{url}/gms"
     elif url.endswith("acryl.io/"):
         url = f"{url}gms"
+    if url.endswith("acryl.io/api/gms"):
+        url = url.replace("acryl.io/api/gms", "acryl.io/gms")
 
     return url
 

--- a/metadata-ingestion/tests/unit/cli/test_cli_utils.py
+++ b/metadata-ingestion/tests/unit/cli/test_cli_utils.py
@@ -66,6 +66,10 @@ def test_fixup_gms_url():
     assert cli_utils.fixup_gms_url("http://localhost:8080") == "http://localhost:8080"
     assert cli_utils.fixup_gms_url("http://localhost:8080/") == "http://localhost:8080"
     assert cli_utils.fixup_gms_url("http://abc.acryl.io") == "https://abc.acryl.io/gms"
+    assert (
+        cli_utils.fixup_gms_url("http://abc.acryl.io/api/gms")
+        == "https://abc.acryl.io/gms"
+    )
 
 
 def test_guess_frontend_url_from_gms_url():


### PR DESCRIPTION
The correct URL is without `/api` and many folks add `/api` in the URL causing problems. This would eliminate those problems

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
