### PR TITLE
feat(ingestion/s3): ignore depth mismatched path

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -866,8 +866,21 @@ class S3Source(StatefulIngestionSourceBase):
         Returns:
         List[Folder]: A list of Folder objects representing the partitions found.
         """
+
+        def _is_allowed_path(path_spec_: PathSpec, s3_uri: str) -> bool:
+            allowed = path_spec_.allowed(s3_uri)
+            if not allowed:
+                logger.debug(f"File {s3_uri} not allowed and skipping")
+                self.report.report_file_dropped(s3_uri)
+            return allowed
+
+        s3_objects = (
+            obj
+            for obj in bucket.objects.filter(Prefix=prefix).page_size(PAGE_SIZE)
+            if _is_allowed_path(path_spec, f"s3://{obj.bucket_name}/{obj.key}")
+        )
+
         partitions: List[Folder] = []
-        s3_objects = bucket.objects.filter(Prefix=prefix).page_size(PAGE_SIZE)
         grouped_s3_objects_by_dirname = groupby_unsorted(
             s3_objects,
             key=lambda obj: obj.key.rsplit("/", 1)[0],
@@ -878,10 +891,6 @@ class S3Source(StatefulIngestionSourceBase):
             modification_time = None
 
             for item in group:
-                file_path = self.create_s3_path(item.bucket_name, item.key)
-                if not path_spec.allowed(file_path):
-                    logger.debug(f"File {file_path} not allowed and skipping")
-                    continue
                 file_size += item.size
                 if creation_time is None or item.last_modified < creation_time:
                     creation_time = item.last_modified

--- a/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
+++ b/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
@@ -1,0 +1,31 @@
+import pytest
+
+from datahub.ingestion.source.data_lake_common.path_spec import PathSpec
+
+
+@pytest.mark.parametrize(
+    "include, s3_uri, expected",
+    [
+        (
+            "s3://bucket/{table}/{partition0}/*.csv",
+            "s3://bucket/table/p1/test.csv",
+            True,
+        ),
+        (
+            "s3://bucket/{table}/{partition0}/*.csv",
+            "s3://bucket/table/p1/p2/test.csv",
+            False,
+        ),
+    ],
+)
+def test_allowed_ignores_depth_mismatch(
+    include: str, s3_uri: str, expected: bool
+) -> None:
+    # arrange
+    path_spec = PathSpec(
+        include=include,
+        table_name="{table}",
+    )
+
+    # act, assert
+    assert path_spec.allowed(s3_uri) == expected


### PR DESCRIPTION
## Summary

**Feature Addition:** 

Ignores the paths whose depth dose not match to `path_spec.include` while ingesting S3.

## Changes

### As-is
- Retrieves all paths under the prefix.

### To-be
- Retrieves only paths whose depth matches path_spec.include.


## Background

- Warning messages were triggered during S3 ingestion.
- This issue was caused by attempting to ingest paths whose depth does not match `path_spec.include`.
- Since this behavior seems unintended, I propose adding this feature.

### Logs
```
path_spec: s3://bucket/{table}/{partition0}/*.csv

s3_files:
1. s3://bucket/shop_log/year=2025/month=01/day=01/0000.csv
2. s3://bucket/shop_log/year=2025/month=01/day=02/0000.csv
3. s3://bucket/user_log/2025/0000.csv

============

**Before**

$ python s3_ingestion.py

INFO - Processing folder: datahub-test/shop_log
WARNING - Unable to find any files in the folder datahub-test/shop_log/year=2025. Skipping...
WARNING - Unable to find any files in the folder datahub-test/shop_log/year=2025/month=01. Skipping...
WARNING - Unable to find any files in the folder datahub-test/shop_log/year=2025/month=01/day=01. Skipping...
WARNING - Unable to find any files in the folder datahub-test/shop_log/year=2025/month=01/day=02. Skipping...
WARNING - Unable to find any files in the folder s3://bucket/datahub-test/shop_log/year=2025/. Skipping...


INFO - Processing folder: datahub-test/user_log
INFO - Getting files from folder: s3://bucket/datahub-test/user_log/2025/
INFO - Extracting table schema from file: s3://bucket/datahub-test/user_log/2025/ai_kpi.04_kst_v4_dag_runs.csv
INFO - Creating dataset urn with name: bucket/datahub-test/user_log

============

**After**

$ python s3_ingestion.py

INFO - Processing folder: datahub-test/shop_log
INFO - Getting files from folder: s3://bucket/datahub-test/shop_log/year=2025/
WARNING - Unable to find any files in the folder s3://bucket/datahub-test/shop_log/year=2025/. Skipping...


INFO - Processing folder: datahub-test/user_log
INFO - Getting files from folder: s3://bucket/datahub-test/user_log/2025/
INFO - Extracting table schema from file: s3://bucket/datahub-test/user_log/2025/ai_kpi.04_kst_v4_dag_runs.csv
INFO - Creating dataset urn with name: bucket/datahub-test/user_log

```

## How to reproduce

You can reproduce this issue by running the code below.

```
# s3_ingestion.py

from datahub.ingestion.run.pipeline import Pipeline

_DATAHUB_GMS_ENDPOINT = "<your_gms_endpoint>"
_DATAHUB_ACCESS_TOKEN = "<your_token>"

_S3_PATH = "s3://<your-bucket>/datahub-test/{table}/{partition0}/*.csv"

s3_config = {
        "source": {
            "type": "s3",
            "config": {
                "path_spec": {
                    "include": _S3_PATH
                },
                "aws_config": {
                    "aws_region": "ap-northeast-2",
                },
            },
        },
        "sink": {
            "type": "datahub-rest",
            "config": {
                "server": _DATAHUB_GMS_ENDPOINT,
                "token": _DATAHUB_ACCESS_TOKEN,
            },
        },
    }

pipeline = Pipeline.create(s3_config)
pipeline.run()
```



## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
