### PR TITLE
feat(metrics): add more fine grained metrics for distinguishing between request sources

### DIFF
--- a/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaEventProducer.java
+++ b/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaEventProducer.java
@@ -1,10 +1,15 @@
 package com.linkedin.metadata.dao.producer;
 
+import static com.linkedin.metadata.utils.metrics.MetricUtils.PRODUCE_MCL_METRIC_NAME;
+import static com.linkedin.metadata.utils.metrics.MetricUtils.PRODUCE_MCP_METRIC_NAME;
+import static com.linkedin.metadata.utils.metrics.MetricUtils.PRODUCE_PE_METRIC_NAME;
+
 import com.datahub.util.exception.ModelConversionException;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.EventUtils;
 import com.linkedin.metadata.event.EventProducer;
 import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.DataHubUpgradeHistoryEvent;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -73,6 +78,7 @@ public class KafkaEventProducer implements EventProducer {
     if (aspectSpec.isTimeseries()) {
       topic = _topicConvention.getMetadataChangeLogTimeseriesTopicName();
     }
+    MetricUtils.counter(this.getClass(), PRODUCE_MCL_METRIC_NAME).inc();
     return _producer.send(
         new ProducerRecord(topic, urn.toString(), record),
         _kafkaHealthChecker.getKafkaCallBack("MCL", urn.toString()));
@@ -97,6 +103,7 @@ public class KafkaEventProducer implements EventProducer {
     }
 
     String topic = _topicConvention.getMetadataChangeProposalTopicName();
+    MetricUtils.counter(this.getClass(), PRODUCE_MCP_METRIC_NAME).inc();
     return _producer.send(
         new ProducerRecord(topic, urn.toString(), record),
         _kafkaHealthChecker.getKafkaCallBack("MCP", urn.toString()));
@@ -116,6 +123,7 @@ public class KafkaEventProducer implements EventProducer {
     }
 
     final String topic = _topicConvention.getPlatformEventTopicName();
+    MetricUtils.counter(this.getClass(), PRODUCE_PE_METRIC_NAME).inc();
     return _producer.send(
         new ProducerRecord(topic, key == null ? name : key, record),
         _kafkaHealthChecker.getKafkaCallBack("Platform Event", name));

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation externalDependency.guava
   implementation externalDependency.reflections
   // https://mvnrepository.com/artifact/nl.basjes.parse.useragent/yauaa
-  implementation 'nl.basjes.parse.useragent:yauaa:7.27.0'
+  api 'nl.basjes.parse.useragent:yauaa:7.27.0'
 
   api(externalDependency.dgraph4j) {
     exclude group: 'com.google.guava', module: 'guava'

--- a/metadata-io/src/main/java/com/linkedin/metadata/dao/throttle/APIThrottle.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/dao/throttle/APIThrottle.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.dao.throttle;
 import static com.linkedin.metadata.dao.throttle.ThrottleType.MANUAL;
 import static com.linkedin.metadata.dao.throttle.ThrottleType.MCL_TIMESERIES_LAG;
 import static com.linkedin.metadata.dao.throttle.ThrottleType.MCL_VERSIONED_LAG;
+import static com.linkedin.metadata.userAgent.UserAgentUtils.UAA;
 
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.RequestContext;
@@ -13,16 +14,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import nl.basjes.parse.useragent.UserAgent;
-import nl.basjes.parse.useragent.UserAgentAnalyzer;
 
 public class APIThrottle {
   private static final Set<String> AGENT_EXEMPTIONS = Set.of("Browser");
-  private static final UserAgentAnalyzer UAA =
-      UserAgentAnalyzer.newBuilder()
-          .hideMatcherLoadStats()
-          .withField(UserAgent.AGENT_CLASS)
-          .withCache(1000)
-          .build();
 
   private APIThrottle() {}
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -14,7 +14,6 @@ import static com.linkedin.metadata.utils.SystemMetadataUtils.createDefaultSyste
 import static com.linkedin.metadata.utils.metrics.ExceptionUtils.collectMetrics;
 import static com.linkedin.metadata.utils.metrics.MetricUtils.INGEST_PROPOSAL_API_SOURCE_METRIC_NAME;
 import static com.linkedin.metadata.utils.metrics.MetricUtils.PRE_PROCESS_MCL_METRIC_NAME;
-import static com.linkedin.metadata.utils.metrics.MetricUtils.PRODUCE_MCL_METRIC_NAME;
 
 import com.codahale.metrics.Timer;
 import com.datahub.util.RecordUtils;
@@ -1785,7 +1784,6 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
       @Nonnull final AspectSpec aspectSpec,
       @Nonnull final MetadataChangeLog metadataChangeLog) {
     Future<?> future = producer.produceMetadataChangeLog(urn, aspectSpec, metadataChangeLog);
-    MetricUtils.counter(this.getClass(), PRODUCE_MCL_METRIC_NAME).inc();
     return Pair.of(future, preprocessEvent(opContext, metadataChangeLog));
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/userAgent/UserAgentUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/userAgent/UserAgentUtils.java
@@ -1,0 +1,16 @@
+package com.linkedin.metadata.userAgent;
+
+import nl.basjes.parse.useragent.UserAgent;
+import nl.basjes.parse.useragent.UserAgentAnalyzer;
+
+public class UserAgentUtils {
+
+  private UserAgentUtils() {}
+
+  public static final UserAgentAnalyzer UAA =
+      UserAgentAnalyzer.newBuilder()
+          .hideMatcherLoadStats()
+          .withField(UserAgent.AGENT_CLASS)
+          .withCache(1000)
+          .build();
+}

--- a/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
+++ b/metadata-operation-context/src/main/java/io/datahubproject/metadata/context/RequestContext.java
@@ -145,7 +145,7 @@ public class RequestContext implements ContextInterface {
               "%s(%s)", action, entityNames.stream().distinct().collect(Collectors.toList()));
     }
 
-    private static String extractUserAgent(@Nonnull HttpServletRequest request) {
+    public static String extractUserAgent(@Nonnull HttpServletRequest request) {
       return Optional.ofNullable(request.getHeader(HttpHeaders.USER_AGENT)).orElse("");
     }
 

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
@@ -16,6 +16,8 @@ public class MetricUtils {
   private static final MetricRegistry REGISTRY = SharedMetricRegistries.getOrCreate(NAME);
 
   public static String PRODUCE_MCL_METRIC_NAME = "produceMCL";
+  public static String PRODUCE_MCP_METRIC_NAME = "produceMCP";
+  public static String PRODUCE_PE_METRIC_NAME = "producePE";
   public static String INGEST_PROPOSAL_API_SOURCE_METRIC_NAME = "ingestProposal_%s_%s";
   public static String PRE_PROCESS_MCL_METRIC_NAME = "preProcessChangeLog";
 

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/metrics/MetricUtils.java
@@ -15,6 +15,10 @@ public class MetricUtils {
   public static final String NAME = "default";
   private static final MetricRegistry REGISTRY = SharedMetricRegistries.getOrCreate(NAME);
 
+  public static String PRODUCE_MCL_METRIC_NAME = "produceMCL";
+  public static String INGEST_PROPOSAL_API_SOURCE_METRIC_NAME = "ingestProposal_%s_%s";
+  public static String PRE_PROCESS_MCL_METRIC_NAME = "preProcessChangeLog";
+
   static {
     final JmxReporter reporter = JmxReporter.forRegistry(REGISTRY).build();
     reporter.start();


### PR DESCRIPTION
Adds the following metrics:

* Accurate ingestProposal metric that accounts for batch sizes. Also splits into several metrics with sync/async + source API. These can be filtered with PromQL using "...ingestProposal_sync.*", "...ingestProposal_async.*", "...ingestProposal_sync_GRAPHQL", etc.
* Finer grained metric for GraphQL based on user agent to allow for tracking true UI errors vs programmatic clients using GraphQL
* Full MCL, MCP, & PE produce count
* Preprocess count for UI based ingestion (things that skip waiting for MCL to be in ES indices)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
