### PR TITLE
feat(delete): delete logic non-strict monotonically increasing version

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/AspectDao.java
@@ -6,6 +6,7 @@ import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.entity.ebean.PartitionedStream;
 import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
+import com.linkedin.util.Pair;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -154,6 +155,16 @@ public interface AspectDao {
   }
 
   long getMaxVersion(@Nonnull final String urn, @Nonnull final String aspectName);
+
+  /**
+   * Return the min/max version for the given URN & aspect
+   *
+   * @param urn the urn
+   * @param aspectName the aspect
+   * @return the range of versions, if they do not exist -1 is returned
+   */
+  @Nonnull
+  Pair<Long, Long> getVersionRange(@Nonnull final String urn, @Nonnull final String aspectName);
 
   void setWritable(boolean canWrite);
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/cassandra/CassandraAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/cassandra/CassandraAspectDao.java
@@ -36,6 +36,7 @@ import com.linkedin.metadata.entity.restoreindices.RestoreIndicesArgs;
 import com.linkedin.metadata.query.ExtraInfo;
 import com.linkedin.metadata.query.ExtraInfoArray;
 import com.linkedin.metadata.query.ListResultMetadata;
+import com.linkedin.util.Pair;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
@@ -110,7 +111,14 @@ public class CassandraAspectDao implements AspectDao, AspectMigrationsDao {
   @Override
   public long getMaxVersion(@Nonnull final String urn, @Nonnull final String aspectName) {
     validateConnection();
-    Map<String, Long> result = getMaxVersions(urn, ImmutableSet.of(aspectName));
+    Map<String, Pair<Long, Long>> result = getVersionRanges(urn, ImmutableSet.of(aspectName));
+    return result.get(aspectName).getSecond();
+  }
+
+  @Override
+  @Nonnull
+  public Pair<Long, Long> getVersionRange(@Nonnull String urn, @Nonnull String aspectName) {
+    Map<String, Pair<Long, Long>> result = getVersionRanges(urn, ImmutableSet.of(aspectName));
     return result.get(aspectName);
   }
 
@@ -148,15 +156,17 @@ public class CassandraAspectDao implements AspectDao, AspectMigrationsDao {
     return rs.one() != null;
   }
 
-  private Map<String, Long> getMaxVersions(
+  private Map<String, Pair<Long, Long>> getVersionRanges(
       @Nonnull final String urn, @Nonnull final Set<String> aspectNames) {
     SimpleStatement ss =
         selectFrom(CassandraAspect.TABLE_NAME)
             .selectors(
                 Selector.column(CassandraAspect.URN_COLUMN),
                 Selector.column(CassandraAspect.ASPECT_COLUMN),
+                Selector.function("min", Selector.column(CassandraAspect.VERSION_COLUMN))
+                    .as("min_version"),
                 Selector.function("max", Selector.column(CassandraAspect.VERSION_COLUMN))
-                    .as(CassandraAspect.VERSION_COLUMN))
+                    .as("max_version"))
             .whereColumn(CassandraAspect.URN_COLUMN)
             .isEqualTo(literal(urn))
             .whereColumn(CassandraAspect.ASPECT_COLUMN)
@@ -168,21 +178,21 @@ public class CassandraAspectDao implements AspectDao, AspectMigrationsDao {
             .build();
 
     ResultSet rs = _cqlSession.execute(ss);
-    Map<String, Long> aspectVersions =
+    Map<String, Pair<Long, Long>> aspectVersionRanges =
         rs.all().stream()
             .collect(
                 Collectors.toMap(
                     row -> row.getString(CassandraAspect.ASPECT_COLUMN),
-                    row -> row.getLong(CassandraAspect.VERSION_COLUMN)));
+                    row -> Pair.of(row.getLong("min_version"), row.getLong("max_version"))));
 
-    // For each requested aspect that didn't come back from DB, add a version -1
+    // For each requested aspect that didn't come back from DB, add a version range of (-1, -1)
     for (String aspect : aspectNames) {
-      if (!aspectVersions.containsKey(aspect)) {
-        aspectVersions.put(aspect, -1L);
+      if (!aspectVersionRanges.containsKey(aspect)) {
+        aspectVersionRanges.put(aspect, Pair.of(-1L, -1L));
       }
     }
 
-    return aspectVersions;
+    return aspectVersionRanges;
   }
 
   @Override
@@ -551,11 +561,12 @@ public class CassandraAspectDao implements AspectDao, AspectMigrationsDao {
     Map<String, Map<String, Long>> result = new HashMap<>();
 
     for (Map.Entry<String, Set<String>> aspectNames : urnAspectMap.entrySet()) {
-      Map<String, Long> maxVersions = getMaxVersions(aspectNames.getKey(), aspectNames.getValue());
+      Map<String, Pair<Long, Long>> maxVersions =
+          getVersionRanges(aspectNames.getKey(), aspectNames.getValue());
       Map<String, Long> nextVersions = new HashMap<>();
 
       for (String aspectName : aspectNames.getValue()) {
-        long latestVersion = maxVersions.get(aspectName);
+        long latestVersion = maxVersions.get(aspectName).getSecond();
         long nextVal = latestVersion < 0 ? ASPECT_LATEST_VERSION : latestVersion + 1L;
         nextVersions.put(aspectName, nextVal);
       }


### PR DESCRIPTION
The delete function in the EnityService assumed a strictly monotonically increasing version. In a batch this can be non-strict, meaning versions can be skipped within a batch leading to only persisting the latest version, accounting for incremented versions within the batch.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
