### PR TITLE
docs(queries_v2): set use_queries_v2 to true in snowflake_recipe.yml

### DIFF
--- a/metadata-ingestion/docs/sources/snowflake/snowflake_recipe.yml
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_recipe.yml
@@ -4,7 +4,7 @@ source:
     # This option is recommended to be used to ingest all lineage
     ignore_start_time_lineage: true
 
-    # This flag tells the snowflake ingestion to use the more modern lineage parsing. This will become the default eventually.
+    # This flag tells the snowflake ingestion to use the more advanced query parsing. This will become the default eventually.
     use_queries_v2: true
 
     # Coordinates

--- a/metadata-ingestion/docs/sources/snowflake/snowflake_recipe.yml
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_recipe.yml
@@ -4,6 +4,9 @@ source:
     # This option is recommended to be used to ingest all lineage
     ignore_start_time_lineage: true
 
+    # This flag tells the snowflake ingestion to use the more modern lineage parsing. This will become the default eventually.
+    use_queries_v2: true
+
     # Coordinates
     account_id: "abc48144"
     warehouse: "COMPUTE_WH"


### PR DESCRIPTION
We always recommend this, especially for someone's first run. the only reason it isn't default already is backward compatibility concerns.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
