### PR TITLE
fix(ingest/datahub): Use server side cursor instead of local one

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -147,12 +147,9 @@ class DataHubDatabaseReader:
             version
         """
 
-    def _get_rows(
-        self, from_createdon: datetime, stop_time: datetime
+    def execute_server_cursor(
+        self, query: str, params: Dict[str, Any]
     ) -> Iterable[Dict[str, Any]]:
-        # Cursor for MySql and PostgreSQL are by default client side cursor and we need to create server side cursor -> https://docs.sqlalchemy.org/en/20/core/connections.html#using-server-side-cursors-a-k-a-stream-results
-        # For MySQL, we need to use SSCursor to create server side cursor
-        # For PostgreSQL, we need to use stream_results=True to create server side cursor and need to be run in transaction
         with self.engine.connect() as conn:
             if self.engine.dialect.name == "postgresql":
                 with conn.begin():  # Transaction required for PostgreSQL server-side cursor
@@ -160,13 +157,7 @@ class DataHubDatabaseReader:
                         stream_results=True,
                         yield_per=self.config.database_query_batch_size,
                     )
-                    result = conn.execute(
-                        self.query,
-                        {
-                            "exclude_aspects": list(self.config.exclude_aspects),
-                            "since_createdon": from_createdon.strftime(DATETIME_FORMAT),
-                        },
-                    )
+                    result = conn.execute(query, params)
                     for row in result:
                         yield dict(row)
             elif self.engine.dialect.name == "mysql":  # MySQL
@@ -176,13 +167,7 @@ class DataHubDatabaseReader:
                     conn.connection.cursor(MySQLdb.cursors.SSCursor)
                 ) as cursor:
                     logger.debug(f"Using Cursor type: {cursor.__class__.__name__}")
-                    cursor.execute(
-                        self.query,
-                        {
-                            "exclude_aspects": list(self.config.exclude_aspects),
-                            "since_createdon": from_createdon.strftime(DATETIME_FORMAT),
-                        },
-                    )
+                    cursor.execute(query, params)
 
                     columns = [desc[0] for desc in cursor.description]
                     while True:
@@ -193,6 +178,15 @@ class DataHubDatabaseReader:
                             yield dict(zip(columns, row))
             else:
                 raise ValueError(f"Unsupported dialect: {self.engine.dialect.name}")
+
+    def _get_rows(
+        self, from_createdon: datetime, stop_time: datetime
+    ) -> Iterable[Dict[str, Any]]:
+        params = {
+            "exclude_aspects": list(self.config.exclude_aspects),
+            "since_createdon": from_createdon.strftime(DATETIME_FORMAT),
+        }
+        yield from self.execute_server_cursor(self.query, params)
 
     def get_aspects(
         self, from_createdon: datetime, stop_time: datetime

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -4,7 +4,6 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar
 
-import MySQLdb
 from sqlalchemy import create_engine
 
 from datahub.emitter.aspect import ASPECT_MAP
@@ -171,6 +170,7 @@ class DataHubDatabaseReader:
                     for row in result:
                         yield dict(row)
             elif self.engine.dialect.name == "mysql":  # MySQL
+                import MySQLdb
                 with contextlib.closing(
                     conn.connection.cursor(MySQLdb.cursors.SSCursor)
                 ) as cursor:

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -171,6 +171,7 @@ class DataHubDatabaseReader:
                         yield dict(row)
             elif self.engine.dialect.name == "mysql":  # MySQL
                 import MySQLdb
+
                 with contextlib.closing(
                     conn.connection.cursor(MySQLdb.cursors.SSCursor)
                 ) as cursor:

--- a/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub/datahub_database_reader.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar
 
+import MySQLdb
 from sqlalchemy import create_engine
 
 from datahub.emitter.aspect import ASPECT_MAP
@@ -147,6 +148,51 @@ class DataHubDatabaseReader:
             version
         """
 
+    def _get_rows(
+        self, from_createdon: datetime, stop_time: datetime
+    ) -> Iterable[Dict[str, Any]]:
+        # Cursor for MySql and PostgreSQL are by default client side cursor and we need to create server side cursor -> https://docs.sqlalchemy.org/en/20/core/connections.html#using-server-side-cursors-a-k-a-stream-results
+        # For MySQL, we need to use SSCursor to create server side cursor
+        # For PostgreSQL, we need to use stream_results=True to create server side cursor and need to be run in transaction
+        with self.engine.connect() as conn:
+            if self.engine.dialect.name == "postgresql":
+                with conn.begin():  # Transaction required for PostgreSQL server-side cursor
+                    conn = conn.execution_options(
+                        stream_results=True,
+                        yield_per=self.config.database_query_batch_size,
+                    )
+                    result = conn.execute(
+                        self.query,
+                        {
+                            "exclude_aspects": list(self.config.exclude_aspects),
+                            "since_createdon": from_createdon.strftime(DATETIME_FORMAT),
+                        },
+                    )
+                    for row in result:
+                        yield dict(row)
+            elif self.engine.dialect.name == "mysql":  # MySQL
+                with contextlib.closing(
+                    conn.connection.cursor(MySQLdb.cursors.SSCursor)
+                ) as cursor:
+                    logger.debug(f"Using Cursor type: {cursor.__class__.__name__}")
+                    cursor.execute(
+                        self.query,
+                        {
+                            "exclude_aspects": list(self.config.exclude_aspects),
+                            "since_createdon": from_createdon.strftime(DATETIME_FORMAT),
+                        },
+                    )
+
+                    columns = [desc[0] for desc in cursor.description]
+                    while True:
+                        rows = cursor.fetchmany(self.config.database_query_batch_size)
+                        if not rows:
+                            break  # Use break instead of return in generator
+                        for row in rows:
+                            yield dict(zip(columns, row))
+            else:
+                raise ValueError(f"Unsupported dialect: {self.engine.dialect.name}")
+
     def get_aspects(
         self, from_createdon: datetime, stop_time: datetime
     ) -> Iterable[Tuple[MetadataChangeProposalWrapper, datetime]]:
@@ -158,27 +204,6 @@ class DataHubDatabaseReader:
             mcp = self._parse_row(row)
             if mcp:
                 yield mcp, row["createdon"]
-
-    def _get_rows(
-        self, from_createdon: datetime, stop_time: datetime
-    ) -> Iterable[Dict[str, Any]]:
-        with self.engine.connect() as conn:
-            with contextlib.closing(conn.connection.cursor()) as cursor:
-                cursor.execute(
-                    self.query,
-                    {
-                        "exclude_aspects": list(self.config.exclude_aspects),
-                        "since_createdon": from_createdon.strftime(DATETIME_FORMAT),
-                    },
-                )
-
-                columns = [desc[0] for desc in cursor.description]
-                while True:
-                    rows = cursor.fetchmany(self.config.database_query_batch_size)
-                    if not rows:
-                        return
-                    for row in rows:
-                        yield dict(zip(columns, row))
 
     def get_soft_deleted_rows(self) -> Iterable[Dict[str, Any]]:
         """


### PR DESCRIPTION
It uses server-side cursor which is the recommended in this case -> https://docs.sqlalchemy.org/en/20/core/connections.html#using-server-side-cursors-a-k-a-stream-results

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
