### PR TITLE
feat(sql-queries): add support for column-level lineage aggregation to SqlQueriesSource

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql_queries.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_queries.py
@@ -70,6 +70,11 @@ class SqlQueriesSourceConfig(PlatformInstanceConfigMixin, EnvConfigMixin):
         description="The SQL dialect to use when parsing queries. Overrides automatic dialect detection.",
         default=None,
     )
+    # Configuration option for column-level lineage aggregation
+    aggregate_column_lineage: bool = Field(
+        description="If set to true, column-level lineage is aggregated across queries in the same file.",
+        default=False,
+    )
 
 
 class SqlQueriesSourceReport(SourceReport):
@@ -158,6 +163,14 @@ class SqlQueriesSource(Source):
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         logger.info(f"Parsing queries from {os.path.basename(self.config.query_file)}")
+        
+        # Initialize the aggregated lineage map if aggregate_column_lineage is enabled
+        if self.config.aggregate_column_lineage:
+            logger.info("Column-level lineage aggregation is enabled.")
+            self.aggregated_lineage = defaultdict(set)  # Tracks lineage for columns across queries in the same file
+        else:
+            logger.info("Column-level lineage aggregation is disabled.")
+        
         with open(self.config.query_file) as f:
             for line in f:
                 try:
@@ -167,6 +180,30 @@ class SqlQueriesSource(Source):
                 except Exception as e:
                     logger.warning("Error processing query", exc_info=True)
                     self.report.report_warning("process-query", str(e))
+
+        # Emit final aggregated lineage if aggregate_column_lineage is enabled
+        if self.config.aggregate_column_lineage:
+            for (table, column), upstreams in self.aggregated_lineage.items():
+                downstream_urn = make_dataset_urn_with_platform_instance(
+                    name=f"{table}.{column}",
+                    platform=self.config.platform,
+                    platform_instance=self.config.platform_instance,
+                    env=self.config.env,
+                )
+                upstream_urns = [
+                    make_dataset_urn_with_platform_instance(
+                        name=f"{upstream_table}.{upstream_column}",
+                        platform=self.config.platform,
+                        platform_instance=self.config.platform_instance,
+                        env=self.config.env,
+                    )
+                    for upstream_table, upstream_column in upstreams
+                ]
+                logger.debug(f"Emitting aggregated lineage for {table}.{column}: {upstreams}")
+                self.builder.add_lineage(
+                    downstream_urn=downstream_urn,
+                    upstream_urns=upstream_urns,
+                )
 
         logger.info("Generating workunits")
         yield from self.builder.gen_workunits()
@@ -199,6 +236,17 @@ class SqlQueriesSource(Source):
                 f"Error parsing column lineage, {result.debug_info.column_error}"
             )
             self.report.num_column_parse_failures += 1
+
+        # Aggregate column-level lineage if aggregate_column_lineage is enabled
+        if self.config.aggregate_column_lineage and result.column_lineage:
+            for col_lineage in result.column_lineage:
+                downstream_col = (col_lineage.downstream.table, col_lineage.downstream.column)
+                previous_upstreams = self.aggregated_lineage[downstream_col]
+                new_upstreams = {
+                    (upstream.table, upstream.column) for upstream in col_lineage.upstreams
+                }
+                self.aggregated_lineage[downstream_col].update(new_upstreams)
+                logger.debug(f"Updated lineage for {downstream_col}: Previous={previous_upstreams}, New={new_upstreams}")
 
         yield from self.builder.process_sql_parsing_result(
             result,


### PR DESCRIPTION
**Problem:**
When processing multiple SQL queries in the same JSON file, column-level lineage for a column in the same downstream table is overwritten by the last query targeting that column. This results in the loss of upstream columns from earlier queries
For example, consider the following JSON file:
```
{"query": "INSERT INTO TableB (col1, col2) SELECT c1, c2 FROM TableA"}
{"query": "INSERT INTO TableB (col1) SELECT c3 FROM TableA"}
{"query": "INSERT INTO TableC (col1) SELECT c3 FROM TableB"}
{"query": "UPDATE TableB b SET col1 = a.c4 FROM TableA a WHERE b.some_column = a.some_column"}
```
Current behavior:
```
{TableA.c4} -> TableB.col1 (earlier upstreams are lost)
{TableA.c2} -> TableB.col2
{TableB.c3} -> TableC.col1
```
Desired behavior:
```
{TableA.c1, TableA.c3, TableA.c4} -> TableB.col1 (aggregate all upstreams)
{TableA.c2} -> TableB.col2
{TableB.c3} -> TableC.col1
```
**Proposed Solution:**
This PR introduces a configuration option (`aggregate_column_lineage`) to enable or disable column-level lineage aggregation for queries in the same JSON file:

- When enabled (`aggregate_column_lineage: true`), column-level lineage is aggregated across queries in the same file.
- When disabled (`aggregate_column_lineage: false`), the default behavior is retained (column-level lineage for a column in the same downstream table is overwritten by the last query targeting that column).

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
