### PR TITLE
feat: sets default java class version 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.jdkVersionDefault = 17
-  ext.javaClassVersionDefault = 11
+  ext.javaClassVersionDefault = 8
 
   def springModules = ['mae-consumer', 'mce-consumer', 'pe-consumer']
 


### PR DESCRIPTION
Some external consumer of the DataHub's Java Client SDK, _eg_ Hudi project, requires java 8 compatible binaries.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
