### PR TITLE
Super type dbt redshift

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -276,6 +276,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         "HLLSKETCH": NullType,
         "TIMETZ": TimeType,
         "VARBYTE": StringType,
+        "SUPER": NullType
     }
 
     def get_platform_instance_id(self) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/redshift/redshift.py
@@ -276,7 +276,7 @@ class RedshiftSource(StatefulIngestionSourceBase, TestableSource):
         "HLLSKETCH": NullType,
         "TIMETZ": TimeType,
         "VARBYTE": StringType,
-        "SUPER": NullType
+        "SUPER": NullType,
     }
 
     def get_platform_instance_id(self) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
@@ -93,7 +93,7 @@ POSTGRES_TYPES_MAP: Dict[str, Any] = {
     "regtype": None,
     "regrole": None,
     "regnamespace": None,
-    "super": None,
+    "super": NullType,
     "uuid": StringType,
     "pg_lsn": None,
     "tsvector": None,  # text search vector

--- a/metadata-ingestion/tests/unit/test_dbt_source.py
+++ b/metadata-ingestion/tests/unit/test_dbt_source.py
@@ -9,7 +9,12 @@ from datahub.emitter import mce_builder
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.source.dbt import dbt_cloud
 from datahub.ingestion.source.dbt.dbt_cloud import DBTCloudConfig
-from datahub.ingestion.source.dbt.dbt_common import DBTNode
+from datahub.ingestion.source.dbt.dbt_common import (
+    DBTNode,
+    DBTSourceReport,
+    NullTypeClass,
+    get_column_type,
+)
 from datahub.ingestion.source.dbt.dbt_core import (
     DBTCoreConfig,
     DBTCoreSource,
@@ -461,3 +466,30 @@ def test_dbt_time_parsing() -> None:
         assert timestamp.tzinfo is not None and timestamp.tzinfo.utcoffset(
             timestamp
         ) == timedelta(0)
+
+
+def test_get_column_type_redshift():
+    report = DBTSourceReport()
+    dataset_name = "test_dataset"
+
+    # Test 'super' type which should not show any warnings/errors
+    result_super = get_column_type(report, dataset_name, "super", "redshift")
+    assert isinstance(result_super.type, NullTypeClass)
+    assert (
+        len(report.infos) == 0
+    ), "No warnings should be generated for known SUPER type"
+
+    # Test unknown type, which generates a warning but resolves to NullTypeClass
+    unknown_type = "unknown_type"
+    result_unknown = get_column_type(report, dataset_name, unknown_type, "redshift")
+    assert isinstance(result_unknown.type, NullTypeClass)
+
+    # exact warning message for an unknown type
+    expected_context = f"{dataset_name} - {unknown_type}"
+    messages = [info for info in report.infos if expected_context in str(info.context)]
+    assert len(messages) == 1
+    assert messages[0].title == "Unable to map column types to DataHub types"
+    assert (
+        messages[0].message
+        == "Got an unexpected column type. The column's parsed field type will not be populated."
+    )


### PR DESCRIPTION
Pretty straightforward. Rather than have the redshift "super" type show up as unknown and give a warning, let's add it to the known types. Linked to issue https://linear.app/acryl-data/issue/CUS-3600/2-is-there-a-way-for-acryl-to-handle-super-type-field

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
