### PR TITLE
fix(ingest/s3): incorrectly parsing path in s3_uri

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from itertools import groupby
 from pathlib import PurePath
 from typing import Any, Dict, Iterable, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import smart_open.compression as so_compression
 from more_itertools import peekable
@@ -993,9 +994,7 @@ class S3Source(StatefulIngestionSourceBase):
                         folders = []
                         for dir in dirs_to_process:
                             logger.info(f"Getting files from folder: {dir}")
-                            prefix_to_process = dir.rstrip("\\").lstrip(
-                                self.create_s3_path(bucket_name, "/")
-                            )
+                            prefix_to_process = urlparse(dir).path.lstrip("/")
 
                             folders.extend(
                                 self.get_folder_info(


### PR DESCRIPTION
## Background
- While ingesting S3 datasets with a [pipeline](https://github.com/datahub-project/datahub/blob/2291c71c293dcf5b83d29723ce129450b6b64b0a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py#L209), I encountered a warning: `Unable to find any files in the folder s3://your-bucket/your-path/year=2024/. Skipping...`, but the file was definitely present.


## How to reproduce

- You can reproduce this bug with the following code.

```python
from datahub.ingestion.run.pipeline import Pipeline

DATAHUB_SERVER = "http://localhost:8080"
DEFAULT_SINK = {"type": "datahub-rest", "config": {"server": DATAHUB_SERVER}}

S3_PATH = "s3://your-bucket/your-path/path/{table}/{partition_key[0]}={partition[0]}/*.parquet"

s3_config = {
        "source": {
            "type": "s3",
            "config": {
                "path_spec": {
                    "include": S3_PATH,
                },
                "aws_config": {
                    "aws_region": "ap-northeast-2",
                },
            },
        },
        "sink": DEFAULT_SINK,
    }

pipeline = Pipeline.create(s3_config)
pipeline.run()
```

## Changes

### As-is

* The path was misparsed due to using lstrip() with `s3://<bucket-name>//`.

``` python
dir = "s3://bucket/test9/abc.txt"
path_to_process = dir.rstrip("\\").lstrip("s3://bucket//")

print(path_to_process) # result: '9/abc.txt', expected: test9/abc.txt
```

### To-be

* Use `urlparse` to parse the path in s3_uri.

```python
from urllib.parse import urlparse

dir = "s3://bucket/test/abc.txt"
path_to_process = urlparse(dir).path.lstrip("/")

print(path_to_process) # result: 'test9/abc.txt'
```


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
