### PR TITLE
fix(ingest/gc): soft deletion loop fix

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/gc/dataprocess_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/dataprocess_cleanup.py
@@ -167,7 +167,7 @@ class DataJobEntity:
 class DataProcessCleanupReport(SourceReport):
     num_aspects_removed: int = 0
     num_aspect_removed_by_type: TopKDict[str, int] = field(default_factory=TopKDict)
-    sample_removed_aspects_by_type: TopKDict[str, LossyList[str]] = field(
+    sample_soft_deleted_aspects_by_type: TopKDict[str, LossyList[str]] = field(
         default_factory=TopKDict
     )
     num_data_flows_found: int = 0
@@ -286,9 +286,9 @@ class DataProcessCleanup:
         self.report.num_aspect_removed_by_type[type] = (
             self.report.num_aspect_removed_by_type.get(type, 0) + 1
         )
-        if type not in self.report.sample_removed_aspects_by_type:
-            self.report.sample_removed_aspects_by_type[type] = LossyList()
-        self.report.sample_removed_aspects_by_type[type].append(urn)
+        if type not in self.report.sample_soft_deleted_aspects_by_type:
+            self.report.sample_soft_deleted_aspects_by_type[type] = LossyList()
+        self.report.sample_soft_deleted_aspects_by_type[type].append(urn)
 
         if self.dry_run:
             logger.info(

--- a/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
@@ -1,9 +1,10 @@
 import logging
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import List, Optional
+from threading import Lock
+from typing import Dict, List, Optional
 
 from pydantic import Field
 
@@ -23,7 +24,7 @@ class SoftDeletedEntitiesCleanupConfig(ConfigModel):
     enabled: bool = Field(
         default=True, description="Whether to do soft deletion cleanup."
     )
-    retention_days: Optional[int] = Field(
+    retention_days: int = Field(
         10,
         description="Number of days to retain metadata in DataHub",
     )
@@ -62,18 +63,26 @@ class SoftDeletedEntitiesCleanupConfig(ConfigModel):
         default=None,
         description="Query to filter entities",
     )
+
     limit_entities_delete: Optional[int] = Field(
         25000, description="Max number of entities to delete."
     )
 
-    runtime_limit_seconds: Optional[int] = Field(
-        None,
+    futures_max_at_time: int = Field(
+        10000, description="Max number of futures to have at a time."
+    )
+
+    runtime_limit_seconds: int = Field(
+        7200,  # 2 hours by default
         description="Runtime limit in seconds",
     )
 
 
 @dataclass
 class SoftDeletedEntitiesReport(SourceReport):
+    num_soft_deleted_entity_processed: int = 0
+    num_soft_deleted_retained_due_to_age: int = 0
+    num_soft_deleted_entity_removal_started: int = 0
     num_soft_deleted_entity_removed: int = 0
     num_soft_deleted_entity_removed_by_type: TopKDict[str, int] = field(
         default_factory=TopKDict
@@ -103,47 +112,61 @@ class SoftDeletedEntitiesCleanup:
         self.config = config
         self.report = report
         self.dry_run = dry_run
+        self.start_time = 0.0
+        self._report_lock: Lock = Lock()
+        self.last_print_time = 0.0
+
+    def _increment_retained_count(self) -> None:
+        """Thread-safe method to update report fields"""
+        with self._report_lock:
+            self.report.num_soft_deleted_retained_due_to_age += 1
+
+    def _increment_removal_started_count(self) -> None:
+        """Thread-safe method to update report fields"""
+        with self._report_lock:
+            self.report.num_soft_deleted_entity_removal_started += 1
+
+    def _update_report(self, urn: str, entity_type: str) -> None:
+        """Thread-safe method to update report fields"""
+        with self._report_lock:
+            self.report.num_soft_deleted_entity_removed += 1
+
+            current_count = self.report.num_soft_deleted_entity_removed_by_type.get(
+                entity_type, 0
+            )
+            self.report.num_soft_deleted_entity_removed_by_type[entity_type] = (
+                current_count + 1
+            )
+            if (
+                entity_type
+                not in self.report.sample_soft_deleted_removed_aspects_by_type
+            ):
+                self.report.sample_soft_deleted_removed_aspects_by_type[
+                    entity_type
+                ] = LossyList()
+            self.report.sample_soft_deleted_removed_aspects_by_type[entity_type].append(
+                urn
+            )
 
     def delete_entity(self, urn: str) -> None:
         assert self.ctx.graph
 
         entity_urn = Urn.from_string(urn)
-        self.report.num_soft_deleted_entity_removed += 1
-        self.report.num_soft_deleted_entity_removed_by_type[entity_urn.entity_type] = (
-            self.report.num_soft_deleted_entity_removed_by_type.get(
-                entity_urn.entity_type, 0
-            )
-            + 1
-        )
-        if (
-            entity_urn.entity_type
-            not in self.report.sample_soft_deleted_removed_aspects_by_type
-        ):
-            self.report.sample_soft_deleted_removed_aspects_by_type[
-                entity_urn.entity_type
-            ] = LossyList()
-        self.report.sample_soft_deleted_removed_aspects_by_type[
-            entity_urn.entity_type
-        ].append(urn)
-
         if self.dry_run:
             logger.info(
                 f"Dry run is on otherwise it would have deleted {urn} with hard deletion"
             )
             return
-
+        self._increment_removal_started_count()
         self.ctx.graph.delete_entity(urn=urn, hard=True)
         self.ctx.graph.delete_references_to_urn(
             urn=urn,
             dry_run=False,
         )
+        self._update_report(urn, entity_urn.entity_type)
 
     def delete_soft_deleted_entity(self, urn: str) -> None:
         assert self.ctx.graph
-
-        if self.config.retention_days is None:
-            logger.info("Retention days is not set, skipping soft delete cleanup")
-            return
 
         retention_time = (
             int(datetime.now(timezone.utc).timestamp())
@@ -157,14 +180,47 @@ class SoftDeletedEntitiesCleanup:
             ]["created"]["time"] < (retention_time * 1000):
                 logger.debug(f"Hard deleting {urn}")
                 self.delete_entity(urn)
+            else:
+                self._increment_retained_count()
+
+    def _print_report(self) -> None:
+        time_taken = round(time.time() - self.last_print_time, 1)
+        # Print report every 5 minutes
+        if time_taken > 300:
+            self.last_print_time = time.time()
+            logger.info(f"\n{self.report.as_string()}")
+
+    def _process_futures(self, futures: Dict[Future, str]) -> Dict[Future, str]:
+        done, not_done = wait(futures, return_when=FIRST_COMPLETED)
+        futures = {future: urn for future, urn in futures.items() if future in not_done}
+
+        for future in done:
+            self._print_report()
+            if future.exception():
+                logger.error(
+                    f"Failed to delete entity {futures[future]}: {future.exception()}"
+                )
+                self.report.failure(
+                    f"Failed to delete entity {futures[future]}",
+                    exc=future.exception(),
+                )
+            self.report.num_soft_deleted_entity_processed += 1
+            if (
+                self.report.num_soft_deleted_entity_processed % self.config.batch_size
+                == 0
+            ):
+                if self.config.delay:
+                    logger.debug(
+                        f"Sleeping for {self.config.delay} seconds before further processing batch"
+                    )
+                    time.sleep(self.config.delay)
+        return futures
 
     def cleanup_soft_deleted_entities(self) -> None:
         if not self.config.enabled:
             return
         assert self.ctx.graph
-        start_time = time.time()
-
-        deleted_count_retention = 0
+        self.start_time = time.time()
         urns = self.ctx.graph.get_urns_by_filter(
             entity_types=self.config.entity_types,
             platform=self.config.platform,
@@ -174,51 +230,35 @@ class SoftDeletedEntitiesCleanup:
             batch_size=self.config.batch_size,
         )
 
-        futures = {}
+        futures: Dict[Future, str] = dict()
         with ThreadPoolExecutor(max_workers=self.config.max_workers) as executor:
-            num_urns_submitted = 0
             for urn in urns:
-                num_urns_submitted += 1
+                self._print_report()
+                while len(futures) > self.config.futures_max_at_time:
+                    futures = self._process_futures(futures)
                 if (
                     self.config.limit_entities_delete
-                    and num_urns_submitted > self.config.limit_entities_delete
+                    and self.report.num_soft_deleted_entity_removed
+                    > self.config.limit_entities_delete
                 ):
                     logger.info(
-                        f"Limit of {self.config.limit_entities_delete} entities reached. Stopping"
+                        f"Limit of {self.config.limit_entities_delete} entities reached. Stopped adding more."
                     )
                     break
                 if (
                     self.config.runtime_limit_seconds
-                    and time.time() - start_time > self.config.runtime_limit_seconds
+                    and time.time() - self.start_time
+                    > self.config.runtime_limit_seconds
                 ):
                     logger.info(
-                        f"Runtime limit of {self.config.runtime_limit_seconds} seconds reached. Stopping"
+                        f"Runtime limit of {self.config.runtime_limit_seconds} seconds reached. Not submitting more futures."
                     )
                     break
 
                 future = executor.submit(self.delete_soft_deleted_entity, urn)
                 futures[future] = urn
 
-            if not futures:
-                return
-            for future in as_completed(futures):
-                if future.exception():
-                    logger.error(
-                        f"Failed to delete entity {futures[future]}: {future.exception()}"
-                    )
-                    self.report.failure(
-                        f"Failed to delete entity {futures[future]}",
-                        exc=future.exception(),
-                    )
-                deleted_count_retention += 1
-
-                if deleted_count_retention % self.config.batch_size == 0:
-                    logger.info(
-                        f"Processed {deleted_count_retention} soft deleted entity and deleted {self.report.num_soft_deleted_entity_removed} entities so far"
-                    )
-
-                    if self.config.delay:
-                        logger.debug(
-                            f"Sleeping for {self.config.delay} seconds before getting next batch"
-                        )
-                        time.sleep(self.config.delay)
+            logger.info(f"Waiting for {len(futures)} futures to complete")
+            while len(futures) > 0:
+                self._print_report()
+                futures = self._process_futures(futures)


### PR DESCRIPTION
- If there were 25k entities that were retained due to age then nothing will get deleted even if there were items after that to be deleted. Because only 25k were being submitted while the limit was actually on 25k deletions.
- reporting improvement to understand how much was retained due to age
- `self.ctx.graph.get_urns_by_filter` does not return `query` entity so getting it separately so we can hard delete soft deleted query entities too

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
