### PR TITLE
fix(ingestion/s3): groupby group-splitting issue

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -6,9 +6,8 @@ import pathlib
 import re
 import time
 from datetime import datetime
-from itertools import groupby
 from pathlib import PurePath
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import smart_open.compression as so_compression
@@ -41,6 +40,7 @@ from datahub.ingestion.source.aws.s3_util import (
     get_bucket_name,
     get_bucket_relative_path,
     get_key_prefix,
+    group_s3_objects_by_dirname,
     strip_s3_prefix,
 )
 from datahub.ingestion.source.data_lake_common.data_lake_utils import ContainerWUCreator
@@ -74,6 +74,9 @@ from datahub.metadata.schema_classes import (
 )
 from datahub.telemetry import stats, telemetry
 from datahub.utilities.perf_timer import PerfTimer
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3.service_resource import Bucket
 
 # hide annoying debug errors from py4j
 logging.getLogger("py4j").setLevel(logging.ERROR)
@@ -842,7 +845,7 @@ class S3Source(StatefulIngestionSourceBase):
     def get_folder_info(
         self,
         path_spec: PathSpec,
-        bucket: Any,  # Todo: proper type
+        bucket: "Bucket",
         prefix: str,
     ) -> List[Folder]:
         """
@@ -857,22 +860,15 @@ class S3Source(StatefulIngestionSourceBase):
 
         Parameters:
         path_spec (PathSpec): The path specification used to determine partitioning.
-        bucket (Any): The S3 bucket object.
+        bucket (Bucket): The S3 bucket object.
         prefix (str): The prefix path in the S3 bucket to list objects from.
 
         Returns:
         List[Folder]: A list of Folder objects representing the partitions found.
         """
-
-        prefix_to_list = prefix
-        files = list(
-            bucket.objects.filter(Prefix=f"{prefix_to_list}").page_size(PAGE_SIZE)
-        )
-        files = sorted(files, key=lambda a: a.last_modified)
-        grouped_files = groupby(files, lambda x: x.key.rsplit("/", 1)[0])
-
         partitions: List[Folder] = []
-        for key, group in grouped_files:
+        s3_objects = bucket.objects.filter(Prefix=prefix).page_size(PAGE_SIZE)
+        for key, group in group_s3_objects_by_dirname(s3_objects).items():
             file_size = 0
             creation_time = None
             modification_time = None
@@ -904,7 +900,7 @@ class S3Source(StatefulIngestionSourceBase):
                 Folder(
                     partition_id=id,
                     is_partition=bool(id),
-                    creation_time=creation_time if creation_time else None,
+                    creation_time=creation_time if creation_time else None,  # type: ignore[arg-type]
                     modification_time=modification_time,
                     sample_file=self.create_s3_path(max_file.bucket_name, max_file.key),
                     size=file_size,

--- a/metadata-ingestion/tests/unit/s3/test_s3_util.py
+++ b/metadata-ingestion/tests/unit/s3/test_s3_util.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+from datahub.ingestion.source.aws.s3_util import group_s3_objects_by_dirname
+
+
+def test_group_s3_objects_by_dirname():
+    s3_objects = [
+        Mock(key="/dir1/file1.txt"),
+        Mock(key="/dir2/file2.txt"),
+        Mock(key="/dir1/file3.txt"),
+    ]
+
+    grouped_objects = group_s3_objects_by_dirname(s3_objects)
+
+    assert len(grouped_objects) == 2
+    assert grouped_objects["/dir1"] == [s3_objects[0], s3_objects[2]]
+    assert grouped_objects["/dir2"] == [s3_objects[1]]
+
+
+def test_group_s3_objects_by_dirname_files_in_root_directory():
+    s3_objects = [
+        Mock(key="file1.txt"),
+        Mock(key="file2.txt"),
+    ]
+
+    grouped_objects = group_s3_objects_by_dirname(s3_objects)
+
+    assert len(grouped_objects) == 1
+    assert grouped_objects["/"] == s3_objects


### PR DESCRIPTION
## Summary

Fix the group-splitting issue caused by `itertools.groupby` when the **input data is not ordered by the group key**.

## Changes

### As-is

- Use `itertools.groupby` for grouping. (group_key: `s3_object.key`)
- Sort s3_objects before grouping. (sort_key: `s3_object.last_modified`)


### To-be

- Use `defaultdict` for grouping without pre-sorting.

## Background
### Behavior of itertools.groupby

- `itertools.groupby()` generates a new group every time the value of the key function changes, which requires the input data to be sorted.
- This means the input data should be sorted and the **group key must be equal to the sort key** for correct grouping.
  
  ```python
  from itertools import groupby

  data = [1, 1, 2, 1]

  # Without sorting
  for key, val in groupby(data, key=lambda x: x):
      print(key, list(val))

  # --- output --- (Group Splitting)
  # 1 [1, 1] 
  # 2 [2]
  # 1 [1]

  # With sorting
  sorted_data = sorted(data, key=lambda x: x)

  for key, val in groupby(sorted_data, key=lambda x: x):
      print(key, list(val))

  # --- output ---
  # 1 [1, 1, 1]
  # 2 [2]
  ```

### Problem part


- [in our code](https://github.com/datahub-project/datahub/pull/12254/files#diff-73a2147c95a5694c1ac39f90959741699356373577ef26345a604baa88d3db50L872), the sorting order is changed to `file.last_modified` even though the group key is `file.key`. This mismatch causes group-splitting issues.
  ```python
  # Current code
  files = sorted(files, key=lambda a: a.last_modified) 
  grouped_files = groupby(files, lambda x: x.key.rsplit("/", 1)[0])
  ```

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
