### PR TITLE
feat(build): use remote gradle cache

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -79,6 +79,20 @@ include ':metadata-service:openapi-servlet:models'
 include ':metadata-integration:java:datahub-schematron:lib'
 include ':metadata-integration:java:datahub-schematron:cli'
 
+buildCache {
+    def depotSecret = System.getenv('DEPOT_TOKEN');
+
+    remote(HttpBuildCache) {
+        url = 'https://cache.depot.dev'
+        enabled = depotSecret != null
+        push = true
+        credentials {
+            username = ''
+            password = depotSecret
+        }
+    }
+}
+
 def installPreCommitHooks() {
     def preCommitInstalled = false
     try {
@@ -116,7 +130,7 @@ def installPreCommitHooks() {
         def stderr = new StringBuilder()
         installHooksProcess.waitForProcessOutput(stdout, stderr)
         if (installHooksProcess.exitValue() != 0) {
-            println "Failed to install hooks: ${stderr}"
+            println "Failed to install hooks: ${stdout}"
             return
         }
         println "Hooks output: ${stdout}"


### PR DESCRIPTION
Uses depot under the hook. Requires a `DEPOT_TOKEN`, otherwise is a no-op.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
