### PR TITLE
ci(vercel): use prebuilt python

### DIFF
--- a/docs-website/vercel-setup.sh
+++ b/docs-website/vercel-setup.sh
@@ -22,6 +22,6 @@ uv python install 3.10
 # Set python3.10 as the default version.
 py3="$(which python3)"
 rm "$py3"
-ln "$(uv python find 3.10)" "$py3"
+ln -s "$(uv python find 3.10)" "$py3"
 python3 --version
 

--- a/docs-website/vercel-setup.sh
+++ b/docs-website/vercel-setup.sh
@@ -8,27 +8,20 @@ set -euxo pipefail
 yum install java-17-amazon-corretto-devel -y
 javac --version
 
-# Build python from source.
-# Amazon Linux 2 has Python 3.8, but it's version of OpenSSL is super old and hence it
-# doesn't work with the packages we use. As such, we have to build Python from source.
-# TODO: This process is extremely slow - ideally we should cache the built Python binary
-# for reuse.
-
 yum groupinstall "Development Tools" -y
-yum install openssl openssl-devel libffi-devel bzip2-devel wget nodejs -y
+yum install openssl openssl-devel libffi-devel bzip2-devel wget nodejs tar -y
 
-wget https://www.python.org/ftp/python/3.10.11/Python-3.10.11.tgz
-tar -xf Python-3.10.11.tgz
-cd Python-3.10.11
-./configure #--enable-optimizations
+# Amazon Linux 2 has Python 3.8, but it's version of OpenSSL is super old and hence it
+# doesn't work with the packages we use. As such, we want to install Python ourselves.
+# Using uv to install Python from https://github.com/indygreg/python-build-standalone
+curl -LsSf https://astral.sh/uv/install.sh | sh
+source $HOME/.local/bin/env
 
-make -j $(nproc)
-
-make install
+uv python install 3.10
 
 # Set python3.10 as the default version.
 py3="$(which python3)"
 rm "$py3"
-ln "$(which python3.10)" "$py3"
+ln "$(uv python find 3.10)" "$py3"
 python3 --version
 


### PR DESCRIPTION
This should speed up CI a bit.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
