### PR TITLE
fix(ingest/gc): also query data process instance

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/gc/soft_deleted_entity_cleanup.py
@@ -20,7 +20,7 @@ from datahub.utilities.urns._urn_base import Urn
 logger = logging.getLogger(__name__)
 
 QUERY_ENTITIES = """
-query listQueries($input: ScrollAcrossEntitiesInput!) {
+query listEntities($input: ScrollAcrossEntitiesInput!) {
   scrollAcrossEntities(input: $input) {
     nextScrollId
     count


### PR DESCRIPTION
There's a bug in the data process mapper that causes failures under specific conditions:
- When querying data process instance with or without any other entity
- AND when a data process instance actually exists

The solution is to sequence the operations, because:
- By handling the query entities first we can ensure that they will be cleaned up
- Once cleaned, even if the data process query fails it won't affect the query clean up

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
