### PR TITLE
fix(graphql/UI) Missing Typo Corrections for AssertionStdAggregation.UNIQUE_PROPORTION

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -7766,6 +7766,14 @@ enum AssertionStdAggregation {
     """
     Assertion is applied on proportion of distinct values in column
     """
+    UNIQUE_PROPORTION
+
+
+    """
+    Assertion is applied on proportion of distinct values in column
+
+    Deprecated! Use UNIQUE_PROPORTION instead.
+    """
     UNIQUE_PROPOTION
 
     """

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/DatasetAssertionDescription.tsx
@@ -92,7 +92,8 @@ const getColumnAggregationText = (
                 </Typography.Text>
             );
         }
-        case AssertionStdAggregation.UniquePropotion: {
+        case AssertionStdAggregation.UniquePropotion:
+        case AssertionStdAggregation.UniqueProportion: {
             return (
                 <Typography.Text>
                     Unique value proportion for column <Typography.Text strong>{columnText}</Typography.Text> is


### PR DESCRIPTION
ref) https://github.com/datahub-project/datahub/issues/6227

There are missing typo corrections for AssertionStdAggregation.UNIQUE_PROPORTION.
I have made some changes to the web UI code and the `entity.graphql` files.

Please let me know if you need any additional code modifications.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
