### PR TITLE
feat(sdk): support urns in other urn constructors

### DIFF
--- a/metadata-ingestion/tests/unit/urns/test_urn.py
+++ b/metadata-ingestion/tests/unit/urns/test_urn.py
@@ -4,7 +4,13 @@ from typing import List
 
 import pytest
 
-from datahub.metadata.urns import CorpUserUrn, DatasetUrn, Urn
+from datahub.metadata.urns import (
+    CorpUserUrn,
+    DataPlatformUrn,
+    DatasetUrn,
+    SchemaFieldUrn,
+    Urn,
+)
 from datahub.utilities.urns.error import InvalidUrnError
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -58,6 +64,20 @@ def test_urn_coercion() -> None:
     assert urn.urn() == "urn:li:corpuser:foo%E2%90%9Fbar"
 
     assert urn == Urn.from_string(urn.urn())
+
+
+def test_urns_in_init() -> None:
+    platform = DataPlatformUrn("abc")
+    assert platform.urn() == "urn:li:dataPlatform:abc"
+
+    dataset_urn = DatasetUrn(platform, "def", "PROD")
+    assert dataset_urn.urn() == "urn:li:dataset:(urn:li:dataPlatform:abc,def,PROD)"
+
+    schema_field = SchemaFieldUrn(dataset_urn, "foo")
+    assert (
+        schema_field.urn()
+        == "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:abc,def,PROD),foo)"
+    )
 
 
 def test_urn_type_dispatch_1() -> None:


### PR DESCRIPTION
It used be the case that things like SchemaFieldUrn(dataset, field) required dataset to be a string. Now it supports `DatasetUrn` as well.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
