### PR TITLE
feat(graphql) Format all graphql schema files to be consistent

### DIFF
--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -1,27 +1,27 @@
 # DataHub UI Application-Specific GraphQL Types
 
 extend type Query {
-    """
-    Fetch details associated with the authenticated user, provided via an auth cookie or header
-    """
-    me: AuthenticatedUser
+  """
+  Fetch details associated with the authenticated user, provided via an auth cookie or header
+  """
+  me: AuthenticatedUser
 
-    """
-    Fetch configurations
-    Used by DataHub UI
-    """
-    appConfig: AppConfig
+  """
+  Fetch configurations
+  Used by DataHub UI
+  """
+  appConfig: AppConfig
 
-    """
-    Fetch the Global Settings related to the Views feature.
-    Requires the 'Manage Global Views' Platform Privilege.
-    """
-    globalViewsSettings: GlobalViewsSettings
+  """
+  Fetch the Global Settings related to the Views feature.
+  Requires the 'Manage Global Views' Platform Privilege.
+  """
+  globalViewsSettings: GlobalViewsSettings
 
-    """
-    Fetch the global settings related to the docs propagation feature.
-    """
-    docPropagationSettings: DocPropagationSettings
+  """
+  Fetch the global settings related to the docs propagation feature.
+  """
+  docPropagationSettings: DocPropagationSettings
 }
 
 extend type Mutation {
@@ -34,7 +34,9 @@ extend type Mutation {
   """
   Update the doc propagation settings.
   """
-  updateDocPropagationSettings(input: UpdateDocPropagationSettingsInput!): Boolean!
+  updateDocPropagationSettings(
+    input: UpdateDocPropagationSettingsInput!
+  ): Boolean!
 }
 
 """
@@ -140,7 +142,7 @@ type PlatformPrivileges {
   Whether the user should be able to create, update, and delete ownership types.
   """
   manageOwnershipTypes: Boolean!
-  
+
   """
   Whether the user can create and delete posts pinned to the home page.
   """
@@ -283,7 +285,6 @@ type QueriesTabConfig {
   queriesTabResultSize: Int
 }
 
-
 """
 Configuration for different entity profiles
 """
@@ -309,10 +310,10 @@ type EntityProfileConfig {
 Configuration for a search result
 """
 type SearchResultsVisualConfig {
-    """
-    Whether a search result should highlight the name/description if it was matched on those fields.
-    """
-    enableNameHighlight: Boolean
+  """
+  Whether a search result should highlight the name/description if it was matched on those fields.
+  """
+  enableNameHighlight: Boolean
 }
 
 """
@@ -354,7 +355,6 @@ type AuthConfig {
   """
   tokenAuthEnabled: Boolean!
 }
-
 
 """
 Configurations related to the Policies Feature

--- a/datahub-graphql-core/src/main/resources/assertions.graphql
+++ b/datahub-graphql-core/src/main/resources/assertions.graphql
@@ -68,7 +68,6 @@ input UpsertCustomAssertionInput {
   Logic comprising a raw, unstructured assertion. for example - custom SQL query for the assertion.
   """
   logic: String
-
 }
 
 """
@@ -279,7 +278,6 @@ type AssertionAction {
   type: AssertionActionType!
 }
 
-
 """
 The type of the Action
 """
@@ -293,7 +291,6 @@ enum AssertionActionType {
   """
   RESOLVE_INCIDENT
 }
-
 
 """
 Information about an Freshness assertion.

--- a/datahub-graphql-core/src/main/resources/auth.graphql
+++ b/datahub-graphql-core/src/main/resources/auth.graphql
@@ -1,48 +1,47 @@
 # GraphQL for authentication related operations
 
 extend type Query {
-    """
-    Generates an access token for DataHub APIs for a particular user & of a particular type
-    Deprecated, use createAccessToken instead
-    """
-    getAccessToken(input: GetAccessTokenInput!): AccessToken
+  """
+  Generates an access token for DataHub APIs for a particular user & of a particular type
+  Deprecated, use createAccessToken instead
+  """
+  getAccessToken(input: GetAccessTokenInput!): AccessToken
 
-    """
-    List access tokens stored in DataHub.
-    """
-    listAccessTokens(input: ListAccessTokenInput!): ListAccessTokenResult!
+  """
+  List access tokens stored in DataHub.
+  """
+  listAccessTokens(input: ListAccessTokenInput!): ListAccessTokenResult!
 
-    """
-    Fetches the metadata of an access token.
-    This is useful to debug when you have a raw token but don't know the actor.
-    """
-    getAccessTokenMetadata(token: String!): AccessTokenMetadata!
+  """
+  Fetches the metadata of an access token.
+  This is useful to debug when you have a raw token but don't know the actor.
+  """
+  getAccessTokenMetadata(token: String!): AccessTokenMetadata!
 
-    """
-    Experimental API to debug Access for users.
-    Backward incompatible changes will be made without notice in the future.
-    Do not build on top of this API.
-    """
-    debugAccess(userUrn: String!): DebugAccessResult!
+  """
+  Experimental API to debug Access for users.
+  Backward incompatible changes will be made without notice in the future.
+  Do not build on top of this API.
+  """
+  debugAccess(userUrn: String!): DebugAccessResult!
 }
 
 extend type Mutation {
-    """
-    Generates an access token for DataHub APIs for a particular user & of a particular type
-    """
-    createAccessToken(input: CreateAccessTokenInput!): AccessToken
+  """
+  Generates an access token for DataHub APIs for a particular user & of a particular type
+  """
+  createAccessToken(input: CreateAccessTokenInput!): AccessToken
 
-    """
-    Revokes access tokens.
-    """
-    revokeAccessToken(tokenId: String!): Boolean!
+  """
+  Revokes access tokens.
+  """
+  revokeAccessToken(tokenId: String!): Boolean!
 }
 
 """
 Input required to fetch a new Access Token.
 """
 input GetAccessTokenInput {
-
   """
   The type of the Access Token.
   """
@@ -142,7 +141,6 @@ enum AccessTokenDuration {
 }
 
 type AccessToken {
-
   """
   The access token itself
   """
@@ -200,7 +198,6 @@ type ListAccessTokenResult {
 }
 
 type AccessTokenMetadata implements Entity {
-
   """
   The primary key of the access token
   """

--- a/datahub-graphql-core/src/main/resources/connection.graphql
+++ b/datahub-graphql-core/src/main/resources/connection.graphql
@@ -47,7 +47,6 @@ type DataHubConnection implements Entity {
   relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
-
 """
 The details of the Connection
 """

--- a/datahub-graphql-core/src/main/resources/contract.graphql
+++ b/datahub-graphql-core/src/main/resources/contract.graphql
@@ -1,15 +1,18 @@
 extend type Mutation {
-    """
-    Create or update a data contract for a given dataset. Requires the "Edit Data Contract" privilege for the provided dataset.
-    """
-    upsertDataContract(urn: String, input: UpsertDataContractInput!): DataContract!
+  """
+  Create or update a data contract for a given dataset. Requires the "Edit Data Contract" privilege for the provided dataset.
+  """
+  upsertDataContract(
+    urn: String
+    input: UpsertDataContractInput!
+  ): DataContract!
 }
 
 extend type Dataset {
-    """
-    An optional Data Contract defined for the Dataset.
-    """
-    contract: DataContract
+  """
+  An optional Data Contract defined for the Dataset.
+  """
+  contract: DataContract
 }
 
 """
@@ -20,164 +23,163 @@ on whether the assertions that compose the contract are passing or failing.
 Note that the data contract entity is currently in early preview (beta).
 """
 type DataContract implements Entity {
-    """
-    A primary key of the data contract
-    """
-    urn: String!
+  """
+  A primary key of the data contract
+  """
+  urn: String!
 
-    """
-    The standard entity type
-    """
-    type: EntityType!
+  """
+  The standard entity type
+  """
+  type: EntityType!
 
-    """
-    Properties describing the data contract
-    """
-    properties: DataContractProperties
+  """
+  Properties describing the data contract
+  """
+  properties: DataContractProperties
 
-    """
-    The status of the data contract
-    """
-    status: DataContractStatus
+  """
+  The status of the data contract
+  """
+  status: DataContractStatus
 
-    """
-    List of relationships between the source Entity and some destination entities with a given types
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  List of relationships between the source Entity and some destination entities with a given types
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 type DataContractProperties {
-    """
-    The urn of the related entity, e.g. the Dataset today. In the future, we may support additional contract entities.
-    """
-    entityUrn: String!
+  """
+  The urn of the related entity, e.g. the Dataset today. In the future, we may support additional contract entities.
+  """
+  entityUrn: String!
 
-    """
-    The Freshness (SLA) portion of the contract.
-    As of today, it is expected that there will not be more than 1 Freshness contract. If there are, only the first will be displayed.
-    """
-    freshness: [FreshnessContract!]
+  """
+  The Freshness (SLA) portion of the contract.
+  As of today, it is expected that there will not be more than 1 Freshness contract. If there are, only the first will be displayed.
+  """
+  freshness: [FreshnessContract!]
 
-    """
-    The schema / structural portion of the contract.
-    As of today, it is expected that there will not be more than 1 Schema contract. If there are, only the first will be displayed.
-    """
-    schema: [SchemaContract!]
+  """
+  The schema / structural portion of the contract.
+  As of today, it is expected that there will not be more than 1 Schema contract. If there are, only the first will be displayed.
+  """
+  schema: [SchemaContract!]
 
-    """
-    A set of data quality related contracts, e.g. table and column-level contract constraints.
-    """
-    dataQuality: [DataQualityContract!]
+  """
+  A set of data quality related contracts, e.g. table and column-level contract constraints.
+  """
+  dataQuality: [DataQualityContract!]
 }
 
 """
 The state of the data contract
 """
 enum DataContractState {
-    """
-    The data contract is active.
-    """
-    ACTIVE
+  """
+  The data contract is active.
+  """
+  ACTIVE
 
-    """
-    The data contract is pending. Note that this symbol is currently experimental.
-    """
-    PENDING
+  """
+  The data contract is pending. Note that this symbol is currently experimental.
+  """
+  PENDING
 }
 
 type DataContractStatus {
-    """
-    The state of the data contract
-    """
-    state: DataContractState!
+  """
+  The state of the data contract
+  """
+  state: DataContractState!
 }
 
 type DataQualityContract {
-    """
-    The assertion representing the schema contract.
-    """
-    assertion: Assertion!
+  """
+  The assertion representing the schema contract.
+  """
+  assertion: Assertion!
 }
 
 type SchemaContract {
-    """
-    The assertion representing the schema contract.
-    """
-    assertion: Assertion!
+  """
+  The assertion representing the schema contract.
+  """
+  assertion: Assertion!
 }
 
 type FreshnessContract {
-    """
-    The assertion representing the Freshness contract.
-    """
-    assertion: Assertion!
+  """
+  The assertion representing the Freshness contract.
+  """
+  assertion: Assertion!
 }
 
 """
 Input required to upsert a Data Contract entity for an asset
 """
 input UpsertDataContractInput {
-    """
-    The urn of the related entity. Dataset is the only entity type supported today.
-    """
-    entityUrn: String!
+  """
+  The urn of the related entity. Dataset is the only entity type supported today.
+  """
+  entityUrn: String!
 
-    """
-    The Freshness / Freshness portion of the contract. If not provided, this will be set to none.
-    For Dataset Contracts, it is expected that there will not be more than 1 Freshness contract. If there are, only the first will be displayed.
-    """
-    freshness: [FreshnessContractInput!]
+  """
+  The Freshness / Freshness portion of the contract. If not provided, this will be set to none.
+  For Dataset Contracts, it is expected that there will not be more than 1 Freshness contract. If there are, only the first will be displayed.
+  """
+  freshness: [FreshnessContractInput!]
 
-    """
-    The schema / structural portion of the contract. If not provided, this will be set to none.
-    For Dataset Contracts, it is expected that there will not be more than 1 Schema contract. If there are, only the first will be displayed.
-    """
-    schema: [SchemaContractInput!]
+  """
+  The schema / structural portion of the contract. If not provided, this will be set to none.
+  For Dataset Contracts, it is expected that there will not be more than 1 Schema contract. If there are, only the first will be displayed.
+  """
+  schema: [SchemaContractInput!]
 
-    """
-    The data quality portion of the contract. If not provided, this will be set to none.
-    """
-    dataQuality: [DataQualityContractInput!]
+  """
+  The data quality portion of the contract. If not provided, this will be set to none.
+  """
+  dataQuality: [DataQualityContractInput!]
 
-    """
-    The state of the data contract. If not provided, it will be in ACTIVE mode by default.
-    """
-    state: DataContractState
+  """
+  The state of the data contract. If not provided, it will be in ACTIVE mode by default.
+  """
+  state: DataContractState
 
-    """
-    Optional ID of the contract you want to create. Only applicable if this is a create operation. If not provided, a random
-    id will be generated for you.
-    """
-    id: String
+  """
+  Optional ID of the contract you want to create. Only applicable if this is a create operation. If not provided, a random
+  id will be generated for you.
+  """
+  id: String
 }
 
 """
 Input required to create an Freshness contract
 """
 input FreshnessContractInput {
-    """
-    The assertion monitoring this part of the data contract. Assertion must be of type Freshness.
-    """
-    assertionUrn: String!
+  """
+  The assertion monitoring this part of the data contract. Assertion must be of type Freshness.
+  """
+  assertionUrn: String!
 }
 
 """
 Input required to create a schema contract
 """
 input SchemaContractInput {
-    """
-    The assertion monitoring this part of the data contract. Assertion must be of type Data Schema.
-    """
-    assertionUrn: String!
+  """
+  The assertion monitoring this part of the data contract. Assertion must be of type Data Schema.
+  """
+  assertionUrn: String!
 }
 
 """
 Input required to create a data quality contract
 """
 input DataQualityContractInput {
-    """
-    The assertion monitoring this part of the data contract. Assertion must be of type Dataset, Volume, Field / Column, or Custom SQL.
-    """
-    assertionUrn: String!
+  """
+  The assertion monitoring this part of the data contract. Assertion must be of type Dataset, Volume, Field / Column, or Custom SQL.
+  """
+  assertionUrn: String!
 }
-

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1204,7 +1204,6 @@ enum EntityType {
   INCIDENT
 
   """
-  "
   A Role from an organisation
   """
   ROLE
@@ -1215,31 +1214,26 @@ enum EntityType {
   DATA_CONTRACT
 
   """
-  "
   An structured property on entities
   """
   STRUCTURED_PROPERTY
 
   """
-  "
   A form entity on entities
   """
   FORM
 
   """
-  "
   A data type registered to DataHub
   """
   DATA_TYPE
 
   """
-  "
   A type of entity registered to DataHub
   """
   ENTITY_TYPE
 
   """
-  "
   A type of entity that is restricted to the user
   """
   RESTRICTED

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -12061,7 +12061,6 @@ The subject for a Query
 type QuerySubject {
   """
   The dataset which is the subject of the Query.
-  If schemaField is not empty, this field represents the parent dataset of the schmeaField.
   """
   dataset: Dataset!
 }

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -5,8 +5,8 @@ scalar Long
 Root GraphQL API Schema
 """
 schema {
-    query: Query
-    mutation: Mutation
+  query: Query
+  mutation: Mutation
 }
 
 """
@@ -14,396 +14,399 @@ Root type used for fetching DataHub Metadata
 Coming soon listEntity queries for listing all entities of a given type
 """
 type Query {
-    """
-    Fetch a Data Platform by primary key (urn)
-    """
-    dataPlatform(urn: String!): DataPlatform
+  """
+  Fetch a Data Platform by primary key (urn)
+  """
+  dataPlatform(urn: String!): DataPlatform
 
-    """
-    Fetch a CorpUser, representing a DataHub platform user, by primary key (urn)
-    """
-    corpUser(urn: String!): CorpUser
+  """
+  Fetch a CorpUser, representing a DataHub platform user, by primary key (urn)
+  """
+  corpUser(urn: String!): CorpUser
 
-    """
-    Fetch a CorpGroup, representing a DataHub platform group by primary key (urn)
-    """
-    corpGroup(urn: String!): CorpGroup
+  """
+  Fetch a CorpGroup, representing a DataHub platform group by primary key (urn)
+  """
+  corpGroup(urn: String!): CorpGroup
 
-    """
-    Fetch a Dataset by primary key (urn)
-    """
-    dataset(urn: String!): Dataset
+  """
+  Fetch a Dataset by primary key (urn)
+  """
+  dataset(urn: String!): Dataset
 
-    """
-    Fetch a Dataset by primary key (urn) at a point in time based on aspect versions (versionStamp)
-    """
-    versionedDataset(urn: String!, versionStamp: String): VersionedDataset
+  """
+  Fetch a Dataset by primary key (urn) at a point in time based on aspect versions (versionStamp)
+  """
+  versionedDataset(urn: String!, versionStamp: String): VersionedDataset
 
-    """
-    Fetch a Dashboard by primary key (urn)
-    """
-    dashboard(urn: String!): Dashboard
+  """
+  Fetch a Dashboard by primary key (urn)
+  """
+  dashboard(urn: String!): Dashboard
 
-    """
-    Fetch a Notebook by primary key (urn)
-    """
-    notebook(urn: String!): Notebook
+  """
+  Fetch a Notebook by primary key (urn)
+  """
+  notebook(urn: String!): Notebook
 
-    """
-    Fetch a Chart by primary key (urn)
-    """
-    chart(urn: String!): Chart
+  """
+  Fetch a Chart by primary key (urn)
+  """
+  chart(urn: String!): Chart
 
-    """
-    Fetch a Data Flow (or Data Pipeline) by primary key (urn)
-    """
-    dataFlow(urn: String!): DataFlow
+  """
+  Fetch a Data Flow (or Data Pipeline) by primary key (urn)
+  """
+  dataFlow(urn: String!): DataFlow
 
-    """
-    Fetch a Data Job (or Data Task) by primary key (urn)
-    """
-    dataJob(urn: String!): DataJob
+  """
+  Fetch a Data Job (or Data Task) by primary key (urn)
+  """
+  dataJob(urn: String!): DataJob
 
-    """
-    Fetch a Tag by primary key (urn)
-    """
-    tag(urn: String!): Tag
+  """
+  Fetch a Tag by primary key (urn)
+  """
+  tag(urn: String!): Tag
 
-    """
-    Fetch a View by primary key (urn)
-    """
-    view(urn: String!): DataHubView
+  """
+  Fetch a View by primary key (urn)
+  """
+  view(urn: String!): DataHubView
 
-    """
-    Fetch a Form by primary key (urn)
-    """
-    form(urn: String!): Form
+  """
+  Fetch a Form by primary key (urn)
+  """
+  form(urn: String!): Form
 
-    """
-    Fetch a Role by primary key (urn)
-    """
-    role(urn: String!): Role
+  """
+  Fetch a Role by primary key (urn)
+  """
+  role(urn: String!): Role
 
-    """
-    Fetch a Structured Property by primary key (urn)
-    """
-    structuredProperty(urn: String!): StructuredPropertyEntity
+  """
+  Fetch a Structured Property by primary key (urn)
+  """
+  structuredProperty(urn: String!): StructuredPropertyEntity
 
-    """
-    Fetch a ERModelRelationship by primary key (urn)
-    """
-    erModelRelationship(urn: String!): ERModelRelationship
+  """
+  Fetch a ERModelRelationship by primary key (urn)
+  """
+  erModelRelationship(urn: String!): ERModelRelationship
 
-    """
-    Fetch a Glossary Term by primary key (urn)
-    """
-    glossaryTerm(urn: String!): GlossaryTerm
+  """
+  Fetch a Glossary Term by primary key (urn)
+  """
+  glossaryTerm(urn: String!): GlossaryTerm
 
-    """
-    Fetch a Glossary Node by primary key (urn)
-    """
-    glossaryNode(urn: String!): GlossaryNode
+  """
+  Fetch a Glossary Node by primary key (urn)
+  """
+  glossaryNode(urn: String!): GlossaryNode
 
-    """
-    Fetch an Entity Container by primary key (urn)
-    """
-    container(urn: String!): Container
+  """
+  Fetch an Entity Container by primary key (urn)
+  """
+  container(urn: String!): Container
 
-    """
-    Fetch a Domain by primary key (urn)
-    """
-    domain(urn: String!): Domain
+  """
+  Fetch a Domain by primary key (urn)
+  """
+  domain(urn: String!): Domain
 
-    """
-    Fetch an Assertion by primary key (urn)
-    """
-    assertion(urn: String!): Assertion
+  """
+  Fetch an Assertion by primary key (urn)
+  """
+  assertion(urn: String!): Assertion
 
-    """
-    List all DataHub Access Policies
-    """
-    listPolicies(input: ListPoliciesInput!): ListPoliciesResult
+  """
+  List all DataHub Access Policies
+  """
+  listPolicies(input: ListPoliciesInput!): ListPoliciesResult
 
-    """
-    Get all granted privileges for the given actor and resource
-    """
-    getGrantedPrivileges(input: GetGrantedPrivilegesInput!): Privileges
+  """
+  Get all granted privileges for the given actor and resource
+  """
+  getGrantedPrivileges(input: GetGrantedPrivilegesInput!): Privileges
 
-    """
-    Incubating: Fetch an ML Model by primary key (urn)
-    """
-    mlModel(urn: String!): MLModel
+  """
+  Incubating: Fetch an ML Model by primary key (urn)
+  """
+  mlModel(urn: String!): MLModel
 
-    """
-    Incubating: Fetch an ML Model Group by primary key (urn)
-    """
-    mlModelGroup(urn: String!): MLModelGroup
+  """
+  Incubating: Fetch an ML Model Group by primary key (urn)
+  """
+  mlModelGroup(urn: String!): MLModelGroup
 
-    """
-    Incubating: Fetch a ML Feature by primary key (urn)
-    """
-    mlFeature(urn: String!): MLFeature
+  """
+  Incubating: Fetch a ML Feature by primary key (urn)
+  """
+  mlFeature(urn: String!): MLFeature
 
-    """
-    Incubating: Fetch a ML Feature Table by primary key (urn)
-    """
-    mlFeatureTable(urn: String!): MLFeatureTable
+  """
+  Incubating: Fetch a ML Feature Table by primary key (urn)
+  """
+  mlFeatureTable(urn: String!): MLFeatureTable
 
-    """
-    Incubating: Fetch a ML Primary Key by primary key (urn)
-    """
-    mlPrimaryKey(urn: String!): MLPrimaryKey
+  """
+  Incubating: Fetch a ML Primary Key by primary key (urn)
+  """
+  mlPrimaryKey(urn: String!): MLPrimaryKey
 
-    """
-    List all DataHub Users
-    """
-    listUsers(input: ListUsersInput!): ListUsersResult
+  """
+  List all DataHub Users
+  """
+  listUsers(input: ListUsersInput!): ListUsersResult
 
-    """
-    List all DataHub Groups
-    """
-    listGroups(input: ListGroupsInput!): ListGroupsResult
+  """
+  List all DataHub Groups
+  """
+  listGroups(input: ListGroupsInput!): ListGroupsResult
 
-    """
-    Fetches the number of entities ingested by type
-    """
-    getEntityCounts(input: EntityCountInput): EntityCountResults
+  """
+  Fetches the number of entities ingested by type
+  """
+  getEntityCounts(input: EntityCountInput): EntityCountResults
 
-    """
-    List all DataHub Domains
-    """
-    listDomains(input: ListDomainsInput!): ListDomainsResult
+  """
+  List all DataHub Domains
+  """
+  listDomains(input: ListDomainsInput!): ListDomainsResult
 
-    """
-    Get all GlossaryTerms without a parentNode
-    """
-    getRootGlossaryTerms(input: GetRootGlossaryEntitiesInput!): GetRootGlossaryTermsResult
+  """
+  Get all GlossaryTerms without a parentNode
+  """
+  getRootGlossaryTerms(
+    input: GetRootGlossaryEntitiesInput!
+  ): GetRootGlossaryTermsResult
 
-    """
-    Get all GlossaryNodes without a parentNode
-    """
-    getRootGlossaryNodes(input: GetRootGlossaryEntitiesInput!): GetRootGlossaryNodesResult
+  """
+  Get all GlossaryNodes without a parentNode
+  """
+  getRootGlossaryNodes(
+    input: GetRootGlossaryEntitiesInput!
+  ): GetRootGlossaryNodesResult
 
-    """
-    Get whether or not not an entity exists
-    """
-    entityExists(urn: String!): Boolean
+  """
+  Get whether or not not an entity exists
+  """
+  entityExists(urn: String!): Boolean
 
-    """
-    Gets an entity based on its urn
-    """
-    entity(urn: String!): Entity
+  """
+  Gets an entity based on its urn
+  """
+  entity(urn: String!): Entity
 
-    """
-    Gets entities based on their urns
-    """
-    entities(urns: [String!]!): [Entity]
+  """
+  Gets entities based on their urns
+  """
+  entities(urns: [String!]!): [Entity]
 
-    """
-    List all DataHub Roles
-    """
-    listRoles(input: ListRolesInput!): ListRolesResult
+  """
+  List all DataHub Roles
+  """
+  listRoles(input: ListRolesInput!): ListRolesResult
 
-    """
-    Get invite token
-    """
-    getInviteToken(input: GetInviteTokenInput!): InviteToken
+  """
+  Get invite token
+  """
+  getInviteToken(input: GetInviteTokenInput!): InviteToken
 
-    """
-    List all Posts
-    """
-    listPosts(input: ListPostsInput!): ListPostsResult
+  """
+  List all Posts
+  """
+  listPosts(input: ListPostsInput!): ListPostsResult
 
-    """
-    List DataHub Views owned by the current user
-    """
-    listMyViews(input: ListMyViewsInput!): ListViewsResult
+  """
+  List DataHub Views owned by the current user
+  """
+  listMyViews(input: ListMyViewsInput!): ListViewsResult
 
-    """
-    List Global DataHub Views
-    """
-    listGlobalViews(input: ListGlobalViewsInput!): ListViewsResult
+  """
+  List Global DataHub Views
+  """
+  listGlobalViews(input: ListGlobalViewsInput!): ListViewsResult
 
-    """
-    List Dataset Queries
-    """
-    listQueries(
-      "Input required for listing queries"
-      input: ListQueriesInput!): ListQueriesResult
+  """
+  List Dataset Queries
+  """
+  listQueries(
+    "Input required for listing queries"
+    input: ListQueriesInput!
+  ): ListQueriesResult
 
-    """
-    Get quick filters to display in auto-complete
-    """
-    getQuickFilters(input: GetQuickFiltersInput!): GetQuickFiltersResult
+  """
+  Get quick filters to display in auto-complete
+  """
+  getQuickFilters(input: GetQuickFiltersInput!): GetQuickFiltersResult
 
-    """
-    Fetch a DataProduct by primary key (urn)
-    """
-    dataProduct(urn: String!): DataProduct
+  """
+  Fetch a DataProduct by primary key (urn)
+  """
+  dataProduct(urn: String!): DataProduct
 
-    """
-    List Custom Ownership Types
-    """
-    listOwnershipTypes(
-        "Input required for listing custom ownership types"
-        input: ListOwnershipTypesInput!): ListOwnershipTypesResult!
+  """
+  List Custom Ownership Types
+  """
+  listOwnershipTypes(
+    "Input required for listing custom ownership types"
+    input: ListOwnershipTypesInput!
+  ): ListOwnershipTypesResult!
 
-    """
-    Fetch a Data Platform Instance by primary key (urn)
-    """
-    dataPlatformInstance(urn: String!): DataPlatformInstance
+  """
+  Fetch a Data Platform Instance by primary key (urn)
+  """
+  dataPlatformInstance(urn: String!): DataPlatformInstance
 
-    """
-    Fetch a Business Attribute by primary key (urn)
-    """
-    businessAttribute(urn: String!): BusinessAttribute
+  """
+  Fetch a Business Attribute by primary key (urn)
+  """
+  businessAttribute(urn: String!): BusinessAttribute
 
-    """
-    Fetch all Business Attributes
-    """
-    listBusinessAttributes(input: ListBusinessAttributesInput!): ListBusinessAttributesResult
+  """
+  Fetch all Business Attributes
+  """
+  listBusinessAttributes(
+    input: ListBusinessAttributesInput!
+  ): ListBusinessAttributesResult
 
-    """
-    Fetch a Data Process Instance by primary key (urn)
-    """
-    dataProcessInstance(urn: String!): DataProcessInstance
-
-
+  """
+  Fetch a Data Process Instance by primary key (urn)
+  """
+  dataProcessInstance(urn: String!): DataProcessInstance
 }
-
 
 """
 An ERModelRelationship is a high-level abstraction that dictates what datasets fields are erModelRelationshiped.
 """
 type ERModelRelationship implements EntityWithRelationships & Entity {
-    """
-    The primary key of the role
-    """
-    urn: String!
+  """
+  The primary key of the role
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Unique id for the erModelRelationship
-    """
-    id: String!
+  """
+  Unique id for the erModelRelationship
+  """
+  id: String!
 
-    """
-    An additional set of read only properties
-    """
-    properties: ERModelRelationshipProperties
+  """
+  An additional set of read only properties
+  """
+  properties: ERModelRelationshipProperties
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: ERModelRelationshipEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: ERModelRelationshipEditableProperties
 
-    """
-    References to internal resources related to the dataset
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dataset
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Ownership metadata of the dataset
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the dataset
+  """
+  ownership: Ownership
 
-    """
-    Status of the Dataset
-    """
-    status: Status
+  """
+  Status of the Dataset
+  """
+  status: Status
 
-    """
-    Tags used for searching dataset
-    """
-    tags: GlobalTags
+  """
+  Tags used for searching dataset
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the dataset
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dataset
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    List of relationships between the source Entity and some destination entities with a given types
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  List of relationships between the source Entity and some destination entities with a given types
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    No-op required for the model
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  No-op required for the model
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 }
 
 """
 Additional properties about a ERModelRelationship
 """
 type ERModelRelationshipEditableProperties {
-
-    """
-    Documentation of the ERModelRelationship
-    """
-    description: String
-    """
-    Display name of the ERModelRelationship
-    """
-    name: String
+  """
+  Documentation of the ERModelRelationship
+  """
+  description: String
+  """
+  Display name of the ERModelRelationship
+  """
+  name: String
 }
 
 """
 Additional properties about a ERModelRelationship
 """
 type ERModelRelationshipProperties {
+  """
+  The name of the ERModelRelationship used in display
+  """
+  name: String!
+  """
+  The urn of source
+  """
+  source: Dataset!
 
-    """
-    The name of the ERModelRelationship used in display
-    """
-    name: String!
-    """
-    The urn of source
-    """
-    source: Dataset!
+  """
+  The urn of destination
+  """
+  destination: Dataset!
 
-    """
-    The urn of destination
-    """
-    destination: Dataset!
+  """
+  The relationFieldMappings
+  """
+  relationshipFieldMappings: [RelationshipFieldMapping!]
 
-    """
-    The relationFieldMappings
-    """
-    relationshipFieldMappings: [RelationshipFieldMapping!]
+  """
+  Created timestamp millis associated with the ERModelRelationship
+  """
+  createdTime: Long
 
-    """
-    Created timestamp millis associated with the ERModelRelationship
-    """
-    createdTime: Long
-
-    """
-    Created actor urn associated with the ERModelRelationship
-    """
-    createdActor: Entity
+  """
+  Created actor urn associated with the ERModelRelationship
+  """
+  createdActor: Entity
 }
 
 """
 ERModelRelationship FieldMap
 """
 type RelationshipFieldMapping {
-    """
-    left field
-    """
-    sourceField: String!
-    """
-    bfield
-    """
-    destinationField: String!
+  """
+  left field
+  """
+  sourceField: String!
+  """
+  bfield
+  """
+  destinationField: String!
 }
 
 """
@@ -411,581 +414,594 @@ Root type used for updating DataHub Metadata
 Coming soon createEntity, addOwner, removeOwner mutations
 """
 type Mutation {
-    """
-    Update the metadata about a particular Dataset
-    """
-    updateDataset(urn: String!, input: DatasetUpdateInput!): Dataset
-
-    """
-    Update the metadata about a batch of Datasets
-    """
-    updateDatasets(input: [BatchDatasetUpdateInput!]!): [Dataset]
-
-    """
-    Update the metadata about a particular Chart
-    """
-    updateChart(urn: String!, input: ChartUpdateInput!): Chart
-
-    """
-    Update the metadata about a particular Dashboard
-    """
-    updateDashboard(urn: String!, input: DashboardUpdateInput!): Dashboard
-
-    """
-    Update the metadata about a particular Notebook
-    """
-    updateNotebook(urn: String!, input: NotebookUpdateInput!): Notebook
-
-    """
-    Update the metadata about a particular Data Flow (Pipeline)
-    """
-    updateDataFlow(urn: String!, input: DataFlowUpdateInput!): DataFlow
-
-    """
-    Update the metadata about a particular Data Job (Task)
-    """
-    updateDataJob(urn: String!, input: DataJobUpdateInput!): DataJob
-
-    """
-    Create a new tag. Requires the 'Manage Tags' or 'Create Tags' Platform Privilege. If a Tag with the provided ID already exists,
-    it will be overwritten.
-    """
-    createTag(
-      "Inputs required to create a new Tag."
-      input: CreateTagInput!): String
-
-    """
-    Update the information about a particular Entity Tag
-    """
-    updateTag(urn: String!, input: TagUpdateInput!): Tag
-
-    """
-    Delete a Tag
-    """
-    deleteTag(
-      "The urn of the Tag to delete"
-      urn: String!): Boolean
-
-    """
-    Set the hex color associated with an existing Tag
-    """
-    setTagColor(urn: String!, colorHex: String!): Boolean
-
-    """
-    Create a policy and returns the resulting urn
-    """
-    createPolicy(input: PolicyUpdateInput!): String
-
-    """
-    Update an existing policy and returns the resulting urn
-    """
-    updatePolicy(urn: String!, input: PolicyUpdateInput!): String
-
-    """
-    Remove an existing policy and returns the policy urn
-    """
-    deletePolicy(urn: String!): String
-
-    """
-		Add a tag to a particular Entity or subresource
-    """
-    addTag(input: TagAssociationInput!): Boolean
-
-    """
-		Add multiple tags to a particular Entity or subresource
-    """
-    addTags(input: AddTagsInput!): Boolean
-
-    """
-    Add tags to multiple Entities or subresources
-    """
-    batchAddTags(input: BatchAddTagsInput!): Boolean
-
-    """
-		Remove a tag from a particular Entity or subresource
-    """
-    removeTag(input: TagAssociationInput!): Boolean
-
-    """
-		Remove tags from multiple Entities or subresource
-    """
-    batchRemoveTags(input: BatchRemoveTagsInput!): Boolean
-
-    """
-		Add a glossary term to a particular Entity or subresource
-    """
-    addTerm(input: TermAssociationInput!): Boolean
-
-    """
-		Add glossary terms to multiple Entities or subresource
-    """
-    batchAddTerms(input: BatchAddTermsInput!): Boolean
-
-    """
-		Add multiple glossary terms to a particular Entity or subresource
-    """
-    addTerms(input: AddTermsInput!): Boolean
-
-    """
-		Remove a glossary term from a particular Entity or subresource
-    """
-    removeTerm(input: TermAssociationInput!): Boolean
-
-    """
-		Remove glossary terms from multiple Entities or subresource
-    """
-    batchRemoveTerms(input: BatchRemoveTermsInput!): Boolean
-
-    """
-    Add an owner to a particular Entity
-    """
-    addOwner(input: AddOwnerInput!): Boolean
-
-    """
-    Add owners to multiple Entities
-    """
-    batchAddOwners(input: BatchAddOwnersInput!): Boolean
-
-    """
-    Add multiple owners to a particular Entity
-    """
-    addOwners(input: AddOwnersInput!): Boolean
-
-    """
-    Remove an owner from a particular Entity
-    """
-    removeOwner(input: RemoveOwnerInput!): Boolean
-
-    """
-    Remove owners from multiple Entities
-    """
-    batchRemoveOwners(input: BatchRemoveOwnersInput!): Boolean
-
-    """
-    Add a link, or institutional memory, from a particular Entity
-    """
-    addLink(input: AddLinkInput!): Boolean
-
-    """
-    Remove a link, or institutional memory, from a particular Entity
-    """
-    removeLink(input: RemoveLinkInput!): Boolean
-
-    """
-    Incubating. Updates the description of a resource. Currently only supports Dataset Schema Fields, Containers
-    """
-    updateDescription(input: DescriptionUpdateInput!): Boolean
-
-    """
-    Remove a user. Requires Manage Users & Groups Platform Privilege
-    """
-    removeUser(urn: String!): Boolean
-
-    """
-    Change the status of a user. Requires Manage Users & Groups Platform Privilege
-    """
-    updateUserStatus(urn: String!, status: CorpUserStatus!): String
-
-    """
-    Remove a group. Requires Manage Users & Groups Platform Privilege
-    """
-    removeGroup(urn: String!): Boolean
-
-    """
-    Add members to a group
-    """
-    addGroupMembers(input: AddGroupMembersInput!): Boolean
-
-    """
-    Remove members from a group
-    """
-    removeGroupMembers(input: RemoveGroupMembersInput!): Boolean
-
-    """
-    Create a new group. Returns the urn of the newly created group. Requires the Manage Users & Groups Platform Privilege
-    """
-    createGroup(input: CreateGroupInput!): String
-
-    """
-    Create a new Domain. Returns the urn of the newly created Domain. Requires the 'Create Domains' or 'Manage Domains' Platform Privilege. If a Domain with the provided ID already exists,
-    it will be overwritten.
-    """
-    createDomain(input: CreateDomainInput!): String
-
-    """
-    Moves a domain to be parented under another domain.
-    """
-    moveDomain(input: MoveDomainInput!): Boolean
-
-    """
-    Delete a Domain
-    """
-    deleteDomain(
-      "The urn of the Domain to delete"
-      urn: String!): Boolean
-
-
-    """
-    Sets the Domain for a Dataset, Chart, Dashboard, Data Flow (Pipeline), or Data Job (Task). Returns true if the Domain was successfully added, or already exists. Requires the Edit Domains privilege for the Entity.
-    """
-    setDomain(entityUrn: String!, domainUrn: String!): Boolean
-
-    """
-    Set domain for multiple Entities
-    """
-    batchSetDomain(input: BatchSetDomainInput!): Boolean
-
-    """
-    Sets the Domain for a Dataset, Chart, Dashboard, Data Flow (Pipeline), or Data Job (Task). Returns true if the Domain was successfully removed, or was already removed. Requires the Edit Domains privilege for an asset.
-    """
-    unsetDomain(entityUrn: String!): Boolean
-
-    """
-    Create a ERModelRelationship
-    """
-    createERModelRelationship(
-        "Input required to create a new ERModelRelationship"
-        input: ERModelRelationshipUpdateInput!): ERModelRelationship
-
-    """
-    Update a ERModelRelationship
-    """
-    updateERModelRelationship(
-        "The urn of the ERModelRelationship to update"
-        urn: String!,
-        "Input required to update an existing DataHub View"
-        input: ERModelRelationshipUpdateInput!): Boolean
-
-    """
-    Delete a ERModelRelationship
-    """
-    deleteERModelRelationship(
-        "The urn of the ERModelRelationship to delete"
-        urn: String!): Boolean
-
-
-
-    """
-    Sets the Deprecation status for a Metadata Entity. Requires the Edit Deprecation status privilege for an entity.
-    """
-    updateDeprecation(
-      "Input required to set deprecation for an Entity."
-      input: UpdateDeprecationInput!): Boolean
-
-    """
-    Updates the deprecation status for a batch of assets.
-    """
-    batchUpdateDeprecation(input: BatchUpdateDeprecationInput!): Boolean
-
-    """
-    Update a particular Corp User's editable properties
-    """
-    updateCorpUserProperties(urn: String!, input: CorpUserUpdateInput!): CorpUser
-
-    """
-    Update a particular Corp Group's editable properties
-    """
-    updateCorpGroupProperties(urn: String!, input: CorpGroupUpdateInput!): CorpGroup
-
-    """
-    Remove an assertion associated with an entity. Requires the 'Edit Assertions' privilege on the entity.
-    """
-    deleteAssertion(
-      """
-      The assertion to remove
-      """
-      urn: String!): Boolean
-
-    """
-    Report a new operation for an asset
-    """
-    reportOperation(
-      """
-      Input required to report an operation
-      """
-      input: ReportOperationInput!): String
-
-    """
-    Create a new GlossaryTerm. Returns the urn of the newly created GlossaryTerm. If a term with the provided ID already exists, it will be overwritten.
-    """
-    createGlossaryTerm(input: CreateGlossaryEntityInput!): String
-
-    """
-    Create a new GlossaryNode. Returns the urn of the newly created GlossaryNode. If a node with the provided ID already exists, it will be overwritten.
-    """
-    createGlossaryNode(input: CreateGlossaryEntityInput!): String
-
-    """
-    Updates the parent node of a resource. Currently only GlossaryNodes and GlossaryTerms have parentNodes.
-    """
-    updateParentNode(input: UpdateParentNodeInput!): Boolean
-
-    """
-    Remove a glossary entity (GlossaryTerm or GlossaryNode). Return boolean whether it was successful or not.
-    """
-    deleteGlossaryEntity(urn: String!): Boolean
-
-    """
-    Updates the name of the entity.
-    """
-    updateName(input: UpdateNameInput!): Boolean
-
-    """
-    Add multiple related Terms to a Glossary Term to establish relationships
-    """
-    addRelatedTerms(input: RelatedTermsInput!): Boolean
-
-    """
-    Remove multiple related Terms for a Glossary Term
-    """
-    removeRelatedTerms(input: RelatedTermsInput!): Boolean
-
-    """
-    Generates a token that can be shared with existing native users to reset their credentials.
-    """
-    createNativeUserResetToken(input: CreateNativeUserResetTokenInput!): ResetToken
-
-    """
-    Updates the soft deleted status for a batch of assets
-    """
-    batchUpdateSoftDeleted(input: BatchUpdateSoftDeletedInput!): Boolean
-
-    """
-    Update the View-related settings for a user.
-    """
-    updateCorpUserViewsSettings(input: UpdateCorpUserViewsSettingsInput!): Boolean
-
-    """
-    Update a user setting
-    """
-    updateUserSetting(input: UpdateUserSettingInput!): Boolean
-
-    """
-    Batch assign roles to users
-    """
-    batchAssignRole(input: BatchAssignRoleInput!): Boolean
-
-    """
-    Accept role using invite token
-    """
-    acceptRole(input: AcceptRoleInput!): Boolean
-
-    """
-    Create invite token
-    """
-    createInviteToken(input: CreateInviteTokenInput!): InviteToken
-
-    """
-    Create a post
-    """
-    createPost(input: CreatePostInput!): Boolean
-
-    """
-    Update or edit a post
-    """
-    updatePost(input: UpdatePostInput!): Boolean
-
-    """
-    Delete a post
-    """
-    deletePost(urn: String!): Boolean
-
-    """
-    Create a new DataHub View (Saved Filter)
-    """
-    createView(
-      "Input required to create a new DataHub View"
-      input: CreateViewInput!): DataHubView
-
-    """
-    Delete a DataHub View (Saved Filter)
-    """
-    updateView(
-      "The urn of the View to update"
-      urn: String!,
-      "Input required to update an existing DataHub View"
-      input: UpdateViewInput!): DataHubView
-
-    """
-    Delete a DataHub View (Saved Filter)
-    """
-    deleteView(
-      "The urn of the View to delete"
-      urn: String!): Boolean
-
-    """
-    Update lineage for an entity
-    """
-    updateLineage(input: UpdateLineageInput!): Boolean
-
-    """
-    Update the Embed information for a Dataset, Dashboard, or Chart.
-    """
-    updateEmbed(input: UpdateEmbedInput!): Boolean
-
-    """
-    Create a new Query
-    """
-    createQuery(
-      "Inputs required to create a new Query."
-      input: CreateQueryInput!): QueryEntity
-
-    """
-    Update an existing Query
-    """
-    updateQuery(
-      "The urn identifier for the query to update."
-      urn: String!,
-      "Inputs required to update a Query."
-      input: UpdateQueryInput!): QueryEntity
-
-    """
-    Delete a Query by urn. This requires the 'Edit Queries' Metadata Privilege.
-    """
-    deleteQuery(
-      "Urn of the query to remove."
-      urn: String!): Boolean
-
-    """
-    Create a new Data Product
-    """
-    createDataProduct(
-      "Inputs required to create a new DataProduct."
-      input: CreateDataProductInput!): DataProduct
-
-    """
-    Update a Data Product
-    """
-    updateDataProduct(
-      "The urn identifier for the Data Product to update."
-      urn: String!,
-      "Inputs required to create a new DataProduct."
-      input: UpdateDataProductInput!): DataProduct
-
-    """
-    Delete a DataProduct by urn.
-    """
-    deleteDataProduct(
-        "Urn of the data product to remove."
-        urn: String!): Boolean
-
-    """
-    Batch set or unset a DataProduct to a list of entities
-    """
-    batchSetDataProduct(
-        "Input for batch setting data product"
-        input: BatchSetDataProductInput!): Boolean
-
-    """
-    Create a Custom Ownership Type. This requires the 'Manage Ownership Types' Metadata Privilege.
-    """
-    createOwnershipType(
-        "Inputs required to create a new Query."
-        input: CreateOwnershipTypeInput!): OwnershipTypeEntity
-
-    """
-    Update an existing Query. This requires the 'Manage Ownership Types' Metadata Privilege.
-    """
-    updateOwnershipType(
-        "The urn identifier for the custom ownership type to update."
-        urn: String!,
-        "Inputs required to update an existing Custom Ownership Type."
-        input: UpdateOwnershipTypeInput!): OwnershipTypeEntity
-
-    """
-    Delete a Custom Ownership Type by urn. This requires the 'Manage Ownership Types' Metadata Privilege.
-    """
-    deleteOwnershipType(
-        "Urn of the Custom Ownership Type to remove."
-        urn: String!, deleteReferences: Boolean): Boolean
-
-    """
-    Submit a response to a prompt from a form collecting metadata on different entities.
-    Provide the urn of the entity you're submitting a form response as well as the required input.
-    """
-    submitFormPrompt(urn: String!, input: SubmitFormPromptInput!): Boolean
-
-    """
-    Assign a form to different entities. This will be a patch by adding this form to the list
-    of forms on an entity.
-    """
-    batchAssignForm(input: BatchAssignFormInput!): Boolean
-
-    """
-    Creates a filter for a form to apply it to certain entities. Entities that match this filter will have
-    a given form applied to them.
-    This feature is ONLY supported in DataHub Cloud.
-    """
-    createDynamicFormAssignment(input: CreateDynamicFormAssignmentInput!): Boolean
-
-    """
-    Verifies a form on an entity when all of the required questions on the form are complete and the form
-    is of type VERIFICATION.
-    """
-    verifyForm(input: VerifyFormInput!): Boolean
-
-    """
-    Create Business Attribute Api
-    """
-    createBusinessAttribute(
-          "Inputs required to create a new BusinessAttribute."
-          input: CreateBusinessAttributeInput!): BusinessAttribute
-
-    """
-    Delete a Business Attribute by urn.
-    """
-    deleteBusinessAttribute(
-        "Urn of the business attribute to remove."
-        urn: String!): Boolean
-
-    """
-    Update Business Attribute
-    """
-    updateBusinessAttribute(
-          "The urn identifier for the Business Attribute to update."
-          urn: String!,
-          "Inputs required to create a new Business Attribute."
-          input: UpdateBusinessAttributeInput!): BusinessAttribute
-
-    """
-    Add Business Attribute
-    """
-    addBusinessAttribute(input: AddBusinessAttributeInput!): Boolean
-
-    """
-    Remove Business Attribute
-    """
-    removeBusinessAttribute(input: AddBusinessAttributeInput!): Boolean
-
-    """
-    Link the latest versioned entity to a Version Set
-    """
-    linkAssetVersion(input: LinkVersionInput!): String
-
-    """
-    Unlink a versioned entity from a Version Set
-    """
-    unlinkAssetVersion(input: UnlinkVersionInput!): Boolean
+  """
+  Update the metadata about a particular Dataset
+  """
+  updateDataset(urn: String!, input: DatasetUpdateInput!): Dataset
+
+  """
+  Update the metadata about a batch of Datasets
+  """
+  updateDatasets(input: [BatchDatasetUpdateInput!]!): [Dataset]
+
+  """
+  Update the metadata about a particular Chart
+  """
+  updateChart(urn: String!, input: ChartUpdateInput!): Chart
+
+  """
+  Update the metadata about a particular Dashboard
+  """
+  updateDashboard(urn: String!, input: DashboardUpdateInput!): Dashboard
+
+  """
+  Update the metadata about a particular Notebook
+  """
+  updateNotebook(urn: String!, input: NotebookUpdateInput!): Notebook
+
+  """
+  Update the metadata about a particular Data Flow (Pipeline)
+  """
+  updateDataFlow(urn: String!, input: DataFlowUpdateInput!): DataFlow
+
+  """
+  Update the metadata about a particular Data Job (Task)
+  """
+  updateDataJob(urn: String!, input: DataJobUpdateInput!): DataJob
+
+  """
+  Create a new tag. Requires the 'Manage Tags' or 'Create Tags' Platform Privilege. If a Tag with the provided ID already exists,
+  it will be overwritten.
+  """
+  createTag(
+    "Inputs required to create a new Tag."
+    input: CreateTagInput!
+  ): String
+
+  """
+  Update the information about a particular Entity Tag
+  """
+  updateTag(urn: String!, input: TagUpdateInput!): Tag
+
+  """
+  Delete a Tag
+  """
+  deleteTag("The urn of the Tag to delete" urn: String!): Boolean
+
+  """
+  Set the hex color associated with an existing Tag
+  """
+  setTagColor(urn: String!, colorHex: String!): Boolean
+
+  """
+  Create a policy and returns the resulting urn
+  """
+  createPolicy(input: PolicyUpdateInput!): String
+
+  """
+  Update an existing policy and returns the resulting urn
+  """
+  updatePolicy(urn: String!, input: PolicyUpdateInput!): String
+
+  """
+  Remove an existing policy and returns the policy urn
+  """
+  deletePolicy(urn: String!): String
+
+  """
+  Add a tag to a particular Entity or subresource
+  """
+  addTag(input: TagAssociationInput!): Boolean
+
+  """
+  Add multiple tags to a particular Entity or subresource
+  """
+  addTags(input: AddTagsInput!): Boolean
+
+  """
+  Add tags to multiple Entities or subresources
+  """
+  batchAddTags(input: BatchAddTagsInput!): Boolean
+
+  """
+  Remove a tag from a particular Entity or subresource
+  """
+  removeTag(input: TagAssociationInput!): Boolean
+
+  """
+  Remove tags from multiple Entities or subresource
+  """
+  batchRemoveTags(input: BatchRemoveTagsInput!): Boolean
+
+  """
+  Add a glossary term to a particular Entity or subresource
+  """
+  addTerm(input: TermAssociationInput!): Boolean
+
+  """
+  Add glossary terms to multiple Entities or subresource
+  """
+  batchAddTerms(input: BatchAddTermsInput!): Boolean
+
+  """
+  Add multiple glossary terms to a particular Entity or subresource
+  """
+  addTerms(input: AddTermsInput!): Boolean
+
+  """
+  Remove a glossary term from a particular Entity or subresource
+  """
+  removeTerm(input: TermAssociationInput!): Boolean
+
+  """
+  Remove glossary terms from multiple Entities or subresource
+  """
+  batchRemoveTerms(input: BatchRemoveTermsInput!): Boolean
+
+  """
+  Add an owner to a particular Entity
+  """
+  addOwner(input: AddOwnerInput!): Boolean
+
+  """
+  Add owners to multiple Entities
+  """
+  batchAddOwners(input: BatchAddOwnersInput!): Boolean
+
+  """
+  Add multiple owners to a particular Entity
+  """
+  addOwners(input: AddOwnersInput!): Boolean
+
+  """
+  Remove an owner from a particular Entity
+  """
+  removeOwner(input: RemoveOwnerInput!): Boolean
+
+  """
+  Remove owners from multiple Entities
+  """
+  batchRemoveOwners(input: BatchRemoveOwnersInput!): Boolean
+
+  """
+  Add a link, or institutional memory, from a particular Entity
+  """
+  addLink(input: AddLinkInput!): Boolean
+
+  """
+  Remove a link, or institutional memory, from a particular Entity
+  """
+  removeLink(input: RemoveLinkInput!): Boolean
+
+  """
+  Incubating. Updates the description of a resource. Currently only supports Dataset Schema Fields, Containers
+  """
+  updateDescription(input: DescriptionUpdateInput!): Boolean
+
+  """
+  Remove a user. Requires Manage Users & Groups Platform Privilege
+  """
+  removeUser(urn: String!): Boolean
+
+  """
+  Change the status of a user. Requires Manage Users & Groups Platform Privilege
+  """
+  updateUserStatus(urn: String!, status: CorpUserStatus!): String
+
+  """
+  Remove a group. Requires Manage Users & Groups Platform Privilege
+  """
+  removeGroup(urn: String!): Boolean
+
+  """
+  Add members to a group
+  """
+  addGroupMembers(input: AddGroupMembersInput!): Boolean
+
+  """
+  Remove members from a group
+  """
+  removeGroupMembers(input: RemoveGroupMembersInput!): Boolean
+
+  """
+  Create a new group. Returns the urn of the newly created group. Requires the Manage Users & Groups Platform Privilege
+  """
+  createGroup(input: CreateGroupInput!): String
+
+  """
+  Create a new Domain. Returns the urn of the newly created Domain. Requires the 'Create Domains' or 'Manage Domains' Platform Privilege. If a Domain with the provided ID already exists,
+  it will be overwritten.
+  """
+  createDomain(input: CreateDomainInput!): String
+
+  """
+  Moves a domain to be parented under another domain.
+  """
+  moveDomain(input: MoveDomainInput!): Boolean
+
+  """
+  Delete a Domain
+  """
+  deleteDomain("The urn of the Domain to delete" urn: String!): Boolean
+
+  """
+  Sets the Domain for a Dataset, Chart, Dashboard, Data Flow (Pipeline), or Data Job (Task). Returns true if the Domain was successfully added, or already exists. Requires the Edit Domains privilege for the Entity.
+  """
+  setDomain(entityUrn: String!, domainUrn: String!): Boolean
+
+  """
+  Set domain for multiple Entities
+  """
+  batchSetDomain(input: BatchSetDomainInput!): Boolean
+
+  """
+  Sets the Domain for a Dataset, Chart, Dashboard, Data Flow (Pipeline), or Data Job (Task). Returns true if the Domain was successfully removed, or was already removed. Requires the Edit Domains privilege for an asset.
+  """
+  unsetDomain(entityUrn: String!): Boolean
+
+  """
+  Create a ERModelRelationship
+  """
+  createERModelRelationship(
+    "Input required to create a new ERModelRelationship"
+    input: ERModelRelationshipUpdateInput!
+  ): ERModelRelationship
+
+  """
+  Update a ERModelRelationship
+  """
+  updateERModelRelationship(
+    "The urn of the ERModelRelationship to update"
+    urn: String!
+    "Input required to update an existing DataHub View"
+    input: ERModelRelationshipUpdateInput!
+  ): Boolean
+
+  """
+  Delete a ERModelRelationship
+  """
+  deleteERModelRelationship(
+    "The urn of the ERModelRelationship to delete"
+    urn: String!
+  ): Boolean
+
+  """
+  Sets the Deprecation status for a Metadata Entity. Requires the Edit Deprecation status privilege for an entity.
+  """
+  updateDeprecation(
+    "Input required to set deprecation for an Entity."
+    input: UpdateDeprecationInput!
+  ): Boolean
+
+  """
+  Updates the deprecation status for a batch of assets.
+  """
+  batchUpdateDeprecation(input: BatchUpdateDeprecationInput!): Boolean
+
+  """
+  Update a particular Corp User's editable properties
+  """
+  updateCorpUserProperties(urn: String!, input: CorpUserUpdateInput!): CorpUser
+
+  """
+  Update a particular Corp Group's editable properties
+  """
+  updateCorpGroupProperties(
+    urn: String!
+    input: CorpGroupUpdateInput!
+  ): CorpGroup
+
+  """
+  Remove an assertion associated with an entity. Requires the 'Edit Assertions' privilege on the entity.
+  """
+  deleteAssertion(
+    """
+    The assertion to remove
+    """
+    urn: String!
+  ): Boolean
+
+  """
+  Report a new operation for an asset
+  """
+  reportOperation(
+    """
+    Input required to report an operation
+    """
+    input: ReportOperationInput!
+  ): String
+
+  """
+  Create a new GlossaryTerm. Returns the urn of the newly created GlossaryTerm. If a term with the provided ID already exists, it will be overwritten.
+  """
+  createGlossaryTerm(input: CreateGlossaryEntityInput!): String
+
+  """
+  Create a new GlossaryNode. Returns the urn of the newly created GlossaryNode. If a node with the provided ID already exists, it will be overwritten.
+  """
+  createGlossaryNode(input: CreateGlossaryEntityInput!): String
+
+  """
+  Updates the parent node of a resource. Currently only GlossaryNodes and GlossaryTerms have parentNodes.
+  """
+  updateParentNode(input: UpdateParentNodeInput!): Boolean
+
+  """
+  Remove a glossary entity (GlossaryTerm or GlossaryNode). Return boolean whether it was successful or not.
+  """
+  deleteGlossaryEntity(urn: String!): Boolean
+
+  """
+  Updates the name of the entity.
+  """
+  updateName(input: UpdateNameInput!): Boolean
+
+  """
+  Add multiple related Terms to a Glossary Term to establish relationships
+  """
+  addRelatedTerms(input: RelatedTermsInput!): Boolean
+
+  """
+  Remove multiple related Terms for a Glossary Term
+  """
+  removeRelatedTerms(input: RelatedTermsInput!): Boolean
+
+  """
+  Generates a token that can be shared with existing native users to reset their credentials.
+  """
+  createNativeUserResetToken(
+    input: CreateNativeUserResetTokenInput!
+  ): ResetToken
+
+  """
+  Updates the soft deleted status for a batch of assets
+  """
+  batchUpdateSoftDeleted(input: BatchUpdateSoftDeletedInput!): Boolean
+
+  """
+  Update the View-related settings for a user.
+  """
+  updateCorpUserViewsSettings(input: UpdateCorpUserViewsSettingsInput!): Boolean
+
+  """
+  Update a user setting
+  """
+  updateUserSetting(input: UpdateUserSettingInput!): Boolean
+
+  """
+  Batch assign roles to users
+  """
+  batchAssignRole(input: BatchAssignRoleInput!): Boolean
+
+  """
+  Accept role using invite token
+  """
+  acceptRole(input: AcceptRoleInput!): Boolean
+
+  """
+  Create invite token
+  """
+  createInviteToken(input: CreateInviteTokenInput!): InviteToken
+
+  """
+  Create a post
+  """
+  createPost(input: CreatePostInput!): Boolean
+
+  """
+  Update or edit a post
+  """
+  updatePost(input: UpdatePostInput!): Boolean
+
+  """
+  Delete a post
+  """
+  deletePost(urn: String!): Boolean
+
+  """
+  Create a new DataHub View (Saved Filter)
+  """
+  createView(
+    "Input required to create a new DataHub View"
+    input: CreateViewInput!
+  ): DataHubView
+
+  """
+  Delete a DataHub View (Saved Filter)
+  """
+  updateView(
+    "The urn of the View to update"
+    urn: String!
+    "Input required to update an existing DataHub View"
+    input: UpdateViewInput!
+  ): DataHubView
+
+  """
+  Delete a DataHub View (Saved Filter)
+  """
+  deleteView("The urn of the View to delete" urn: String!): Boolean
+
+  """
+  Update lineage for an entity
+  """
+  updateLineage(input: UpdateLineageInput!): Boolean
+
+  """
+  Update the Embed information for a Dataset, Dashboard, or Chart.
+  """
+  updateEmbed(input: UpdateEmbedInput!): Boolean
+
+  """
+  Create a new Query
+  """
+  createQuery(
+    "Inputs required to create a new Query."
+    input: CreateQueryInput!
+  ): QueryEntity
+
+  """
+  Update an existing Query
+  """
+  updateQuery(
+    "The urn identifier for the query to update."
+    urn: String!
+    "Inputs required to update a Query."
+    input: UpdateQueryInput!
+  ): QueryEntity
+
+  """
+  Delete a Query by urn. This requires the 'Edit Queries' Metadata Privilege.
+  """
+  deleteQuery("Urn of the query to remove." urn: String!): Boolean
+
+  """
+  Create a new Data Product
+  """
+  createDataProduct(
+    "Inputs required to create a new DataProduct."
+    input: CreateDataProductInput!
+  ): DataProduct
+
+  """
+  Update a Data Product
+  """
+  updateDataProduct(
+    "The urn identifier for the Data Product to update."
+    urn: String!
+    "Inputs required to create a new DataProduct."
+    input: UpdateDataProductInput!
+  ): DataProduct
+
+  """
+  Delete a DataProduct by urn.
+  """
+  deleteDataProduct("Urn of the data product to remove." urn: String!): Boolean
+
+  """
+  Batch set or unset a DataProduct to a list of entities
+  """
+  batchSetDataProduct(
+    "Input for batch setting data product"
+    input: BatchSetDataProductInput!
+  ): Boolean
+
+  """
+  Create a Custom Ownership Type. This requires the 'Manage Ownership Types' Metadata Privilege.
+  """
+  createOwnershipType(
+    "Inputs required to create a new Query."
+    input: CreateOwnershipTypeInput!
+  ): OwnershipTypeEntity
+
+  """
+  Update an existing Query. This requires the 'Manage Ownership Types' Metadata Privilege.
+  """
+  updateOwnershipType(
+    "The urn identifier for the custom ownership type to update."
+    urn: String!
+    "Inputs required to update an existing Custom Ownership Type."
+    input: UpdateOwnershipTypeInput!
+  ): OwnershipTypeEntity
+
+  """
+  Delete a Custom Ownership Type by urn. This requires the 'Manage Ownership Types' Metadata Privilege.
+  """
+  deleteOwnershipType(
+    "Urn of the Custom Ownership Type to remove."
+    urn: String!
+    deleteReferences: Boolean
+  ): Boolean
+
+  """
+  Submit a response to a prompt from a form collecting metadata on different entities.
+  Provide the urn of the entity you're submitting a form response as well as the required input.
+  """
+  submitFormPrompt(urn: String!, input: SubmitFormPromptInput!): Boolean
+
+  """
+  Assign a form to different entities. This will be a patch by adding this form to the list
+  of forms on an entity.
+  """
+  batchAssignForm(input: BatchAssignFormInput!): Boolean
+
+  """
+  Creates a filter for a form to apply it to certain entities. Entities that match this filter will have
+  a given form applied to them.
+  This feature is ONLY supported in DataHub Cloud.
+  """
+  createDynamicFormAssignment(input: CreateDynamicFormAssignmentInput!): Boolean
+
+  """
+  Verifies a form on an entity when all of the required questions on the form are complete and the form
+  is of type VERIFICATION.
+  """
+  verifyForm(input: VerifyFormInput!): Boolean
+
+  """
+  Create Business Attribute Api
+  """
+  createBusinessAttribute(
+    "Inputs required to create a new BusinessAttribute."
+    input: CreateBusinessAttributeInput!
+  ): BusinessAttribute
+
+  """
+  Delete a Business Attribute by urn.
+  """
+  deleteBusinessAttribute(
+    "Urn of the business attribute to remove."
+    urn: String!
+  ): Boolean
+
+  """
+  Update Business Attribute
+  """
+  updateBusinessAttribute(
+    "The urn identifier for the Business Attribute to update."
+    urn: String!
+    "Inputs required to create a new Business Attribute."
+    input: UpdateBusinessAttributeInput!
+  ): BusinessAttribute
+
+  """
+  Add Business Attribute
+  """
+  addBusinessAttribute(input: AddBusinessAttributeInput!): Boolean
+
+  """
+  Remove Business Attribute
+  """
+  removeBusinessAttribute(input: AddBusinessAttributeInput!): Boolean
+
+  """
+  Link the latest versioned entity to a Version Set
+  """
+  linkAssetVersion(input: LinkVersionInput!): String
+
+  """
+  Unlink a versioned entity from a Version Set
+  """
+  unlinkAssetVersion(input: UnlinkVersionInput!): Boolean
 }
 
 """
 A top level Metadata Entity
 """
 interface Entity {
-    """
-    A primary key of the Metadata Entity
-    """
-    urn: String!
+  """
+  A primary key of the Metadata Entity
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    List of relationships between the source Entity and some destination entities with a given types
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  List of relationships between the source Entity and some destination entities with a given types
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
@@ -1002,285 +1018,291 @@ interface BrowsableEntity {
 A top level Metadata Entity Type
 """
 enum EntityType {
-    """
-    A Domain containing Metadata Entities
-    """
-    DOMAIN
+  """
+  A Domain containing Metadata Entities
+  """
+  DOMAIN
 
-    """
-    The Dataset Entity
-    """
-    DATASET
+  """
+  The Dataset Entity
+  """
+  DATASET
 
-    """
-    The CorpUser Entity
-    """
-    CORP_USER
+  """
+  The CorpUser Entity
+  """
+  CORP_USER
 
-    """
-    The CorpGroup Entity
-    """
-    CORP_GROUP
+  """
+  The CorpGroup Entity
+  """
+  CORP_GROUP
 
-    """
-    The DataPlatform Entity
-    """
-    DATA_PLATFORM
+  """
+  The DataPlatform Entity
+  """
+  DATA_PLATFORM
 
-    """
-    The ERModelRelationship Entity
-    """
-    ER_MODEL_RELATIONSHIP
+  """
+  The ERModelRelationship Entity
+  """
+  ER_MODEL_RELATIONSHIP
 
-    """
-    The Dashboard Entity
-    """
-    DASHBOARD
+  """
+  The Dashboard Entity
+  """
+  DASHBOARD
 
-    """
-    The Notebook Entity
-    """
-    NOTEBOOK
+  """
+  The Notebook Entity
+  """
+  NOTEBOOK
 
-    """
-    The Chart Entity
-    """
-    CHART
+  """
+  The Chart Entity
+  """
+  CHART
 
-    """
-    The Data Flow (or Data Pipeline) Entity,
-    """
-    DATA_FLOW
+  """
+  The Data Flow (or Data Pipeline) Entity,
+  """
+  DATA_FLOW
 
-    """
-    The Data Job (or Data Task) Entity
-    """
-    DATA_JOB
+  """
+  The Data Job (or Data Task) Entity
+  """
+  DATA_JOB
 
-    """
-    The Tag Entity
-    """
-    TAG
+  """
+  The Tag Entity
+  """
+  TAG
 
-    """
-    The Glossary Term Entity
-    """
-    GLOSSARY_TERM
+  """
+  The Glossary Term Entity
+  """
+  GLOSSARY_TERM
 
-    """
-    The Glossary Node Entity
-    """
-    GLOSSARY_NODE
+  """
+  The Glossary Node Entity
+  """
+  GLOSSARY_NODE
 
-    """
-    A container of Metadata Entities
-    """
-    CONTAINER
+  """
+  A container of Metadata Entities
+  """
+  CONTAINER
 
-    """
-    The ML Model Entity
-    """
-    MLMODEL
+  """
+  The ML Model Entity
+  """
+  MLMODEL
 
-    """
-    The MLModelGroup Entity
-    """
-    MLMODEL_GROUP
+  """
+  The MLModelGroup Entity
+  """
+  MLMODEL_GROUP
 
-    """
-    ML Feature Table Entity
-    """
-    MLFEATURE_TABLE
+  """
+  ML Feature Table Entity
+  """
+  MLFEATURE_TABLE
 
-    """
-    The ML Feature Entity
-    """
-    MLFEATURE
+  """
+  The ML Feature Entity
+  """
+  MLFEATURE
 
-    """
-    The ML Primary Key Entity
-    """
-    MLPRIMARY_KEY
+  """
+  The ML Primary Key Entity
+  """
+  MLPRIMARY_KEY
 
-    """
-    A DataHub Managed Ingestion Source
-    """
-    INGESTION_SOURCE
+  """
+  A DataHub Managed Ingestion Source
+  """
+  INGESTION_SOURCE
 
-    """
-    A DataHub ExecutionRequest
-    """
-    EXECUTION_REQUEST
+  """
+  A DataHub ExecutionRequest
+  """
+  EXECUTION_REQUEST
 
-    """
-    A DataHub Assertion
-    """
-    ASSERTION
+  """
+  A DataHub Assertion
+  """
+  ASSERTION
 
-    """
-    An instance of an individual run of a data job or data flow
-    """
-    DATA_PROCESS_INSTANCE
+  """
+  An instance of an individual run of a data job or data flow
+  """
+  DATA_PROCESS_INSTANCE
 
-    """
-    Data Platform Instance Entity
-    """
-    DATA_PLATFORM_INSTANCE
+  """
+  Data Platform Instance Entity
+  """
+  DATA_PLATFORM_INSTANCE
 
-    """
-    A DataHub Access Token
-    """
-    ACCESS_TOKEN
+  """
+  A DataHub Access Token
+  """
+  ACCESS_TOKEN
 
-    """
-    A DataHub Test
-    """
-    TEST
+  """
+  A DataHub Test
+  """
+  TEST
 
-    """
-    A DataHub Policy
-    """
-    DATAHUB_POLICY
+  """
+  A DataHub Policy
+  """
+  DATAHUB_POLICY
 
-    """
-    A DataHub Role
-    """
-    DATAHUB_ROLE
+  """
+  A DataHub Role
+  """
+  DATAHUB_ROLE
 
-    """
-    A DataHub Post
-    """
-    POST
+  """
+  A DataHub Post
+  """
+  POST
 
-    """
-    A Schema Field
-    """
-    SCHEMA_FIELD
+  """
+  A Schema Field
+  """
+  SCHEMA_FIELD
 
-    """
-    A DataHub View
-    """
-    DATAHUB_VIEW
+  """
+  A DataHub View
+  """
+  DATAHUB_VIEW
 
-    """
-    A dataset query
-    """
-    QUERY
+  """
+  A dataset query
+  """
+  QUERY
 
-    """
-    A Data Product
-    """
-    DATA_PRODUCT
+  """
+  A Data Product
+  """
+  DATA_PRODUCT
 
-    """
-    A Custom Ownership Type
-    """
-    CUSTOM_OWNERSHIP_TYPE
+  """
+  A Custom Ownership Type
+  """
+  CUSTOM_OWNERSHIP_TYPE
 
-    """
-    A connection to an external source.
-    """
-    DATAHUB_CONNECTION
+  """
+  A connection to an external source.
+  """
+  DATAHUB_CONNECTION
 
-    """
-    A DataHub incident - SaaS only
-    """
-    INCIDENT
+  """
+  A DataHub incident - SaaS only
+  """
+  INCIDENT
 
-    """"
-    A Role from an organisation
-    """
-    ROLE
+  """
+  "
+  A Role from an organisation
+  """
+  ROLE
 
-    """
-    A data contract
-    """
-    DATA_CONTRACT
+  """
+  A data contract
+  """
+  DATA_CONTRACT
 
-    """"
-    An structured property on entities
-    """
-    STRUCTURED_PROPERTY
+  """
+  "
+  An structured property on entities
+  """
+  STRUCTURED_PROPERTY
 
-    """"
-    A form entity on entities
-    """
-    FORM
+  """
+  "
+  A form entity on entities
+  """
+  FORM
 
-    """"
-    A data type registered to DataHub
-    """
-    DATA_TYPE
+  """
+  "
+  A data type registered to DataHub
+  """
+  DATA_TYPE
 
-    """"
-    A type of entity registered to DataHub
-    """
-    ENTITY_TYPE
+  """
+  "
+  A type of entity registered to DataHub
+  """
+  ENTITY_TYPE
 
-    """"
-    A type of entity that is restricted to the user
-    """
-    RESTRICTED
+  """
+  "
+  A type of entity that is restricted to the user
+  """
+  RESTRICTED
 
-    """
-    Another entity type - refer to a provided entity type urn.
-    """
-    OTHER
+  """
+  Another entity type - refer to a provided entity type urn.
+  """
+  OTHER
 
-    """
-    A Business Attribute
-    """
-    BUSINESS_ATTRIBUTE
+  """
+  A Business Attribute
+  """
+  BUSINESS_ATTRIBUTE
 }
 
 """
 Input for the get entity counts endpoint
 """
 input EntityCountInput {
-    types: [EntityType!]
+  types: [EntityType!]
 
-    """
-    Optional - A View to apply when generating results
-    """
-    viewUrn: String
+  """
+  Optional - A View to apply when generating results
+  """
+  viewUrn: String
 }
 
 """
 Input for the list lineage property of an Entity
 """
 input LineageInput {
-    """
-    The direction of the relationship, either incoming or outgoing from the source entity
-    """
-    direction: LineageDirection!
+  """
+  The direction of the relationship, either incoming or outgoing from the source entity
+  """
+  direction: LineageDirection!
 
-    """
-    The starting offset of the result set
-    """
-    start: Int
+  """
+  The starting offset of the result set
+  """
+  start: Int
 
-    """
-    The number of results to be returned
-    """
-    count: Int
+  """
+  The number of results to be returned
+  """
+  count: Int
 
-    """
-    Optional flag to not merge siblings in the response. They are merged by default.
-    """
-    separateSiblings: Boolean
-    """
-    An optional starting time to filter on
-    """
-    startTimeMillis: Long
-    """
-    An optional ending time to filter on
-    """
-    endTimeMillis: Long
+  """
+  Optional flag to not merge siblings in the response. They are merged by default.
+  """
+  separateSiblings: Boolean
+  """
+  An optional starting time to filter on
+  """
+  startTimeMillis: Long
+  """
+  An optional ending time to filter on
+  """
+  endTimeMillis: Long
 
-    """
-    If enabled, include entities that do not exist or are soft deleted.
-    """
-    includeGhostEntities: Boolean = false
+  """
+  If enabled, include entities that do not exist or are soft deleted.
+  """
+  includeGhostEntities: Boolean = false
 }
 
 """
@@ -1317,7 +1339,6 @@ input RelationshipsInput {
 A list of relationship information associated with a source Entity
 """
 type EntityRelationshipsResult {
-
   """
   Start offset of the result set
   """
@@ -1343,120 +1364,120 @@ type EntityRelationshipsResult {
 A relationship between two entities TODO Migrate all entity relationships to this more generic model
 """
 type EntityRelationship {
-    """
-    The type of the relationship
-    """
-    type: String!
+  """
+  The type of the relationship
+  """
+  type: String!
 
-    """
-    The direction of the relationship relative to the source entity
-    """
-    direction: RelationshipDirection!
+  """
+  The direction of the relationship relative to the source entity
+  """
+  direction: RelationshipDirection!
 
-    """
-    Entity that is related via lineage
-    """
-    entity: Entity
+  """
+  Entity that is related via lineage
+  """
+  entity: Entity
 
-    """
-    An AuditStamp corresponding to the last modification of this relationship
-    """
-    created: AuditStamp
+  """
+  An AuditStamp corresponding to the last modification of this relationship
+  """
+  created: AuditStamp
 }
 
 """
 A list of lineage information associated with a source Entity
 """
 type EntityLineageResult {
-    """
-    Start offset of the result set
-    """
-    start: Int
+  """
+  Start offset of the result set
+  """
+  start: Int
 
-    """
-    Number of results in the returned result set
-    """
-    count: Int
+  """
+  Number of results in the returned result set
+  """
+  count: Int
 
-    """
-    Total number of results in the result set
-    """
-    total: Int
+  """
+  Total number of results in the result set
+  """
+  total: Int
 
-    """
-    The number of results that were filtered out of the page (soft-deleted or non-existent)
-    """
-    filtered: Int
+  """
+  The number of results that were filtered out of the page (soft-deleted or non-existent)
+  """
+  filtered: Int
 
-    """
-    Relationships in the result set
-    """
-    relationships: [LineageRelationship!]!
+  """
+  Relationships in the result set
+  """
+  relationships: [LineageRelationship!]!
 }
 
 """
 Metadata about a lineage relationship between two entities
 """
 type LineageRelationship {
-    """
-    The type of the relationship
-    """
-    type: String!
+  """
+  The type of the relationship
+  """
+  type: String!
 
-    """
-    Entity that is related via lineage
-    """
-    entity: Entity
+  """
+  Entity that is related via lineage
+  """
+  entity: Entity
 
-    """
-    Degree of relationship (number of hops to get to entity)
-    """
-    degree: Int!
+  """
+  Degree of relationship (number of hops to get to entity)
+  """
+  degree: Int!
 
-    """
-    Timestamp for when this lineage relationship was created. Could be null.
-    """
-    createdOn: Long
+  """
+  Timestamp for when this lineage relationship was created. Could be null.
+  """
+  createdOn: Long
 
-    """
-    The actor who created this lineage relationship. Could be null.
-    """
-    createdActor: Entity
+  """
+  The actor who created this lineage relationship. Could be null.
+  """
+  createdActor: Entity
 
-    """
-    Timestamp for when this lineage relationship was last updated. Could be null.
-    """
-    updatedOn: Long
+  """
+  Timestamp for when this lineage relationship was last updated. Could be null.
+  """
+  updatedOn: Long
 
-    """
-    The actor who last updated this lineage relationship. Could be null.
-    """
-    updatedActor: Entity
+  """
+  The actor who last updated this lineage relationship. Could be null.
+  """
+  updatedActor: Entity
 
-    """
-    Whether this edge is a manual edge. Could be null.
-    """
-    isManual: Boolean
+  """
+  Whether this edge is a manual edge. Could be null.
+  """
+  isManual: Boolean
 
-    """
-    The paths traversed for this relationship
-    """
-    paths: [EntityPath]
+  """
+  The paths traversed for this relationship
+  """
+  paths: [EntityPath]
 }
 
 """
 Direction between two nodes in the lineage graph
 """
 enum LineageDirection {
-    """
-    Upstream, or left-to-right in the lineage visualization
-    """
-    UPSTREAM,
+  """
+  Upstream, or left-to-right in the lineage visualization
+  """
+  UPSTREAM
 
-    """
-    Downstream, or right-to-left in the lineage visualization
-    """
-    DOWNSTREAM
+  """
+  Downstream, or right-to-left in the lineage visualization
+  """
+  DOWNSTREAM
 }
 
 """
@@ -1466,7 +1487,7 @@ enum RelationshipDirection {
   """
   A directed edge pointing at the source Entity
   """
-  INCOMING,
+  INCOMING
 
   """
   A directed edge pointing at the destination Entity
@@ -1478,716 +1499,727 @@ enum RelationshipDirection {
 A versioned aspect, or single group of related metadata, associated with an Entity and having a unique version
 """
 interface Aspect {
-    """
-    The version of the aspect, where zero represents the latest version
-    """
-    version: Long
+  """
+  The version of the aspect, where zero represents the latest version
+  """
+  version: Long
 }
 
 """
 A time series aspect, or a group of related metadata associated with an Entity and corresponding to a particular timestamp
 """
 interface TimeSeriesAspect {
-    """
-    The timestamp associated with the time series aspect in milliseconds
-    """
-    timestampMillis: Long!
+  """
+  The timestamp associated with the time series aspect in milliseconds
+  """
+  timestampMillis: Long!
 }
 
 """
 Deprecated, use relationships field instead
 """
 interface EntityWithRelationships implements Entity {
-    """
-    A primary key associated with the Metadata Entity
-    """
-    urn: String!
+  """
+  A primary key associated with the Metadata Entity
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 }
 
 """
 A Dataset entity, which encompasses Relational Tables, Document store collections, streaming topics, and other sets of data having an independent lifecycle
 """
 type Dataset implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the Dataset
-    """
-    urn: String!
+  """
+  The primary key of the Dataset
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    Standardized platform urn where the dataset is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the dataset is defined
+  """
+  platform: DataPlatform!
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    Unique guid for dataset
-    No longer to be used as the Dataset display name. Use properties.name instead
-    """
-    name: String!
+  """
+  Unique guid for dataset
+  No longer to be used as the Dataset display name. Use properties.name instead
+  """
+  name: String!
 
-    """
-    An additional set of read only properties
-    """
-    properties: DatasetProperties
+  """
+  An additional set of read only properties
+  """
+  properties: DatasetProperties
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: DatasetEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: DatasetEditableProperties
 
-    """
-    Ownership metadata of the dataset
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the dataset
+  """
+  ownership: Ownership
 
-    """
-    The deprecation status of the dataset
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the dataset
+  """
+  deprecation: Deprecation
 
-    """
-    References to internal resources related to the dataset
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dataset
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Schema metadata of the dataset, available by version number
-    """
-    schemaMetadata(version: Long): SchemaMetadata
+  """
+  Schema metadata of the dataset, available by version number
+  """
+  schemaMetadata(version: Long): SchemaMetadata
 
-    """
-    Editable schema metadata of the dataset
-    """
-    editableSchemaMetadata: EditableSchemaMetadata
+  """
+  Editable schema metadata of the dataset
+  """
+  editableSchemaMetadata: EditableSchemaMetadata
 
-    """
-    Status of the Dataset
-    """
-    status: Status
+  """
+  Status of the Dataset
+  """
+  status: Status
 
-    """
-    Embed information about the Dataset
-    """
-    embed: Embed
+  """
+  Embed information about the Dataset
+  """
+  embed: Embed
 
-    """
-    Tags used for searching dataset
-    """
-    tags: GlobalTags
+  """
+  Tags used for searching dataset
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the dataset
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dataset
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    The Domain associated with the Dataset
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Dataset
+  """
+  domain: DomainAssociation
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    The Roles and the properties to access the dataset
-    """
-    access: Access
+  """
+  The Roles and the properties to access the dataset
+  """
+  access: Access
 
-    """
-    Statistics about how this Dataset is used
-    The first parameter, `resource`, is deprecated and no longer needs to be provided
-    """
-    usageStats(resource: String, range: TimeRange): UsageQueryResult
+  """
+  Statistics about how this Dataset is used
+  The first parameter, `resource`, is deprecated and no longer needs to be provided
+  """
+  usageStats(resource: String, range: TimeRange): UsageQueryResult
 
-    """
-    Experimental - Summary operational & usage statistics about a Dataset
-    """
-    statsSummary: DatasetStatsSummary
+  """
+  Experimental - Summary operational & usage statistics about a Dataset
+  """
+  statsSummary: DatasetStatsSummary
 
-    """
-    Profile Stats resource that retrieves the events in a previous unit of time in descending order
-    If no start or end time are provided, the most recent events will be returned
-    """
-    datasetProfiles(startTimeMillis: Long, endTimeMillis: Long, filter: FilterInput, limit: Int): [DatasetProfile!]
+  """
+  Profile Stats resource that retrieves the events in a previous unit of time in descending order
+  If no start or end time are provided, the most recent events will be returned
+  """
+  datasetProfiles(
+    startTimeMillis: Long
+    endTimeMillis: Long
+    filter: FilterInput
+    limit: Int
+  ): [DatasetProfile!]
 
-    """
-    Operational events for an entity.
-    """
-    operations(startTimeMillis: Long, endTimeMillis: Long, filter: FilterInput, limit: Int): [Operation!]
+  """
+  Operational events for an entity.
+  """
+  operations(
+    startTimeMillis: Long
+    endTimeMillis: Long
+    filter: FilterInput
+    limit: Int
+  ): [Operation!]
 
-    """
-    Assertions associated with the Dataset
-    """
-    assertions(start: Int, count: Int, includeSoftDeleted: Boolean): EntityAssertionsResult
+  """
+  Assertions associated with the Dataset
+  """
+  assertions(
+    start: Int
+    count: Int
+    includeSoftDeleted: Boolean
+  ): EntityAssertionsResult
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the dataset. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the dataset. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Experimental! The resolved health statuses of the Dataset
-    """
-    health: [Health!]
+  """
+  Experimental! The resolved health statuses of the Dataset
+  """
+  health: [Health!]
 
-    """
-    Schema metadata of the dataset
-    """
-    schema: Schema @deprecated(reason: "Use `schemaMetadata`")
+  """
+  Schema metadata of the dataset
+  """
+  schema: Schema @deprecated(reason: "Use `schemaMetadata`")
 
-    """
-    Deprecated, use properties field instead
-    External URL associated with the Dataset
-    """
-    externalUrl: String @deprecated
+  """
+  Deprecated, use properties field instead
+  External URL associated with the Dataset
+  """
+  externalUrl: String @deprecated
 
-    """
-    Deprecated, see the properties field instead
-    Environment in which the dataset belongs to or where it was generated
-    Note that this field will soon be deprecated in favor of a more standardized concept of Environment
-    """
-    origin: FabricType! @deprecated
+  """
+  Deprecated, see the properties field instead
+  Environment in which the dataset belongs to or where it was generated
+  Note that this field will soon be deprecated in favor of a more standardized concept of Environment
+  """
+  origin: FabricType! @deprecated
 
-    """
-    Deprecated, use the properties field instead
-    Read only technical description for dataset
-    """
-    description: String @deprecated
+  """
+  Deprecated, use the properties field instead
+  Read only technical description for dataset
+  """
+  description: String @deprecated
 
-    """
-    Deprecated, do not use this field
-    The logical type of the dataset ie table, stream, etc
-    """
-    platformNativeType: PlatformNativeType @deprecated
+  """
+  Deprecated, do not use this field
+  The logical type of the dataset ie table, stream, etc
+  """
+  platformNativeType: PlatformNativeType @deprecated
 
-    """
-    Deprecated, use properties instead
-    Native Dataset Uri
-    Uri should not include any environment specific properties
-    """
-    uri: String @deprecated
+  """
+  Deprecated, use properties instead
+  Native Dataset Uri
+  Uri should not include any environment specific properties
+  """
+  uri: String @deprecated
 
-    """
-    Deprecated, use tags field instead
-    The structured tags associated with the dataset
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags field instead
+  The structured tags associated with the dataset
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Sub Types that this entity implements
-    """
-    subTypes: SubTypes
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 
-    """
-    View related properties. Only relevant if subtypes field contains view.
-    """
-    viewProperties: ViewProperties
+  """
+  View related properties. Only relevant if subtypes field contains view.
+  """
+  viewProperties: ViewProperties
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    History of datajob runs that either produced or consumed this dataset
-    """
-    runs(start: Int, count: Int, direction: RelationshipDirection!): DataProcessInstanceResult
+  """
+  History of datajob runs that either produced or consumed this dataset
+  """
+  runs(
+    start: Int
+    count: Int
+    direction: RelationshipDirection!
+  ): DataProcessInstanceResult
 
-    """
-    Metadata about the datasets siblings
-    """
-    siblings: SiblingProperties
+  """
+  Metadata about the datasets siblings
+  """
+  siblings: SiblingProperties
 
-    """
-    Lineage information for the column-level. Includes a list of objects
-    detailing which columns are upstream and which are downstream of each other.
-    The upstream and downstream columns are from datasets.
-    """
-    fineGrainedLineages: [FineGrainedLineage!]
+  """
+  Lineage information for the column-level. Includes a list of objects
+  detailing which columns are upstream and which are downstream of each other.
+  The upstream and downstream columns are from datasets.
+  """
+  fineGrainedLineages: [FineGrainedLineage!]
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Structured properties about this Dataset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this Dataset
+  """
+  structuredProperties: StructuredProperties
 }
 
 type RoleAssociation {
+  """
+  The Role entity itself
+  """
+  role: Role!
 
-    """
-    The Role entity itself
-    """
-    role: Role!
-
-    """
-    Reference back to the tagged urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
-
+  """
+  Reference back to the tagged urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 type Access {
-    roles: [RoleAssociation!]
+  roles: [RoleAssociation!]
 }
 
 type Role implements Entity {
-    """
-    A primary key of the Metadata Entity
-    """
-    urn: String!
+  """
+  A primary key of the Metadata Entity
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    List of relationships between the source Entity and some destination entities with a given types
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  List of relationships between the source Entity and some destination entities with a given types
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Id of the Role
-    """
-    id: String!
+  """
+  Id of the Role
+  """
+  id: String!
 
-    """
-    Role properties to include Request Access Url
-    """
-    properties: RoleProperties
+  """
+  Role properties to include Request Access Url
+  """
+  properties: RoleProperties
 
-    """
-    A standard Entity Type
-    """
-    actors: Actor
+  """
+  A standard Entity Type
+  """
+  actors: Actor
 
-    isAssignedToMe: Boolean!
-
+  isAssignedToMe: Boolean!
 }
 
 type Actor {
-    """
-    List of users for which the role is provisioned
-    """
-    users: [RoleUser!]
+  """
+  List of users for which the role is provisioned
+  """
+  users: [RoleUser!]
 }
 
 type RoleUser {
-    """
-    Linked corp user of a role
-    """
-    user: CorpUser!
+  """
+  Linked corp user of a role
+  """
+  user: CorpUser!
 }
 
 type RoleProperties {
-    """
-    Name of the Role in an organisation
-    """
-    name: String!
+  """
+  Name of the Role in an organisation
+  """
+  name: String!
 
-    """
-    Description about the role
-    """
-    description: String
+  """
+  Description about the role
+  """
+  description: String
 
-    """
-    Role type can be READ, WRITE or ADMIN
-    """
-    type: String
+  """
+  Role type can be READ, WRITE or ADMIN
+  """
+  type: String
 
-    """
-    Url to request a role for a user in an organisation
-    """
-    requestUrl: String
+  """
+  Url to request a role for a user in an organisation
+  """
+  requestUrl: String
 }
 
 type FineGrainedLineage {
-    upstreams: [SchemaFieldRef!]
-    downstreams: [SchemaFieldRef!]
-    query: String
-    transformOperation: String
+  upstreams: [SchemaFieldRef!]
+  downstreams: [SchemaFieldRef!]
+  query: String
+  transformOperation: String
 }
 
 """
 Metadata about the entity's siblings
 """
 type SiblingProperties {
-    """
-    If this entity is the primary sibling among the sibling set
-    """
-    isPrimary: Boolean
+  """
+  If this entity is the primary sibling among the sibling set
+  """
+  isPrimary: Boolean
 
-    """
-    The sibling entities
-    """
-    siblings: [Entity]
+  """
+  The sibling entities
+  """
+  siblings: [Entity]
 }
 
 """
 All of the parent containers for a given entity. Returns parents with direct parent first followed by the parent's parent etc.
 """
 type ParentContainersResult {
-    """
-    The number of containers bubbling up for this entity
-    """
-    count: Int!
+  """
+  The number of containers bubbling up for this entity
+  """
+  count: Int!
 
-    """
-    A list of parent containers in order from direct parent, to parent's parent etc. If there are no containers, return an emty list
-    """
-    containers: [Container!]!
+  """
+  A list of parent containers in order from direct parent, to parent's parent etc. If there are no containers, return an emty list
+  """
+  containers: [Container!]!
 }
 
 """
 A Dataset entity, which encompasses Relational Tables, Document store collections, streaming topics, and other sets of data having an independent lifecycle
 """
 type VersionedDataset implements Entity {
-    """
-    The primary key of the Dataset
-    """
-    urn: String!
+  """
+  The primary key of the Dataset
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Standardized platform urn where the dataset is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the dataset is defined
+  """
+  platform: DataPlatform!
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    Unique guid for dataset
-    No longer to be used as the Dataset display name. Use properties.name instead
-    """
-    name: String!
+  """
+  Unique guid for dataset
+  No longer to be used as the Dataset display name. Use properties.name instead
+  """
+  name: String!
 
-    """
-    An additional set of read only properties
-    """
-    properties: DatasetProperties
+  """
+  An additional set of read only properties
+  """
+  properties: DatasetProperties
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: DatasetEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: DatasetEditableProperties
 
-    """
-    Ownership metadata of the dataset
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the dataset
+  """
+  ownership: Ownership
 
-    """
-    The deprecation status of the dataset
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the dataset
+  """
+  deprecation: Deprecation
 
-    """
-    References to internal resources related to the dataset
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dataset
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Editable schema metadata of the dataset
-    """
-    editableSchemaMetadata: EditableSchemaMetadata
+  """
+  Editable schema metadata of the dataset
+  """
+  editableSchemaMetadata: EditableSchemaMetadata
 
-    """
-    Status of the Dataset
-    """
-    status: Status
+  """
+  Status of the Dataset
+  """
+  status: Status
 
-    """
-    Tags used for searching dataset
-    """
-    tags: GlobalTags
+  """
+  Tags used for searching dataset
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the dataset
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dataset
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the Dataset
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Dataset
+  """
+  domain: DomainAssociation
 
-    """
-    Experimental! The resolved health status of the asset
-    """
-    health: [Health!]
+  """
+  Experimental! The resolved health status of the asset
+  """
+  health: [Health!]
 
-    """
-    Schema metadata of the dataset
-    """
-    schema: Schema
+  """
+  Schema metadata of the dataset
+  """
+  schema: Schema
 
-    """
-    Sub Types that this entity implements
-    """
-    subTypes: SubTypes
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 
-    """
-    View related properties. Only relevant if subtypes field contains view.
-    """
-    viewProperties: ViewProperties
+  """
+  View related properties. Only relevant if subtypes field contains view.
+  """
+  viewProperties: ViewProperties
 
-    """
-    Deprecated, see the properties field instead
-    Environment in which the dataset belongs to or where it was generated
-    Note that this field will soon be deprecated in favor of a more standardized concept of Environment
-    """
-    origin: FabricType! @deprecated
+  """
+  Deprecated, see the properties field instead
+  Environment in which the dataset belongs to or where it was generated
+  Note that this field will soon be deprecated in favor of a more standardized concept of Environment
+  """
+  origin: FabricType! @deprecated
 
-    """
-    No-op, has to be included due to model
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult @deprecated
+  """
+  No-op, has to be included due to model
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
+    @deprecated
 }
 
 """
 Data Process instances that match the provided query
 """
 type DataProcessInstanceResult {
-    """
-    The number of entities to include in result set
-    """
-    count: Int
+  """
+  The number of entities to include in result set
+  """
+  count: Int
 
-    """
-    The offset of the result set
-    """
-    start: Int
+  """
+  The offset of the result set
+  """
+  start: Int
 
-    """
-    The total number of run events returned
-    """
-    total: Int
+  """
+  The total number of run events returned
+  """
+  total: Int
 
-    """
-    The data process instances that produced or consumed the entity
-    """
-    runs: [DataProcessInstance]
+  """
+  The data process instances that produced or consumed the entity
+  """
+  runs: [DataProcessInstance]
 }
-
 
 """
 Params to configure what list of aspects should be fetched by the aspects property
 """
 input AspectParams {
-    """
-    Only fetch auto render aspects
-    """
-    autoRenderOnly: Boolean
+  """
+  Only fetch auto render aspects
+  """
+  autoRenderOnly: Boolean
 
-    """
-    Fetch using aspect names
-    If absent, returns all aspects matching other inputs
-    """
-    aspectNames: [String!]
+  """
+  Fetch using aspect names
+  If absent, returns all aspects matching other inputs
+  """
+  aspectNames: [String!]
 }
-
 
 """
 Payload representing data about a single aspect
 """
 type RawAspect {
-    """
-    The name of the aspect
-    """
-    aspectName: String!
+  """
+  The name of the aspect
+  """
+  aspectName: String!
 
-    """
-    JSON string containing the aspect's payload
-    """
-    payload: String
+  """
+  JSON string containing the aspect's payload
+  """
+  payload: String
 
-    """
-    Details for the frontend on how the raw aspect should be rendered
-    """
-    renderSpec: AspectRenderSpec
+  """
+  Details for the frontend on how the raw aspect should be rendered
+  """
+  renderSpec: AspectRenderSpec
 }
 
 """
 Details for the frontend on how the raw aspect should be rendered
 """
 type AspectRenderSpec {
-    """
-    Format the aspect should be displayed in for the UI. Powered by the renderSpec annotation on the aspect model
-    """
-    displayType: String
+  """
+  Format the aspect should be displayed in for the UI. Powered by the renderSpec annotation on the aspect model
+  """
+  displayType: String
 
-    """
-    Name to refer to the aspect type by for the UI. Powered by the renderSpec annotation on the aspect model
-    """
-    displayName: String
+  """
+  Name to refer to the aspect type by for the UI. Powered by the renderSpec annotation on the aspect model
+  """
+  displayName: String
 
-    """
-    Field in the aspect payload to index into for rendering.
-    """
-    key: String
+  """
+  Field in the aspect payload to index into for rendering.
+  """
+  key: String
 }
 
 """
 Additional read only properties about a Dataset
 """
 type DatasetProperties {
+  """
+  The name of the dataset used in display
+  """
+  name: String!
 
-    """
-    The name of the dataset used in display
-    """
-    name: String!
+  """
+  Fully-qualified name of the Dataset
+  """
+  qualifiedName: String
 
-    """
-    Fully-qualified name of the Dataset
-    """
-    qualifiedName: String
+  """
+  Environment in which the dataset belongs to or where it was generated
+  Note that this field will soon be deprecated in favor of a more standardized concept of Environment
+  """
+  origin: FabricType!
 
-    """
-    Environment in which the dataset belongs to or where it was generated
-    Note that this field will soon be deprecated in favor of a more standardized concept of Environment
-    """
-    origin: FabricType!
+  """
+  Read only technical description for dataset
+  """
+  description: String
 
-    """
-    Read only technical description for dataset
-    """
-    description: String
+  """
+  Custom properties of the Dataset
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    Custom properties of the Dataset
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  External URL associated with the Dataset
+  """
+  externalUrl: String
 
-    """
-    External URL associated with the Dataset
-    """
-    externalUrl: String
+  """
+  Created timestamp millis associated with the Dataset
+  """
+  created: Long
 
-    """
-    Created timestamp millis associated with the Dataset
-    """
-    created: Long
+  """
+  Actor associated with the Dataset's created timestamp
+  """
+  createdActor: String
 
-    """
-    Actor associated with the Dataset's created timestamp
-    """
-    createdActor: String
+  """
+  Last Modified timestamp millis associated with the Dataset
+  """
+  lastModified: AuditStamp!
 
-    """
-    Last Modified timestamp millis associated with the Dataset
-    """
-    lastModified: AuditStamp!
-
-    """
-    Actor associated with the Dataset's lastModified timestamp.
-    Deprecated - Use lastModified.actor instead.
-    """
-    lastModifiedActor: String @deprecated
+  """
+  Actor associated with the Dataset's lastModified timestamp.
+  Deprecated - Use lastModified.actor instead.
+  """
+  lastModifiedActor: String @deprecated
 }
-
 
 """
 Additional read only properties about a DataPlatformInstance
 """
 type DataPlatformInstanceProperties {
+  """
+  The name of the data platform instance used in display
+  """
+  name: String
 
-    """
-    The name of the data platform instance used in display
-    """
-    name: String
+  """
+  Read only technical description for the data platform instance
+  """
+  description: String
 
-    """
-    Read only technical description for the data platform instance
-    """
-    description: String
+  """
+  Custom properties of the data platform instance
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    Custom properties of the data platform instance
-    """
-    customProperties: [CustomPropertiesEntry!]
-
-    """
-    External URL associated with the data platform instance
-    """
-    externalUrl: String
+  """
+  External URL associated with the data platform instance
+  """
+  externalUrl: String
 }
 
 """
@@ -2195,97 +2227,97 @@ A Glossary Term, or a node in a Business Glossary representing a standardized do
 data type
 """
 type GlossaryTerm implements Entity {
-    """
-    The primary key of the glossary term
-    """
-    urn: String!
+  """
+  The primary key of the glossary term
+  """
+  urn: String!
 
-    """
-    Ownership metadata of the glossary term
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the glossary term
+  """
+  ownership: Ownership
 
-    """
-    The Domain associated with the glossary term
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the glossary term
+  """
+  domain: DomainAssociation
 
-    """
-    References to internal resources related to the Glossary Term
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the Glossary Term
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    A unique identifier for the Glossary Term. Deprecated - Use properties.name field instead.
-    """
-    name: String! @deprecated
+  """
+  A unique identifier for the Glossary Term. Deprecated - Use properties.name field instead.
+  """
+  name: String! @deprecated
 
-    """
-    hierarchicalName of glossary term
-    """
-    hierarchicalName: String!
+  """
+  hierarchicalName of glossary term
+  """
+  hierarchicalName: String!
 
-    """
-    Additional properties associated with the Glossary Term
-    """
-    properties: GlossaryTermProperties
+  """
+  Additional properties associated with the Glossary Term
+  """
+  properties: GlossaryTermProperties
 
-    """
-    Deprecated, use properties field instead
-    Details of the Glossary Term
-    """
-    glossaryTermInfo: GlossaryTermInfo
+  """
+  Deprecated, use properties field instead
+  Details of the Glossary Term
+  """
+  glossaryTermInfo: GlossaryTermInfo
 
-    """
-    The deprecation status of the Glossary Term
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the Glossary Term
+  """
+  deprecation: Deprecation
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Schema metadata of the dataset
-    """
-    schemaMetadata(version: Long): SchemaMetadata
+  """
+  Schema metadata of the dataset
+  """
+  schemaMetadata(version: Long): SchemaMetadata
 
-    """
-    Recursively get the lineage of glossary nodes for this entity
-    """
-    parentNodes: ParentNodesResult
+  """
+  Recursively get the lineage of glossary nodes for this entity
+  """
+  parentNodes: ParentNodesResult
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 }
 
 """
@@ -2293,90 +2325,90 @@ Deprecated, use GlossaryTermProperties instead
 Information about a glossary term
 """
 type GlossaryTermInfo {
-    """
-    The name of the Glossary Term
-    """
-    name: String
+  """
+  The name of the Glossary Term
+  """
+  name: String
 
-    """
-    Description of the glossary term
-    """
-    description: String
+  """
+  Description of the glossary term
+  """
+  description: String
 
-    """
-    Definition of the glossary term. Deprecated - Use 'description' instead.
-    """
-    definition: String! @deprecated
+  """
+  Definition of the glossary term. Deprecated - Use 'description' instead.
+  """
+  definition: String! @deprecated
 
-    """
-    Term Source of the glossary term
-    """
-    termSource: String!
+  """
+  Term Source of the glossary term
+  """
+  termSource: String!
 
-    """
-    Source Ref of the glossary term
-    """
-    sourceRef: String
+  """
+  Source Ref of the glossary term
+  """
+  sourceRef: String
 
-    """
-    Source Url of the glossary term
-    """
-    sourceUrl: String
+  """
+  Source Url of the glossary term
+  """
+  sourceUrl: String
 
-    """
-    Properties of the glossary term
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Properties of the glossary term
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    Schema definition of glossary term
-    """
-    rawSchema: String
+  """
+  Schema definition of glossary term
+  """
+  rawSchema: String
 }
 
 """
 Additional read only properties about a Glossary Term
 """
 type GlossaryTermProperties {
-    """
-    The name of the Glossary Term
-    """
-    name: String!
+  """
+  The name of the Glossary Term
+  """
+  name: String!
 
-    """
-    Description of the glossary term
-    """
-    description: String
+  """
+  Description of the glossary term
+  """
+  description: String
 
-    """
-    Definition of the glossary term. Deprecated - Use 'description' instead.
-    """
-    definition: String! @deprecated
+  """
+  Definition of the glossary term. Deprecated - Use 'description' instead.
+  """
+  definition: String! @deprecated
 
-    """
-    Term Source of the glossary term
-    """
-    termSource: String!
+  """
+  Term Source of the glossary term
+  """
+  termSource: String!
 
-    """
-    Source Ref of the glossary term
-    """
-    sourceRef: String
+  """
+  Source Ref of the glossary term
+  """
+  sourceRef: String
 
-    """
-    Source Url of the glossary term
-    """
-    sourceUrl: String
+  """
+  Source Url of the glossary term
+  """
+  sourceUrl: String
 
-    """
-    Properties of the glossary term
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Properties of the glossary term
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    Schema definition of glossary term
-    """
-    rawSchema: String
+  """
+  Schema definition of glossary term
+  """
+  rawSchema: String
 }
 
 """
@@ -2384,95 +2416,95 @@ A Glossary Node, or a directory in a Business Glossary represents a container of
 Glossary Terms or other Glossary Nodes
 """
 type GlossaryNode implements Entity {
-    """
-    The primary key of the glossary term
-    """
-    urn: String!
+  """
+  The primary key of the glossary term
+  """
+  urn: String!
 
-    """
-    Ownership metadata of the glossary term
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the glossary term
+  """
+  ownership: Ownership
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Additional properties associated with the Glossary Term
-    """
-    properties: GlossaryNodeProperties
+  """
+  Additional properties associated with the Glossary Term
+  """
+  properties: GlossaryNodeProperties
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Recursively get the lineage of glossary nodes for this entity
-    """
-    parentNodes: ParentNodesResult
+  """
+  Recursively get the lineage of glossary nodes for this entity
+  """
+  parentNodes: ParentNodesResult
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 }
 
 """
 All of the parent nodes for GlossaryTerms and GlossaryNodes
 """
 type ParentNodesResult {
-    """
-    The number of parent nodes bubbling up for this entity
-    """
-    count: Int!
-    """
-    A list of parent nodes in order from direct parent, to parent's parent etc. If there are no nodes, return an empty list
-    """
-    nodes: [GlossaryNode!]!
+  """
+  The number of parent nodes bubbling up for this entity
+  """
+  count: Int!
+  """
+  A list of parent nodes in order from direct parent, to parent's parent etc. If there are no nodes, return an empty list
+  """
+  nodes: [GlossaryNode!]!
 }
 
 """
 Additional read only properties about a Glossary Node
 """
 type GlossaryNodeProperties {
-    """
-    The name of the Glossary Term
-    """
-    name: String!
+  """
+  The name of the Glossary Term
+  """
+  name: String!
 
-    """
-    Description of the glossary term
-    """
-    description: String
+  """
+  Description of the glossary term
+  """
+  description: String
 
-    """
-    Custom properties of the Glossary Node
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Custom properties of the Glossary Node
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
@@ -2480,107 +2512,107 @@ A Data Platform represents a specific third party Data System or Tool Examples i
 warehouses like Snowflake, orchestrators like Airflow, and dashboarding tools like Looker
 """
 type DataPlatform implements Entity {
-    """
-    Urn of the data platform
-    """
-    urn: String!
+  """
+  Urn of the data platform
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    Name of the data platform
-    """
-    name: String!
+  """
+  Name of the data platform
+  """
+  name: String!
 
-    """
-    Additional read only properties associated with a data platform
-    """
-    properties: DataPlatformProperties
+  """
+  Additional read only properties associated with a data platform
+  """
+  properties: DataPlatformProperties
 
-    """
-    Deprecated, use properties displayName instead
-    Display name of the data platform
-    """
-    displayName: String @deprecated
+  """
+  Deprecated, use properties displayName instead
+  Display name of the data platform
+  """
+  displayName: String @deprecated
 
-    """
-    Deprecated, use properties field instead
-    Additional properties associated with a data platform
-    """
-    info: DataPlatformInfo @deprecated
+  """
+  Deprecated, use properties field instead
+  Additional properties associated with a data platform
+  """
+  info: DataPlatformInfo @deprecated
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
 A Data Platform instance represents an instance of a 3rd party platform like Looker, Snowflake, etc.
 """
 type DataPlatformInstance implements Entity {
-    """
-    Urn of the data platform
-    """
-    urn: String!
+  """
+  Urn of the data platform
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Name of the data platform
-    """
-    platform: DataPlatform!
+  """
+  Name of the data platform
+  """
+  platform: DataPlatform!
 
-    """
-    The platform instance id
-    """
-    instanceId: String!
+  """
+  The platform instance id
+  """
+  instanceId: String!
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Additional read only properties associated with a data platform instance
-    """
-    properties: DataPlatformInstanceProperties
+  """
+  Additional read only properties associated with a data platform instance
+  """
+  properties: DataPlatformInstanceProperties
 
-    """
-    Ownership metadata of the data platform instance
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the data platform instance
+  """
+  ownership: Ownership
 
-    """
-    References to internal resources related to the data platform instance
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the data platform instance
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Tags used for searching the data platform instance
-    """
-    tags: GlobalTags
+  """
+  Tags used for searching the data platform instance
+  """
+  tags: GlobalTags
 
-    """
-    The deprecation status of the data platform instance
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the data platform instance
+  """
+  deprecation: Deprecation
 
-    """
-    Status metadata of the container
-    """
-    status: Status
+  """
+  Status metadata of the container
+  """
+  status: Status
 }
 
 """
@@ -2588,100 +2620,100 @@ Deprecated, use DataPlatformProperties instead
 Additional read only information about a Data Platform
 """
 type DataPlatformInfo {
-    """
-    The platform category
-    """
-    type: PlatformType!
+  """
+  The platform category
+  """
+  type: PlatformType!
 
-    """
-    Display name associated with the platform
-    """
-    displayName: String
+  """
+  Display name associated with the platform
+  """
+  displayName: String
 
-    """
-    The delimiter in the dataset names on the data platform
-    """
-    datasetNameDelimiter: String!
+  """
+  The delimiter in the dataset names on the data platform
+  """
+  datasetNameDelimiter: String!
 
-    """
-    A logo URL associated with the platform
-    """
-    logoUrl: String
+  """
+  A logo URL associated with the platform
+  """
+  logoUrl: String
 }
 
 """
 Additional read only properties about a Data Platform
 """
 type DataPlatformProperties {
-    """
-    The platform category
-    """
-    type: PlatformType!
+  """
+  The platform category
+  """
+  type: PlatformType!
 
-    """
-    Display name associated with the platform
-    """
-    displayName: String
+  """
+  Display name associated with the platform
+  """
+  displayName: String
 
-    """
-    The delimiter in the dataset names on the data platform
-    """
-    datasetNameDelimiter: String!
+  """
+  The delimiter in the dataset names on the data platform
+  """
+  datasetNameDelimiter: String!
 
-    """
-    A logo URL associated with the platform
-    """
-    logoUrl: String
+  """
+  A logo URL associated with the platform
+  """
+  logoUrl: String
 }
 
 """
 The category of a specific Data Platform
 """
 enum PlatformType {
-    """
-    Value for a file system
-    """
-    FILE_SYSTEM
+  """
+  Value for a file system
+  """
+  FILE_SYSTEM
 
-    """
-    Value for a key value store
-    """
-    KEY_VALUE_STORE
+  """
+  Value for a key value store
+  """
+  KEY_VALUE_STORE
 
-    """
-    Value for a message broker
-    """
-    MESSAGE_BROKER
+  """
+  Value for a message broker
+  """
+  MESSAGE_BROKER
 
-    """
-    Value for an object store
-    """
-    OBJECT_STORE
+  """
+  Value for an object store
+  """
+  OBJECT_STORE
 
-    """
-    Value for an OLAP datastore
-    """
-    OLAP_DATASTORE
+  """
+  Value for an OLAP datastore
+  """
+  OLAP_DATASTORE
 
-    """
-    Value for a query engine
-    """
-    QUERY_ENGINE
+  """
+  Value for a query engine
+  """
+  QUERY_ENGINE
 
-    """
-    Value for a relational database
-    """
-    RELATIONAL_DB
+  """
+  Value for a relational database
+  """
+  RELATIONAL_DB
 
-    """
-    Value for a search engine
-    """
-    SEARCH_ENGINE
+  """
+  Value for a search engine
+  """
+  SEARCH_ENGINE
 
-    """
-    Value for other platforms
-    """
-    OTHERS
+  """
+  Value for other platforms
+  """
+  OTHERS
 }
 
 """
@@ -2690,196 +2722,196 @@ Note that this model will soon be deprecated in favor of a more general purpose 
 of data environment
 """
 enum FabricType {
-    """
-    Designates development fabrics
-    """
-    DEV
+  """
+  Designates development fabrics
+  """
+  DEV
 
-    """
-    Designates testing fabrics
-    """
-    TEST
+  """
+  Designates testing fabrics
+  """
+  TEST
 
-    """
-    Designates quality assurance fabrics
-    """
-    QA
+  """
+  Designates quality assurance fabrics
+  """
+  QA
 
-    """
-    Designates user acceptance testing fabrics
-    """
-    UAT
+  """
+  Designates user acceptance testing fabrics
+  """
+  UAT
 
-    """
-    Designates early integration fabrics
-    """
-    EI
+  """
+  Designates early integration fabrics
+  """
+  EI
 
-    """
-    Designates pre-production fabrics
-    """
-    PRE
+  """
+  Designates pre-production fabrics
+  """
+  PRE
 
-    """
-    Designates staging fabrics
-    """
-    STG
+  """
+  Designates staging fabrics
+  """
+  STG
 
-    """
-    Designates non-production fabrics
-    """
-    NON_PROD
+  """
+  Designates non-production fabrics
+  """
+  NON_PROD
 
-    """
-    Designates production fabrics
-    """
-    PROD
+  """
+  Designates production fabrics
+  """
+  PROD
 
-    """
-    Designates corporation fabrics
-    """
-    CORP
+  """
+  Designates corporation fabrics
+  """
+  CORP
 
-    """
-    Designates review fabrics
-    """
-    RVW
+  """
+  Designates review fabrics
+  """
+  RVW
 
-    """
-    Designates sandbox fabrics
-    """
-    SANDBOX
+  """
+  Designates sandbox fabrics
+  """
+  SANDBOX
 }
 
 """
 A container of other Metadata Entities
 """
 type Container implements Entity {
-    """
-    The primary key of the container
-    """
-    urn: String!
+  """
+  The primary key of the container
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    Standardized platform.
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform.
+  """
+  platform: DataPlatform!
 
-    """
-    Fetch an Entity Container by primary key (urn)
-    """
-    container: Container
+  """
+  Fetch an Entity Container by primary key (urn)
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    Read-only properties that originate in the source data platform
-    """
-    properties: ContainerProperties
+  """
+  Read-only properties that originate in the source data platform
+  """
+  properties: ContainerProperties
 
-    """
-    Read-write properties that originate in DataHub
-    """
-    editableProperties: ContainerEditableProperties
+  """
+  Read-write properties that originate in DataHub
+  """
+  editableProperties: ContainerEditableProperties
 
-    """
-    Ownership metadata of the dataset
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the dataset
+  """
+  ownership: Ownership
 
-    """
-    References to internal resources related to the dataset
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dataset
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Tags used for searching dataset
-    """
-    tags: GlobalTags
+  """
+  Tags used for searching dataset
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the dataset
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dataset
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    Sub types of the container, e.g. "Database" etc
-    """
-    subTypes: SubTypes
+  """
+  Sub types of the container, e.g. "Database" etc
+  """
+  subTypes: SubTypes
 
-    """
-    The Domain associated with the Dataset
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Dataset
+  """
+  domain: DomainAssociation
 
-    """
-    The deprecation status of the container
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the container
+  """
+  deprecation: Deprecation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Children entities inside of the Container
-    """
-    entities(input: ContainerEntitiesInput): SearchResults
+  """
+  Children entities inside of the Container
+  """
+  entities(input: ContainerEntitiesInput): SearchResults
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Status metadata of the container
-    """
-    status: Status
+  """
+  Status metadata of the container
+  """
+  status: Status
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-	The Roles and the properties to access the container
-	"""
-	access: Access
+  """
+  The Roles and the properties to access the container
+  """
+  access: Access
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
@@ -2951,23 +2983,23 @@ input ContainerEntitiesInput {
 The data type associated with an individual Machine Learning Feature
 """
 enum MLFeatureDataType {
-    USELESS
-    NOMINAL
-    ORDINAL
-    BINARY
-    COUNT
-    TIME
-    INTERVAL
-    IMAGE
-    VIDEO
-    AUDIO
-    TEXT
-    MAP
-    SEQUENCE
-    SET
-    CONTINUOUS
-    BYTE
-    UNKNOWN
+  USELESS
+  NOMINAL
+  ORDINAL
+  BINARY
+  COUNT
+  TIME
+  INTERVAL
+  IMAGE
+  VIDEO
+  AUDIO
+  TEXT
+  MAP
+  SEQUENCE
+  SET
+  CONTINUOUS
+  BYTE
+  UNKNOWN
 }
 
 """
@@ -2976,168 +3008,168 @@ Information about Dataset deprecation status
 Note that this model will soon be migrated to a more general purpose Entity status
 """
 type DatasetDeprecation {
-    """
-    Whether the dataset has been deprecated by owner
-    """
-    deprecated: Boolean!
+  """
+  Whether the dataset has been deprecated by owner
+  """
+  deprecated: Boolean!
 
-    """
-    The time user plan to decommission this dataset
-    """
-    decommissionTime: Long
+  """
+  The time user plan to decommission this dataset
+  """
+  decommissionTime: Long
 
-    """
-    Additional information about the dataset deprecation plan
-    """
-    note: String!
+  """
+  Additional information about the dataset deprecation plan
+  """
+  note: String!
 
-    """
-    The user who will be credited for modifying this deprecation content
-    """
-    actor: String
+  """
+  The user who will be credited for modifying this deprecation content
+  """
+  actor: String
 }
 
 """
 Institutional memory metadata, meaning internal links and pointers related to an Entity
 """
 type InstitutionalMemory {
-    """
-    List of records that represent the institutional memory or internal documentation of an entity
-    """
-    elements: [InstitutionalMemoryMetadata!]!
+  """
+  List of records that represent the institutional memory or internal documentation of an entity
+  """
+  elements: [InstitutionalMemoryMetadata!]!
 }
 
 """
 An institutional memory resource about a particular Metadata Entity
 """
 type InstitutionalMemoryMetadata {
-    """
-    Link to a document or wiki page or another internal resource
-    """
-    url: String!
+  """
+  Link to a document or wiki page or another internal resource
+  """
+  url: String!
 
-    """
-    Label associated with the URL
-    """
-    label: String!
+  """
+  Label associated with the URL
+  """
+  label: String!
 
-    """
-    The author of this metadata
-    Deprecated! Use actor instead for users or groups.
-    """
-    author: CorpUser! @deprecated(reason: "Use `actor`")
+  """
+  The author of this metadata
+  Deprecated! Use actor instead for users or groups.
+  """
+  author: CorpUser! @deprecated(reason: "Use `actor`")
 
-    """
-    The author of this metadata
-    """
-    actor: ResolvedActor!
+  """
+  The author of this metadata
+  """
+  actor: ResolvedActor!
 
-    """
-    An AuditStamp corresponding to the creation of this resource
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the creation of this resource
+  """
+  created: AuditStamp!
 
-    """
-    Deprecated, use label instead
-    Description of the resource
-    """
-    description: String! @deprecated
+  """
+  Deprecated, use label instead
+  Description of the resource
+  """
+  description: String! @deprecated
 
-    """
-    Reference back to the owned urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the owned urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 Metadata about a Dataset schema
 """
 type SchemaMetadata implements Aspect {
-    """
-    The logical version of the schema metadata, where zero represents the latest version
-    with otherwise monotonic ordering starting at one
-    """
-    aspectVersion: Long
+  """
+  The logical version of the schema metadata, where zero represents the latest version
+  with otherwise monotonic ordering starting at one
+  """
+  aspectVersion: Long
 
-    """
-    Dataset this schema metadata is associated with
-    """
-    datasetUrn: String
+  """
+  Dataset this schema metadata is associated with
+  """
+  datasetUrn: String
 
-    """
-    Schema name
-    """
-    name: String!
+  """
+  Schema name
+  """
+  name: String!
 
-    """
-    Platform this schema metadata is associated with
-    """
-    platformUrn: String!
+  """
+  Platform this schema metadata is associated with
+  """
+  platformUrn: String!
 
-    """
-    The version of the GMS Schema metadata
-    """
-    version: Long!
+  """
+  The version of the GMS Schema metadata
+  """
+  version: Long!
 
-    """
-    The cluster this schema metadata is derived from
-    """
-    cluster: String
+  """
+  The cluster this schema metadata is derived from
+  """
+  cluster: String
 
-    """
-    The SHA1 hash of the schema content
-    """
-    hash: String!
+  """
+  The SHA1 hash of the schema content
+  """
+  hash: String!
 
-    """
-    The native schema in the datasets platform, schemaless if it was not provided
-    """
-    platformSchema: PlatformSchema
+  """
+  The native schema in the datasets platform, schemaless if it was not provided
+  """
+  platformSchema: PlatformSchema
 
-    """
-    Client provided a list of fields from value schema
-    """
-    fields: [SchemaField!]!
+  """
+  Client provided a list of fields from value schema
+  """
+  fields: [SchemaField!]!
 
-    """
-    Client provided list of fields that define primary keys to access record
-    """
-    primaryKeys: [String!]
+  """
+  Client provided list of fields that define primary keys to access record
+  """
+  primaryKeys: [String!]
 
-    """
-    Client provided list of foreign key constraints
-    """
-    foreignKeys: [ForeignKeyConstraint]
+  """
+  Client provided list of foreign key constraints
+  """
+  foreignKeys: [ForeignKeyConstraint]
 
-    """
-    The time at which the schema metadata information was created
-    """
-    createdAt: Long
+  """
+  The time at which the schema metadata information was created
+  """
+  createdAt: Long
 }
 
 """
 Metadata around a foreign key constraint between two datasets
 """
 type ForeignKeyConstraint {
-    """
-    The human-readable name of the constraint
-    """
-    name: String
+  """
+  The human-readable name of the constraint
+  """
+  name: String
 
-    """
-    List of fields in the foreign dataset
-    """
-    foreignFields: [SchemaFieldEntity]
+  """
+  List of fields in the foreign dataset
+  """
+  foreignFields: [SchemaFieldEntity]
 
-    """
-    List of fields in this dataset
-    """
-    sourceFields: [SchemaFieldEntity]
+  """
+  List of fields in this dataset
+  """
+  sourceFields: [SchemaFieldEntity]
 
-    """
-    The foreign dataset for easy reference
-    """
-    foreignDataset: Dataset
+  """
+  The foreign dataset for easy reference
+  """
+  foreignDataset: Dataset
 }
 
 """
@@ -3145,65 +3177,65 @@ Deprecated, use SchemaMetadata instead
 Metadata about a Dataset schema
 """
 type Schema {
-    """
-    Dataset this schema metadata is associated with
-    """
-    datasetUrn: String
+  """
+  Dataset this schema metadata is associated with
+  """
+  datasetUrn: String
 
-    """
-    Schema name
-    """
-    name: String!
+  """
+  Schema name
+  """
+  name: String!
 
-    """
-    Platform this schema metadata is associated with
-    """
-    platformUrn: String!
+  """
+  Platform this schema metadata is associated with
+  """
+  platformUrn: String!
 
-    """
-    The version of the GMS Schema metadata
-    """
-    version: Long!
+  """
+  The version of the GMS Schema metadata
+  """
+  version: Long!
 
-    """
-    The cluster this schema metadata is derived from
-    """
-    cluster: String
+  """
+  The cluster this schema metadata is derived from
+  """
+  cluster: String
 
-    """
-    The SHA1 hash of the schema content
-    """
-    hash: String!
+  """
+  The SHA1 hash of the schema content
+  """
+  hash: String!
 
-    """
-    The native schema in the datasets platform, schemaless if it was not provided
-    """
-    platformSchema: PlatformSchema
+  """
+  The native schema in the datasets platform, schemaless if it was not provided
+  """
+  platformSchema: PlatformSchema
 
-    """
-    Client provided a list of fields from value schema
-    """
-    fields: [SchemaField!]!
+  """
+  Client provided a list of fields from value schema
+  """
+  fields: [SchemaField!]!
 
-    """
-    Client provided list of fields that define primary keys to access record
-    """
-    primaryKeys: [String!]
+  """
+  Client provided list of fields that define primary keys to access record
+  """
+  primaryKeys: [String!]
 
-    """
-    Client provided list of foreign key constraints
-    """
-    foreignKeys: [ForeignKeyConstraint]
+  """
+  Client provided list of foreign key constraints
+  """
+  foreignKeys: [ForeignKeyConstraint]
 
-    """
-    The time at which the schema metadata information was created
-    """
-    createdAt: Long
+  """
+  The time at which the schema metadata information was created
+  """
+  createdAt: Long
 
-    """
-    The time at which the schema metadata information was last ingested
-    """
-    lastObserved: Long
+  """
+  The time at which the schema metadata information was last ingested
+  """
+  lastObserved: Long
 }
 
 """
@@ -3215,25 +3247,25 @@ union PlatformSchema = TableSchema | KeyValueSchema
 Information about a raw Table Schema
 """
 type TableSchema {
-    """
-    Raw table schema
-    """
-    schema: String!
+  """
+  Raw table schema
+  """
+  schema: String!
 }
 
 """
 Information about a raw Key Value Schema
 """
 type KeyValueSchema {
-    """
-    Raw key schema
-    """
-    keySchema: String!
+  """
+  Raw key schema
+  """
+  keySchema: String!
 
-    """
-    Raw value schema
-    """
-    valueSchema: String!
+  """
+  Raw value schema
+  """
+  valueSchema: String!
 }
 
 """
@@ -3241,253 +3273,252 @@ Standalone schema field entity. Differs from the SchemaField struct because it i
 schema field
 """
 type SchemaFieldEntity implements Entity {
-    """
-    Primary key of the schema field
-    """
-    urn: String!
+  """
+  Primary key of the schema field
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Field path identifying the field in its dataset
-    """
-    fieldPath: String!
+  """
+  Field path identifying the field in its dataset
+  """
+  fieldPath: String!
 
-    """
-    The field's parent.
-    """
-    parent: Entity!
+  """
+  The field's parent.
+  """
+  parent: Entity!
 
-    """
-    Structured properties on this schema field
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties on this schema field
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Business Attribute associated with the field
-    """
-    businessAttributes: BusinessAttributes
+  """
+  Business Attribute associated with the field
+  """
+  businessAttributes: BusinessAttributes
 
-    """
-    Documentation aspect for this schema field
-    """
-    documentation: Documentation
+  """
+  Documentation aspect for this schema field
+  """
+  documentation: Documentation
 }
 
 """
 Object containing structured properties for an entity
 """
 type StructuredProperties {
-    """
-    Structured properties on this entity
-    """
-    properties: [StructuredPropertiesEntry!]
+  """
+  Structured properties on this entity
+  """
+  properties: [StructuredPropertiesEntry!]
 }
 
 """
 Information about an individual field in a Dataset schema
 """
 type SchemaField {
-    """
-    Flattened name of the field computed from jsonPath field
-    """
-    fieldPath: String!
+  """
+  Flattened name of the field computed from jsonPath field
+  """
+  fieldPath: String!
 
-    """
-    Flattened name of a field in JSON Path notation
-    """
-    jsonPath: String
+  """
+  Flattened name of a field in JSON Path notation
+  """
+  jsonPath: String
 
-    """
-    Human readable label for the field. Not supplied by all data sources
-    """
-    label: String
+  """
+  Human readable label for the field. Not supplied by all data sources
+  """
+  label: String
 
-    """
-    Indicates if this field is optional or nullable
-    """
-    nullable: Boolean!
+  """
+  Indicates if this field is optional or nullable
+  """
+  nullable: Boolean!
 
-    """
-    Description of the field
-    """
-    description: String
+  """
+  Description of the field
+  """
+  description: String
 
-    """
-    Platform independent field type of the field
-    """
-    type: SchemaFieldDataType!
+  """
+  Platform independent field type of the field
+  """
+  type: SchemaFieldDataType!
 
-    """
-    The native type of the field in the datasets platform as declared by platform schema
-    """
-    nativeDataType: String
+  """
+  The native type of the field in the datasets platform as declared by platform schema
+  """
+  nativeDataType: String
 
-    """
-    Whether the field references its own type recursively
-    """
-    recursive: Boolean!
+  """
+  Whether the field references its own type recursively
+  """
+  recursive: Boolean!
 
-    """
-    Deprecated, use tags field instead
-    Tags associated with the field
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags field instead
+  Tags associated with the field
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Tags associated with the field
-    """
-    tags: GlobalTags
+  """
+  Tags associated with the field
+  """
+  tags: GlobalTags
 
-    """
-    Glossary terms associated with the field
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  Glossary terms associated with the field
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    Whether the field is part of a key schema
-    """
-    isPartOfKey: Boolean
+  """
+  Whether the field is part of a key schema
+  """
+  isPartOfKey: Boolean
 
-    """
-    Whether the field is part of a partitioning key schema
-    """
-    isPartitioningKey: Boolean
+  """
+  Whether the field is part of a partitioning key schema
+  """
+  isPartitioningKey: Boolean
 
-    """
-    For schema fields that have other properties that are not modeled explicitly, represented as a JSON string.
-    """
-    jsonProps: String
+  """
+  For schema fields that have other properties that are not modeled explicitly, represented as a JSON string.
+  """
+  jsonProps: String
 
-    """
-    Schema field entity that exist in the database for this schema field
-    """
-    schemaFieldEntity: SchemaFieldEntity
+  """
+  Schema field entity that exist in the database for this schema field
+  """
+  schemaFieldEntity: SchemaFieldEntity
 }
 
 """
 Information about schema metadata that is editable via the UI
 """
 type EditableSchemaMetadata {
-    """
-    Editable schema field metadata
-    """
-    editableSchemaFieldInfo: [EditableSchemaFieldInfo!]!
+  """
+  Editable schema field metadata
+  """
+  editableSchemaFieldInfo: [EditableSchemaFieldInfo!]!
 }
 
 """
 Editable schema field metadata ie descriptions, tags, etc
 """
 type EditableSchemaFieldInfo {
-    """
-    Flattened name of a field identifying the field the editable info is applied to
-    """
-    fieldPath: String!
+  """
+  Flattened name of a field identifying the field the editable info is applied to
+  """
+  fieldPath: String!
 
-    """
-    Edited description of the field
-    """
-    description: String
+  """
+  Edited description of the field
+  """
+  description: String
 
-    """
-    Deprecated, use tags field instead
-    Tags associated with the field
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags field instead
+  Tags associated with the field
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Tags associated with the field
-    """
-    tags: GlobalTags
+  """
+  Tags associated with the field
+  """
+  tags: GlobalTags
 
-    """
-    Glossary terms associated with the field
-    """
-    glossaryTerms: GlossaryTerms
-
+  """
+  Glossary terms associated with the field
+  """
+  glossaryTerms: GlossaryTerms
 }
 
 """
 The type associated with a single Dataset schema field
 """
 enum SchemaFieldDataType {
-    """
-    A boolean type
-    """
-    BOOLEAN
+  """
+  A boolean type
+  """
+  BOOLEAN
 
-    """
-    A fixed bytestring type
-    """
-    FIXED
+  """
+  A fixed bytestring type
+  """
+  FIXED
 
-    """
-    A string type
-    """
-    STRING
+  """
+  A string type
+  """
+  STRING
 
-    """
-    A string of bytes
-    """
-    BYTES
+  """
+  A string of bytes
+  """
+  BYTES
 
-    """
-    A number, including integers, floats, and doubles
-    """
-    NUMBER
+  """
+  A number, including integers, floats, and doubles
+  """
+  NUMBER
 
-    """
-    A datestrings type
-    """
-    DATE
+  """
+  A datestrings type
+  """
+  DATE
 
-    """
-    A timestamp type
-    """
-    TIME
+  """
+  A timestamp type
+  """
+  TIME
 
-    """
-    An enum type
-    """
-    ENUM
+  """
+  An enum type
+  """
+  ENUM
 
-    """
-    A NULL type
-    """
-    NULL
+  """
+  A NULL type
+  """
+  NULL
 
-    """
-    A map collection type
-    """
-    MAP
+  """
+  A map collection type
+  """
+  MAP
 
-    """
-    An array collection type
-    """
-    ARRAY
+  """
+  An array collection type
+  """
+  ARRAY
 
-    """
-    An union type
-    """
-    UNION
+  """
+  An union type
+  """
+  UNION
 
-    """
-    An complex struct type
-    """
-    STRUCT
+  """
+  An complex struct type
+  """
+  STRUCT
 }
 
 """
@@ -3516,21 +3547,20 @@ type ViewProperties {
   language: String!
 }
 
-
 """
 Dataset properties that are editable via the UI This represents logical metadata,
 as opposed to technical metadata
 """
 type DatasetEditableProperties {
-    """
-    Description of the Dataset
-    """
-    description: String
+  """
+  Description of the Dataset
+  """
+  description: String
 
-    """
-    Editable name of the Dataset
-    """
-    name: String
+  """
+  Editable name of the Dataset
+  """
+  name: String
 }
 
 """
@@ -3538,10 +3568,10 @@ Chart properties that are editable via the UI This represents logical metadata,
 as opposed to technical metadata
 """
 type ChartEditableProperties {
-    """
-    Description of the Chart
-    """
-    description: String
+  """
+  Description of the Chart
+  """
+  description: String
 }
 
 """
@@ -3549,10 +3579,10 @@ Dashboard properties that are editable via the UI This represents logical metada
 as opposed to technical metadata
 """
 type DashboardEditableProperties {
-    """
-    Description of the Dashboard
-    """
-    description: String
+  """
+  Description of the Dashboard
+  """
+  description: String
 }
 
 """
@@ -3560,10 +3590,10 @@ Notebook properties that are editable via the UI This represents logical metadat
 as opposed to technical metadata
 """
 type NotebookEditableProperties {
-    """
-    Description of the Notebook
-    """
-    description: String
+  """
+  Description of the Notebook
+  """
+  description: String
 }
 
 """
@@ -3571,10 +3601,10 @@ Data Job properties that are editable via the UI This represents logical metadat
 as opposed to technical metadata
 """
 type DataJobEditableProperties {
-    """
-    Description of the Data Job
-    """
-    description: String
+  """
+  Description of the Data Job
+  """
+  description: String
 }
 
 """
@@ -3582,46 +3612,46 @@ Data Flow properties that are editable via the UI This represents logical metada
 as opposed to technical metadata
 """
 type DataFlowEditableProperties {
-    """
-    Description of the Data Flow
-    """
-    description: String
+  """
+  Description of the Data Flow
+  """
+  description: String
 }
 
 """
 Deprecated, use relationships query instead
 """
 type EntityRelationshipLegacy {
-    """
-    Entity that is related via lineage
-    """
-    entity: EntityWithRelationships
+  """
+  Entity that is related via lineage
+  """
+  entity: EntityWithRelationships
 
-    """
-    An AuditStamp corresponding to the last modification of this relationship
-    """
-    created: AuditStamp
+  """
+  An AuditStamp corresponding to the last modification of this relationship
+  """
+  created: AuditStamp
 }
 
 """
 Deprecated, use relationships query instead
 """
 type UpstreamEntityRelationships {
-    entities: [EntityRelationshipLegacy]
+  entities: [EntityRelationshipLegacy]
 }
 
 """
 Deprecated, use relationships query instead
 """
 type DownstreamEntityRelationships {
-    entities: [EntityRelationshipLegacy]
+  entities: [EntityRelationshipLegacy]
 }
 
 """
 Deprecated, use relationships query instead
 """
 type DataFlowDataJobsRelationships {
-    entities: [EntityRelationshipLegacy]
+  entities: [EntityRelationshipLegacy]
 }
 
 """
@@ -3629,30 +3659,30 @@ Deprecated
 The type of an edge between two Datasets
 """
 enum DatasetLineageType {
-    """
-    Direct copy without modification
-    """
-    COPY
+  """
+  Direct copy without modification
+  """
+  COPY
 
-    """
-    Transformed dataset
-    """
-    TRANSFORMED
+  """
+  Transformed dataset
+  """
+  TRANSFORMED
 
-    """
-    Represents a view defined on the sources
-    """
-    VIEW
+  """
+  Represents a view defined on the sources
+  """
+  VIEW
 }
 
 """
 The status of a particular Metadata Entity
 """
 type Status {
-    """
-    Whether the entity is removed or not
-    """
-    removed: Boolean!
+  """
+  Whether the entity is removed or not
+  """
+  removed: Boolean!
 }
 
 """
@@ -3660,125 +3690,125 @@ Deprecated, do not use this type
 The logical type associated with an individual Dataset
 """
 enum PlatformNativeType {
-    """
-    Table
-    """
-    TABLE
+  """
+  Table
+  """
+  TABLE
 
-    """
-    View
-    """
-    VIEW
+  """
+  View
+  """
+  VIEW
 
-    """
-    Directory in file system
-    """
-    DIRECTORY
+  """
+  Directory in file system
+  """
+  DIRECTORY
 
-    """
-    Stream
-    """
-    STREAM
+  """
+  Stream
+  """
+  STREAM
 
-    """
-    Bucket in key value store
-    """
-    BUCKET
+  """
+  Bucket in key value store
+  """
+  BUCKET
 }
 
 """
 An entry in a string string map represented as a tuple
 """
 type StringMapEntry {
-    """
-    The key of the map entry
-    """
-    key: String!
+  """
+  The key of the map entry
+  """
+  key: String!
 
-    """
-    The value fo the map entry
-    """
-    value: String
+  """
+  The value for the map entry
+  """
+  value: String
 }
 
 """
 An entry in a custom properties map represented as a tuple
 """
 type CustomPropertiesEntry {
-    """
-    The key of the map entry
-    """
-    key: String!
+  """
+  The key of the map entry
+  """
+  key: String!
 
-    """
-    The value fo the map entry
-    """
-    value: String
+  """
+  The value for the map entry
+  """
+  value: String
 
-    """
-    The urn of the entity this property came from for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  The urn of the entity this property came from for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 The origin of Ownership metadata associated with a Metadata Entity
 """
 enum OwnershipSourceType {
-    """
-    Auditing system or audit logs
-    """
-    AUDIT
+  """
+  Auditing system or audit logs
+  """
+  AUDIT
 
-    """
-    Database, eg GRANTS table
-    """
-    DATABASE
+  """
+  Database, eg GRANTS table
+  """
+  DATABASE
 
-    """
-    File system, eg file or directory owner
-    """
-    FILE_SYSTEM
+  """
+  File system, eg file or directory owner
+  """
+  FILE_SYSTEM
 
-    """
-    Issue tracking system, eg Jira
-    """
-    ISSUE_TRACKING_SYSTEM
+  """
+  Issue tracking system, eg Jira
+  """
+  ISSUE_TRACKING_SYSTEM
 
-    """
-    Manually provided by a user
-    """
-    MANUAL
+  """
+  Manually provided by a user
+  """
+  MANUAL
 
-    """
-    Other ownership like service, eg Nuage, ACL service etc
-    """
-    SERVICE
+  """
+  Other ownership like service, eg Nuage, ACL service etc
+  """
+  SERVICE
 
-    """
-    SCM system, eg GIT, SVN
-    """
-    SOURCE_CONTROL
+  """
+  SCM system, eg GIT, SVN
+  """
+  SOURCE_CONTROL
 
-    """
-    Other sources
-    """
-    OTHER
+  """
+  Other sources
+  """
+  OTHER
 }
 
 """
 Information about the source of Ownership metadata about a Metadata Entity
 """
 type OwnershipSource {
-    """
-    The type of the source
-    """
-    type: OwnershipSourceType!
+  """
+  The type of the source
+  """
+  type: OwnershipSourceType!
 
-    """
-    An optional reference URL for the source
-    """
-    url: String
+  """
+  An optional reference URL for the source
+  """
+  url: String
 }
 
 """
@@ -3786,66 +3816,66 @@ The type of the ownership relationship between a Person and a Metadata Entity
 Note that this field will soon become deprecated due to low usage
 """
 enum OwnershipType {
-    """
-    A person or group who is responsible for technical aspects of the asset.
-    """
-    TECHNICAL_OWNER
+  """
+  A person or group who is responsible for technical aspects of the asset.
+  """
+  TECHNICAL_OWNER
 
-    """
-    A person or group who is responsible for logical, or business related, aspects of the asset.
-    """
-    BUSINESS_OWNER
+  """
+  A person or group who is responsible for logical, or business related, aspects of the asset.
+  """
+  BUSINESS_OWNER
 
-    """
-    A steward, expert, or delegate responsible for the asset.
-    """
-    DATA_STEWARD
+  """
+  A steward, expert, or delegate responsible for the asset.
+  """
+  DATA_STEWARD
 
-    """
-    No specific type associated with the owner.
-    """
-    NONE
+  """
+  No specific type associated with the owner.
+  """
+  NONE
 
-    """
-    Associated ownership type is a custom ownership type. Please check OwnershipTypeEntity urn for custom value.
-    """
-    CUSTOM
+  """
+  Associated ownership type is a custom ownership type. Please check OwnershipTypeEntity urn for custom value.
+  """
+  CUSTOM
 
-    """
-    A person or group that owns the data.
-    Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
-    """
-    DATAOWNER @deprecated
+  """
+  A person or group that owns the data.
+  Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
+  """
+  DATAOWNER @deprecated
 
-    """
-    A person or group that is in charge of developing the code
-    Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
-    """
-    DEVELOPER @deprecated
+  """
+  A person or group that is in charge of developing the code
+  Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
+  """
+  DEVELOPER @deprecated
 
-    """
-    A person or a group that overseas the operation, eg a DBA or SRE
-    Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
-    """
-    DELEGATE @deprecated
+  """
+  A person or a group that overseas the operation, eg a DBA or SRE
+  Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
+  """
+  DELEGATE @deprecated
 
-    """
-    A person, group, or service that produces or generates the data
-    Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
-    """
-    PRODUCER @deprecated
+  """
+  A person, group, or service that produces or generates the data
+  Deprecated! This ownership type is no longer supported. Use TECHNICAL_OWNER instead.
+  """
+  PRODUCER @deprecated
 
-    """
-    A person or a group that has direct business interest
-    Deprecated! Use BUSINESS_OWNER instead.
-    """
-    STAKEHOLDER @deprecated
+  """
+  A person or a group that has direct business interest
+  Deprecated! Use BUSINESS_OWNER instead.
+  """
+  STAKEHOLDER @deprecated
 
-    """
-    A person, group, or service that consumes the data
-    Deprecated! This ownership type is no longer supported.
-    """
-    CONSUMER @deprecated
+  """
+  A person, group, or service that consumes the data
+  Deprecated! This ownership type is no longer supported.
+  """
+  CONSUMER @deprecated
 }
 
 """
@@ -3869,136 +3899,136 @@ union ResolvedActor = CorpUser | CorpGroup
 A DataHub User entity, which represents a Person on the Metadata Entity Graph
 """
 type CorpUser implements Entity {
-    """
-    The primary key of the user
-    """
-    urn: String!
+  """
+  The primary key of the user
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    A username associated with the user
-    This uniquely identifies the user within DataHub
-    """
-    username: String!
+  """
+  A username associated with the user
+  This uniquely identifies the user within DataHub
+  """
+  username: String!
 
-    """
-    Additional read only properties about the corp user
-    """
-    properties: CorpUserProperties
+  """
+  Additional read only properties about the corp user
+  """
+  properties: CorpUserProperties
 
-    """
-    Read write properties about the corp user
-    """
-    editableProperties: CorpUserEditableProperties
+  """
+  Read write properties about the corp user
+  """
+  editableProperties: CorpUserEditableProperties
 
-    """
-    The status of the user
-    """
-    status: CorpUserStatus
+  """
+  The status of the user
+  """
+  status: CorpUserStatus
 
-    """
-    The tags associated with the user
-    """
-    tags: GlobalTags
+  """
+  The tags associated with the user
+  """
+  tags: GlobalTags
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Whether or not this user is a native DataHub user
-    """
-    isNativeUser: Boolean
+  """
+  Whether or not this user is a native DataHub user
+  """
+  isNativeUser: Boolean
 
-    """
-    Deprecated, use properties field instead
-    Additional read only info about the corp user
-    """
-    info: CorpUserInfo @deprecated
+  """
+  Deprecated, use properties field instead
+  Additional read only info about the corp user
+  """
+  info: CorpUserInfo @deprecated
 
-    """
-    Deprecated, use editableProperties field instead
-    Read write info about the corp user
-    """
-    editableInfo: CorpUserEditableInfo @deprecated
+  """
+  Deprecated, use editableProperties field instead
+  Read write info about the corp user
+  """
+  editableInfo: CorpUserEditableInfo @deprecated
 
-    """
-    Deprecated, use the tags field instead
-    The structured tags associated with the user
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use the tags field instead
+  The structured tags associated with the user
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Settings that a user can customize through the datahub ui
-    """
-    settings: CorpUserSettings
+  """
+  Settings that a user can customize through the datahub ui
+  """
+  settings: CorpUserSettings
 
-    """
-    Experimental API.
-    For fetching extra aspects that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra aspects that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
 Settings that a user can customize through the datahub ui
 """
 type CorpUserSettings {
-    """
-    Settings that control look and feel of the DataHub UI for the user
-    """
-    appearance: CorpUserAppearanceSettings
+  """
+  Settings that control look and feel of the DataHub UI for the user
+  """
+  appearance: CorpUserAppearanceSettings
 
-    """
-    Settings related to the DataHub Views feature
-    """
-    views: CorpUserViewsSettings
+  """
+  Settings related to the DataHub Views feature
+  """
+  views: CorpUserViewsSettings
 }
 
 """
 Settings that control look and feel of the DataHub UI for the user
 """
 type CorpUserAppearanceSettings {
-    """
-    Flag whether the user should see a homepage with only datasets, charts & dashboards. Intended for users
-    who have less operational use cases for the datahub tool.
-    """
-    showSimplifiedHomepage: Boolean
+  """
+  Flag whether the user should see a homepage with only datasets, charts & dashboards. Intended for users
+  who have less operational use cases for the datahub tool.
+  """
+  showSimplifiedHomepage: Boolean
 }
 
 """
 Settings related to the Views feature of DataHub.
 """
 type CorpUserViewsSettings {
-    """
-    The default view for the User.
-    """
-    defaultView: DataHubView
+  """
+  The default view for the User.
+  """
+  defaultView: DataHubView
 }
 
 """
@@ -4006,130 +4036,130 @@ Deprecated, use CorpUserProperties instead
 Additional read only info about a user
 """
 type CorpUserInfo {
-    """
-    Whether the user is active
-    """
-    active: Boolean!
+  """
+  Whether the user is active
+  """
+  active: Boolean!
 
-    """
-    Display name of the user
-    """
-    displayName: String
+  """
+  Display name of the user
+  """
+  displayName: String
 
-    """
-    Email address of the user
-    """
-    email: String
+  """
+  Email address of the user
+  """
+  email: String
 
-    """
-    Title of the user
-    """
-    title: String
+  """
+  Title of the user
+  """
+  title: String
 
-    """
-    Direct manager of the user
-    """
-    manager: CorpUser
+  """
+  Direct manager of the user
+  """
+  manager: CorpUser
 
-    """
-    department id the user belong to
-    """
-    departmentId: Long
+  """
+  department id the user belong to
+  """
+  departmentId: Long
 
-    """
-    department name this user belong to
-    """
-    departmentName: String
+  """
+  department name this user belong to
+  """
+  departmentName: String
 
-    """
-    first name of the user
-    """
-    firstName: String
+  """
+  first name of the user
+  """
+  firstName: String
 
-    """
-    last name of the user
-    """
-    lastName: String
+  """
+  last name of the user
+  """
+  lastName: String
 
-    """
-    Common name of this user, format is firstName plus lastName
-    """
-    fullName: String
+  """
+  Common name of this user, format is firstName plus lastName
+  """
+  fullName: String
 
-    """
-    two uppercase letters country code
-    """
-    countryCode: String
+  """
+  two uppercase letters country code
+  """
+  countryCode: String
 
-    """
-    Custom properties of the ldap
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Custom properties of the ldap
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 Additional read only properties about a user
 """
 type CorpUserProperties {
-    """
-    Whether the user is active
-    """
-    active: Boolean!
+  """
+  Whether the user is active
+  """
+  active: Boolean!
 
-    """
-    Display name of the user
-    """
-    displayName: String
+  """
+  Display name of the user
+  """
+  displayName: String
 
-    """
-    Email address of the user
-    """
-    email: String
+  """
+  Email address of the user
+  """
+  email: String
 
-    """
-    Title of the user
-    """
-    title: String
+  """
+  Title of the user
+  """
+  title: String
 
-    """
-    Direct manager of the user
-    """
-    manager: CorpUser
+  """
+  Direct manager of the user
+  """
+  manager: CorpUser
 
-    """
-    department id the user belong to
-    """
-    departmentId: Long
+  """
+  department id the user belong to
+  """
+  departmentId: Long
 
-    """
-    department name this user belong to
-    """
-    departmentName: String
+  """
+  department name this user belong to
+  """
+  departmentName: String
 
-    """
-    first name of the user
-    """
-    firstName: String
+  """
+  first name of the user
+  """
+  firstName: String
 
-    """
-    last name of the user
-    """
-    lastName: String
+  """
+  last name of the user
+  """
+  lastName: String
 
-    """
-    Common name of this user, format is firstName plus lastName
-    """
-    fullName: String
+  """
+  Common name of this user, format is firstName plus lastName
+  """
+  fullName: String
 
-    """
-    two uppercase letters country code
-    """
-    countryCode: String
+  """
+  two uppercase letters country code
+  """
+  countryCode: String
 
-    """
-    Custom properties of the ldap
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Custom properties of the ldap
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
@@ -4137,233 +4167,232 @@ Deprecated, use CorpUserEditableProperties instead
 Additional read write info about a user
 """
 type CorpUserEditableInfo {
-    """
-    Display name to show on DataHub
-    """
-    displayName: String
+  """
+  Display name to show on DataHub
+  """
+  displayName: String
 
-    """
-    Title to show on DataHub
-    """
-    title: String
+  """
+  Title to show on DataHub
+  """
+  title: String
 
-    """
-    About me section of the user
-    """
-    aboutMe: String
+  """
+  About me section of the user
+  """
+  aboutMe: String
 
-    """
-    Teams that the user belongs to
-    """
-    teams: [String!]
+  """
+  Teams that the user belongs to
+  """
+  teams: [String!]
 
-    """
-    Skills that the user possesses
-    """
-    skills: [String!]
+  """
+  Skills that the user possesses
+  """
+  skills: [String!]
 
-    """
-    A URL which points to a picture which user wants to set as a profile photo
-    """
-    pictureLink: String
+  """
+  A URL which points to a picture which user wants to set as a profile photo
+  """
+  pictureLink: String
 }
 
 """
 Additional read write properties about a user
 """
 type CorpUserEditableProperties {
-    """
-    Display name to show on DataHub
-    """
-    displayName: String
+  """
+  Display name to show on DataHub
+  """
+  displayName: String
 
-    """
-    Title to show on DataHub
-    """
-    title: String
+  """
+  Title to show on DataHub
+  """
+  title: String
 
-    """
-    About me section of the user
-    """
-    aboutMe: String
+  """
+  About me section of the user
+  """
+  aboutMe: String
 
-    """
-    Teams that the user belongs to
-    """
-    teams: [String!]
+  """
+  Teams that the user belongs to
+  """
+  teams: [String!]
 
-    """
-    Skills that the user possesses
-    """
-    skills: [String!]
+  """
+  Skills that the user possesses
+  """
+  skills: [String!]
 
-    """
-    A URL which points to a picture which user wants to set as a profile photo
-    """
-    pictureLink: String
+  """
+  A URL which points to a picture which user wants to set as a profile photo
+  """
+  pictureLink: String
 
-    """
-    The slack handle of the user
-    """
-    slack: String
+  """
+  The slack handle of the user
+  """
+  slack: String
 
-    """
-    Phone number for the user
-    """
-    phone: String
+  """
+  Phone number for the user
+  """
+  phone: String
 
-    """
-    Email address for the user
-    """
-    email: String
+  """
+  Email address for the user
+  """
+  email: String
 
-    """
-    User persona, if present
-    """
-    persona: DataHubPersona
+  """
+  User persona, if present
+  """
+  persona: DataHubPersona
 
-    """
-    Platforms commonly used by the user, if present.
-    """
-    platforms: [DataPlatform!]
+  """
+  Platforms commonly used by the user, if present.
+  """
+  platforms: [DataPlatform!]
 }
 
 """
 Arguments provided to update a CorpUser Entity
 """
 input CorpUserUpdateInput {
-    """
-    Display name to show on DataHub
-    """
-    displayName: String
+  """
+  Display name to show on DataHub
+  """
+  displayName: String
 
-    """
-    Title to show on DataHub
-    """
-    title: String
+  """
+  Title to show on DataHub
+  """
+  title: String
 
-    """
-    About me section of the user
-    """
-    aboutMe: String
+  """
+  About me section of the user
+  """
+  aboutMe: String
 
-    """
-    Teams that the user belongs to
-    """
-    teams: [String!]
+  """
+  Teams that the user belongs to
+  """
+  teams: [String!]
 
-    """
-    Skills that the user possesses
-    """
-    skills: [String!]
+  """
+  Skills that the user possesses
+  """
+  skills: [String!]
 
-    """
-    A URL which points to a picture which user wants to set as a profile photo
-    """
-    pictureLink: String
+  """
+  A URL which points to a picture which user wants to set as a profile photo
+  """
+  pictureLink: String
 
-    """
-    The slack handle of the user
-    """
-    slack: String
+  """
+  The slack handle of the user
+  """
+  slack: String
 
-    """
-    Phone number for the user
-    """
-    phone: String
+  """
+  Phone number for the user
+  """
+  phone: String
 
-    """
-    Email address for the user
-    """
-    email: String
+  """
+  Email address for the user
+  """
+  email: String
 
-    """
-    The platforms that the user frequently works with
-    """
-    platformUrns: [String!]
+  """
+  The platforms that the user frequently works with
+  """
+  platformUrns: [String!]
 
-    """
-    The user's persona urn"
-    """
-    personaUrn: String
+  """
+  The user's persona urn"
+  """
+  personaUrn: String
 }
 
 """
 A DataHub Group entity, which represents a Person on the Metadata Entity Graph
 """
 type CorpGroup implements Entity {
-    """
+  """
+  The primary key of the group
+  """
+  urn: String!
 
-    The primary key of the group
-    """
-    urn: String!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  Group name eg wherehows dev, ask_metadata
+  """
+  name: String!
 
-    """
-    Group name eg wherehows dev, ask_metadata
-    """
-    name: String!
+  """
+  Ownership metadata of the Corp Group
+  """
+  ownership: Ownership
 
-    """
-    Ownership metadata of the Corp Group
-    """
-    ownership: Ownership
+  """
+  Additional read only properties about the group
+  """
+  properties: CorpGroupProperties
 
-    """
-    Additional read only properties about the group
-    """
-    properties: CorpGroupProperties
+  """
+  Additional read write properties about the group
+  """
+  editableProperties: CorpGroupEditableProperties
 
-    """
-    Additional read write properties about the group
-    """
-    editableProperties: CorpGroupEditableProperties
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Origin info about this group.
+  """
+  origin: Origin
 
-    """
-    Origin info about this group.
-    """
-    origin: Origin
+  """
+  Deprecated, use properties field instead
+  Additional read only info about the group
+  """
+  info: CorpGroupInfo @deprecated
 
-    """
-    Deprecated, use properties field instead
-    Additional read only info about the group
-    """
-    info: CorpGroupInfo @deprecated
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
-
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
@@ -4371,63 +4400,63 @@ Deprecated, use CorpUserProperties instead
 Additional read only info about a group
 """
 type CorpGroupInfo {
-    """
-    The name to display when rendering the group
-    """
-    displayName: String
+  """
+  The name to display when rendering the group
+  """
+  displayName: String
 
-    """
-    The description provided for the group
-    """
-    description: String
+  """
+  The description provided for the group
+  """
+  description: String
 
-    """
-    email of this group
-    """
-    email: String
+  """
+  email of this group
+  """
+  email: String
 
-    """
-    Deprecated, do not use
-    owners of this group
-    """
-    admins: [CorpUser!] @deprecated
+  """
+  Deprecated, do not use
+  owners of this group
+  """
+  admins: [CorpUser!] @deprecated
 
-    """
-    Deprecated, use relationship IsMemberOfGroup instead
-    List of ldap urn in this group
-    """
-    members: [CorpUser!] @deprecated
+  """
+  Deprecated, use relationship IsMemberOfGroup instead
+  List of ldap urn in this group
+  """
+  members: [CorpUser!] @deprecated
 
-    """
-    Deprecated, do not use
-    List of groups urns in this group
-    """
-    groups: [String!] @deprecated
+  """
+  Deprecated, do not use
+  List of groups urns in this group
+  """
+  groups: [String!] @deprecated
 }
 
 """
 Additional read only properties about a group
 """
 type CorpGroupProperties {
-    """
-    display name of this group
-    """
-    displayName: String
+  """
+  display name of this group
+  """
+  displayName: String
 
-    """
-    The description provided for the group
-    """
-    description: String
+  """
+  The description provided for the group
+  """
+  description: String
 
-    """
-    email of this group
-    """
-    email: String
+  """
+  email of this group
+  """
+  email: String
 
-    """
-    Slack handle for the group
-    """
-    slack: String
+  """
+  Slack handle for the group
+  """
+  slack: String
 }
 
 """
@@ -4449,7 +4478,7 @@ type CorpGroupEditableProperties {
   """
   email: String
 
-  """ 
+  """
   A URL which points to a picture which user wants to set as a profile photo
   """
   pictureLink: String
@@ -4489,98 +4518,97 @@ union OwnerType = CorpUser | CorpGroup
 An owner of a Metadata Entity
 """
 type Owner {
-    """
-    Owner object
-    """
-    owner: OwnerType!
+  """
+  Owner object
+  """
+  owner: OwnerType!
 
-    """
-    The type of the ownership. Deprecated - Use ownershipType field instead.
-    """
-    type: OwnershipType @deprecated
+  """
+  The type of the ownership. Deprecated - Use ownershipType field instead.
+  """
+  type: OwnershipType @deprecated
 
-    """
-    Ownership type information
-    """
-    ownershipType: OwnershipTypeEntity
+  """
+  Ownership type information
+  """
+  ownershipType: OwnershipTypeEntity
 
-    """
-    Source information for the ownership
-    """
-    source: OwnershipSource
+  """
+  Source information for the ownership
+  """
+  source: OwnershipSource
 
-    """
-    Reference back to the owned urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the owned urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 Ownership information about a Metadata Entity
 """
 type Ownership {
-    """
-    List of owners of the entity
-    """
-    owners: [Owner!]
+  """
+  List of owners of the entity
+  """
+  owners: [Owner!]
 
-    """
-    Audit stamp containing who last modified the record and when
-    """
-    lastModified: AuditStamp!
+  """
+  Audit stamp containing who last modified the record and when
+  """
+  lastModified: AuditStamp!
 }
 
 """
 A Tag Entity, which can be associated with other Metadata Entities and subresources
 """
 type Tag implements Entity {
+  """
+  The primary key of the TAG
+  """
+  urn: String!
 
-    """
-    The primary key of the TAG
-    """
-    urn: String!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A unique identifier for the Tag. Deprecated - Use properties.name field instead.
+  """
+  name: String! @deprecated
 
-    """
-    A unique identifier for the Tag. Deprecated - Use properties.name field instead.
-    """
-    name: String! @deprecated
+  """
+  Additional properties about the Tag
+  """
+  properties: TagProperties
 
-    """
-    Additional properties about the Tag
-    """
-    properties: TagProperties
+  """
+  Additional read write properties about the Tag
+  Deprecated! Use 'properties' field instead.
+  """
+  editableProperties: EditableTagProperties @deprecated
 
-    """
-    Additional read write properties about the Tag
-    Deprecated! Use 'properties' field instead.
-    """
-    editableProperties: EditableTagProperties @deprecated
+  """
+  Ownership metadata of the dataset
+  """
+  ownership: Ownership
 
-    """
-    Ownership metadata of the dataset
-    """
-    ownership: Ownership
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Deprecated, use properties.description field instead
+  """
+  description: String @deprecated
 
-    """
-    Deprecated, use properties.description field instead
-    """
-    description: String @deprecated
-
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 }
 
 """
@@ -4619,49 +4647,48 @@ type TagProperties {
   colorHex: String
 }
 
-
 """
 An edge between a Metadata Entity and a Tag Modeled as a struct to permit
 additional attributes
 TODO Consider whether this query should be serviced by the relationships field
 """
 type TagAssociation {
-    """
-    The tag itself
-    """
-    tag: Tag!
+  """
+  The tag itself
+  """
+  tag: Tag!
 
-    """
-    Reference back to the tagged urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the tagged urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 Tags attached to a particular Metadata Entity
 """
 type GlobalTags {
-    """
-    The set of tags attached to the Metadata Entity
-    """
-    tags: [TagAssociation!]
+  """
+  The set of tags attached to the Metadata Entity
+  """
+  tags: [TagAssociation!]
 }
 
 """
 The technical version associated with a given Metadata Entity
 """
 type VersionTag {
-    versionTag: String
+  versionTag: String
 }
 
 """
 Glossary Terms attached to a particular Metadata Entity
 """
 type GlossaryTerms {
-     """
-     The set of glossary terms attached to the Metadata Entity
-     """
-    terms: [GlossaryTermAssociation!]
+  """
+  The set of glossary terms attached to the Metadata Entity
+  """
+  terms: [GlossaryTermAssociation!]
 }
 
 """
@@ -4670,311 +4697,309 @@ additional attributes
 TODO Consider whether this query should be serviced by the relationships field
 """
 type GlossaryTermAssociation {
-    """
-    The glossary term itself
-    """
-    term: GlossaryTerm!
+  """
+  The glossary term itself
+  """
+  term: GlossaryTerm!
 
-    """
-    The actor who is responsible for the term being added"
-    """
-    actor: CorpUser
+  """
+  The actor who is responsible for the term being added"
+  """
+  actor: CorpUser
 
-    """
-    Reference back to the associated urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the associated urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 Arguments provided to update a Chart Entity
 """
 input ChartUpdateInput {
-    """
-    Update to ownership
-    """
-    ownership: OwnershipUpdate
+  """
+  Update to ownership
+  """
+  ownership: OwnershipUpdate
 
-    """
-    Deprecated, use tags field instead
-    Update to global tags
-    """
-    globalTags: GlobalTagsUpdate
+  """
+  Deprecated, use tags field instead
+  Update to global tags
+  """
+  globalTags: GlobalTagsUpdate
 
-    """
-    Update to tags
-    """
-    tags: GlobalTagsUpdate
+  """
+  Update to tags
+  """
+  tags: GlobalTagsUpdate
 
-    """
-    Update to editable properties
-    """
-    editableProperties: ChartEditablePropertiesUpdate
+  """
+  Update to editable properties
+  """
+  editableProperties: ChartEditablePropertiesUpdate
 }
 
 """
 Arguments provided to update a Dashboard Entity
 """
 input DashboardUpdateInput {
-    """
-    Update to ownership
-    """
-    ownership: OwnershipUpdate
+  """
+  Update to ownership
+  """
+  ownership: OwnershipUpdate
 
-    """
-    Deprecated, use tags field instead
-    Update to global tags
-    """
-    globalTags: GlobalTagsUpdate
+  """
+  Deprecated, use tags field instead
+  Update to global tags
+  """
+  globalTags: GlobalTagsUpdate
 
-    """
-    Update to tags
-    """
-    tags: GlobalTagsUpdate
+  """
+  Update to tags
+  """
+  tags: GlobalTagsUpdate
 
-    """
-    Update to editable properties
-    """
-    editableProperties: DashboardEditablePropertiesUpdate
+  """
+  Update to editable properties
+  """
+  editableProperties: DashboardEditablePropertiesUpdate
 }
 
 """
 Arguments provided to update a Notebook Entity
 """
 input NotebookUpdateInput {
-    """
-    Update to ownership
-    """
-    ownership: OwnershipUpdate
+  """
+  Update to ownership
+  """
+  ownership: OwnershipUpdate
 
-    """
-    Update to tags
-    """
-    tags: GlobalTagsUpdate
+  """
+  Update to tags
+  """
+  tags: GlobalTagsUpdate
 
-    """
-    Update to editable properties
-    """
-    editableProperties: NotebookEditablePropertiesUpdate
+  """
+  Update to editable properties
+  """
+  editableProperties: NotebookEditablePropertiesUpdate
 }
 
 """
 Arguments provided to update a Data Flow aka Pipeline Entity
 """
 input DataFlowUpdateInput {
-    """
-    Update to ownership
-    """
-    ownership: OwnershipUpdate
+  """
+  Update to ownership
+  """
+  ownership: OwnershipUpdate
 
-    """
-    Deprecated, use tags field instead
-    Update to global tags
-    """
-    globalTags: GlobalTagsUpdate
+  """
+  Deprecated, use tags field instead
+  Update to global tags
+  """
+  globalTags: GlobalTagsUpdate
 
-    """
-    Update to tags
-    """
-    tags: GlobalTagsUpdate
+  """
+  Update to tags
+  """
+  tags: GlobalTagsUpdate
 
-    """
-    Update to editable properties
-    """
-    editableProperties: DataFlowEditablePropertiesUpdate
+  """
+  Update to editable properties
+  """
+  editableProperties: DataFlowEditablePropertiesUpdate
 }
 
 """
 Arguments provided to update a Data Job aka Task Entity
 """
 input DataJobUpdateInput {
-    """
-    Update to ownership
-    """
-    ownership: OwnershipUpdate
+  """
+  Update to ownership
+  """
+  ownership: OwnershipUpdate
 
-    """
-    Deprecated, use tags field instead
-    Update to global tags
-    """
-    globalTags: GlobalTagsUpdate
+  """
+  Deprecated, use tags field instead
+  Update to global tags
+  """
+  globalTags: GlobalTagsUpdate
 
-    """
-    Update to tags
-    """
-    tags: GlobalTagsUpdate
+  """
+  Update to tags
+  """
+  tags: GlobalTagsUpdate
 
-    """
-    Update to editable properties
-    """
-    editableProperties: DataJobEditablePropertiesUpdate
+  """
+  Update to editable properties
+  """
+  editableProperties: DataJobEditablePropertiesUpdate
 }
 
 """
 Arguments provided to update a Dataset Entity
 """
 input DatasetUpdateInput {
-    """
-    Update to ownership
-    """
-    ownership: OwnershipUpdate
+  """
+  Update to ownership
+  """
+  ownership: OwnershipUpdate
 
-    """
-    Update to deprecation status
-    """
-    deprecation: DatasetDeprecationUpdate
+  """
+  Update to deprecation status
+  """
+  deprecation: DatasetDeprecationUpdate
 
-    """
-    Update to institutional memory, ie documentation
-    """
-    institutionalMemory: InstitutionalMemoryUpdate
+  """
+  Update to institutional memory, ie documentation
+  """
+  institutionalMemory: InstitutionalMemoryUpdate
 
-    """
-    Deprecated, use tags field instead
-    Update to global tags
-    """
-    globalTags: GlobalTagsUpdate
+  """
+  Deprecated, use tags field instead
+  Update to global tags
+  """
+  globalTags: GlobalTagsUpdate
 
-    """
-    Update to tags
-    """
-    tags: GlobalTagsUpdate
+  """
+  Update to tags
+  """
+  tags: GlobalTagsUpdate
 
-    """
-    Update to editable schema metadata of the dataset
-    """
-    editableSchemaMetadata: EditableSchemaMetadataUpdate
+  """
+  Update to editable schema metadata of the dataset
+  """
+  editableSchemaMetadata: EditableSchemaMetadataUpdate
 
-    """
-    Update to editable properties
-    """
-    editableProperties: DatasetEditablePropertiesUpdate
+  """
+  Update to editable properties
+  """
+  editableProperties: DatasetEditablePropertiesUpdate
 }
 
 """
 Arguments provided to batch update Dataset entities
 """
 input BatchDatasetUpdateInput {
+  """
+  Primary key of the Dataset to which the update will be applied
+  """
+  urn: String!
 
-    """
-    Primary key of the Dataset to which the update will be applied
-    """
-    urn: String!
-
-    """
-    Arguments provided to update the Dataset
-    """
-    update: DatasetUpdateInput!
+  """
+  Arguments provided to update the Dataset
+  """
+  update: DatasetUpdateInput!
 }
-
 
 """
 Update to editable schema metadata of the dataset
 """
 input EditableSchemaMetadataUpdate {
-    """
-    Update to writable schema field metadata
-    """
-    editableSchemaFieldInfo: [EditableSchemaFieldInfoUpdate!]!
+  """
+  Update to writable schema field metadata
+  """
+  editableSchemaFieldInfo: [EditableSchemaFieldInfoUpdate!]!
 }
 
 """
 Update to writable schema field metadata
 """
 input EditableSchemaFieldInfoUpdate {
-    """
-    Flattened name of a field identifying the field the editable info is applied to
-    """
-    fieldPath: String!
+  """
+  Flattened name of a field identifying the field the editable info is applied to
+  """
+  fieldPath: String!
 
-    """
-    Edited description of the field
-    """
-    description: String
+  """
+  Edited description of the field
+  """
+  description: String
 
-    """
-    Tags associated with the field
-    """
-    globalTags: GlobalTagsUpdate
+  """
+  Tags associated with the field
+  """
+  globalTags: GlobalTagsUpdate
 }
 
 """
 Update to writable Dataset fields
 """
 input DatasetEditablePropertiesUpdate {
-    """
-    Writable description aka documentation for a Dataset
-    """
-    description: String!
-    """
-    Editable name of the Dataset
-    """
-    name: String
+  """
+  Writable description aka documentation for a Dataset
+  """
+  description: String!
+  """
+  Editable name of the Dataset
+  """
+  name: String
 }
 
 """
 Update to writable Dataset fields
 """
 input ERModelRelationshipEditablePropertiesUpdate {
-    """
-    Display name of the ERModelRelationship
-    """
-    name: String
+  """
+  Display name of the ERModelRelationship
+  """
+  name: String
 
-    """
-    Writable description for ERModelRelationship
-    """
-    description: String!
+  """
+  Writable description for ERModelRelationship
+  """
+  description: String!
 }
 
 """
 Update to writable Chart fields
 """
 input ChartEditablePropertiesUpdate {
-    """
-    Writable description aka documentation for a Chart
-    """
-    description: String!
+  """
+  Writable description aka documentation for a Chart
+  """
+  description: String!
 }
 
 """
 Update to writable Notebook fields
 """
 input NotebookEditablePropertiesUpdate {
-    """
-    Writable description aka documentation for a Notebook
-    """
-    description: String!
+  """
+  Writable description aka documentation for a Notebook
+  """
+  description: String!
 }
 
 """
 Update to writable Dashboard fields
 """
 input DashboardEditablePropertiesUpdate {
-    """
-    Writable description aka documentation for a Dashboard
-    """
-    description: String!
+  """
+  Writable description aka documentation for a Dashboard
+  """
+  description: String!
 }
 
 """
 Update to writable Data Job fields
 """
 input DataJobEditablePropertiesUpdate {
-    """
-    Writable description aka documentation for a Data Job
-    """
-    description: String!
+  """
+  Writable description aka documentation for a Data Job
+  """
+  description: String!
 }
 
 """
 Update to writable Data Flow fields
 """
 input DataFlowEditablePropertiesUpdate {
-    """
-    Writable description aka documentation for a Data Flow
-    """
-    description: String!
+  """
+  Writable description aka documentation for a Data Flow
+  """
+  description: String!
 }
 
 """
@@ -4982,10 +5007,10 @@ Deprecated, use addTag or removeTag mutation instead
 Update to the Tags associated with a Metadata Entity
 """
 input GlobalTagsUpdate {
-    """
-    The new set of tags
-    """
-    tags: [TagAssociationUpdate!]
+  """
+  The new set of tags
+  """
+  tags: [TagAssociationUpdate!]
 }
 
 """
@@ -4993,10 +5018,10 @@ Deprecated, use addTag or removeTag mutation instead
 A tag update to be applied
 """
 input TagAssociationUpdate {
-    """
-    The tag being applied
-    """
-    tag: TagUpdateInput!
+  """
+  The tag being applied
+  """
+  tag: TagUpdateInput!
 }
 
 """
@@ -5004,25 +5029,25 @@ Deprecated, use addTag or removeTag mutations instead
 An update for a particular Tag entity
 """
 input TagUpdateInput {
-    """
-    The primary key of the Tag
-    """
-    urn: String!
+  """
+  The primary key of the Tag
+  """
+  urn: String!
 
-    """
-    The display name of a Tag
-    """
-    name: String!
+  """
+  The display name of a Tag
+  """
+  name: String!
 
-    """
-    Description of the tag
-    """
-    description: String
+  """
+  Description of the tag
+  """
+  description: String
 
-    """
-    Ownership metadata of the tag
-    """
-    ownership: OwnershipUpdate
+  """
+  Ownership metadata of the tag
+  """
+  ownership: OwnershipUpdate
 }
 
 """
@@ -5049,72 +5074,72 @@ input CreateTagInput {
 Input required to create/update a new ERModelRelationship
 """
 input ERModelRelationshipUpdateInput {
-    """
-    Details about the ERModelRelationship
-    """
-    properties: ERModelRelationshipPropertiesInput
-    """
-    Update to editable properties
-    """
-    editableProperties: ERModelRelationshipEditablePropertiesUpdate
+  """
+  Details about the ERModelRelationship
+  """
+  properties: ERModelRelationshipPropertiesInput
+  """
+  Update to editable properties
+  """
+  editableProperties: ERModelRelationshipEditablePropertiesUpdate
 }
 
 """
 Details about the ERModelRelationship
 """
 input ERModelRelationshipPropertiesInput {
-    """
-    Details about the ERModelRelationship
-    """
-    name: String!
-    """
-    Details about the ERModelRelationship
-    """
-    source: String!
-    """
-    Details about the ERModelRelationship
-    """
-    destination: String!
-    """
-    Details about the ERModelRelationship
-    """
-    relationshipFieldmappings: [RelationshipFieldMappingInput!]
-    """
-    optional flag about the ERModelRelationship is getting create
-    """
-    created: Boolean
-    """
-    optional field to prevent created time while the ERModelRelationship is getting update
-    """
-    createdAt: Long
-    """
-    optional field to prevent create actor while the ERModelRelationship is getting update
-    """
-    createdBy: String
+  """
+  Details about the ERModelRelationship
+  """
+  name: String!
+  """
+  Details about the ERModelRelationship
+  """
+  source: String!
+  """
+  Details about the ERModelRelationship
+  """
+  destination: String!
+  """
+  Details about the ERModelRelationship
+  """
+  relationshipFieldmappings: [RelationshipFieldMappingInput!]
+  """
+  optional flag about the ERModelRelationship is getting create
+  """
+  created: Boolean
+  """
+  optional field to prevent created time while the ERModelRelationship is getting update
+  """
+  createdAt: Long
+  """
+  optional field to prevent create actor while the ERModelRelationship is getting update
+  """
+  createdBy: String
 }
 
 """
 Details about the ERModelRelationship
 """
 input RelationshipFieldMappingInput {
-    """
-    Details about the ERModelRelationship
-    """
-    sourceField: String
-    """
-    Details about the ERModelRelationship
-    """
-    destinationField: String
+  """
+  Details about the ERModelRelationship
+  """
+  sourceField: String
+  """
+  Details about the ERModelRelationship
+  """
+  destinationField: String
 }
 
 """
 An update for the ownership information for a Metadata Entity
 """
 input OwnershipUpdate {
-    """
-    The updated list of owners
-    """
-   owners: [OwnerUpdate!]!
+  """
+  The updated list of owners
+  """
+  owners: [OwnerUpdate!]!
 }
 
 """
@@ -5122,50 +5147,50 @@ An owner to add to a Metadata Entity
 TODO Add a USER or GROUP actor enum
 """
 input OwnerUpdate {
-    """
-    The owner URN, either a corpGroup or corpuser
-    """
-    owner: String!
+  """
+  The owner URN, either a corpGroup or corpuser
+  """
+  owner: String!
 
-    """
-    The owner type. Deprecated - Use ownershipTypeUrn field instead.
-    """
-    type: OwnershipType @deprecated
+  """
+  The owner type. Deprecated - Use ownershipTypeUrn field instead.
+  """
+  type: OwnershipType @deprecated
 
-    """
-    The urn of the ownership type entity.
-    """
-    ownershipTypeUrn: String
+  """
+  The urn of the ownership type entity.
+  """
+  ownershipTypeUrn: String
 }
 
 """
 An update for the deprecation information for a Metadata Entity
 """
 input DatasetDeprecationUpdate {
-    """
-    Whether the dataset is deprecated
-    """
-    deprecated: Boolean!
+  """
+  Whether the dataset is deprecated
+  """
+  deprecated: Boolean!
 
-    """
-    The time user plan to decommission this dataset
-    """
-    decommissionTime: Long
+  """
+  The time user plan to decommission this dataset
+  """
+  decommissionTime: Long
 
-    """
-    Additional information about the dataset deprecation plan
-    """
-    note: String!
+  """
+  Additional information about the dataset deprecation plan
+  """
+  note: String!
 }
 
 """
 An update for the institutional memory information for a Metadata Entity
 """
 input InstitutionalMemoryUpdate {
-    """
-    The individual references in the institutional memory
-    """
-    elements: [InstitutionalMemoryMetadataUpdate!]!
+  """
+  The individual references in the institutional memory
+  """
+  elements: [InstitutionalMemoryMetadataUpdate!]!
 }
 
 """
@@ -5173,477 +5198,480 @@ An institutional memory to add to a Metadata Entity
 TODO Add a USER or GROUP actor enum
 """
 input InstitutionalMemoryMetadataUpdate {
-    """
-    Link to a document or wiki page or another internal resource
-    """
-    url: String!
+  """
+  Link to a document or wiki page or another internal resource
+  """
+  url: String!
 
-    """
-    Description of the resource
-    """
-    description: String
+  """
+  Description of the resource
+  """
+  description: String
 
-    """
-    The corp user urn of the author of the metadata
-    """
-    author: String!
+  """
+  The corp user urn of the author of the metadata
+  """
+  author: String!
 
-    """
-    The time at which this metadata was created
-    """
-    createdAt: Long
+  """
+  The time at which this metadata was created
+  """
+  createdAt: Long
 }
 
 """
 A Notebook Metadata Entity
 """
 type Notebook implements Entity & BrowsableEntity {
-    """
-    The primary key of the Notebook
-    """
-    urn: String!
+  """
+  The primary key of the Notebook
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The Notebook tool name
-    """
-    tool: String!
+  """
+  The Notebook tool name
+  """
+  tool: String!
 
-    """
-    An id unique within the Notebook tool
-    """
-    notebookId: String!
+  """
+  An id unique within the Notebook tool
+  """
+  notebookId: String!
 
-    """
-    Additional read only information about the Notebook
-    """
-    info: NotebookInfo
+  """
+  Additional read only information about the Notebook
+  """
+  info: NotebookInfo
 
-    """
-    Additional read write properties about the Notebook
-    """
-    editableProperties: NotebookEditableProperties
+  """
+  Additional read write properties about the Notebook
+  """
+  editableProperties: NotebookEditableProperties
 
-    """
-    Ownership metadata of the Notebook
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the Notebook
+  """
+  ownership: Ownership
 
-    """
-    Status metadata of the Notebook
-    """
-    status: Status
+  """
+  Status metadata of the Notebook
+  """
+  status: Status
 
-    """
-    The content of this Notebook
-    """
-    content: NotebookContent!
+  """
+  The content of this Notebook
+  """
+  content: NotebookContent!
 
-    """
-    The tags associated with the Notebook
-    """
-    tags: GlobalTags
+  """
+  The tags associated with the Notebook
+  """
+  tags: GlobalTags
 
-    """
-    References to internal resources related to the Notebook
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the Notebook
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    The Domain associated with the Notebook
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Notebook
+  """
+  domain: DomainAssociation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Sub Types that this entity implements
-    """
-    subTypes: SubTypes
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 
-    """
-    The structured glossary terms associated with the notebook
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the notebook
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    Standardized platform.
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform.
+  """
+  platform: DataPlatform!
 
-    """
-    The browse paths corresponding to the Notebook. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the Notebook. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 }
 
 """
 The actual content in a Notebook
 """
 type NotebookContent {
-    """
-    The content of a Notebook which is composed by a list of NotebookCell
-    """
-    cells: [NotebookCell!]!
+  """
+  The content of a Notebook which is composed by a list of NotebookCell
+  """
+  cells: [NotebookCell!]!
 }
 
 """
 The Union of every NotebookCell
 """
 type NotebookCell {
-    """
-    The chart cell content. The will be non-null only when all other cell field is null.
-    """
-    chartCell: ChartCell
+  """
+  The chart cell content. The will be non-null only when all other cell field is null.
+  """
+  chartCell: ChartCell
 
-    """
-    The text cell content. The will be non-null only when all other cell field is null.
-    """
-    textCell: TextCell
+  """
+  The text cell content. The will be non-null only when all other cell field is null.
+  """
+  textCell: TextCell
 
-    """
-    The query cell content. The will be non-null only when all other cell field is null.
-    """
-    queryChell: QueryCell
+  """
+  The query cell content. The will be non-null only when all other cell field is null.
+  """
+  queryChell: QueryCell
 
-    """
-    The type of this Notebook cell
-    """
-    type: NotebookCellType!
+  """
+  The type of this Notebook cell
+  """
+  type: NotebookCellType!
 }
 
 """
 The type for a NotebookCell
 """
 enum NotebookCellType {
-    """
-    TEXT Notebook cell type. The cell context is text only.
-    """
-    TEXT_CELL,
+  """
+  TEXT Notebook cell type. The cell context is text only.
+  """
+  TEXT_CELL
 
-    """
-    QUERY Notebook cell type. The cell context is query only.
-    """
-    QUERY_CELL,
+  """
+  QUERY Notebook cell type. The cell context is query only.
+  """
+  QUERY_CELL
 
-    """
-    CHART Notebook cell type. The cell content is chart only.
-    """
-    CHART_CELL
+  """
+  CHART Notebook cell type. The cell content is chart only.
+  """
+  CHART_CELL
 }
 
 """
 A Notebook cell which contains text as content
 """
 type TextCell {
+  """
+  Title of the cell
+  """
+  cellTitle: String!
 
-    """
-    Title of the cell
-    """
-    cellTitle: String!
+  """
+  Unique id for the cell.
+  """
+  cellId: String!
 
-    """
-    Unique id for the cell.
-    """
-    cellId: String!
+  """
+  Captures information about who created/last modified/deleted this TextCell and when
+  """
+  changeAuditStamps: ChangeAuditStamps
 
-    """
-    Captures information about who created/last modified/deleted this TextCell and when
-    """
-    changeAuditStamps: ChangeAuditStamps
-
-    """
-    The actual text in a TextCell in a Notebook
-    """
-    text: String!
+  """
+  The actual text in a TextCell in a Notebook
+  """
+  text: String!
 }
 
 """
 A Notebook cell which contains Query as content
 """
 type QueryCell {
-    """
-    Title of the cell
-    """
-    cellTitle: String!
+  """
+  Title of the cell
+  """
+  cellTitle: String!
 
-    """
-    Unique id for the cell.
-    """
-    cellId: String!
+  """
+  Unique id for the cell.
+  """
+  cellId: String!
 
-    """
-    Captures information about who created/last modified/deleted this TextCell and when
-    """
-    changeAuditStamps: ChangeAuditStamps
+  """
+  Captures information about who created/last modified/deleted this TextCell and when
+  """
+  changeAuditStamps: ChangeAuditStamps
 
-    """
-    Raw query to explain some specific logic in a Notebook
-    """
-    rawQuery: String!
+  """
+  Raw query to explain some specific logic in a Notebook
+  """
+  rawQuery: String!
 
-    """
-    Captures information about who last executed this query cell and when
-    """
-    lastExecuted: AuditStamp
+  """
+  Captures information about who last executed this query cell and when
+  """
+  lastExecuted: AuditStamp
 }
 
 """
 A Notebook cell which contains chart as content
 """
 type ChartCell {
-    """
-    Title of the cell
-    """
-    cellTitle: String!
+  """
+  Title of the cell
+  """
+  cellTitle: String!
 
-    """
-    Unique id for the cell.
-    """
-    cellId: String!
+  """
+  Unique id for the cell.
+  """
+  cellId: String!
 
-    """
-    Captures information about who created/last modified/deleted this TextCell and when
-    """
-    changeAuditStamps: ChangeAuditStamps
+  """
+  Captures information about who created/last modified/deleted this TextCell and when
+  """
+  changeAuditStamps: ChangeAuditStamps
 }
 
 """
 Captures information about who created/last modified/deleted the entity and when
 """
 type ChangeAuditStamps {
-    """
-    An AuditStamp corresponding to the creation
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the creation
+  """
+  created: AuditStamp!
 
-    """
-    An AuditStamp corresponding to the modification
-    """
-    lastModified: AuditStamp!
+  """
+  An AuditStamp corresponding to the modification
+  """
+  lastModified: AuditStamp!
 
-    """
-    An optional AuditStamp corresponding to the deletion
-    """
-    deleted: AuditStamp
+  """
+  An optional AuditStamp corresponding to the deletion
+  """
+  deleted: AuditStamp
 }
 
 """
 A Dashboard Metadata Entity
 """
 type Dashboard implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the Dashboard
-    """
-    urn: String!
+  """
+  The primary key of the Dashboard
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    The dashboard tool name
-    Note that this will soon be deprecated in favor of a standardized notion of Data Platform
-    """
-    tool: String!
+  """
+  The dashboard tool name
+  Note that this will soon be deprecated in favor of a standardized notion of Data Platform
+  """
+  tool: String!
 
-    """
-    An id unique within the dashboard tool
-    """
-    dashboardId: String!
+  """
+  An id unique within the dashboard tool
+  """
+  dashboardId: String!
 
-    """
-    Additional read only properties about the dashboard
-    """
-    properties: DashboardProperties
+  """
+  Additional read only properties about the dashboard
+  """
+  properties: DashboardProperties
 
-    """
-    Additional read write properties about the dashboard
-    """
-    editableProperties: DashboardEditableProperties
+  """
+  Additional read write properties about the dashboard
+  """
+  editableProperties: DashboardEditableProperties
 
-    """
-    Ownership metadata of the dashboard
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the dashboard
+  """
+  ownership: Ownership
 
-    """
-    Status metadata of the dashboard
-    """
-    status: Status
+  """
+  Status metadata of the dashboard
+  """
+  status: Status
 
-    """
-    Embed information about the Dashboard
-    """
-    embed: Embed
+  """
+  Embed information about the Dashboard
+  """
+  embed: Embed
 
-    """
-    The deprecation status of the dashboard
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the dashboard
+  """
+  deprecation: Deprecation
 
-    """
-    The tags associated with the dashboard
-    """
-    tags: GlobalTags
+  """
+  The tags associated with the dashboard
+  """
+  tags: GlobalTags
 
-    """
-    References to internal resources related to the dashboard
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dashboard
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    The structured glossary terms associated with the dashboard
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dashboard
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the Dashboard
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Dashboard
+  """
+  domain: DomainAssociation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the dashboard. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the dashboard. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Experimental (Subject to breaking change) -- Statistics about how this Dashboard is used
-    """
-    usageStats(startTimeMillis: Long, endTimeMillis: Long, limit: Int): DashboardUsageQueryResult
+  """
+  Experimental (Subject to breaking change) -- Statistics about how this Dashboard is used
+  """
+  usageStats(
+    startTimeMillis: Long
+    endTimeMillis: Long
+    limit: Int
+  ): DashboardUsageQueryResult
 
-    """
-    Experimental - Summary operational & usage statistics about a Dashboard
-    """
-    statsSummary: DashboardStatsSummary
+  """
+  Experimental - Summary operational & usage statistics about a Dashboard
+  """
+  statsSummary: DashboardStatsSummary
 
-    """
-    Deprecated, use properties field instead
-    Additional read only information about the dashboard
-    """
-    info: DashboardInfo @deprecated
+  """
+  Deprecated, use properties field instead
+  Additional read only information about the dashboard
+  """
+  info: DashboardInfo @deprecated
 
-    """
-    Deprecated, use editableProperties instead
-    Additional read write properties about the Dashboard
-    """
-    editableInfo: DashboardEditableProperties @deprecated
+  """
+  Deprecated, use editableProperties instead
+  Additional read write properties about the Dashboard
+  """
+  editableInfo: DashboardEditableProperties @deprecated
 
-    """
-    Deprecated, use tags field instead
-    The structured tags associated with the dashboard
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags field instead
+  The structured tags associated with the dashboard
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Standardized platform urn where the dashboard is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the dashboard is defined
+  """
+  platform: DataPlatform!
 
-    """
-    Input fields that power all the charts in the dashboard
-    """
-    inputFields: InputFields
+  """
+  Input fields that power all the charts in the dashboard
+  """
+  inputFields: InputFields
 
-    """
-    Sub Types of the dashboard
-    """
-    subTypes: SubTypes
+  """
+  Sub Types of the dashboard
+  """
+  subTypes: SubTypes
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    Experimental! The resolved health statuses of the asset
-    """
-    health: [Health!]
+  """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!]
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 }
 
 """
@@ -5651,330 +5679,330 @@ Deprecated, use DashboardProperties instead
 Additional read only info about a Dashboard
 """
 type DashboardInfo {
-    """
-    Display of the dashboard
-    """
-    name: String!
+  """
+  Display of the dashboard
+  """
+  name: String!
 
-    """
-    Description of the dashboard
-    """
-    description: String
+  """
+  Description of the dashboard
+  """
+  description: String
 
-    """
-    Deprecated, use relationship Contains instead
-    Charts that comprise the dashboard
-    """
-    charts: [Chart!]! @deprecated
+  """
+  Deprecated, use relationship Contains instead
+  Charts that comprise the dashboard
+  """
+  charts: [Chart!]! @deprecated
 
-    """
-    Native platform URL of the dashboard
-    """
-    externalUrl: String
+  """
+  Native platform URL of the dashboard
+  """
+  externalUrl: String
 
-    """
-    Access level for the dashboard
-    Note that this will soon be deprecated for low usage
-    """
-    access: AccessLevel
+  """
+  Access level for the dashboard
+  Note that this will soon be deprecated for low usage
+  """
+  access: AccessLevel
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    The time when this dashboard last refreshed
-    """
-    lastRefreshed: Long
+  """
+  The time when this dashboard last refreshed
+  """
+  lastRefreshed: Long
 
-    """
-    An AuditStamp corresponding to the creation of this dashboard
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the creation of this dashboard
+  """
+  created: AuditStamp!
 
-    """
-    An AuditStamp corresponding to the modification of this dashboard
-    """
-    lastModified: AuditStamp!
+  """
+  An AuditStamp corresponding to the modification of this dashboard
+  """
+  lastModified: AuditStamp!
 
-    """
-    An optional AuditStamp corresponding to the deletion of this dashboard
-    """
-    deleted: AuditStamp
+  """
+  An optional AuditStamp corresponding to the deletion of this dashboard
+  """
+  deleted: AuditStamp
 }
 
 """
 Additional read only information about a Notebook
 """
 type NotebookInfo {
-    """
-    Display of the Notebook
-    """
-    title: String
+  """
+  Display of the Notebook
+  """
+  title: String
 
-    """
-    Description of the Notebook
-    """
-    description: String
+  """
+  Description of the Notebook
+  """
+  description: String
 
-    """
-    Native platform URL of the Notebook
-    """
-    externalUrl: String
+  """
+  Native platform URL of the Notebook
+  """
+  externalUrl: String
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    Captures information about who created/last modified/deleted this Notebook and when
-    """
-    changeAuditStamps: ChangeAuditStamps
+  """
+  Captures information about who created/last modified/deleted this Notebook and when
+  """
+  changeAuditStamps: ChangeAuditStamps
 }
 
 """
 Additional read only properties about a Dashboard
 """
 type DashboardProperties {
-    """
-    Display of the dashboard
-    """
-    name: String!
+  """
+  Display of the dashboard
+  """
+  name: String!
 
-    """
-    Description of the dashboard
-    """
-    description: String
+  """
+  Description of the dashboard
+  """
+  description: String
 
-    """
-    Native platform URL of the dashboard
-    """
-    externalUrl: String
+  """
+  Native platform URL of the dashboard
+  """
+  externalUrl: String
 
-    """
-    Access level for the dashboard
-    Note that this will soon be deprecated for low usage
-    """
-    access: AccessLevel
+  """
+  Access level for the dashboard
+  Note that this will soon be deprecated for low usage
+  """
+  access: AccessLevel
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    The time when this dashboard last refreshed
-    """
-    lastRefreshed: Long
+  """
+  The time when this dashboard last refreshed
+  """
+  lastRefreshed: Long
 
-    """
-    An AuditStamp corresponding to the creation of this dashboard
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the creation of this dashboard
+  """
+  created: AuditStamp!
 
-    """
-    An AuditStamp corresponding to the modification of this dashboard
-    """
-    lastModified: AuditStamp!
+  """
+  An AuditStamp corresponding to the modification of this dashboard
+  """
+  lastModified: AuditStamp!
 
-    """
-    An optional AuditStamp corresponding to the deletion of this dashboard
-    """
-    deleted: AuditStamp
+  """
+  An optional AuditStamp corresponding to the deletion of this dashboard
+  """
+  deleted: AuditStamp
 }
 
 """
 A Chart Metadata Entity
 """
 type Chart implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the Chart
-    """
-    urn: String!
+  """
+  The primary key of the Chart
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    The chart tool name
-    Note that this field will soon be deprecated in favor a unified notion of Data Platform
-    """
-    tool: String!
+  """
+  The chart tool name
+  Note that this field will soon be deprecated in favor a unified notion of Data Platform
+  """
+  tool: String!
 
-    """
-    An id unique within the charting tool
-    """
-    chartId: String!
+  """
+  An id unique within the charting tool
+  """
+  chartId: String!
 
-    """
-    Additional read only properties about the Chart
-    """
-    properties: ChartProperties
+  """
+  Additional read only properties about the Chart
+  """
+  properties: ChartProperties
 
-    """
-    Additional read write properties about the Chart
-    """
-    editableProperties: ChartEditableProperties
+  """
+  Additional read write properties about the Chart
+  """
+  editableProperties: ChartEditableProperties
 
-    """
-    Info about the query which is used to render the chart
-    """
-    query: ChartQuery
+  """
+  Info about the query which is used to render the chart
+  """
+  query: ChartQuery
 
-    """
-    Ownership metadata of the chart
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the chart
+  """
+  ownership: Ownership
 
-    """
-    Status metadata of the chart
-    """
-    status: Status
+  """
+  Status metadata of the chart
+  """
+  status: Status
 
-    """
-    The deprecation status of the chart
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the chart
+  """
+  deprecation: Deprecation
 
-    """
-    Embed information about the Chart
-    """
-    embed: Embed
+  """
+  Embed information about the Chart
+  """
+  embed: Embed
 
-    """
-    The tags associated with the chart
-    """
-    tags: GlobalTags
+  """
+  The tags associated with the chart
+  """
+  tags: GlobalTags
 
-    """
-    References to internal resources related to the dashboard
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dashboard
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    The structured glossary terms associated with the dashboard
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dashboard
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the Chart
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Chart
+  """
+  domain: DomainAssociation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Not yet implemented.
+  """
+  Not yet implemented.
 
-    Experimental - Summary operational & usage statistics about a Chart
-    """
-    statsSummary: ChartStatsSummary
+  Experimental - Summary operational & usage statistics about a Chart
+  """
+  statsSummary: ChartStatsSummary
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the chart. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the chart. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Deprecated, use properties field instead
-    Additional read only information about the chart
-    """
-    info: ChartInfo @deprecated
+  """
+  Deprecated, use properties field instead
+  Additional read only information about the chart
+  """
+  info: ChartInfo @deprecated
 
-    """
-    Deprecated, use editableProperties field instead
-    Additional read write information about the Chart
-    """
-    editableInfo: ChartEditableProperties @deprecated
+  """
+  Deprecated, use editableProperties field instead
+  Additional read write information about the Chart
+  """
+  editableInfo: ChartEditableProperties @deprecated
 
-    """
-    Deprecated, use tags instead
-    The structured tags associated with the chart
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags instead
+  The structured tags associated with the chart
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Standardized platform urn where the chart is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the chart is defined
+  """
+  platform: DataPlatform!
 
-    """
-    Input fields to power the chart
-    """
-    inputFields: InputFields
+  """
+  Input fields to power the chart
+  """
+  inputFields: InputFields
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Sub Types that this entity implements
-    """
-    subTypes: SubTypes
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    Experimental! The resolved health statuses of the asset
-    """
-    health: [Health!]
+  """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!]
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 }
 
 """
@@ -5982,392 +6010,391 @@ Deprecated, use ChartProperties instead
 Additional read only information about the chart
 """
 type ChartInfo {
-    """
-    Display name of the chart
-    """
-    name: String!
+  """
+  Display name of the chart
+  """
+  name: String!
 
-    """
-    Description of the chart
-    """
-    description: String
+  """
+  Description of the chart
+  """
+  description: String
 
-    """
-    Deprecated, use relationship Consumes instead
-    Data sources for the chart
-    """
-    inputs: [Dataset!] @deprecated
+  """
+  Deprecated, use relationship Consumes instead
+  Data sources for the chart
+  """
+  inputs: [Dataset!] @deprecated
 
-    """
-    Native platform URL of the chart
-    """
-    externalUrl: String
+  """
+  Native platform URL of the chart
+  """
+  externalUrl: String
 
-    """
-    Access level for the chart
-    """
-    type: ChartType
+  """
+  Access level for the chart
+  """
+  type: ChartType
 
-    """
-    Access level for the chart
-    """
-    access: AccessLevel
+  """
+  Access level for the chart
+  """
+  access: AccessLevel
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    The time when this chart last refreshed
-    """
-    lastRefreshed: Long
+  """
+  The time when this chart last refreshed
+  """
+  lastRefreshed: Long
 
-    """
-    An AuditStamp corresponding to the creation of this chart
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the creation of this chart
+  """
+  created: AuditStamp!
 
-    """
-    An AuditStamp corresponding to the modification of this chart
-    """
-    lastModified: AuditStamp!
+  """
+  An AuditStamp corresponding to the modification of this chart
+  """
+  lastModified: AuditStamp!
 
-    """
-    An optional AuditStamp corresponding to the deletion of this chart
-    """
-    deleted: AuditStamp
+  """
+  An optional AuditStamp corresponding to the deletion of this chart
+  """
+  deleted: AuditStamp
 }
 
 """
 Additional read only properties about the chart
 """
 type ChartProperties {
-    """
-    Display name of the chart
-    """
-    name: String!
+  """
+  Display name of the chart
+  """
+  name: String!
 
-    """
-    Description of the chart
-    """
-    description: String
+  """
+  Description of the chart
+  """
+  description: String
 
-    """
-    Native platform URL of the chart
-    """
-    externalUrl: String
+  """
+  Native platform URL of the chart
+  """
+  externalUrl: String
 
-    """
-    Access level for the chart
-    """
-    type: ChartType
+  """
+  Access level for the chart
+  """
+  type: ChartType
 
-    """
-    Access level for the chart
-    """
-    access: AccessLevel
+  """
+  Access level for the chart
+  """
+  access: AccessLevel
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    The time when this chart last refreshed
-    """
-    lastRefreshed: Long
+  """
+  The time when this chart last refreshed
+  """
+  lastRefreshed: Long
 
-    """
-    An AuditStamp corresponding to the creation of this chart
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the creation of this chart
+  """
+  created: AuditStamp!
 
-    """
-    An AuditStamp corresponding to the modification of this chart
-    """
-    lastModified: AuditStamp!
+  """
+  An AuditStamp corresponding to the modification of this chart
+  """
+  lastModified: AuditStamp!
 
-    """
-    An optional AuditStamp corresponding to the deletion of this chart
-    """
-    deleted: AuditStamp
+  """
+  An optional AuditStamp corresponding to the deletion of this chart
+  """
+  deleted: AuditStamp
 }
 
 """
 The access level for a Metadata Entity, either public or private
 """
 enum AccessLevel {
-    """
-    Publicly available
-    """
-    PUBLIC
+  """
+  Publicly available
+  """
+  PUBLIC
 
-    """
-    Restricted to a subset of viewers
-    """
-    PRIVATE
+  """
+  Restricted to a subset of viewers
+  """
+  PRIVATE
 }
 
 """
 The type of a Chart Entity
 """
 enum ChartType {
-    """
-    Bar graph
-    """
-    BAR
+  """
+  Bar graph
+  """
+  BAR
 
-    """
-    Pie chart
-    """
-    PIE
+  """
+  Pie chart
+  """
+  PIE
 
-    """
-    Scatter plot
-    """
-    SCATTER
+  """
+  Scatter plot
+  """
+  SCATTER
 
-    """
-    Table
-    """
-    TABLE
+  """
+  Table
+  """
+  TABLE
 
-    """
-    Markdown formatted text
-    """
-    TEXT
+  """
+  Markdown formatted text
+  """
+  TEXT
 
-    """
-    A line chart
-    """
-    LINE
+  """
+  A line chart
+  """
+  LINE
 
-    """
-    An area chart
-    """
-    AREA
+  """
+  An area chart
+  """
+  AREA
 
-    """
-    A histogram chart
-    """
-    HISTOGRAM
+  """
+  A histogram chart
+  """
+  HISTOGRAM
 
-    """
-    A box plot chart
-    """
-    BOX_PLOT
+  """
+  A box plot chart
+  """
+  BOX_PLOT
 
-    """
-    A word cloud chart
-    """
-    WORD_CLOUD
+  """
+  A word cloud chart
+  """
+  WORD_CLOUD
 
-    """
-    A Cohort Analysis chart
-    """
-    COHORT
+  """
+  A Cohort Analysis chart
+  """
+  COHORT
 }
 
 """
 The query that was used to populate a Chart
 """
 type ChartQuery {
-    """
-    Raw query to build a chart from input datasets
-    """
-    rawQuery: String!
+  """
+  Raw query to build a chart from input datasets
+  """
+  rawQuery: String!
 
-    """
-    The type of the chart query
-    """
-    type: ChartQueryType!
+  """
+  The type of the chart query
+  """
+  type: ChartQueryType!
 }
 
 """
 The type of the Chart Query
 """
 enum ChartQueryType {
-    """
-    Standard ANSI SQL
-    """
-    SQL
+  """
+  Standard ANSI SQL
+  """
+  SQL
 
-    """
-    LookML
-    """
-    LOOKML
+  """
+  LookML
+  """
+  LOOKML
 }
-
 
 """
 A Data Flow Metadata Entity, representing an set of pipelined Data Job or Tasks required
 to produce an output Dataset Also known as a Data Pipeline
 """
 type DataFlow implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of a Data Flow
-    """
-    urn: String!
+  """
+  The primary key of a Data Flow
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    Workflow orchestrator ei Azkaban, Airflow
-    """
-    orchestrator: String!
+  """
+  Workflow orchestrator ei Azkaban, Airflow
+  """
+  orchestrator: String!
 
-    """
-    Id of the flow
-    """
-    flowId: String!
+  """
+  Id of the flow
+  """
+  flowId: String!
 
-    """
-    Cluster of the flow
-    """
-    cluster: String!
+  """
+  Cluster of the flow
+  """
+  cluster: String!
 
-    """
-    Additional read only properties about a Data flow
-    """
-    properties: DataFlowProperties
+  """
+  Additional read only properties about a Data flow
+  """
+  properties: DataFlowProperties
 
-    """
-    Additional read write properties about a Data Flow
-    """
-    editableProperties: DataFlowEditableProperties
+  """
+  Additional read write properties about a Data Flow
+  """
+  editableProperties: DataFlowEditableProperties
 
-    """
-    Ownership metadata of the flow
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the flow
+  """
+  ownership: Ownership
 
-    """
-    The tags associated with the dataflow
-    """
-    tags: GlobalTags
+  """
+  The tags associated with the dataflow
+  """
+  tags: GlobalTags
 
-    """
-    Status metadata of the dataflow
-    """
-    status: Status
+  """
+  Status metadata of the dataflow
+  """
+  status: Status
 
-    """
-    The deprecation status of the Data Flow
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the Data Flow
+  """
+  deprecation: Deprecation
 
-    """
-    References to internal resources related to the dashboard
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dashboard
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    The structured glossary terms associated with the dashboard
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dashboard
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the DataFlow
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the DataFlow
+  """
+  domain: DomainAssociation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the data flow. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the data flow. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Deprecated, use properties field instead
-    Additional read only information about a Data flow
-    """
-    info: DataFlowInfo @deprecated
+  """
+  Deprecated, use properties field instead
+  Additional read only information about a Data flow
+  """
+  info: DataFlowInfo @deprecated
 
-    """
-    Deprecated, use tags field instead
-    The structured tags associated with the dataflow
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags field instead
+  The structured tags associated with the dataflow
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    Deprecated, use relationship IsPartOf instead
-    Data Jobs
-    """
-    dataJobs: DataFlowDataJobsRelationships @deprecated
+  """
+  Deprecated, use relationship IsPartOf instead
+  Data Jobs
+  """
+  dataJobs: DataFlowDataJobsRelationships @deprecated
 
-    """
-    Standardized platform urn where the datflow is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the datflow is defined
+  """
+  platform: DataPlatform!
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    Experimental! The resolved health statuses of the asset
-    """
-    health: [Health!]
+  """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!]
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
@@ -6375,60 +6402,60 @@ Deprecated, use DataFlowProperties instead
 Additional read only properties about a Data Flow aka Pipeline
 """
 type DataFlowInfo {
-    """
-    Display name of the flow
-    """
-    name: String!
+  """
+  Display name of the flow
+  """
+  name: String!
 
-    """
-    Description of the flow
-    """
-    description: String
+  """
+  Description of the flow
+  """
+  description: String
 
-    """
-    Optional project or namespace associated with the flow
-    """
-    project: String
+  """
+  Optional project or namespace associated with the flow
+  """
+  project: String
 
-    """
-    External URL associated with the DataFlow
-    """
-    externalUrl: String
+  """
+  External URL associated with the DataFlow
+  """
+  externalUrl: String
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 Additional read only properties about a Data Flow aka Pipeline
 """
 type DataFlowProperties {
-    """
-    Display name of the flow
-    """
-    name: String!
+  """
+  Display name of the flow
+  """
+  name: String!
 
-    """
-    Description of the flow
-    """
-    description: String
+  """
+  Description of the flow
+  """
+  description: String
 
-    """
-    Optional project or namespace associated with the flow
-    """
-    project: String
+  """
+  Optional project or namespace associated with the flow
+  """
+  project: String
 
-    """
-    External URL associated with the DataFlow
-    """
-    externalUrl: String
+  """
+  External URL associated with the DataFlow
+  """
+  externalUrl: String
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
@@ -6436,174 +6463,174 @@ A Data Job Metadata Entity, representing an individual unit of computation or Ta
 to produce an output Dataset Always part of a parent Data Flow aka Pipeline
 """
 type DataJob implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the Data Job
-    """
-    urn: String!
+  """
+  The primary key of the Data Job
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Sub Types that this entity implements
-    """
-    subTypes: SubTypes
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    Deprecated, use relationship IsPartOf instead
-    The associated data flow
-    """
-    dataFlow: DataFlow
+  """
+  Deprecated, use relationship IsPartOf instead
+  The associated data flow
+  """
+  dataFlow: DataFlow
 
-    """
-    Id of the job
-    """
-    jobId: String!
+  """
+  Id of the job
+  """
+  jobId: String!
 
-    """
-    Additional read only properties associated with the Data Job
-    """
-    properties: DataJobProperties
+  """
+  Additional read only properties associated with the Data Job
+  """
+  properties: DataJobProperties
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    Additional read write properties associated with the Data Job
-    """
-    editableProperties: DataJobEditableProperties
+  """
+  Additional read write properties associated with the Data Job
+  """
+  editableProperties: DataJobEditableProperties
 
-    """
-    The tags associated with the DataJob
-    """
-    tags: GlobalTags
+  """
+  The tags associated with the DataJob
+  """
+  tags: GlobalTags
 
-    """
-    Ownership metadata of the job
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the job
+  """
+  ownership: Ownership
 
-    """
-    Status metadata of the DataJob
-    """
-    status: Status
+  """
+  Status metadata of the DataJob
+  """
+  status: Status
 
-    """
-    The deprecation status of the Data Flow
-    """
-    deprecation: Deprecation
+  """
+  The deprecation status of the Data Flow
+  """
+  deprecation: Deprecation
 
-    """
-    References to internal resources related to the dashboard
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dashboard
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    The structured glossary terms associated with the dashboard
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the dashboard
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the Data Job
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Data Job
+  """
+  domain: DomainAssociation
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the data job. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the data job. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Deprecated, use properties field instead
-    Additional read only information about a Data processing job
-    """
-    info: DataJobInfo @deprecated
+  """
+  Deprecated, use properties field instead
+  Additional read only information about a Data processing job
+  """
+  info: DataJobInfo @deprecated
 
-    """
-    Information about the inputs and outputs of a Data processing job including column-level lineage.
-    """
-    inputOutput: DataJobInputOutput
+  """
+  Information about the inputs and outputs of a Data processing job including column-level lineage.
+  """
+  inputOutput: DataJobInputOutput
 
-    """
-    Deprecated, use the tags field instead
-    The structured tags associated with the DataJob
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use the tags field instead
+  The structured tags associated with the DataJob
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    History of runs of this task
-    """
-    runs(start: Int, count: Int): DataProcessInstanceResult
+  """
+  History of runs of this task
+  """
+  runs(start: Int, count: Int): DataProcessInstanceResult
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    Experimental! The resolved health statuses of the asset
-    """
-    health: [Health!]
+  """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!]
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Data Transform Logic associated with the Data Job
-    """
-    dataTransformLogic: DataTransformLogic
+  """
+  Data Transform Logic associated with the Data Job
+  """
+  dataTransformLogic: DataTransformLogic
 }
 
 """
@@ -6611,183 +6638,186 @@ A DataProcessInstance Metadata Entity, representing an individual run of
 a task or datajob.
 """
 type DataProcessInstance implements EntityWithRelationships & Entity {
-    """
-    The primary key of the DataProcessInstance
-    """
-    urn: String!
+  """
+  The primary key of the DataProcessInstance
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The history of state changes for the run
-    """
-    state(startTimeMillis: Long, endTimeMillis: Long, limit: Int): [DataProcessRunEvent]
+  """
+  The history of state changes for the run
+  """
+  state(
+    startTimeMillis: Long
+    endTimeMillis: Long
+    limit: Int
+  ): [DataProcessRunEvent]
 
-    """
-    When the run was kicked off
-    """
-    created: AuditStamp
+  """
+  When the run was kicked off
+  """
+  created: AuditStamp
 
-    """
-    The name of the data process
-    """
-    name: String
+  """
+  The name of the data process
+  """
+  name: String
 
-    """
-    Edges extending from this entity.
-    In the UI, used for inputs, outputs and parentTemplate
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity.
+  In the UI, used for inputs, outputs and parentTemplate
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The link to view the task run in the source system
-    """
-    externalUrl: String
+  """
+  The link to view the task run in the source system
+  """
+  externalUrl: String
 }
 
 """
 A state change event in the data process instance lifecycle
 """
 type DataProcessRunEvent implements TimeSeriesAspect {
-    """
-    The status of the data process instance
-    """
-    status: DataProcessRunStatus
+  """
+  The status of the data process instance
+  """
+  status: DataProcessRunStatus
 
-    """
-    The try number that this instance run is in
-    """
-    attempt: Int
+  """
+  The try number that this instance run is in
+  """
+  attempt: Int
 
-    """
-    The result of a run
-    """
-    result: DataProcessInstanceRunResult
+  """
+  The result of a run
+  """
+  result: DataProcessInstanceRunResult
 
-    """
-    The timestamp associated with the run event in milliseconds
-    """
-    timestampMillis: Long!
+  """
+  The timestamp associated with the run event in milliseconds
+  """
+  timestampMillis: Long!
 
-    """
-    The duration of the run in milliseconds
-    """
-    durationMillis: Long
+  """
+  The duration of the run in milliseconds
+  """
+  durationMillis: Long
 }
 
 """
 The status of the data process instance
 """
 enum DataProcessRunStatus {
-    """
-    The data process instance has started but not completed
-    """
-    STARTED
+  """
+  The data process instance has started but not completed
+  """
+  STARTED
 
-    """
-    The data process instance has completed
-    """
-    COMPLETE
+  """
+  The data process instance has completed
+  """
+  COMPLETE
 }
 
 """
 the result of a run, part of the run state
 """
 type DataProcessInstanceRunResult {
-    """
-    The outcome of the run
-    """
-    resultType: DataProcessInstanceRunResultType
+  """
+  The outcome of the run
+  """
+  resultType: DataProcessInstanceRunResultType
 
-    """
-    The outcome of the run in the data platforms native language
-    """
-    nativeResultType: String
+  """
+  The outcome of the run in the data platforms native language
+  """
+  nativeResultType: String
 }
 
 """
 The result of the data process run
 """
 enum DataProcessInstanceRunResultType {
-    """
-    The run finished successfully
-    """
-    SUCCESS
+  """
+  The run finished successfully
+  """
+  SUCCESS
 
-    """
-    The run finished in failure
-    """
-    FAILURE
+  """
+  The run finished in failure
+  """
+  FAILURE
 
-    """
-    The run was skipped
-    """
-    SKIPPED
+  """
+  The run was skipped
+  """
+  SKIPPED
 
-    """
-    The run failed and is up for retry
-    """
-    UP_FOR_RETRY
+  """
+  The run failed and is up for retry
+  """
+  UP_FOR_RETRY
 }
-
 
 """
 Deprecated, use DataJobProperties instead
 Additional read only information about a Data Job aka Task
 """
 type DataJobInfo {
-    """
-    Job display name
-    """
-    name: String!
+  """
+  Job display name
+  """
+  name: String!
 
-    """
-    Job description
-    """
-    description: String
+  """
+  Job description
+  """
+  description: String
 
-    """
-    External URL associated with the DataJob
-    """
-    externalUrl: String
+  """
+  External URL associated with the DataJob
+  """
+  externalUrl: String
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 Additional read only properties about a Data Job aka Task
 """
 type DataJobProperties {
-    """
-    Job display name
-    """
-    name: String!
+  """
+  Job display name
+  """
+  name: String!
 
-    """
-    Job description
-    """
-    description: String
+  """
+  Job description
+  """
+  description: String
 
-    """
-    External URL associated with the DataJob
-    """
-    externalUrl: String
+  """
+  External URL associated with the DataJob
+  """
+  externalUrl: String
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
@@ -6795,30 +6825,30 @@ The lineage information for a DataJob
 TODO Rename this to align with other Lineage models
 """
 type DataJobInputOutput {
-    """
-    Deprecated, use relationship Consumes instead
-    Input datasets produced by the data job during processing
-    """
-    inputDatasets: [Dataset!] @deprecated
+  """
+  Deprecated, use relationship Consumes instead
+  Input datasets produced by the data job during processing
+  """
+  inputDatasets: [Dataset!] @deprecated
 
-    """
-    Deprecated, use relationship Produces instead
-    Output datasets produced by the data job during processing
-    """
-    outputDatasets: [Dataset!] @deprecated
+  """
+  Deprecated, use relationship Produces instead
+  Output datasets produced by the data job during processing
+  """
+  outputDatasets: [Dataset!] @deprecated
 
-    """
-    Deprecated, use relationship DownstreamOf instead
-    Input datajobs that this data job depends on
-    """
-    inputDatajobs: [DataJob!] @deprecated
+  """
+  Deprecated, use relationship DownstreamOf instead
+  Input datajobs that this data job depends on
+  """
+  inputDatajobs: [DataJob!] @deprecated
 
-    """
-    Lineage information for the column-level. Includes a list of objects
-    detailing which columns are upstream and which are downstream of each other.
-    The upstream and downstream columns are from datasets.
-    """
-    fineGrainedLineages: [FineGrainedLineage!]
+  """
+  Lineage information for the column-level. Includes a list of objects
+  detailing which columns are upstream and which are downstream of each other.
+  The upstream and downstream columns are from datasets.
+  """
+  fineGrainedLineages: [FineGrainedLineage!]
 }
 
 """
@@ -6845,416 +6875,409 @@ type DataTransformLogic {
 Information about individual user usage of a Dataset
 """
 type UserUsageCounts {
-    """
-    The user of the Dataset
-    """
-    user: CorpUser
+  """
+  The user of the Dataset
+  """
+  user: CorpUser
 
-    """
-    The number of queries issued by the user
-    """
-    count: Int
+  """
+  The number of queries issued by the user
+  """
+  count: Int
 
-    """
-    The extracted user email
-    Note that this field will soon be deprecated and merged with user
-    """
-    userEmail: String
+  """
+  The extracted user email
+  Note that this field will soon be deprecated and merged with user
+  """
+  userEmail: String
 }
 
 """
 The result of a Dataset usage query
 """
 type UsageQueryResult {
-    """
-    A set of relevant time windows for use in displaying usage statistics
-    """
-    buckets: [UsageAggregation]
+  """
+  A set of relevant time windows for use in displaying usage statistics
+  """
+  buckets: [UsageAggregation]
 
-    """
-    A set of rolled up aggregations about the Dataset usage
-    """
-    aggregations: UsageQueryResultAggregations
+  """
+  A set of rolled up aggregations about the Dataset usage
+  """
+  aggregations: UsageQueryResultAggregations
 }
 
 """
 A set of rolled up aggregations about the Dataset usage
 """
 type UsageQueryResultAggregations {
-    """
-    The count of unique Dataset users within the queried time range
-    """
-    uniqueUserCount: Int
+  """
+  The count of unique Dataset users within the queried time range
+  """
+  uniqueUserCount: Int
 
-    """
-    The specific per user usage counts within the queried time range
-    """
-    users: [UserUsageCounts]
+  """
+  The specific per user usage counts within the queried time range
+  """
+  users: [UserUsageCounts]
 
-    """
-    The specific per field usage counts within the queried time range
-    """
-    fields: [FieldUsageCounts]
+  """
+  The specific per field usage counts within the queried time range
+  """
+  fields: [FieldUsageCounts]
 
-    """
-    The total number of queries executed within the queried time range
-    Note that this field will likely be deprecated in favor of a totalQueries field
-    """
-    totalSqlQueries: Int
+  """
+  The total number of queries executed within the queried time range
+  Note that this field will likely be deprecated in favor of a totalQueries field
+  """
+  totalSqlQueries: Int
 }
 
 """
 An aggregation of Dataset usage statistics
 """
 type UsageAggregation {
-    """
-    The time window start time
-    """
-    bucket: Long
+  """
+  The time window start time
+  """
+  bucket: Long
 
-    """
-    The time window span
-    """
-    duration: WindowDuration
+  """
+  The time window span
+  """
+  duration: WindowDuration
 
-    """
-    The resource urn associated with the usage information, eg a Dataset urn
-    """
-    resource: String
+  """
+  The resource urn associated with the usage information, eg a Dataset urn
+  """
+  resource: String
 
-    """
-    The rolled up usage metrics
-    """
-    metrics: UsageAggregationMetrics
+  """
+  The rolled up usage metrics
+  """
+  metrics: UsageAggregationMetrics
 }
 
 """
 Rolled up metrics about Dataset usage over time
 """
 type UsageAggregationMetrics {
-    """
-    The unique number of users who have queried the dataset within the time range
-    """
-    uniqueUserCount: Int
+  """
+  The unique number of users who have queried the dataset within the time range
+  """
+  uniqueUserCount: Int
 
-    """
-    Usage statistics within the time range by user
-    """
-    users: [UserUsageCounts]
+  """
+  Usage statistics within the time range by user
+  """
+  users: [UserUsageCounts]
 
-    """
-    The total number of queries issued against the dataset within the time range
-    """
-    totalSqlQueries: Int
+  """
+  The total number of queries issued against the dataset within the time range
+  """
+  totalSqlQueries: Int
 
-    """
-    A set of common queries issued against the dataset within the time range
-    """
-    topSqlQueries: [String]
+  """
+  A set of common queries issued against the dataset within the time range
+  """
+  topSqlQueries: [String]
 
-    """
-    Per field usage statistics within the time range
-    """
-    fields: [FieldUsageCounts]
+  """
+  Per field usage statistics within the time range
+  """
+  fields: [FieldUsageCounts]
 }
 
 """
 The usage for a particular Dataset field
 """
 type FieldUsageCounts {
-    """
-    The path of the field
-    """
-    fieldName: String
+  """
+  The path of the field
+  """
+  fieldName: String
 
-    """
-    The count of usages
-    """
-    count: Int
+  """
+  The count of usages
+  """
+  count: Int
 }
 
 """
 Experimental - subject to change. A summary of usage metrics about a Dataset.
 """
 type DatasetStatsSummary {
-    """
-    The query count in the past 30 days
-    """
-    queryCountLast30Days: Int
+  """
+  The query count in the past 30 days
+  """
+  queryCountLast30Days: Int
 
-    """
-    The unique user count in the past 30 days
-    """
-    uniqueUserCountLast30Days: Int
+  """
+  The unique user count in the past 30 days
+  """
+  uniqueUserCountLast30Days: Int
 
-    """
-    The top users in the past 30 days
-    """
-    topUsersLast30Days: [CorpUser!]
+  """
+  The top users in the past 30 days
+  """
+  topUsersLast30Days: [CorpUser!]
 }
 
 """
 Information about individual user usage of a Dashboard
 """
 type DashboardUserUsageCounts {
-    """
-    The user of the Dashboard
-    """
-    user: CorpUser
+  """
+  The user of the Dashboard
+  """
+  user: CorpUser
 
-    """
-    number of times dashboard has been viewed by the user
-    """
-    viewsCount: Int
+  """
+  number of times dashboard has been viewed by the user
+  """
+  viewsCount: Int
 
-    """
-    number of dashboard executions by the user
-    """
-    executionsCount: Int
+  """
+  number of dashboard executions by the user
+  """
+  executionsCount: Int
 
-    """
-    Normalized numeric metric representing user's dashboard usage
-    Higher value represents more usage
-    """
-    usageCount: Int
+  """
+  Normalized numeric metric representing user's dashboard usage
+  Higher value represents more usage
+  """
+  usageCount: Int
 }
 
 """
 The result of a dashboard usage query
 """
 type DashboardUsageQueryResult {
-    """
-    A set of relevant time windows for use in displaying usage statistics
-    """
-    buckets: [DashboardUsageAggregation]
+  """
+  A set of relevant time windows for use in displaying usage statistics
+  """
+  buckets: [DashboardUsageAggregation]
 
-    """
-    A set of rolled up aggregations about the dashboard usage
-    """
-    aggregations: DashboardUsageQueryResultAggregations
+  """
+  A set of rolled up aggregations about the dashboard usage
+  """
+  aggregations: DashboardUsageQueryResultAggregations
 
-    """
-    A set of absolute dashboard usage metrics
-    """
-    metrics: [DashboardUsageMetrics!]
-
+  """
+  A set of absolute dashboard usage metrics
+  """
+  metrics: [DashboardUsageMetrics!]
 }
 
 """
 A set of rolled up aggregations about the Dashboard usage
 """
 type DashboardUsageQueryResultAggregations {
-    """
-    The count of unique Dashboard users within the queried time range
-    """
-    uniqueUserCount: Int
+  """
+  The count of unique Dashboard users within the queried time range
+  """
+  uniqueUserCount: Int
 
-    """
-    The specific per user usage counts within the queried time range
-    """
-    users: [DashboardUserUsageCounts]
+  """
+  The specific per user usage counts within the queried time range
+  """
+  users: [DashboardUserUsageCounts]
 
-    """
-    The total number of dashboard views within the queried time range
-    """
-    viewsCount: Int
+  """
+  The total number of dashboard views within the queried time range
+  """
+  viewsCount: Int
 
-    """
-    The total number of dashboard executions within the queried time range
-    """
-    executionsCount: Int
-
+  """
+  The total number of dashboard executions within the queried time range
+  """
+  executionsCount: Int
 }
-
 
 """
 A set of absolute dashboard usage metrics
 """
 type DashboardUsageMetrics implements TimeSeriesAspect {
-    """
-    The time at which the metrics were reported
-    """
-    timestampMillis: Long!
+  """
+  The time at which the metrics were reported
+  """
+  timestampMillis: Long!
 
-    """
-    The total number of times dashboard has been favorited
-    FIXME: Qualifies as Popularity Metric rather than Usage Metric?
-    """
-    favoritesCount: Int
+  """
+  The total number of times dashboard has been favorited
+  FIXME: Qualifies as Popularity Metric rather than Usage Metric?
+  """
+  favoritesCount: Int
 
-    """
-    The total number of dashboard views
-    """
-    viewsCount: Int
+  """
+  The total number of dashboard views
+  """
+  viewsCount: Int
 
-    """
-    The total number of dashboard execution
-    """
-    executionsCount: Int
+  """
+  The total number of dashboard execution
+  """
+  executionsCount: Int
 
-    """
-    The time when this dashboard was last viewed
-    """
-    lastViewed: Long
-
+  """
+  The time when this dashboard was last viewed
+  """
+  lastViewed: Long
 }
 
 """
 An aggregation of Dashboard usage statistics
 """
 type DashboardUsageAggregation {
-    """
-    The time window start time
-    """
-    bucket: Long
+  """
+  The time window start time
+  """
+  bucket: Long
 
-    """
-    The time window span
-    """
-    duration: WindowDuration
+  """
+  The time window span
+  """
+  duration: WindowDuration
 
-    """
-    The resource urn associated with the usage information, eg a Dashboard urn
-    """
-    resource: String
+  """
+  The resource urn associated with the usage information, eg a Dashboard urn
+  """
+  resource: String
 
-    """
-    The rolled up usage metrics
-    """
-    metrics: DashboardUsageAggregationMetrics
+  """
+  The rolled up usage metrics
+  """
+  metrics: DashboardUsageAggregationMetrics
 }
 
 """
 Rolled up metrics about Dashboard usage over time
 """
 type DashboardUsageAggregationMetrics {
-    """
-    The unique number of dashboard users within the time range
-    """
-    uniqueUserCount: Int
+  """
+  The unique number of dashboard users within the time range
+  """
+  uniqueUserCount: Int
 
-    """
-    The total number of dashboard views within the time range
-    """
-    viewsCount: Int
+  """
+  The total number of dashboard views within the time range
+  """
+  viewsCount: Int
 
-    """
-    The total number of dashboard executions within the time range
-    """
-    executionsCount: Int
-
+  """
+  The total number of dashboard executions within the time range
+  """
+  executionsCount: Int
 }
 
 """
 Experimental - subject to change. A summary of usage metrics about a Dashboard.
 """
 type DashboardStatsSummary {
-    """
-    The total view count for the dashboard
-    """
-    viewCount: Int
+  """
+  The total view count for the dashboard
+  """
+  viewCount: Int
 
-    """
-    The view count in the last 30 days
-    """
-    viewCountLast30Days: Int
+  """
+  The view count in the last 30 days
+  """
+  viewCountLast30Days: Int
 
-    """
-    The unique user count in the past 30 days
-    """
-    uniqueUserCountLast30Days: Int
+  """
+  The unique user count in the past 30 days
+  """
+  uniqueUserCountLast30Days: Int
 
-    """
-    The top users in the past 30 days
-    """
-    topUsersLast30Days: [CorpUser!]
+  """
+  The top users in the past 30 days
+  """
+  topUsersLast30Days: [CorpUser!]
 }
-
 
 """
 Experimental - subject to change. A summary of usage metrics about a Chart.
 """
 type ChartStatsSummary {
-    """
-    The total view count for the chart
-    """
-    viewCount: Int
+  """
+  The total view count for the chart
+  """
+  viewCount: Int
 
-    """
-    The view count in the last 30 days
-    """
-    viewCountLast30Days: Int
+  """
+  The view count in the last 30 days
+  """
+  viewCountLast30Days: Int
 
-    """
-    The unique user count in the past 30 days
-    """
-    uniqueUserCountLast30Days: Int
+  """
+  The unique user count in the past 30 days
+  """
+  uniqueUserCountLast30Days: Int
 
-    """
-    The top users in the past 30 days
-    """
-    topUsersLast30Days: [CorpUser!]
+  """
+  The top users in the past 30 days
+  """
+  topUsersLast30Days: [CorpUser!]
 }
-
 
 """
 The duration of a fixed window of time
 """
 enum WindowDuration {
-    """
-    A one day window
-    """
-    DAY
+  """
+  A one day window
+  """
+  DAY
 
-    """
-    A one week window
-    """
-    WEEK
+  """
+  A one week window
+  """
+  WEEK
 
-    """
-    A one month window
-    """
-    MONTH
+  """
+  A one month window
+  """
+  MONTH
 
-    """
-    A one year window
-    """
-    YEAR
+  """
+  A one year window
+  """
+  YEAR
 }
 
 """
 A time range used in fetching Usage statistics
 """
 enum TimeRange {
-    """
-    Last day
-    """
-    DAY
+  """
+  Last day
+  """
+  DAY
 
-    """
-    Last week
-    """
-    WEEK
+  """
+  Last week
+  """
+  WEEK
 
-    """
-    Last month
-    """
-    MONTH
+  """
+  Last month
+  """
+  MONTH
 
-    """
-    Last quarter
-    """
-    QUARTER
+  """
+  Last quarter
+  """
+  QUARTER
 
-    """
-    Last year
-    """
-    YEAR
+  """
+  Last year
+  """
+  YEAR
 
-    """
-    All time
-    """
-    ALL
+  """
+  All time
+  """
+  ALL
 }
 
 """
@@ -7299,64 +7322,63 @@ type DatasetFieldProfile {
   """
   The standardized path of the field
   """
-	fieldPath: String!
+  fieldPath: String!
 
   """
   The unique value count for the field across the Dataset
   """
-	uniqueCount: Long
+  uniqueCount: Long
 
   """
   The proportion of rows with unique values across the Dataset
   """
-	uniqueProportion: Float
+  uniqueProportion: Float
 
   """
   The number of NULL row values across the Dataset
   """
-	nullCount: Long
+  nullCount: Long
 
   """
   The proportion of rows with NULL values across the Dataset
   """
-	nullProportion: Float
+  nullProportion: Float
 
   """
   The min value for the field
   """
-	min: String
+  min: String
 
   """
   The max value for the field
   """
-	max: String
+  max: String
 
   """
   The mean value for the field
   """
-	mean: String
+  mean: String
 
   """
   The median value for the field
   """
-	median: String
+  median: String
 
   """
   The standard deviation for the field
   """
-	stdev: String
+  stdev: String
 
   """
   A set of sample values for the field
   """
-	sampleValues: [String!]
+  sampleValues: [String!]
 }
 
 """
 Information about the partition being profiled
 """
 type PartitionSpec {
-
   """
   The partition type
   """
@@ -7374,9 +7396,9 @@ type PartitionSpec {
 }
 
 enum PartitionType {
-    FULL_TABLE,
-    QUERY,
-    PARTITION
+  FULL_TABLE
+  QUERY
+  PARTITION
 }
 
 """
@@ -7398,137 +7420,143 @@ type TimeWindow {
 An assertion represents a programmatic validation, check, or test performed periodically against another Entity.
 """
 type Assertion implements EntityWithRelationships & Entity {
-    """
-    The primary key of the Assertion
-    """
-    urn: String!
+  """
+  The primary key of the Assertion
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Standardized platform urn where the assertion is evaluated
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the assertion is evaluated
+  """
+  platform: DataPlatform!
 
-    """
-    Details about assertion
-    """
-    info: AssertionInfo
+  """
+  Details about assertion
+  """
+  info: AssertionInfo
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Lifecycle events detailing individual runs of this assertion. If startTimeMillis & endTimeMillis are not provided, the most
-    recent events will be returned.
-    """
-    runEvents(status: AssertionRunStatus, startTimeMillis: Long, endTimeMillis: Long, filter: FilterInput, limit: Int): AssertionRunEventsResult
+  """
+  Lifecycle events detailing individual runs of this assertion. If startTimeMillis & endTimeMillis are not provided, the most
+  recent events will be returned.
+  """
+  runEvents(
+    status: AssertionRunStatus
+    startTimeMillis: Long
+    endTimeMillis: Long
+    filter: FilterInput
+    limit: Int
+  ): AssertionRunEventsResult
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    Status metadata of the assertion
-    """
-    status: Status
+  """
+  Status metadata of the assertion
+  """
+  status: Status
 
-    """
-    The standard tags for the Assertion
-    """
-    tags: GlobalTags
+  """
+  The standard tags for the Assertion
+  """
+  tags: GlobalTags
 
-    """
-    Experimental API.
-    For fetching extra aspects that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra aspects that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 }
 
 """
 Type of assertion. Assertion types can evolve to span Datasets, Flows (Pipelines), Models, Features etc.
 """
 type AssertionInfo {
-    """
-    Top-level type of the assertion.
-    """
-    type: AssertionType!
+  """
+  Top-level type of the assertion.
+  """
+  type: AssertionType!
 
-    """
-    Dataset-specific assertion information
-    """
-    datasetAssertion: DatasetAssertionInfo
+  """
+  Dataset-specific assertion information
+  """
+  datasetAssertion: DatasetAssertionInfo
 
-    """
-    An optional human-readable description of the assertion
-    """
-    description: String
+  """
+  An optional human-readable description of the assertion
+  """
+  description: String
 
-    """
-    URL where assertion details are available
-    """
-    externalUrl: String
+  """
+  URL where assertion details are available
+  """
+  externalUrl: String
 }
 
 """
 Detailed information about a Dataset Assertion
 """
 type DatasetAssertionInfo {
-    """
-    The urn of the dataset that the assertion is related to
-    """
-    datasetUrn: String!
+  """
+  The urn of the dataset that the assertion is related to
+  """
+  datasetUrn: String!
 
-    """
-    The scope of the Dataset assertion.
-    """
-    scope: DatasetAssertionScope!
+  """
+  The scope of the Dataset assertion.
+  """
+  scope: DatasetAssertionScope!
 
-    """
-    The fields serving as input to the assertion. Empty if there are none.
-    """
-    fields: [SchemaFieldRef!]
+  """
+  The fields serving as input to the assertion. Empty if there are none.
+  """
+  fields: [SchemaFieldRef!]
 
-    """
-    Standardized assertion operator
-    """
-    aggregation: AssertionStdAggregation
+  """
+  Standardized assertion operator
+  """
+  aggregation: AssertionStdAggregation
 
-    """
-    Standardized assertion operator
-    """
-    operator: AssertionStdOperator!
+  """
+  Standardized assertion operator
+  """
+  operator: AssertionStdOperator!
 
-    """
-    Standard parameters required for the assertion. e.g. min_value, max_value, value, columns
-    """
-    parameters: AssertionStdParameters
+  """
+  Standard parameters required for the assertion. e.g. min_value, max_value, value, columns
+  """
+  parameters: AssertionStdParameters
 
-    """
-    The native operator for the assertion. For Great Expectations, this will contain the original expectation name.
-    """
-    nativeType: String
+  """
+  The native operator for the assertion. For Great Expectations, this will contain the original expectation name.
+  """
+  nativeType: String
 
-    """
-    Native parameters required for the assertion.
-    """
-    nativeParameters: [StringMapEntry!]
+  """
+  Native parameters required for the assertion.
+  """
+  nativeParameters: [StringMapEntry!]
 
-    """
-    Logic comprising a raw, unstructured assertion.
-    """
-    logic: String
+  """
+  Logic comprising a raw, unstructured assertion.
+  """
+  logic: String
 }
 
 """
@@ -7599,351 +7627,349 @@ type AssertionRunEvent implements TimeSeriesAspect {
   Results of assertion, present if the status is COMPLETE
   """
   result: AssertionResult
-
 }
 
 """
 The result of evaluating an assertion.
 """
 type AssertionResult {
-    """
-    The final result, e.g. either SUCCESS or FAILURE.
-    """
-    type: AssertionResultType!
+  """
+  The final result, e.g. either SUCCESS or FAILURE.
+  """
+  type: AssertionResultType!
 
-    """
-    Number of rows for evaluated batch
-    """
-    rowCount: Long
+  """
+  Number of rows for evaluated batch
+  """
+  rowCount: Long
 
-    """
-    Number of rows with missing value for evaluated batch
-    """
-    missingCount: Long
+  """
+  Number of rows with missing value for evaluated batch
+  """
+  missingCount: Long
 
-    """
-    Number of rows with unexpected value for evaluated batch
-    """
-    unexpectedCount: Long
+  """
+  Number of rows with unexpected value for evaluated batch
+  """
+  unexpectedCount: Long
 
-    """
-    Observed aggregate value for evaluated batch
-    """
-    actualAggValue: Float
+  """
+  Observed aggregate value for evaluated batch
+  """
+  actualAggValue: Float
 
-    """
-    URL where full results are available
-    """
-    externalUrl: String
+  """
+  URL where full results are available
+  """
+  externalUrl: String
 
-    """
-    Native results / properties of evaluation
-    """
-    nativeResults: [StringMapEntry!]
+  """
+  Native results / properties of evaluation
+  """
+  nativeResults: [StringMapEntry!]
 
-    """
-    Error details, if type is ERROR
-    """
-    error: AssertionResultError
+  """
+  Error details, if type is ERROR
+  """
+  error: AssertionResultError
 }
 
 """
 An error encountered when evaluating an AssertionResult
 """
 type AssertionResultError {
-    """
-    The type of error encountered
-    """
-    type: AssertionResultErrorType!
+  """
+  The type of error encountered
+  """
+  type: AssertionResultErrorType!
 
-    """
-    Additional metadata depending on the type of error
-    """
-    properties: [StringMapEntry!]
+  """
+  Additional metadata depending on the type of error
+  """
+  properties: [StringMapEntry!]
 }
 
 """
 The type of error encountered when evaluating an AssertionResult
 """
 enum AssertionResultErrorType {
-    """
-    Source is unreachable
-    """
-    SOURCE_CONNECTION_ERROR
+  """
+  Source is unreachable
+  """
+  SOURCE_CONNECTION_ERROR
 
-    """
-    Source query failed to execute
-    """
-    SOURCE_QUERY_FAILED
+  """
+  Source query failed to execute
+  """
+  SOURCE_QUERY_FAILED
 
-    """
-    Invalid parameters were detected
-    """
-    INVALID_PARAMETERS
+  """
+  Invalid parameters were detected
+  """
+  INVALID_PARAMETERS
 
-    """
-    Insufficient data to evaluate assertion
-    """
-    INSUFFICIENT_DATA
+  """
+  Insufficient data to evaluate assertion
+  """
+  INSUFFICIENT_DATA
 
-    """
-    Event type not supported by the specified source
-    """
-    INVALID_SOURCE_TYPE
+  """
+  Event type not supported by the specified source
+  """
+  INVALID_SOURCE_TYPE
 
-    """
-    Platform not supported
-    """
-    UNSUPPORTED_PLATFORM
+  """
+  Platform not supported
+  """
+  UNSUPPORTED_PLATFORM
 
-    """
-    Error while executing a custom SQL assertion
-    """
-    CUSTOM_SQL_ERROR
+  """
+  Error while executing a custom SQL assertion
+  """
+  CUSTOM_SQL_ERROR
 
-    """
-    Error while executing a field assertion
-    """
-    FIELD_ASSERTION_ERROR
+  """
+  Error while executing a field assertion
+  """
+  FIELD_ASSERTION_ERROR
 
-    """
-    Unknown error
-    """
-    UNKNOWN_ERROR
+  """
+  Unknown error
+  """
+  UNKNOWN_ERROR
 }
 
 type BatchSpec {
-    """
-    The native identifier as specified by the system operating on the batch.
-    """
-    nativeBatchId: String
+  """
+  The native identifier as specified by the system operating on the batch.
+  """
+  nativeBatchId: String
 
-    """
-    A query that identifies a batch of data
-    """
-    query: String
+  """
+  A query that identifies a batch of data
+  """
+  query: String
 
-    """
-    Any limit to the number of rows in the batch, if applied
-    """
-    limit: Int
+  """
+  Any limit to the number of rows in the batch, if applied
+  """
+  limit: Int
 
-    """
-    Custom properties of the Batch
-    """
-    customProperties: [StringMapEntry!]
+  """
+  Custom properties of the Batch
+  """
+  customProperties: [StringMapEntry!]
 }
 
 """
 The result type of an assertion, success or failure.
 """
 enum AssertionResultType {
-    """
-    The assertion has not yet been fully evaluated.
-    """
-    INIT
+  """
+  The assertion has not yet been fully evaluated.
+  """
+  INIT
 
-    """
-    The assertion succeeded.
-    """
-    SUCCESS
+  """
+  The assertion succeeded.
+  """
+  SUCCESS
 
-    """
-    The assertion failed.
-    """
-    FAILURE
+  """
+  The assertion failed.
+  """
+  FAILURE
 
-    """
-    The assertion errored.
-    """
-    ERROR
+  """
+  The assertion errored.
+  """
+  ERROR
 }
 
 """
 The state of an assertion run, as defined within an Assertion Run Event.
 """
 enum AssertionRunStatus {
-    """
-    An assertion run has completed.
-    """
-    COMPLETE
+  """
+  An assertion run has completed.
+  """
+  COMPLETE
 }
 
 """
 An "aggregation" function that can be applied to column values of a Dataset to create the input to an Assertion Operator.
 """
 enum AssertionStdAggregation {
-    """
-    Assertion is applied on individual column value
-    """
-    IDENTITY
+  """
+  Assertion is applied on individual column value
+  """
+  IDENTITY
 
-    """
-    Assertion is applied on column mean
-    """
-    MEAN
+  """
+  Assertion is applied on column mean
+  """
+  MEAN
 
-    """
-    Assertion is applied on column median
-    """
-    MEDIAN
+  """
+  Assertion is applied on column median
+  """
+  MEDIAN
 
-    """
-    Assertion is applied on number of distinct values in column
-    """
-    UNIQUE_COUNT
+  """
+  Assertion is applied on number of distinct values in column
+  """
+  UNIQUE_COUNT
 
-    """
-    Assertion is applied on proportion of distinct values in column
-    """
-    UNIQUE_PROPOTION
+  """
+  Assertion is applied on proportion of distinct values in column
+  """
+  UNIQUE_PROPOTION
 
-    """
-    Assertion is applied on number of null values in column
-    """
-    NULL_COUNT
+  """
+  Assertion is applied on number of null values in column
+  """
+  NULL_COUNT
 
-    """
-    Assertion is applied on proportion of null values in column
-    """
-    NULL_PROPORTION
+  """
+  Assertion is applied on proportion of null values in column
+  """
+  NULL_PROPORTION
 
-    """
-    Assertion is applied on column std deviation
-    """
-    STDDEV
+  """
+  Assertion is applied on column std deviation
+  """
+  STDDEV
 
-    """
-    Assertion is applied on column min
-    """
-    MIN
+  """
+  Assertion is applied on column min
+  """
+  MIN
 
-    """
-    Assertion is applied on column std deviation
-    """
-    MAX
+  """
+  Assertion is applied on column std deviation
+  """
+  MAX
 
-    """
-    Assertion is applied on column sum
-    """
-    SUM
+  """
+  Assertion is applied on column sum
+  """
+  SUM
 
-    """
-    Assertion is applied on all columns
-    """
-    COLUMNS
+  """
+  Assertion is applied on all columns
+  """
+  COLUMNS
 
-    """
-    Assertion is applied on number of columns
-    """
-    COLUMN_COUNT
+  """
+  Assertion is applied on number of columns
+  """
+  COLUMN_COUNT
 
-    """
-    Assertion is applied on number of rows
-    """
-    ROW_COUNT
+  """
+  Assertion is applied on number of rows
+  """
+  ROW_COUNT
 
-    """
-    Other
-    """
-    _NATIVE_
+  """
+  Other
+  """
+  _NATIVE_
 }
 
 """
 A standard operator or condition that constitutes an assertion definition
 """
 enum AssertionStdOperator {
-    """
-    Value being asserted is between min_value and max_value
-    """
-    BETWEEN
+  """
+  Value being asserted is between min_value and max_value
+  """
+  BETWEEN
 
-    """
-    Value being asserted is less than max_value
-    """
-    LESS_THAN
+  """
+  Value being asserted is less than max_value
+  """
+  LESS_THAN
 
-    """
-    Value being asserted is less than or equal to max_value
-    """
-    LESS_THAN_OR_EQUAL_TO
+  """
+  Value being asserted is less than or equal to max_value
+  """
+  LESS_THAN_OR_EQUAL_TO
 
-    """
-    Value being asserted is greater than min_value
-    """
-    GREATER_THAN
+  """
+  Value being asserted is greater than min_value
+  """
+  GREATER_THAN
 
-    """
-    Value being asserted is greater than or equal to min_value
-    """
-    GREATER_THAN_OR_EQUAL_TO
+  """
+  Value being asserted is greater than or equal to min_value
+  """
+  GREATER_THAN_OR_EQUAL_TO
 
-    """
-    Value being asserted is equal to value
-    """
-    EQUAL_TO
+  """
+  Value being asserted is equal to value
+  """
+  EQUAL_TO
 
-    """
-    Value being asserted is not equal to value
-    """
-    NOT_EQUAL_TO
+  """
+  Value being asserted is not equal to value
+  """
+  NOT_EQUAL_TO
 
-    """
-    Value being asserted is null
-    """
-    NULL
+  """
+  Value being asserted is null
+  """
+  NULL
 
-    """
-    Value being asserted is not null
-    """
-    NOT_NULL
+  """
+  Value being asserted is not null
+  """
+  NOT_NULL
 
-    """
-    Value being asserted contains value
-    """
-    CONTAIN
+  """
+  Value being asserted contains value
+  """
+  CONTAIN
 
-    """
-    Value being asserted ends with value
-    """
-    END_WITH
+  """
+  Value being asserted ends with value
+  """
+  END_WITH
 
-    """
-    Value being asserted starts with value
-    """
-    START_WITH
+  """
+  Value being asserted starts with value
+  """
+  START_WITH
 
-    """
-    Value being asserted matches the regex value.
-    """
-    REGEX_MATCH
+  """
+  Value being asserted matches the regex value.
+  """
+  REGEX_MATCH
 
-    """
-    Value being asserted is one of the array values
-    """
-    IN
+  """
+  Value being asserted is one of the array values
+  """
+  IN
 
-    """
-    Value being asserted is not in one of the array values.
-    """
-    NOT_IN
+  """
+  Value being asserted is not in one of the array values.
+  """
+  NOT_IN
 
-    """
-    Value being asserted is true
-    """
-    IS_TRUE
+  """
+  Value being asserted is true
+  """
+  IS_TRUE
 
-    """
-    Value being asserted is false
-    """
-    IS_FALSE
+  """
+  Value being asserted is false
+  """
+  IS_FALSE
 
-    """
-    Other
-    """
-    _NATIVE_
+  """
+  Other
+  """
+  _NATIVE_
 }
-
 
 """
 Parameters for AssertionStdOperators
@@ -8014,60 +8040,60 @@ enum AssertionStdParameterType {
 The scope that a Dataset-level assertion applies to.
 """
 enum DatasetAssertionScope {
-    """
-    Assertion applies to columns of a dataset.
-    """
-    DATASET_COLUMN,
+  """
+  Assertion applies to columns of a dataset.
+  """
+  DATASET_COLUMN
 
-    """
-    Assertion applies to rows of a dataset.
-    """
-    DATASET_ROWS,
+  """
+  Assertion applies to rows of a dataset.
+  """
+  DATASET_ROWS
 
-    """
-    Assertion applies to schema of a dataset.
-    """
-    DATASET_SCHEMA
+  """
+  Assertion applies to schema of a dataset.
+  """
+  DATASET_SCHEMA
 
-    """
-    The scope of an assertion is unknown.
-    """
-    UNKNOWN
+  """
+  The scope of an assertion is unknown.
+  """
+  UNKNOWN
 }
 
 """
 The top-level assertion type.
 """
 enum AssertionType {
-    """
-    A single-dataset assertion.
-    """
-    DATASET
-    """
-    An assertion which indicates when a particular operation should occur to an asset.
-    """
-    FRESHNESS
-    """
-    An assertion which indicates how much data should be available for a particular asset.
-    """
-    VOLUME
-    """
-    A raw SQL-statement based assertion.
-    """
-    SQL
-    """
-    A structured assertion targeting a specific column or field of the Dataset.
-    """
-    FIELD
-    """
-    A schema or structural assertion.
-    """
-    DATA_SCHEMA
+  """
+  A single-dataset assertion.
+  """
+  DATASET
+  """
+  An assertion which indicates when a particular operation should occur to an asset.
+  """
+  FRESHNESS
+  """
+  An assertion which indicates how much data should be available for a particular asset.
+  """
+  VOLUME
+  """
+  A raw SQL-statement based assertion.
+  """
+  SQL
+  """
+  A structured assertion targeting a specific column or field of the Dataset.
+  """
+  FIELD
+  """
+  A schema or structural assertion.
+  """
+  DATA_SCHEMA
 
-    """
-    A custom assertion.
-    """
-    CUSTOM
+  """
+  A custom assertion.
+  """
+  CUSTOM
 }
 
 """
@@ -8129,417 +8155,416 @@ type EntityAssertionsResult {
 Operational info for an entity.
 """
 type Operation implements TimeSeriesAspect {
-    """
-    The time at which the operation was reported
-    """
-    timestampMillis: Long!
+  """
+  The time at which the operation was reported
+  """
+  timestampMillis: Long!
 
-    """
-    Actor who issued this operation.
-    """
-    actor: String
+  """
+  Actor who issued this operation.
+  """
+  actor: String
 
-    """
-    Operation type of change.
-    """
-    operationType: OperationType!
+  """
+  Operation type of change.
+  """
+  operationType: OperationType!
 
-    """
-    A custom operation type
-    """
-    customOperationType: String
+  """
+  A custom operation type
+  """
+  customOperationType: String
 
-    """
-    Source of the operation
-    """
-    sourceType: OperationSourceType
+  """
+  Source of the operation
+  """
+  sourceType: OperationSourceType
 
-    """
-    How many rows were affected by this operation.
-    """
-    numAffectedRows: Long
+  """
+  How many rows were affected by this operation.
+  """
+  numAffectedRows: Long
 
-    """
-    Which other datasets were affected by this operation.
-    """
-    affectedDatasets: [String!]
+  """
+  Which other datasets were affected by this operation.
+  """
+  affectedDatasets: [String!]
 
-    """
-    When time at which the asset was actually updated
-    """
-    lastUpdatedTimestamp: Long!
+  """
+  When time at which the asset was actually updated
+  """
+  lastUpdatedTimestamp: Long!
 
-    """
-    Optional partition identifier
-    """
-    partition: String
+  """
+  Optional partition identifier
+  """
+  partition: String
 
-    """
-    Custom operation properties
-    """
-    customProperties: [StringMapEntry!]
+  """
+  Custom operation properties
+  """
+  customProperties: [StringMapEntry!]
 }
 
 """
 Enum to define the operation type when an entity changes.
 """
 enum OperationType {
-    """
-    When data is inserted.
-    """
-    INSERT
+  """
+  When data is inserted.
+  """
+  INSERT
 
-    """
-    When data is updated.
-    """
-    UPDATE
+  """
+  When data is updated.
+  """
+  UPDATE
 
-    """
-    When data is deleted.
-    """
-    DELETE
+  """
+  When data is deleted.
+  """
+  DELETE
 
-    """
-    When table is created.
-    """
-    CREATE
+  """
+  When table is created.
+  """
+  CREATE
 
-    """
-    When table is altered
-    """
-    ALTER
+  """
+  When table is altered
+  """
+  ALTER
 
-    """
-    When table is dropped
-    """
-    DROP
+  """
+  When table is dropped
+  """
+  DROP
 
-    """
-    Unknown operation
-    """
-    UNKNOWN
+  """
+  Unknown operation
+  """
+  UNKNOWN
 
-    """
-    Custom
-    """
-    CUSTOM
+  """
+  Custom
+  """
+  CUSTOM
 }
 
 """
 Input provided to report an asset operation
 """
 input ReportOperationInput {
-    """
-    The urn of the asset (e.g. dataset) to report the operation for
-    """
-    urn: String!
+  """
+  The urn of the asset (e.g. dataset) to report the operation for
+  """
+  urn: String!
 
-    """
-    The type of operation that was performed. Required
-    """
-    operationType: OperationType!
+  """
+  The type of operation that was performed. Required
+  """
+  operationType: OperationType!
 
-    """
-    A custom type of operation. Required if operation type is CUSTOM.
-    """
-    customOperationType: String
+  """
+  A custom type of operation. Required if operation type is CUSTOM.
+  """
+  customOperationType: String
 
-    """
-    The source or reporter of the operation
-    """
-    sourceType: OperationSourceType!
+  """
+  The source or reporter of the operation
+  """
+  sourceType: OperationSourceType!
 
-    """
-    A list of key-value parameters to include
-    """
-    customProperties: [StringMapEntryInput!]
+  """
+  A list of key-value parameters to include
+  """
+  customProperties: [StringMapEntryInput!]
 
-    """
-    An optional partition identifier
-    """
-    partition: String
+  """
+  An optional partition identifier
+  """
+  partition: String
 
-    """
-    Optional: The number of affected rows
-    """
-    numAffectedRows: Long
+  """
+  Optional: The number of affected rows
+  """
+  numAffectedRows: Long
 
-    """
-    Optional: Provide a timestamp associated with the operation. If not provided, one will be generated for you based
-    on the current time.
-    """
-    timestampMillis: Long
+  """
+  Optional: Provide a timestamp associated with the operation. If not provided, one will be generated for you based
+  on the current time.
+  """
+  timestampMillis: Long
 }
 
 """
 Enum to define the source/reporter type for an Operation.
 """
 enum OperationSourceType {
-    """
-    A data process reported the operation.
-    """
-    DATA_PROCESS
+  """
+  A data process reported the operation.
+  """
+  DATA_PROCESS
 
-    """
-    A data platform reported the operation.
-    """
-    DATA_PLATFORM
+  """
+  A data platform reported the operation.
+  """
+  DATA_PLATFORM
 }
 
 """
 Information about Metadata Entity deprecation status
 """
 type Deprecation {
-    """
-    Whether the entity has been deprecated by owner
-    """
-    deprecated: Boolean!
+  """
+  Whether the entity has been deprecated by owner
+  """
+  deprecated: Boolean!
 
-    """
-    The time user plan to decommission this entity
-    """
-    decommissionTime: Long
+  """
+  The time user plan to decommission this entity
+  """
+  decommissionTime: Long
 
-    """
-    Additional information about the entity deprecation plan
-    """
-    note: String
+  """
+  Additional information about the entity deprecation plan
+  """
+  note: String
 
-    """
-    The user who will be credited for modifying this deprecation content
-    """
-    actor: String
+  """
+  The user who will be credited for modifying this deprecation content
+  """
+  actor: String
 
-    """
-    The hydrated user who will be credited for modifying this deprecation content
-    """
-    actorEntity: Entity
+  """
+  The hydrated user who will be credited for modifying this deprecation content
+  """
+  actorEntity: Entity
 }
 
 """
 Input provided when updating the association between a Metadata Entity and a Glossary Term
 """
 input TermAssociationInput {
-    """
-    The primary key of the Glossary Term to add or remove
-    """
-    termUrn: String!
+  """
+  The primary key of the Glossary Term to add or remove
+  """
+  termUrn: String!
 
-    """
-    The target Metadata Entity to add or remove the Glossary Term from
-    """
-    resourceUrn: String!
+  """
+  The target Metadata Entity to add or remove the Glossary Term from
+  """
+  resourceUrn: String!
 
-    """
-    An optional type of a sub resource to attach the Glossary Term to
-    """
-    subResourceType: SubResourceType
+  """
+  An optional type of a sub resource to attach the Glossary Term to
+  """
+  subResourceType: SubResourceType
 
-    """
-    An optional sub resource identifier to attach the Glossary Term to
-    """
-    subResource: String
+  """
+  An optional sub resource identifier to attach the Glossary Term to
+  """
+  subResource: String
 }
 
 """
 Input provided when adding Terms to an asset
 """
 input AddTermsInput {
-    """
-    The primary key of the Glossary Term to add or remove
-    """
-    termUrns: [String!]!
+  """
+  The primary key of the Glossary Term to add or remove
+  """
+  termUrns: [String!]!
 
-    """
-    The target Metadata Entity to add or remove the Glossary Term from
-    """
-    resourceUrn: String!
+  """
+  The target Metadata Entity to add or remove the Glossary Term from
+  """
+  resourceUrn: String!
 
-    """
-    An optional type of a sub resource to attach the Glossary Term to
-    """
-    subResourceType: SubResourceType
+  """
+  An optional type of a sub resource to attach the Glossary Term to
+  """
+  subResourceType: SubResourceType
 
-    """
-    An optional sub resource identifier to attach the Glossary Term to
-    """
-    subResource: String
+  """
+  An optional sub resource identifier to attach the Glossary Term to
+  """
+  subResource: String
 }
 
 """
 A type of Metadata Entity sub resource
 """
 enum SubResourceType {
-    """
-    A Dataset field or column
-    """
-    DATASET_FIELD
+  """
+  A Dataset field or column
+  """
+  DATASET_FIELD
 }
-
 
 """
 Input provided when adding Terms to an asset
 """
 input RelatedTermsInput {
-    """
-    The Glossary Term urn to add or remove this relationship to/from
-    """
-    urn: String!
+  """
+  The Glossary Term urn to add or remove this relationship to/from
+  """
+  urn: String!
 
-    """
-    The primary key of the Glossary Term to add or remove
-    """
-    termUrns: [String!]!
+  """
+  The primary key of the Glossary Term to add or remove
+  """
+  termUrns: [String!]!
 
-    """
-    The type of relationship we're adding or removing to/from for a Glossary Term
-    """
-    relationshipType: TermRelationshipType!
+  """
+  The type of relationship we're adding or removing to/from for a Glossary Term
+  """
+  relationshipType: TermRelationshipType!
 }
 
 """
 A type of Metadata Entity sub resource
 """
 enum TermRelationshipType {
-    """
-    When a Term inherits from, or has an 'Is A' relationship with another Term
-    """
-    isA
+  """
+  When a Term inherits from, or has an 'Is A' relationship with another Term
+  """
+  isA
 
-    """
-    When a Term contains, or has a 'Has A' relationship with another Term
-    """
-    hasA
+  """
+  When a Term contains, or has a 'Has A' relationship with another Term
+  """
+  hasA
 }
 
 """
 Input provided when adding glossary terms to a batch of assets
 """
 input BatchAddTermsInput {
-    """
-    The primary key of the Glossary Terms
-    """
-    termUrns: [String!]!
+  """
+  The primary key of the Glossary Terms
+  """
+  termUrns: [String!]!
 
-    """
-    The target assets to attach the glossary terms to
-    """
-    resources: [ResourceRefInput]!
+  """
+  The target assets to attach the glossary terms to
+  """
+  resources: [ResourceRefInput]!
 }
 
 """
 Input provided when removing glossary terms from a batch of assets
 """
 input BatchRemoveTermsInput {
-    """
-    The primary key of the Glossary Terms
-    """
-    termUrns: [String!]!
+  """
+  The primary key of the Glossary Terms
+  """
+  termUrns: [String!]!
 
-    """
-    The target assets to remove the glossary terms from
-    """
-    resources: [ResourceRefInput]!
+  """
+  The target assets to remove the glossary terms from
+  """
+  resources: [ResourceRefInput]!
 }
 
 """
 Input provided when updating the association between a Metadata Entity and a Tag
 """
 input TagAssociationInput {
-    """
-    The primary key of the Tag to add or remove
-    """
-    tagUrn: String!
+  """
+  The primary key of the Tag to add or remove
+  """
+  tagUrn: String!
 
-    """
-    The target Metadata Entity to add or remove the Tag to
-    """
-    resourceUrn: String!
+  """
+  The target Metadata Entity to add or remove the Tag to
+  """
+  resourceUrn: String!
 
-    """
-    An optional type of a sub resource to attach the Tag to
-    """
-    subResourceType: SubResourceType
+  """
+  An optional type of a sub resource to attach the Tag to
+  """
+  subResourceType: SubResourceType
 
-    """
-    An optional sub resource identifier to attach the Tag to
-    """
-    subResource: String
+  """
+  An optional sub resource identifier to attach the Tag to
+  """
+  subResource: String
 }
 
 """
 Input provided when adding tags to an asset
 """
 input AddTagsInput {
-    """
-    The primary key of the Tags
-    """
-    tagUrns: [String!]!
+  """
+  The primary key of the Tags
+  """
+  tagUrns: [String!]!
 
-    """
-    The target Metadata Entity to add or remove the Tag to
-    """
-    resourceUrn: String!
+  """
+  The target Metadata Entity to add or remove the Tag to
+  """
+  resourceUrn: String!
 
-    """
-    An optional type of a sub resource to attach the Tag to
-    """
-    subResourceType: SubResourceType
+  """
+  An optional type of a sub resource to attach the Tag to
+  """
+  subResourceType: SubResourceType
 
-    """
-    An optional sub resource identifier to attach the Tag to
-    """
-    subResource: String
+  """
+  An optional sub resource identifier to attach the Tag to
+  """
+  subResource: String
 }
 
 """
 Input provided when adding tags to a batch of assets
 """
 input BatchAddTagsInput {
-    """
-    The primary key of the Tags
-    """
-    tagUrns: [String!]!
+  """
+  The primary key of the Tags
+  """
+  tagUrns: [String!]!
 
-    """
-    The target assets to attach the tags to
-    """
-    resources: [ResourceRefInput!]!
+  """
+  The target assets to attach the tags to
+  """
+  resources: [ResourceRefInput!]!
 }
 
 """
 Input provided when removing tags from a batch of assets
 """
 input BatchRemoveTagsInput {
-    """
-    The primary key of the Tags
-    """
-    tagUrns: [String!]!
+  """
+  The primary key of the Tags
+  """
+  tagUrns: [String!]!
 
-    """
-    The target assets to remove the tags from
-    """
-    resources: [ResourceRefInput]!
+  """
+  The target assets to remove the tags from
+  """
+  resources: [ResourceRefInput]!
 }
 
 """
 Reference to a resource to apply an action to
 """
 input ResourceRefInput {
-    """
-    The urn of the resource being referenced
-    """
-    resourceUrn: String!
+  """
+  The urn of the resource being referenced
+  """
+  resourceUrn: String!
 
-    """
-    An optional type of a sub resource to attach the Tag to
-    """
-    subResourceType: SubResourceType
+  """
+  An optional type of a sub resource to attach the Tag to
+  """
+  subResourceType: SubResourceType
 
-    """
-    An optional sub resource identifier to attach the Tag to
-    """
-    subResource: String
+  """
+  An optional sub resource identifier to attach the Tag to
+  """
+  subResource: String
 }
 
 """
@@ -8549,7 +8574,7 @@ enum OwnerEntityType {
   """
   A corp user owner
   """
-  CORP_USER,
+  CORP_USER
 
   """
   A corp group owner
@@ -8561,303 +8586,302 @@ enum OwnerEntityType {
 Input provided when adding the association between a Metadata Entity and an user or group owner
 """
 input AddOwnerInput {
-    """
-    The primary key of the Owner to add or remove
-    """
-    ownerUrn: String!
+  """
+  The primary key of the Owner to add or remove
+  """
+  ownerUrn: String!
 
-    """
-    The owner type, either a user or group
-    """
-    ownerEntityType: OwnerEntityType!
+  """
+  The owner type, either a user or group
+  """
+  ownerEntityType: OwnerEntityType!
 
-    """
-    The ownership type for the new owner. If none is provided, then a new NONE will be added.
-    Deprecated - Use ownershipTypeUrn field instead.
-    """
-    type: OwnershipType @deprecated
+  """
+  The ownership type for the new owner. If none is provided, then a new NONE will be added.
+  Deprecated - Use ownershipTypeUrn field instead.
+  """
+  type: OwnershipType @deprecated
 
-    """
-    The urn of the ownership type entity.
-    """
-    ownershipTypeUrn: String
+  """
+  The urn of the ownership type entity.
+  """
+  ownershipTypeUrn: String
 
-    """
-    The urn of the resource or entity to attach or remove the owner from, for example a dataset urn
-    """
-    resourceUrn: String!
+  """
+  The urn of the resource or entity to attach or remove the owner from, for example a dataset urn
+  """
+  resourceUrn: String!
 }
 
 """
 Input provided when adding an owner to an asset
 """
 input OwnerInput {
-    """
-    The primary key of the Owner to add or remove
-    """
-    ownerUrn: String!
+  """
+  The primary key of the Owner to add or remove
+  """
+  ownerUrn: String!
 
-    """
-    The owner type, either a user or group
-    """
-    ownerEntityType: OwnerEntityType!
+  """
+  The owner type, either a user or group
+  """
+  ownerEntityType: OwnerEntityType!
 
-    """
-    The ownership type for the new owner. If none is provided, then a new NONE will be added.
-    Deprecated - Use ownershipTypeUrn field instead.
-    """
-    type: OwnershipType @deprecated
+  """
+  The ownership type for the new owner. If none is provided, then a new NONE will be added.
+  Deprecated - Use ownershipTypeUrn field instead.
+  """
+  type: OwnershipType @deprecated
 
-    """
-    The urn of the ownership type entity.
-    """
-    ownershipTypeUrn: String
+  """
+  The urn of the ownership type entity.
+  """
+  ownershipTypeUrn: String
 }
 
 """
 Input provided when adding multiple associations between a Metadata Entity and an user or group owner
 """
 input AddOwnersInput {
-    """
-    The primary key of the Owner to add or remove
-    """
-    owners: [OwnerInput!]!
+  """
+  The primary key of the Owner to add or remove
+  """
+  owners: [OwnerInput!]!
 
-    """
-    The urn of the resource or entity to attach or remove the owner from, for example a dataset urn
-    """
-    resourceUrn: String!
+  """
+  The urn of the resource or entity to attach or remove the owner from, for example a dataset urn
+  """
+  resourceUrn: String!
 }
 
 """
 Input provided when adding owners to a batch of assets
 """
 input BatchAddOwnersInput {
-    """
-    The primary key of the owners
-    """
-    owners: [OwnerInput!]!
+  """
+  The primary key of the owners
+  """
+  owners: [OwnerInput!]!
 
-    """
-    The ownership type to remove, optional. By default will remove regardless of ownership type.
-    """
-    ownershipTypeUrn: String
+  """
+  The ownership type to remove, optional. By default will remove regardless of ownership type.
+  """
+  ownershipTypeUrn: String
 
-    """
-    The target assets to attach the owners to
-    """
-    resources: [ResourceRefInput]!
+  """
+  The target assets to attach the owners to
+  """
+  resources: [ResourceRefInput]!
 }
 
 """
 Input provided when removing owners from a batch of assets
 """
 input BatchRemoveOwnersInput {
-    """
-    The primary key of the owners
-    """
-    ownerUrns: [String!]!
+  """
+  The primary key of the owners
+  """
+  ownerUrns: [String!]!
 
-    """
-    The ownership type to remove, optional. By default will remove regardless of ownership type.
-    """
-    ownershipTypeUrn: String
+  """
+  The ownership type to remove, optional. By default will remove regardless of ownership type.
+  """
+  ownershipTypeUrn: String
 
-    """
-    The target assets to remove the owners from
-    """
-    resources: [ResourceRefInput]!
+  """
+  The target assets to remove the owners from
+  """
+  resources: [ResourceRefInput]!
 }
 
 """
 Input provided when removing the association between a Metadata Entity and an user or group owner
 """
 input RemoveOwnerInput {
-    """
-    The primary key of the Owner to add or remove
-    """
-    ownerUrn: String!
+  """
+  The primary key of the Owner to add or remove
+  """
+  ownerUrn: String!
 
-    """
-    The ownership type to remove, optional. By default will remove regardless of ownership type.
-    """
-    ownershipTypeUrn: String
+  """
+  The ownership type to remove, optional. By default will remove regardless of ownership type.
+  """
+  ownershipTypeUrn: String
 
-    """
-    The urn of the resource or entity to attach or remove the owner from, for example a dataset urn
-    """
-    resourceUrn: String!
+  """
+  The urn of the resource or entity to attach or remove the owner from, for example a dataset urn
+  """
+  resourceUrn: String!
 }
 
 """
 Input provided when adding the association between a Metadata Entity and a Link
 """
 input AddLinkInput {
-    """
-    The url of the link to add or remove
-    """
-    linkUrl: String!
+  """
+  The url of the link to add or remove
+  """
+  linkUrl: String!
 
-    """
-    A label to attach to the link
-    """
-    label: String!
+  """
+  A label to attach to the link
+  """
+  label: String!
 
-    """
-    The urn of the resource or entity to attach the link to, for example a dataset urn
-    """
-    resourceUrn: String!
+  """
+  The urn of the resource or entity to attach the link to, for example a dataset urn
+  """
+  resourceUrn: String!
 }
 
 """
 Input provided when removing the association between a Metadata Entity and a Link
 """
 input RemoveLinkInput {
-    """
-    The url of the link to add or remove, which uniquely identifies the Link
-    """
-    linkUrl: String!
+  """
+  The url of the link to add or remove, which uniquely identifies the Link
+  """
+  linkUrl: String!
 
-    """
-    The urn of the resource or entity to attach the link to, for example a dataset urn
-    """
-    resourceUrn: String!
+  """
+  The urn of the resource or entity to attach the link to, for example a dataset urn
+  """
+  resourceUrn: String!
 }
 
 """
 Incubating. Updates the description of a resource. Currently supports DatasetField descriptions only
 """
 input DescriptionUpdateInput {
-    """
-    The new description
-    """
-    description: String!
+  """
+  The new description
+  """
+  description: String!
 
-    """
-    The primary key of the resource to attach the description to, eg dataset urn
-    """
-    resourceUrn: String!
+  """
+  The primary key of the resource to attach the description to, eg dataset urn
+  """
+  resourceUrn: String!
 
-    """
-    An optional sub resource type
-    """
-    subResourceType: SubResourceType
+  """
+  An optional sub resource type
+  """
+  subResourceType: SubResourceType
 
-    """
-    A sub resource identifier, eg dataset field path
-    """
-    subResource: String
+  """
+  A sub resource identifier, eg dataset field path
+  """
+  subResource: String
 }
 
 """
 Input for updating the parent node of a resource. Currently only GlossaryNodes and GlossaryTerms have parentNodes.
 """
 input UpdateParentNodeInput {
-    """
-    The new parent node urn. If parentNode is null, this will remove the parent from this entity
-    """
-    parentNode: String
+  """
+  The new parent node urn. If parentNode is null, this will remove the parent from this entity
+  """
+  parentNode: String
 
-    """
-    The primary key of the resource to update the parent node for
-    """
-    resourceUrn: String!
+  """
+  The primary key of the resource to update the parent node for
+  """
+  resourceUrn: String!
 }
 
 """
 Input for updating the parent domain of a domain.
 """
 input MoveDomainInput {
-    """
-    The new parent domain urn. If parentDomain is null, this will remove the parent from this entity
-    """
-    parentDomain: String
+  """
+  The new parent domain urn. If parentDomain is null, this will remove the parent from this entity
+  """
+  parentDomain: String
 
-    """
-    The primary key of the resource to update the parent domain for
-    """
-    resourceUrn: String!
+  """
+  The primary key of the resource to update the parent domain for
+  """
+  resourceUrn: String!
 }
 
 """
 Input for updating the name of an entity
 """
 input UpdateNameInput {
-    """
-    The new name
-    """
-    name: String!
+  """
+  The new name
+  """
+  name: String!
 
-    """
-    The primary key of the resource to update the name for
-    """
-    urn: String!
+  """
+  The primary key of the resource to update the name for
+  """
+  urn: String!
 }
 
 """
 Input provided when setting the Deprecation status for an Entity.
 """
 input UpdateDeprecationInput {
-    """
-    The urn of the Entity to set deprecation for.
-    """
-    urn: String!
+  """
+  The urn of the Entity to set deprecation for.
+  """
+  urn: String!
 
-    """
-    Whether the Entity is marked as deprecated.
-    """
-    deprecated: Boolean!
+  """
+  Whether the Entity is marked as deprecated.
+  """
+  deprecated: Boolean!
 
-    """
-    Optional - The time user plan to decommission this entity
-    """
-    decommissionTime: Long
+  """
+  Optional - The time user plan to decommission this entity
+  """
+  decommissionTime: Long
 
-    """
-    Optional - Additional information about the entity deprecation plan
-    """
-    note: String
+  """
+  Optional - Additional information about the entity deprecation plan
+  """
+  note: String
 }
-
 
 """
 Input provided when updating the deprecation status for a batch of assets.
 """
 input BatchUpdateDeprecationInput {
-    """
-    Whether the Entity is marked as deprecated.
-    """
-    deprecated: Boolean!
+  """
+  Whether the Entity is marked as deprecated.
+  """
+  deprecated: Boolean!
 
-    """
-    Optional - The time user plan to decommission this entity
-    """
-    decommissionTime: Long
+  """
+  Optional - The time user plan to decommission this entity
+  """
+  decommissionTime: Long
 
-    """
-    Optional - Additional information about the entity deprecation plan
-    """
-    note: String
+  """
+  Optional - Additional information about the entity deprecation plan
+  """
+  note: String
 
-    """
-    The target assets to attach the tags to
-    """
-    resources: [ResourceRefInput]!
+  """
+  The target assets to attach the tags to
+  """
+  resources: [ResourceRefInput]!
 }
 
 """
 Input provided when adding tags to a batch of assets
 """
 input BatchSetDomainInput {
-    """
-    The primary key of the Domain, or null if the domain will be unset
-    """
-    domainUrn: String
+  """
+  The primary key of the Domain, or null if the domain will be unset
+  """
+  domainUrn: String
 
-    """
-    The target assets to attach the Domain
-    """
-    resources: [ResourceRefInput!]!
+  """
+  The target assets to attach the Domain
+  """
+  resources: [ResourceRefInput!]!
 }
 
 """
@@ -8919,45 +8943,45 @@ input AddNativeGroupMembersInput {
 Input required to add members to an external DataHub group
 """
 input AddGroupMembersInput {
-    """
-    The group to add members to
-    """
-    groupUrn: String!
+  """
+  The group to add members to
+  """
+  groupUrn: String!
 
-    """
-    The members to add to the group
-    """
-    userUrns: [String!]!
+  """
+  The members to add to the group
+  """
+  userUrns: [String!]!
 }
 
 """
 Input required to remove members from a native DataHub group
 """
 input RemoveNativeGroupMembersInput {
-    """
-    The group to remove members from
-    """
-    groupUrn: String!
+  """
+  The group to remove members from
+  """
+  groupUrn: String!
 
-    """
-    The members to remove from the group
-    """
-    userUrns: [String!]!
+  """
+  The members to remove from the group
+  """
+  userUrns: [String!]!
 }
 
 """
 Input required to remove members from an external DataHub group
 """
 input RemoveGroupMembersInput {
-    """
-    The group to remove members from
-    """
-    groupUrn: String!
+  """
+  The group to remove members from
+  """
+  groupUrn: String!
 
-    """
-    The members to remove from the group
-    """
-    userUrns: [String!]!
+  """
+  The members to remove from the group
+  """
+  userUrns: [String!]!
 }
 
 """
@@ -9002,50 +9026,50 @@ TODO: Eventually get rid of this in favor of DataHub Policy
 An DataHub Platform Access Policy Access Policies determine who can perform what actions against which resources on the platform
 """
 type Policy {
-    """
-    The primary key of the Policy
-    """
-    urn: String!
+  """
+  The primary key of the Policy
+  """
+  urn: String!
 
-    """
-    The type of the Policy
-    """
-    type: PolicyType!
+  """
+  The type of the Policy
+  """
+  type: PolicyType!
 
-    """
-    The name of the Policy
-    """
-    name: String!
+  """
+  The name of the Policy
+  """
+  name: String!
 
-    """
-    The present state of the Policy
-    """
-    state: PolicyState!
+  """
+  The present state of the Policy
+  """
+  state: PolicyState!
 
-    """
-    The description of the Policy
-    """
-    description: String
+  """
+  The description of the Policy
+  """
+  description: String
 
-    """
-    The resources that the Policy privileges apply to
-    """
-    resources: ResourceFilter
+  """
+  The resources that the Policy privileges apply to
+  """
+  resources: ResourceFilter
 
-    """
-    The privileges that the Policy grants
-    """
-    privileges: [String!]!
+  """
+  The privileges that the Policy grants
+  """
+  privileges: [String!]!
 
-    """
-    The actors that the Policy grants privileges to
-    """
-    actors: ActorFilter!
+  """
+  The actors that the Policy grants privileges to
+  """
+  actors: ActorFilter!
 
-    """
-    Whether the Policy is editable, ie system policies, or not
-    """
-    editable: Boolean!
+  """
+  Whether the Policy is editable, ie system policies, or not
+  """
+  editable: Boolean!
 }
 
 """
@@ -9503,12 +9527,12 @@ input ListGroupsInput {
 }
 
 type EntityCountResults {
-    counts: [EntityCountResult!]
+  counts: [EntityCountResult!]
 }
 
 type EntityCountResult {
-    entityType: EntityType!
-    count: Int!
+  entityType: EntityType!
+  count: Int!
 }
 
 """
@@ -9540,15 +9564,15 @@ type ListGroupsResult {
 A time stamp along with an optional actor
 """
 type AuditStamp {
-    """
-    When the audited action took place
-    """
-    time: Long!
+  """
+  When the audited action took place
+  """
+  time: Long!
 
-    """
-    Who performed the audited action
-    """
-    actor: String
+  """
+  Who performed the audited action
+  """
+  actor: String
 }
 
 """
@@ -9575,192 +9599,192 @@ input CreateGroupInput {
 An ML Model Metadata Entity Note that this entity is incubating
 """
 type MLModel implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the ML model
-    """
-    urn: String!
+  """
+  The primary key of the ML model
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    ML model display name
-    """
-    name: String!
+  """
+  ML model display name
+  """
+  name: String!
 
-    """
-    Standardized platform urn where the MLModel is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the MLModel is defined
+  """
+  platform: DataPlatform!
 
-    """
-    Fabric type where mlmodel belongs to or where it was generated
-    """
-    origin: FabricType!
+  """
+  Fabric type where mlmodel belongs to or where it was generated
+  """
+  origin: FabricType!
 
-    """
-    Human readable description for mlmodel
-    """
-    description: String
+  """
+  Human readable description for mlmodel
+  """
+  description: String
 
-    """
-    Deprecated, use tags field instead
-    The standard tags for the ML Model
-    """
-    globalTags: GlobalTags @deprecated
+  """
+  Deprecated, use tags field instead
+  The standard tags for the ML Model
+  """
+  globalTags: GlobalTags @deprecated
 
-    """
-    The standard tags for the ML Model
-    """
-    tags: GlobalTags
+  """
+  The standard tags for the ML Model
+  """
+  tags: GlobalTags
 
-    """
-    Ownership metadata of the mlmodel
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the mlmodel
+  """
+  ownership: Ownership
 
-    """
-    Additional read only information about the ML Model
-    """
-    properties: MLModelProperties
+  """
+  Additional read only information about the ML Model
+  """
+  properties: MLModelProperties
 
-    """
-    Intended use of the mlmodel
-    """
-    intendedUse: IntendedUse
+  """
+  Intended use of the mlmodel
+  """
+  intendedUse: IntendedUse
 
-    """
-    Factors metadata of the mlmodel
-    """
-    factorPrompts: MLModelFactorPrompts
+  """
+  Factors metadata of the mlmodel
+  """
+  factorPrompts: MLModelFactorPrompts
 
-    """
-    Metrics metadata of the mlmodel
-    """
-    metrics: Metrics
+  """
+  Metrics metadata of the mlmodel
+  """
+  metrics: Metrics
 
-    """
-    Evaluation Data of the mlmodel
-    """
-    evaluationData: [BaseData!]
+  """
+  Evaluation Data of the mlmodel
+  """
+  evaluationData: [BaseData!]
 
-    """
-    Training Data of the mlmodel
-    """
-    trainingData: [BaseData!]
+  """
+  Training Data of the mlmodel
+  """
+  trainingData: [BaseData!]
 
-    """
-    Quantitative Analyses of the mlmodel
-    """
-    quantitativeAnalyses: QuantitativeAnalyses
+  """
+  Quantitative Analyses of the mlmodel
+  """
+  quantitativeAnalyses: QuantitativeAnalyses
 
-    """
-    Ethical Considerations of the mlmodel
-    """
-    ethicalConsiderations: EthicalConsiderations
+  """
+  Ethical Considerations of the mlmodel
+  """
+  ethicalConsiderations: EthicalConsiderations
 
-    """
-    Caveats and Recommendations of the mlmodel
-    """
-    caveatsAndRecommendations: CaveatsAndRecommendations
+  """
+  Caveats and Recommendations of the mlmodel
+  """
+  caveatsAndRecommendations: CaveatsAndRecommendations
 
-    """
-    References to internal resources related to the mlmodel
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the mlmodel
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Source Code
-    """
-    sourceCode: SourceCode
+  """
+  Source Code
+  """
+  sourceCode: SourceCode
 
-    """
-    Status metadata of the mlmodel
-    """
-    status: Status
+  """
+  Status metadata of the mlmodel
+  """
+  status: Status
 
-    """
-    Cost Aspect of the mlmodel
-    """
-    cost: Cost
+  """
+  Cost Aspect of the mlmodel
+  """
+  cost: Cost
 
-    """
-    Deprecation
-    """
-    deprecation: Deprecation
+  """
+  Deprecation
+  """
+  deprecation: Deprecation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the ML Model. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the ML Model. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    The structured glossary terms associated with the entity
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the entity
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the entity
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the entity
+  """
+  domain: DomainAssociation
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: MLModelEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: MLModelEditableProperties
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
@@ -9768,1140 +9792,1136 @@ An ML Model Group Metadata Entity
 Note that this entity is incubating
 """
 type MLModelGroup implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the ML Model Group
-    """
-    urn: String!
+  """
+  The primary key of the ML Model Group
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    The display name for the Entity
-    """
-    name: String!
+  """
+  The display name for the Entity
+  """
+  name: String!
 
-    """
-    Standardized platform urn where the MLModelGroup is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the MLModelGroup is defined
+  """
+  platform: DataPlatform!
 
-    """
-    Fabric type where MLModelGroup belongs to or where it was generated
-    """
-    origin: FabricType!
+  """
+  Fabric type where MLModelGroup belongs to or where it was generated
+  """
+  origin: FabricType!
 
-    """
-    Human readable description for MLModelGroup
-    """
-    description: String
+  """
+  Human readable description for MLModelGroup
+  """
+  description: String
 
-    """
-    Additional read only properties about the ML Model Group
-    """
-    properties: MLModelGroupProperties
+  """
+  Additional read only properties about the ML Model Group
+  """
+  properties: MLModelGroupProperties
 
-    """
-    Ownership metadata of the MLModelGroup
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the MLModelGroup
+  """
+  ownership: Ownership
 
-    """
-    Status metadata of the MLModelGroup
-    """
-    status: Status
+  """
+  Status metadata of the MLModelGroup
+  """
+  status: Status
 
-    """
-    Deprecation
-    """
-    deprecation: Deprecation
+  """
+  Deprecation
+  """
+  deprecation: Deprecation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the ML Model Group. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the ML Model Group. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Tags applied to entity
-    """
-    tags: GlobalTags
+  """
+  Tags applied to entity
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the entity
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the entity
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the entity
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the entity
+  """
+  domain: DomainAssociation
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: MLModelGroupEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: MLModelGroupEditableProperties
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
 Properties describing a group of related ML models
 """
 type MLModelGroupProperties {
-    """
-    Display name of the model group
-    """
-    name: String
+  """
+  Display name of the model group
+  """
+  name: String
 
-    """
-    Detailed description of the model group's purpose and contents
-    """
-    description: String
+  """
+  Detailed description of the model group's purpose and contents
+  """
+  description: String
 
-    """
-    When this model group was created
-    """
-    created: AuditStamp
+  """
+  When this model group was created
+  """
+  created: AuditStamp
 
-    """
-    When this model group was last modified
-    """
-    lastModified: AuditStamp
+  """
+  When this model group was last modified
+  """
+  lastModified: AuditStamp
 
-    """
-    Version identifier for this model group
-    """
-    version: VersionTag
+  """
+  Version identifier for this model group
+  """
+  version: VersionTag
 
-    """
-    Custom key-value properties for the model group
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Custom key-value properties for the model group
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    Deprecated creation timestamp
-    @deprecated Use the 'created' field instead
-    """
-    createdAt: Long @deprecated(reason: "Use `created` instead")
+  """
+  Deprecated creation timestamp
+  @deprecated Use the 'created' field instead
+  """
+  createdAt: Long @deprecated(reason: "Use `created` instead")
 }
 
 """
 An ML Feature Metadata Entity Note that this entity is incubating
 """
 type MLFeature implements EntityWithRelationships & Entity {
-    """
-    The primary key of the ML Feature
-    """
-    urn: String!
+  """
+  The primary key of the ML Feature
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    The display name for the ML Feature
-    """
-    name: String!
+  """
+  The display name for the ML Feature
+  """
+  name: String!
 
-    """
-    MLFeature featureNamespace
-    """
-    featureNamespace: String!
+  """
+  MLFeature featureNamespace
+  """
+  featureNamespace: String!
 
-    """
-    The description about the ML Feature
-    """
-    description: String
+  """
+  The description about the ML Feature
+  """
+  description: String
 
-    """
-    MLFeature data type
-    """
-    dataType: MLFeatureDataType
+  """
+  MLFeature data type
+  """
+  dataType: MLFeatureDataType
 
-    """
-    Ownership metadata of the MLFeature
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the MLFeature
+  """
+  ownership: Ownership
 
-    """
-    ModelProperties metadata of the MLFeature
-    """
-    featureProperties: MLFeatureProperties @deprecated
+  """
+  ModelProperties metadata of the MLFeature
+  """
+  featureProperties: MLFeatureProperties @deprecated
 
-    """
-    ModelProperties metadata of the MLFeature
-    """
-    properties: MLFeatureProperties
+  """
+  ModelProperties metadata of the MLFeature
+  """
+  properties: MLFeatureProperties
 
-    """
-    References to internal resources related to the MLFeature
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the MLFeature
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Status metadata of the MLFeature
-    """
-    status: Status
+  """
+  Status metadata of the MLFeature
+  """
+  status: Status
 
-    """
-    Deprecation
-    """
-    deprecation: Deprecation
+  """
+  Deprecation
+  """
+  deprecation: Deprecation
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    Tags applied to entity
-    """
-    tags: GlobalTags
+  """
+  Tags applied to entity
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the entity
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the entity
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the entity
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the entity
+  """
+  domain: DomainAssociation
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: MLFeatureEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: MLFeatureEditableProperties
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 type MLHyperParam {
-name: String
+  name: String
 
-description: String
+  description: String
 
-    value: String
+  value: String
 
-    createdAt: Long
+  createdAt: Long
 }
 
 type MLMetric {
-    """
-    Name of the metric (e.g. accuracy, precision, recall)
-    """
-    name: String
+  """
+  Name of the metric (e.g. accuracy, precision, recall)
+  """
+  name: String
 
-    """
-    Description of what this metric measures
-    """
-    description: String
+  """
+  Description of what this metric measures
+  """
+  description: String
 
-    """
-    The computed value of the metric
-    """
-    value: String
+  """
+  The computed value of the metric
+  """
+  value: String
 
-    """
-    Timestamp when this metric was recorded
-    """
-    createdAt: Long
+  """
+  Timestamp when this metric was recorded
+  """
+  createdAt: Long
 }
 
 type MLModelProperties {
-    """
-    The display name of the model used in the UI
-    """
-    name: String
+  """
+  The display name of the model used in the UI
+  """
+  name: String
 
-    """
-    Detailed description of the model's purpose and characteristics
-    """
-    description: String
+  """
+  Detailed description of the model's purpose and characteristics
+  """
+  description: String
 
-    """
-    When the model was last modified
-    """
-    lastModified: AuditStamp
+  """
+  When the model was last modified
+  """
+  lastModified: AuditStamp
 
-    """
-    Version identifier for this model
-    """
-    version: String
+  """
+  Version identifier for this model
+  """
+  version: String
 
-    """
-    The type/category of ML model (e.g. classification, regression)
-    """
-    type: String
+  """
+  The type/category of ML model (e.g. classification, regression)
+  """
+  type: String
 
-    """
-    Mapping of hyperparameter configurations
-    """
-    hyperParameters: HyperParameterMap
+  """
+  Mapping of hyperparameter configurations
+  """
+  hyperParameters: HyperParameterMap
 
-    """
-    List of hyperparameter settings used to train this model
-    """
-    hyperParams: [MLHyperParam]
+  """
+  List of hyperparameter settings used to train this model
+  """
+  hyperParams: [MLHyperParam]
 
-    """
-    Performance metrics from model training
-    """
-    trainingMetrics: [MLMetric]
+  """
+  Performance metrics from model training
+  """
+  trainingMetrics: [MLMetric]
 
-    """
-    Names of ML features used by this model
-    """
-    mlFeatures: [String!]
+  """
+  Names of ML features used by this model
+  """
+  mlFeatures: [String!]
 
-    """
-    Tags for categorizing and searching models
-    """
-    tags: [String!]
+  """
+  Tags for categorizing and searching models
+  """
+  tags: [String!]
 
-    """
-    Model groups this model belongs to
-    """
-    groups: [MLModelGroup]
+  """
+  Model groups this model belongs to
+  """
+  groups: [MLModelGroup]
 
-    """
-    Additional custom properties specific to this model
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Additional custom properties specific to this model
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    URL to view this model in external system
-    """
-    externalUrl: String
+  """
+  URL to view this model in external system
+  """
+  externalUrl: String
 
-    """
-    When this model was created
-    """
-    created: AuditStamp
+  """
+  When this model was created
+  """
+  created: AuditStamp
 
-    """
-    Deprecated timestamp for model creation
-    @deprecated Use 'created' field instead
-    """
-    date: Long @deprecated(reason: "Use `created` instead")
+  """
+  Deprecated timestamp for model creation
+  @deprecated Use 'created' field instead
+  """
+  date: Long @deprecated(reason: "Use `created` instead")
 }
 
 type MLFeatureProperties {
+  description: String
 
-    description: String
+  dataType: MLFeatureDataType
 
-    dataType: MLFeatureDataType
+  version: VersionTag
 
-    version: VersionTag
+  sources: [Dataset]
 
-    sources: [Dataset]
-
-    customProperties: [CustomPropertiesEntry!]
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 An ML Primary Key Entity Note that this entity is incubating
 """
 type MLPrimaryKey implements EntityWithRelationships & Entity {
-    """
-    The primary key of the ML Primary Key
-    """
-    urn: String!
+  """
+  The primary key of the ML Primary Key
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    The display name
-    """
-    name: String!
+  """
+  The display name
+  """
+  name: String!
 
-    """
-    MLPrimaryKey featureNamespace
-    """
-    featureNamespace: String!
+  """
+  MLPrimaryKey featureNamespace
+  """
+  featureNamespace: String!
 
-    """
-    MLPrimaryKey description
-    """
-    description: String
+  """
+  MLPrimaryKey description
+  """
+  description: String
 
-    """
-    MLPrimaryKey data type
-    """
-    dataType: MLFeatureDataType
+  """
+  MLPrimaryKey data type
+  """
+  dataType: MLFeatureDataType
 
-    """
-    Additional read only properties of the ML Primary Key
-    """
-    properties: MLPrimaryKeyProperties
+  """
+  Additional read only properties of the ML Primary Key
+  """
+  properties: MLPrimaryKeyProperties
 
-    """
-    Deprecated, use properties field instead
-    MLPrimaryKeyProperties
-    """
-    primaryKeyProperties: MLPrimaryKeyProperties @deprecated
+  """
+  Deprecated, use properties field instead
+  MLPrimaryKeyProperties
+  """
+  primaryKeyProperties: MLPrimaryKeyProperties @deprecated
 
-    """
-    Ownership metadata of the MLPrimaryKey
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the MLPrimaryKey
+  """
+  ownership: Ownership
 
-    """
-    References to internal resources related to the MLPrimaryKey
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the MLPrimaryKey
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Status metadata of the MLPrimaryKey
-    """
-    status: Status
+  """
+  Status metadata of the MLPrimaryKey
+  """
+  status: Status
 
-    """
-    Deprecation
-    """
-    deprecation: Deprecation
+  """
+  Deprecation
+  """
+  deprecation: Deprecation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    Tags applied to entity
-    """
-    tags: GlobalTags
+  """
+  Tags applied to entity
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the entity
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the entity
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the entity
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the entity
+  """
+  domain: DomainAssociation
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: MLPrimaryKeyEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: MLPrimaryKeyEditableProperties
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 type MLPrimaryKeyProperties {
+  description: String
 
-    description: String
+  dataType: MLFeatureDataType
 
-    dataType: MLFeatureDataType
+  version: VersionTag
 
-    version: VersionTag
+  sources: [Dataset]
 
-    sources: [Dataset]
-
-    customProperties: [CustomPropertiesEntry!]
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 An ML Feature Table Entity Note that this entity is incubating
 """
 type MLFeatureTable implements EntityWithRelationships & Entity & BrowsableEntity {
-    """
-    The primary key of the ML Feature Table
-    """
-    urn: String!
+  """
+  The primary key of the ML Feature Table
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The timestamp for the last time this entity was ingested
-    """
-    lastIngested: Long
+  """
+  The timestamp for the last time this entity was ingested
+  """
+  lastIngested: Long
 
-    """
-    The display name
-    """
-    name: String!
+  """
+  The display name
+  """
+  name: String!
 
-    """
-    Standardized platform urn where the MLFeatureTable is defined
-    """
-    platform: DataPlatform!
+  """
+  Standardized platform urn where the MLFeatureTable is defined
+  """
+  platform: DataPlatform!
 
-    """
-    MLFeatureTable description
-    """
-    description: String
+  """
+  MLFeatureTable description
+  """
+  description: String
 
-    """
-    Ownership metadata of the MLFeatureTable
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the MLFeatureTable
+  """
+  ownership: Ownership
 
-    """
-    Additional read only properties associated the the ML Feature Table
-    """
-    properties: MLFeatureTableProperties
+  """
+  Additional read only properties associated the the ML Feature Table
+  """
+  properties: MLFeatureTableProperties
 
-    """
-    Deprecated, use properties field instead
-    ModelProperties metadata of the MLFeature
-    """
-    featureTableProperties: MLFeatureTableProperties @deprecated
+  """
+  Deprecated, use properties field instead
+  ModelProperties metadata of the MLFeature
+  """
+  featureTableProperties: MLFeatureTableProperties @deprecated
 
-    """
-    References to internal resources related to the MLFeature
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the MLFeature
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Status metadata of the MLFeatureTable
-    """
-    status: Status
+  """
+  Status metadata of the MLFeatureTable
+  """
+  status: Status
 
-    """
-    Deprecation
-    """
-    deprecation: Deprecation
+  """
+  Deprecation
+  """
+  deprecation: Deprecation
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 
-    """
-    The browse paths corresponding to the ML Feature Table. If no Browse Paths have been generated before, this will be null.
-    """
-    browsePaths: [BrowsePath!]
+  """
+  The browse paths corresponding to the ML Feature Table. If no Browse Paths have been generated before, this will be null.
+  """
+  browsePaths: [BrowsePath!]
 
-    """
-    The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
-    """
-    browsePathV2: BrowsePathV2
+  """
+  The browse path V2 corresponding to an entity. If no Browse Paths V2 have been generated before, this will be null.
+  """
+  browsePathV2: BrowsePathV2
 
-    """
-    Tags applied to entity
-    """
-    tags: GlobalTags
+  """
+  Tags applied to entity
+  """
+  tags: GlobalTags
 
-    """
-    The structured glossary terms associated with the entity
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the entity
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the entity
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the entity
+  """
+  domain: DomainAssociation
 
-    """
-    An additional set of of read write properties
-    """
-    editableProperties: MLFeatureTableEditableProperties
+  """
+  An additional set of of read write properties
+  """
+  editableProperties: MLFeatureTableEditableProperties
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 type MLFeatureTableEditableProperties {
-    """
-    The edited description
-    """
-    description: String
+  """
+  The edited description
+  """
+  description: String
 }
 
 type MLFeatureEditableProperties {
-    """
-    The edited description
-    """
-    description: String
+  """
+  The edited description
+  """
+  description: String
 }
 
 type MLPrimaryKeyEditableProperties {
-    """
-    The edited description
-    """
-    description: String
+  """
+  The edited description
+  """
+  description: String
 }
 
 type MLModelEditableProperties {
-    """
-    The edited description
-    """
-    description: String
+  """
+  The edited description
+  """
+  description: String
 }
 
 type MLModelGroupEditableProperties {
-    """
-    The edited description
-    """
-    description: String
+  """
+  The edited description
+  """
+  description: String
 }
 
 type MLFeatureTableProperties {
+  description: String
 
-    description: String
+  mlFeatures: [MLFeature]
 
-    mlFeatures: [MLFeature]
+  mlPrimaryKeys: [MLPrimaryKey]
 
-    mlPrimaryKeys: [MLPrimaryKey]
-
-    customProperties: [CustomPropertiesEntry!]
+  customProperties: [CustomPropertiesEntry!]
 }
 
 type HyperParameterMap {
-    key: String!
-    value: HyperParameterValueType!
+  key: String!
+  value: HyperParameterValueType!
 }
 
 type StringBox {
-    stringValue: String!
+  stringValue: String!
 }
 
 type IntBox {
-    intValue: Int!
+  intValue: Int!
 }
 
 type FloatBox {
-    floatValue: Float!
+  floatValue: Float!
 }
 
 type BooleanBox {
-    booleanValue: Boolean!
+  booleanValue: Boolean!
 }
 
 union HyperParameterValueType = StringBox | IntBox | FloatBox | BooleanBox
 
 type MLModelFactorPrompts {
-    """
-    What are foreseeable salient factors for which MLModel performance may vary, and how were these determined
-    """
-    relevantFactors: [MLModelFactors!]
+  """
+  What are foreseeable salient factors for which MLModel performance may vary, and how were these determined
+  """
+  relevantFactors: [MLModelFactors!]
 
-    """
-    Which factors are being reported, and why were these chosen
-    """
-    evaluationFactors: [MLModelFactors!]
+  """
+  Which factors are being reported, and why were these chosen
+  """
+  evaluationFactors: [MLModelFactors!]
 }
 
 type MLModelFactors {
-    """
-    Distinct categories with similar characteristics that are present in the evaluation data instances
-    """
-    groups: [String!]
+  """
+  Distinct categories with similar characteristics that are present in the evaluation data instances
+  """
+  groups: [String!]
 
-    """
-    Instrumentation used for MLModel
-    """
-    instrumentation: [String!]
+  """
+  Instrumentation used for MLModel
+  """
+  instrumentation: [String!]
 
-    """
-    Environment in which the MLModel is deployed
-    """
-    environment: [String!]
+  """
+  Environment in which the MLModel is deployed
+  """
+  environment: [String!]
 }
 
 type QuantitativeAnalyses {
-    """
-    Link to a dashboard with results showing how the model performed with respect to each factor
-    """
-    unitaryResults: ResultsType
+  """
+  Link to a dashboard with results showing how the model performed with respect to each factor
+  """
+  unitaryResults: ResultsType
 
-    """
-    Link to a dashboard with results showing how the model performed with respect to the intersection of evaluated factors
-    """
-    intersectionalResults: ResultsType
+  """
+  Link to a dashboard with results showing how the model performed with respect to the intersection of evaluated factors
+  """
+  intersectionalResults: ResultsType
 }
 
 union ResultsType = StringBox
 
 type CaveatsAndRecommendations {
-    """
-    Caveats on using this MLModel
-    """
-    caveats: CaveatDetails
+  """
+  Caveats on using this MLModel
+  """
+  caveats: CaveatDetails
 
-    """
-    Recommendations on where this MLModel should be used
-    """
-    recommendations: String
+  """
+  Recommendations on where this MLModel should be used
+  """
+  recommendations: String
 
-    """
-    Ideal characteristics of an evaluation dataset for this MLModel
-    """
-    idealDatasetCharacteristics: [String!]
+  """
+  Ideal characteristics of an evaluation dataset for this MLModel
+  """
+  idealDatasetCharacteristics: [String!]
 }
 
 type CaveatDetails {
-    """
-    Did the results suggest any further testing
-    """
-    needsFurtherTesting: Boolean
+  """
+  Did the results suggest any further testing
+  """
+  needsFurtherTesting: Boolean
 
-    """
-    Caveat Description
-    """
-    caveatDescription: String
+  """
+  Caveat Description
+  """
+  caveatDescription: String
 
-    """
-    Relevant groups that were not represented in the evaluation dataset
-    """
-    groupsNotRepresented: [String!]
+  """
+  Relevant groups that were not represented in the evaluation dataset
+  """
+  groupsNotRepresented: [String!]
 }
 
 type EthicalConsiderations {
-    """
-    Does the model use any sensitive data eg, protected classes
-    """
-    data: [String!]
+  """
+  Does the model use any sensitive data eg, protected classes
+  """
+  data: [String!]
 
-    """
-    Is the model intended to inform decisions about matters central to human life or flourishing eg, health or safety
-    """
-    humanLife: [String!]
+  """
+  Is the model intended to inform decisions about matters central to human life or flourishing eg, health or safety
+  """
+  humanLife: [String!]
 
-    """
-    What risk mitigation strategies were used during model development
-    """
-    mitigations: [String!]
+  """
+  What risk mitigation strategies were used during model development
+  """
+  mitigations: [String!]
 
-    """
-    What risks may be present in model usage
-    Try to identify the potential recipients, likelihood, and magnitude of harms
-    If these cannot be determined, note that they were considered but remain unknown
-    """
-    risksAndHarms: [String!]
+  """
+  What risks may be present in model usage
+  Try to identify the potential recipients, likelihood, and magnitude of harms
+  If these cannot be determined, note that they were considered but remain unknown
+  """
+  risksAndHarms: [String!]
 
-    """
-    Are there any known model use cases that are especially fraught
-    This may connect directly to the intended use section
-    """
-    useCases: [String!]
+  """
+  Are there any known model use cases that are especially fraught
+  This may connect directly to the intended use section
+  """
+  useCases: [String!]
 }
 
 type BaseData {
-    """
-    Dataset used for the Training or Evaluation of the MLModel
-    """
-    dataset: String!
+  """
+  Dataset used for the Training or Evaluation of the MLModel
+  """
+  dataset: String!
 
-    """
-    Motivation to pick these datasets
-    """
-    motivation: String
+  """
+  Motivation to pick these datasets
+  """
+  motivation: String
 
-    """
-    Details of Data Proprocessing
-    """
-    preProcessing: [String!]
+  """
+  Details of Data Proprocessing
+  """
+  preProcessing: [String!]
 }
 
 type Metrics {
-    """
-    Measures of ML Model performance
-    """
-    performanceMeasures: [String!]
+  """
+  Measures of ML Model performance
+  """
+  performanceMeasures: [String!]
 
-    """
-    Decision Thresholds used if any
-    """
-    decisionThreshold: [String!]
+  """
+  Decision Thresholds used if any
+  """
+  decisionThreshold: [String!]
 }
 
 type IntendedUse {
-    """
-    Primary Use cases for the model
-    """
-    primaryUses: [String!]
+  """
+  Primary Use cases for the model
+  """
+  primaryUses: [String!]
 
-    """
-    Primary Intended Users
-    """
-    primaryUsers: [IntendedUserType!]
+  """
+  Primary Intended Users
+  """
+  primaryUsers: [IntendedUserType!]
 
-    """
-    Out of scope uses of the MLModel
-    """
-    outOfScopeUses: [String!]
+  """
+  Out of scope uses of the MLModel
+  """
+  outOfScopeUses: [String!]
 }
 
 enum IntendedUserType {
-    """
-    Developed for Enterprise Users
-    """
-    ENTERPRISE
+  """
+  Developed for Enterprise Users
+  """
+  ENTERPRISE
 
-    """
-    Developed for Hobbyists
-    """
-    HOBBY
+  """
+  Developed for Hobbyists
+  """
+  HOBBY
 
-    """
-    Developed for Entertainment Purposes
-    """
-    ENTERTAINMENT
+  """
+  Developed for Entertainment Purposes
+  """
+  ENTERTAINMENT
 }
 
 type SourceCode {
-    """
-    Source Code along with types
-    """
-    sourceCode: [SourceCodeUrl!]
+  """
+  Source Code along with types
+  """
+  sourceCode: [SourceCodeUrl!]
 }
 
 type SourceCodeUrl {
-    """
-    Source Code Url Types
-    """
-    type: SourceCodeUrlType!
+  """
+  Source Code Url Types
+  """
+  type: SourceCodeUrlType!
 
-    """
-    Source Code Url
-    """
-    sourceCodeUrl: String!
+  """
+  Source Code Url
+  """
+  sourceCodeUrl: String!
 }
 
 enum SourceCodeUrlType {
-    """
-    MLModel Source Code
-    """
-    ML_MODEL_SOURCE_CODE
+  """
+  MLModel Source Code
+  """
+  ML_MODEL_SOURCE_CODE
 
-    """
-    Training Pipeline Source Code
-    """
-    TRAINING_PIPELINE_SOURCE_CODE
+  """
+  Training Pipeline Source Code
+  """
+  TRAINING_PIPELINE_SOURCE_CODE
 
-    """
-    Evaluation Pipeline Source Code
-    """
-    EVALUATION_PIPELINE_SOURCE_CODE
+  """
+  Evaluation Pipeline Source Code
+  """
+  EVALUATION_PIPELINE_SOURCE_CODE
 }
 
 type Cost {
-    """
-    Type of Cost Code
-    """
-    costType: CostType!
+  """
+  Type of Cost Code
+  """
+  costType: CostType!
 
-    """
-    Code to which the Cost of this entity should be attributed to ie organizational cost ID
-    """
-    costValue: CostValue!
+  """
+  Code to which the Cost of this entity should be attributed to ie organizational cost ID
+  """
+  costValue: CostValue!
 }
 
 type CostValue {
-    """
-    Organizational Cost ID
-    """
-    costId: Float
+  """
+  Organizational Cost ID
+  """
+  costId: Float
 
-    """
-    Organizational Cost Code
-    """
-    costCode: String
+  """
+  Organizational Cost Code
+  """
+  costCode: String
 }
 
 enum CostType {
-    """
-    Org Cost Type to which the Cost of this entity should be attributed to
-    """
-    ORG_COST_TYPE
+  """
+  Org Cost Type to which the Cost of this entity should be attributed to
+  """
+  ORG_COST_TYPE
 }
-
 
 """
 Audit stamp containing a resolved actor
 """
 type ResolvedAuditStamp {
-    """
-    When the audited action took place
-    """
-    time: Long!
+  """
+  When the audited action took place
+  """
+  time: Long!
 
-    """
-    Who performed the audited action
-    """
-    actor: CorpUser
+  """
+  Who performed the audited action
+  """
+  actor: CorpUser
 }
 
 type SubTypes {
-   """
-    The sub-types that this entity implements. e.g. Datasets that are views will implement the "view" subtype
-   """
-   typeNames: [String!]
+  """
+  The sub-types that this entity implements. e.g. Datasets that are views will implement the "view" subtype
+  """
+  typeNames: [String!]
 }
 
 type DomainAssociation {
-    """
-    The domain related to the assocaited urn
-    """
-    domain: Domain!
+  """
+  The domain related to the assocaited urn
+  """
+  domain: Domain!
 
-    """
-    Reference back to the tagged urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the tagged urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 A domain, or a logical grouping of Metadata Entities
 """
 type Domain implements Entity {
-    """
-    The primary key of the domain
-    """
-    urn: String!
+  """
+  The primary key of the domain
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Id of the domain
-    """
-    id: String!
+  """
+  Id of the domain
+  """
+  id: String!
 
-    """
-    Properties about a domain
-    """
-    properties: DomainProperties
+  """
+  Properties about a domain
+  """
+  properties: DomainProperties
 
-    """
-    Ownership metadata of the dataset
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the dataset
+  """
+  ownership: Ownership
 
-    """
-    References to internal resources related to the dataset
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the dataset
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Children entities inside of the Domain
-    """
-    entities(input: DomainEntitiesInput): SearchResults
+  """
+  Children entities inside of the Domain
+  """
+  entities(input: DomainEntitiesInput): SearchResults
 
-    """
-    Recursively get the lineage of parent domains for this entity
-    """
-    parentDomains: ParentDomainsResult
+  """
+  Recursively get the lineage of parent domains for this entity
+  """
+  parentDomains: ParentDomainsResult
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
 All of the parent domains starting from a single Domain through all of its ancestors
 """
 type ParentDomainsResult {
-    """
-    The number of parent domains bubbling up for this entity
-    """
-    count: Int!
+  """
+  The number of parent domains bubbling up for this entity
+  """
+  count: Int!
 
-    """
-    A list of parent domains in order from direct parent, to parent's parent etc. If there are no parents, return an empty list
-    """
-    domains: [Entity!]!
+  """
+  A list of parent domains in order from direct parent, to parent's parent etc. If there are no parents, return an empty list
+  """
+  domains: [Entity!]!
 }
 
 """
@@ -11023,90 +11043,90 @@ type ListDomainsResult {
 Input required when getting Business Glossary entities
 """
 input GetRootGlossaryEntitiesInput {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of Glossary Entities in the returned result set
-    """
-    count: Int!
+  """
+  The number of Glossary Entities in the returned result set
+  """
+  count: Int!
 }
 
 """
 The result when getting root GlossaryTerms
 """
 type GetRootGlossaryTermsResult {
-    """
-    A list of Glossary Terms without a parent node
-    """
-    terms: [GlossaryTerm!]!
+  """
+  A list of Glossary Terms without a parent node
+  """
+  terms: [GlossaryTerm!]!
 
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of terms in the returned result
-    """
-    count: Int!
+  """
+  The number of terms in the returned result
+  """
+  count: Int!
 
-    """
-    The total number of terms in the result set
-    """
-    total: Int!
+  """
+  The total number of terms in the result set
+  """
+  total: Int!
 }
 
 """
 The result when getting Glossary entities
 """
 type GetRootGlossaryNodesResult {
-    """
-    A list of Glossary Nodes without a parent node
-    """
-    nodes: [GlossaryNode!]!
+  """
+  A list of Glossary Nodes without a parent node
+  """
+  nodes: [GlossaryNode!]!
 
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of nodes in the returned result
-    """
-    count: Int!
+  """
+  The number of nodes in the returned result
+  """
+  count: Int!
 
-    """
-    The total number of nodes in the result set
-    """
-    total: Int!
+  """
+  The total number of nodes in the result set
+  """
+  total: Int!
 }
 
 """
 Input required to create a new Glossary Entity - a Node or a Term.
 """
 input CreateGlossaryEntityInput {
-    """
-    Optional! A custom id to use as the primary key identifier for the domain. If not provided, a random UUID will be generated as the id.
-    """
-    id: String
+  """
+  Optional! A custom id to use as the primary key identifier for the domain. If not provided, a random UUID will be generated as the id.
+  """
+  id: String
 
-    """
-    Display name for the Node or Term
-    """
-    name: String!
+  """
+  Display name for the Node or Term
+  """
+  name: String!
 
-    """
-    Description for the Node or Term
-    """
-    description: String
+  """
+  Description for the Node or Term
+  """
+  description: String
 
-    """
-    Optional parent node urn for the Glossary Node or Term
-    """
-    parentNode: String
+  """
+  Optional parent node urn for the Glossary Node or Term
+  """
+  parentNode: String
 }
 
 enum HealthStatus {
@@ -11185,499 +11205,499 @@ input StringMapEntryInput {
 Token that allows users to sign up as a native user
 """
 type InviteToken {
-    """
-    The invite token
-    """
-    inviteToken: String!
+  """
+  The invite token
+  """
+  inviteToken: String!
 }
 
 """
 Input required to generate a password reset token for a native user.
 """
 input CreateNativeUserResetTokenInput {
-    """
-    The urn of the user to reset the password of
-    """
-    userUrn: String!
+  """
+  The urn of the user to reset the password of
+  """
+  userUrn: String!
 }
 
 """
 Token that allows native users to reset their credentials
 """
 type ResetToken {
-    """
-    The reset token
-    """
-    resetToken: String!
+  """
+  The reset token
+  """
+  resetToken: String!
 }
 
 """
 Carries information about where an entity originated from.
 """
 type Origin {
-    """
-    Where an entity originated from. Either NATIVE or EXTERNAL
-    """
-    type: OriginType!
+  """
+  Where an entity originated from. Either NATIVE or EXTERNAL
+  """
+  type: OriginType!
 
-    """
-    Only populated if type is EXTERNAL. The externalType of the entity, such as the name of the identity provider.
-    """
-    externalType: String
+  """
+  Only populated if type is EXTERNAL. The externalType of the entity, such as the name of the identity provider.
+  """
+  externalType: String
 }
 
 """
 Enum to define where an entity originated from.
 """
 enum OriginType {
-    """
-    The entity is native to DataHub.
-    """
-    NATIVE
-    """
-    The entity is external to DataHub.
-    """
-    EXTERNAL
-    """
-    The entity is of unknown origin.
-    """
-    UNKNOWN
+  """
+  The entity is native to DataHub.
+  """
+  NATIVE
+  """
+  The entity is external to DataHub.
+  """
+  EXTERNAL
+  """
+  The entity is of unknown origin.
+  """
+  UNKNOWN
 }
 
 """
 Input provided when updating the soft-deleted status for a batch of assets
 """
 input BatchUpdateSoftDeletedInput {
-    """
-    The urns of the assets to soft delete
-    """
-    urns: [String!]!
+  """
+  The urns of the assets to soft delete
+  """
+  urns: [String!]!
 
-    """
-    Whether to mark the asset as soft-deleted (hidden)
-    """
-    deleted: Boolean!
+  """
+  Whether to mark the asset as soft-deleted (hidden)
+  """
+  deleted: Boolean!
 }
 
 """
 Input fields of the chart
 """
 type InputFields {
-    fields: [InputField]
+  fields: [InputField]
 }
 
 """
 Input field of the chart
 """
 type InputField {
-    schemaFieldUrn: String
-    schemaField: SchemaField
+  schemaFieldUrn: String
+  schemaField: SchemaField
 }
 
 """
 An individual setting type for a Corp User.
 """
 enum UserSetting {
-    """
-    Show simplified homepage
-    """
-    SHOW_SIMPLIFIED_HOMEPAGE
+  """
+  Show simplified homepage
+  """
+  SHOW_SIMPLIFIED_HOMEPAGE
 }
 
 """
 Input for updating a user setting
 """
 input UpdateUserSettingInput {
-    """
-    The name of the setting
-    """
-    name: UserSetting!
+  """
+  The name of the setting
+  """
+  name: UserSetting!
 
-    """
-    The new value of the setting
-    """
-    value: Boolean!
+  """
+  The new value of the setting
+  """
+  value: Boolean!
 }
 
 """
 Input provided when batch assigning a role to a list of users
 """
 input BatchAssignRoleInput {
-    """
-    The urn of the role to assign to the actors. If undefined, will remove the role.
-    """
-    roleUrn: String
+  """
+  The urn of the role to assign to the actors. If undefined, will remove the role.
+  """
+  roleUrn: String
 
-    """
-    The urns of the actors to assign the role to
-    """
-    actors: [String!]!
+  """
+  The urns of the actors to assign the role to
+  """
+  actors: [String!]!
 }
 
 """
 Input provided when listing existing roles
 """
 input ListRolesInput {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int
+  """
+  The starting offset of the result set returned
+  """
+  start: Int
 
-    """
-    The maximum number of Roles to be returned in the result set
-    """
-    count: Int
+  """
+  The maximum number of Roles to be returned in the result set
+  """
+  count: Int
 
-    """
-    Optional search query
-    """
-    query: String
+  """
+  Optional search query
+  """
+  query: String
 }
 
 """
 The result obtained when listing DataHub Roles
 """
 type ListRolesResult {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of Roles in the returned result set
-    """
-    count: Int!
+  """
+  The number of Roles in the returned result set
+  """
+  count: Int!
 
-    """
-    The total number of Roles in the result set
-    """
-    total: Int!
+  """
+  The total number of Roles in the result set
+  """
+  total: Int!
 
-    """
-    The Roles themselves
-    """
-    roles: [DataHubRole!]!
+  """
+  The Roles themselves
+  """
+  roles: [DataHubRole!]!
 }
 
 """
 A DataHub Role is a high-level abstraction on top of Policies that dictates what actions users can take.
 """
 type DataHubRole implements Entity {
-    """
-    The primary key of the role
-    """
-    urn: String!
+  """
+  The primary key of the role
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Granular API for querying edges extending from the Role
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from the Role
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    The name of the Role.
-    """
-    name: String!
+  """
+  The name of the Role.
+  """
+  name: String!
 
-    """
-    The description of the Role
-    """
-    description: String!
+  """
+  The description of the Role
+  """
+  description: String!
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 }
 
 """
 Input provided when getting an invite token
 """
 input GetInviteTokenInput {
-    """
-    The urn of the role to get the invite token for
-    """
-    roleUrn: String
+  """
+  The urn of the role to get the invite token for
+  """
+  roleUrn: String
 }
 
 """
 Input provided when creating an invite token
 """
 input CreateInviteTokenInput {
-    """
-    The urn of the role to create the invite token for
-    """
-    roleUrn: String
+  """
+  The urn of the role to create the invite token for
+  """
+  roleUrn: String
 }
 
 """
 Input provided when accepting a DataHub role using an invite token
 """
 input AcceptRoleInput {
-    """
-    The token needed to accept the role
-    """
-    inviteToken: String!
+  """
+  The token needed to accept the role
+  """
+  inviteToken: String!
 }
 
 """
 The type of post
 """
 enum PostType {
-    """
-    Posts on the home page
-    """
-    HOME_PAGE_ANNOUNCEMENT,
+  """
+  Posts on the home page
+  """
+  HOME_PAGE_ANNOUNCEMENT
 }
 
 """
 The type of post
 """
 enum PostContentType {
-    """
-    Text content
-    """
-    TEXT,
+  """
+  Text content
+  """
+  TEXT
 
-    """
-    Link content
-    """
-    LINK
+  """
+  Link content
+  """
+  LINK
 }
 
 """
 The type of media
 """
 enum MediaType {
-    """
-    An image
-    """
-    IMAGE
+  """
+  An image
+  """
+  IMAGE
 }
 
 """
 Input provided when creating a Post
 """
 input CreatePostInput {
-    """
-    The type of post
-    """
-    postType: PostType!
+  """
+  The type of post
+  """
+  postType: PostType!
 
-    """
-    The content of the post
-    """
-    content: UpdatePostContentInput!
+  """
+  The content of the post
+  """
+  content: UpdatePostContentInput!
 
-    """
-    Optional target URN for the post
-    """
-    resourceUrn: String
+  """
+  Optional target URN for the post
+  """
+  resourceUrn: String
 
-    """
-    An optional type of a sub resource to attach the Tag to
-    """
-    subResourceType: SubResourceType
+  """
+  An optional type of a sub resource to attach the Tag to
+  """
+  subResourceType: SubResourceType
 
-    """
-    Optional target subresource for the post
-    """
-    subResource: String
+  """
+  Optional target subresource for the post
+  """
+  subResource: String
 }
 
 """
 Input provided when creating a Post
 """
 input UpdatePostInput {
-    """
-    The urn of the post to edit or update
-    """
-    urn: String!,
+  """
+  The urn of the post to edit or update
+  """
+  urn: String!
 
-    """
-    The type of post
-    """
-    postType: PostType!
+  """
+  The type of post
+  """
+  postType: PostType!
 
-    """
-    The content of the post
-    """
-    content: UpdatePostContentInput!
+  """
+  The content of the post
+  """
+  content: UpdatePostContentInput!
 }
 
 """
 Input provided for filling in a post content
 """
 input UpdatePostContentInput {
-    """
-    The type of post content
-    """
-    contentType: PostContentType!
+  """
+  The type of post content
+  """
+  contentType: PostContentType!
 
-    """
-    The title of the post
-    """
-    title: String!
+  """
+  The title of the post
+  """
+  title: String!
 
-    """
-    Optional content of the post
-    """
-    description: String
+  """
+  Optional content of the post
+  """
+  description: String
 
-    """
-    Optional link that the post is associated with
-    """
-    link: String
+  """
+  Optional link that the post is associated with
+  """
+  link: String
 
-    """
-    Optional media contained in the post
-    """
-    media: UpdateMediaInput
+  """
+  Optional media contained in the post
+  """
+  media: UpdateMediaInput
 }
 
 """
 Input provided for filling in a post content
 """
 input UpdateMediaInput {
-    """
-    The type of media
-    """
-    type: MediaType!
+  """
+  The type of media
+  """
+  type: MediaType!
 
-    """
-    The location of the media (a URL)
-    """
-    location: String!
+  """
+  The location of the media (a URL)
+  """
+  location: String!
 }
 
 """
 Input provided when listing existing posts
 """
 input ListPostsInput {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int
+  """
+  The starting offset of the result set returned
+  """
+  start: Int
 
-    """
-    The maximum number of Roles to be returned in the result set
-    """
-    count: Int
+  """
+  The maximum number of Roles to be returned in the result set
+  """
+  count: Int
 
-    """
-    Optional search query
-    """
-    query: String
+  """
+  Optional search query
+  """
+  query: String
 }
 
 """
 The result obtained when listing Posts
 """
 type ListPostsResult {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of Roles in the returned result set
-    """
-    count: Int!
+  """
+  The number of Roles in the returned result set
+  """
+  count: Int!
 
-    """
-    The total number of Roles in the result set
-    """
-    total: Int!
+  """
+  The total number of Roles in the result set
+  """
+  total: Int!
 
-    """
-    The Posts themselves
-    """
-    posts: [Post!]!
+  """
+  The Posts themselves
+  """
+  posts: [Post!]!
 }
 
 """
 Input provided when creating a Post
 """
 type Post implements Entity {
-    """
-    The primary key of the Post
-    """
-    urn: String!
+  """
+  The primary key of the Post
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Granular API for querying edges extending from the Post
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from the Post
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    The type of post
-    """
-    postType: PostType!
+  """
+  The type of post
+  """
+  postType: PostType!
 
-    """
-    The content of the post
-    """
-    content: PostContent!
+  """
+  The content of the post
+  """
+  content: PostContent!
 
-    """
-    When the post was last modified
-    """
-    lastModified: AuditStamp!
+  """
+  When the post was last modified
+  """
+  lastModified: AuditStamp!
 }
 
 """
 Post content
 """
 type PostContent {
-    """
-    The type of post content
-    """
-    contentType: PostContentType!
+  """
+  The type of post content
+  """
+  contentType: PostContentType!
 
-    """
-    The title of the post
-    """
-    title: String!
+  """
+  The title of the post
+  """
+  title: String!
 
-    """
-    Optional content of the post
-    """
-    description: String
+  """
+  Optional content of the post
+  """
+  description: String
 
-    """
-    Optional link that the post is associated with
-    """
-    link: String
+  """
+  Optional link that the post is associated with
+  """
+  link: String
 
-    """
-    Optional media contained in the post
-    """
-    media: Media
+  """
+  Optional media contained in the post
+  """
+  media: Media
 }
 
 """
 Media content
 """
 type Media {
-    """
-    The type of media
-    """
-    type: MediaType!
+  """
+  The type of media
+  """
+  type: MediaType!
 
-    """
-    The location of the media (a URL)
-    """
-    location: String!
+  """
+  The location of the media (a URL)
+  """
+  location: String!
 }
 
 """
@@ -11784,95 +11804,95 @@ type DataHubViewFilter {
 Input provided when listing DataHub Views
 """
 input ListMyViewsInput {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int
+  """
+  The starting offset of the result set returned
+  """
+  start: Int
 
-    """
-    The maximum number of Views to be returned in the result set
-    """
-    count: Int
+  """
+  The maximum number of Views to be returned in the result set
+  """
+  count: Int
 
-    """
-    Optional search query
-    """
-    query: String
+  """
+  Optional search query
+  """
+  query: String
 
-    """
-    Optional - List the type of View to filter for.
-    """
-    viewType: DataHubViewType
+  """
+  Optional - List the type of View to filter for.
+  """
+  viewType: DataHubViewType
 }
 
 """
 Input provided when listing DataHub Global Views
 """
 input ListGlobalViewsInput {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int
+  """
+  The starting offset of the result set returned
+  """
+  start: Int
 
-    """
-    The maximum number of Views to be returned in the result set
-    """
-    count: Int
+  """
+  The maximum number of Views to be returned in the result set
+  """
+  count: Int
 
-    """
-    Optional search query
-    """
-    query: String
+  """
+  Optional search query
+  """
+  query: String
 }
 
 """
 The result obtained when listing DataHub Views
 """
 type ListViewsResult {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of Views in the returned result set
-    """
-    count: Int!
+  """
+  The number of Views in the returned result set
+  """
+  count: Int!
 
-    """
-    The total number of Views in the result set
-    """
-    total: Int!
+  """
+  The total number of Views in the result set
+  """
+  total: Int!
 
-    """
-    The Views themselves
-    """
-    views: [DataHubView!]!
+  """
+  The Views themselves
+  """
+  views: [DataHubView!]!
 }
 
 """
 Input provided when creating a DataHub View
 """
 input CreateViewInput {
-    """
-    The type of View
-    """
-    viewType: DataHubViewType!
+  """
+  The type of View
+  """
+  viewType: DataHubViewType!
 
-    """
-    The name of the View
-    """
-    name: String!
+  """
+  The name of the View
+  """
+  name: String!
 
-    """
-    An optional description of the View
-    """
-    description: String
+  """
+  An optional description of the View
+  """
+  description: String
 
-    """
-    The view definition itself
-    """
-    definition: DataHubViewDefinitionInput!
+  """
+  The view definition itself
+  """
+  definition: DataHubViewDefinitionInput!
 }
 
 """
@@ -11909,20 +11929,20 @@ input DataHubViewFilterInput {
 Input provided when updating a DataHub View
 """
 input UpdateViewInput {
-    """
-    The name of the View
-    """
-    name: String
+  """
+  The name of the View
+  """
+  name: String
 
-    """
-    An optional description of the View
-    """
-    description: String
+  """
+  An optional description of the View
+  """
+  description: String
 
-    """
-    The view definition itself
-    """
-    definition: DataHubViewDefinitionInput
+  """
+  The view definition itself
+  """
+  definition: DataHubViewDefinitionInput
 }
 
 """
@@ -11940,10 +11960,10 @@ input UpdateCorpUserViewsSettingsInput {
 Information required to render an embedded version of an asset
 """
 type Embed {
-    """
-    A URL which can be rendered inside of an iframe.
-    """
-    renderUrl: String
+  """
+  A URL which can be rendered inside of an iframe.
+  """
+  renderUrl: String
 }
 
 """
@@ -12046,7 +12066,8 @@ The subject for a Query
 """
 type QuerySubject {
   """
-  The dataset which is the subject of the Query
+  The dataset which is the subject of the Query.
+  If schemaField is not empty, this field represents the parent dataset of the schmeaField.
   """
   dataset: Dataset!
 }
@@ -12250,356 +12271,350 @@ type ListQueriesResult {
 A Data Product, or a logical grouping of Metadata Entities
 """
 type DataProduct implements Entity {
-    """
-    The primary key of the Data Product
-    """
-    urn: String!
+  """
+  The primary key of the Data Product
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Properties about a Data Product
-    """
-    properties: DataProductProperties
+  """
+  Properties about a Data Product
+  """
+  properties: DataProductProperties
 
-    """
-    Ownership metadata of the Data Product
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the Data Product
+  """
+  ownership: Ownership
 
-    """
-    References to internal resources related to the Data Product
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to the Data Product
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Children entities inside of the DataProduct
-    """
-    entities(input: SearchAcrossEntitiesInput): SearchResults
+  """
+  Children entities inside of the DataProduct
+  """
+  entities(input: SearchAcrossEntitiesInput): SearchResults
 
-    """
-    The structured glossary terms associated with the Data Product
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  The structured glossary terms associated with the Data Product
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    The Domain associated with the Data Product
-    """
-    domain: DomainAssociation
+  """
+  The Domain associated with the Data Product
+  """
+  domain: DomainAssociation
 
-    """
-    Tags used for searching Data Product
-    """
-    tags: GlobalTags
+  """
+  Tags used for searching Data Product
+  """
+  tags: GlobalTags
 
-    """
-    Experimental API.
-    For fetching extra entities that do not have custom UI code yet
-    """
-    aspects(input: AspectParams): [RawAspect!]
+  """
+  Experimental API.
+  For fetching extra entities that do not have custom UI code yet
+  """
+  aspects(input: AspectParams): [RawAspect!]
 
-    """
-    Structured properties about this asset
-    """
-    structuredProperties: StructuredProperties
+  """
+  Structured properties about this asset
+  """
+  structuredProperties: StructuredProperties
 
-    """
-    The forms associated with the Dataset
-    """
-    forms: Forms
+  """
+  The forms associated with the Dataset
+  """
+  forms: Forms
 
-    """
-    Privileges given to a user relevant to this entity
-    """
-    privileges: EntityPrivileges
+  """
+  Privileges given to a user relevant to this entity
+  """
+  privileges: EntityPrivileges
 }
 
 """
 Properties about a domain
 """
 type DataProductProperties {
-    """
-    Display name of the Data Product
-    """
-    name: String!
+  """
+  Display name of the Data Product
+  """
+  name: String!
 
-    """
-    Description of the Data Product
-    """
-    description: String
+  """
+  Description of the Data Product
+  """
+  description: String
 
-    """
-    External URL for the DataProduct (most likely GitHub repo where Data Products are managed as code)
-    """
-    externalUrl: String
+  """
+  External URL for the DataProduct (most likely GitHub repo where Data Products are managed as code)
+  """
+  externalUrl: String
 
-    """
-    Number of children entities inside of the Data Product. This number includes soft deleted entities.
-    """
-    numAssets: Int
+  """
+  Number of children entities inside of the Data Product. This number includes soft deleted entities.
+  """
+  numAssets: Int
 
-    """
-    Custom properties of the Data Product
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Custom properties of the Data Product
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 Input required to fetch the entities inside of a Data Product.
 """
 input DataProductEntitiesInput {
-    """
-    Optional query filter for particular entities inside the Data Product
-    """
-    query: String
+  """
+  Optional query filter for particular entities inside the Data Product
+  """
+  query: String
 
-    """
-    The offset of the result set
-    """
-    start: Int
+  """
+  The offset of the result set
+  """
+  start: Int
 
-    """
-    The number of entities to include in result set
-    """
-    count: Int
+  """
+  The number of entities to include in result set
+  """
+  count: Int
 
-    """
-    Optional Facet filters to apply to the result set
-    """
-    filters: [FacetFilterInput!]
+  """
+  Optional Facet filters to apply to the result set
+  """
+  filters: [FacetFilterInput!]
 }
 
 """
 Input required for creating a DataProduct.
 """
 input CreateDataProductInput {
-    """
-    Properties about the Query
-    """
-    properties: CreateDataProductPropertiesInput!
+  """
+  Properties about the Query
+  """
+  properties: CreateDataProductPropertiesInput!
 
-    """
-    The primary key of the Domain
-    """
-    domainUrn: String!
-    """
-    An optional id for the new data product
-    """
-    id: String
+  """
+  The primary key of the Domain
+  """
+  domainUrn: String!
+  """
+  An optional id for the new data product
+  """
+  id: String
 }
 
 """
 Input properties required for creating a DataProduct
 """
 input CreateDataProductPropertiesInput {
-    """
-    A display name for the DataProduct
-    """
-    name: String!
+  """
+  A display name for the DataProduct
+  """
+  name: String!
 
-    """
-    An optional description for the DataProduct
-    """
-    description: String
+  """
+  An optional description for the DataProduct
+  """
+  description: String
 }
-
 
 """
 Input properties required for update a DataProduct
 """
 input UpdateDataProductInput {
-    """
-    A display name for the DataProduct
-    """
-    name: String
+  """
+  A display name for the DataProduct
+  """
+  name: String
 
-    """
-    An optional description for the DataProduct
-    """
-    description: String
+  """
+  An optional description for the DataProduct
+  """
+  description: String
 }
 
 """
 Input properties required for batch setting a DataProduct on other entities
 """
 input BatchSetDataProductInput {
-    """
-    The urn of the data product you are setting on a group of resources.
-    If this is null, the Data Product will be unset for the given resources.
-    """
-    dataProductUrn: String
+  """
+  The urn of the data product you are setting on a group of resources.
+  If this is null, the Data Product will be unset for the given resources.
+  """
+  dataProductUrn: String
 
-    """
-    The urns of the entities the given data product should be set on
-    """
-    resourceUrns: [String!]!
+  """
+  The urns of the entities the given data product should be set on
+  """
+  resourceUrns: [String!]!
 }
-
-
 
 """
 Properties about an individual Custom Ownership Type.
 """
 type OwnershipTypeInfo {
+  """
+  The name of the Custom Ownership Type
+  """
+  name: String!
 
-    """
-    The name of the Custom Ownership Type
-    """
-    name: String!
+  """
+  The description of the Custom Ownership Type
+  """
+  description: String
 
-    """
-    The description of the Custom Ownership Type
-    """
-    description: String
+  """
+  An Audit Stamp corresponding to the creation of this resource
+  """
+  created: AuditStamp
 
-    """
-    An Audit Stamp corresponding to the creation of this resource
-    """
-    created: AuditStamp
-
-    """
-    An Audit Stamp corresponding to the update of this resource
-    """
-    lastModified: AuditStamp
+  """
+  An Audit Stamp corresponding to the update of this resource
+  """
+  lastModified: AuditStamp
 }
 
 """
 A single Custom Ownership Type
 """
 type OwnershipTypeEntity implements Entity {
-    """
-    A primary key associated with the custom ownership type.
-    """
-    urn: String!
+  """
+  A primary key associated with the custom ownership type.
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Information about the Custom Ownership Type
-    """
-    info: OwnershipTypeInfo
+  """
+  Information about the Custom Ownership Type
+  """
+  info: OwnershipTypeInfo
 
-    """
-    Status of the Custom Ownership Type
-    """
-    status: Status
+  """
+  Status of the Custom Ownership Type
+  """
+  status: Status
 
-    """
-    Granular API for querying edges extending from the Custom Ownership Type
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from the Custom Ownership Type
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
 Input required for listing custom ownership types entities
 """
 input ListOwnershipTypesInput {
-    """
-    The starting offset of the result set returned, default is 0
-    """
-    start: Int
+  """
+  The starting offset of the result set returned, default is 0
+  """
+  start: Int
 
-    """
-    The maximum number of Custom Ownership Types to be returned in the result set, default is 20
-    """
-    count: Int
+  """
+  The maximum number of Custom Ownership Types to be returned in the result set, default is 20
+  """
+  count: Int
 
-    """
-    Optional search query
-    """
-    query: String
+  """
+  Optional search query
+  """
+  query: String
 
-    """
-    Optional Facet filters to apply to the result set
-    """
-    filters: [FacetFilterInput!]
+  """
+  Optional Facet filters to apply to the result set
+  """
+  filters: [FacetFilterInput!]
 }
 
 """
 Results when listing custom ownership types.
 """
 type ListOwnershipTypesResult {
-    """
-    The starting offset of the result set
-    """
-    start: Int!
+  """
+  The starting offset of the result set
+  """
+  start: Int!
 
-    """
-    The number of results to be returned
-    """
-    count: Int!
+  """
+  The number of results to be returned
+  """
+  count: Int!
 
-    """
-    The total number of results in the result set
-    """
-    total: Int!
+  """
+  The total number of results in the result set
+  """
+  total: Int!
 
-    """
-    The Custom Ownership Types themselves
-    """
-    ownershipTypes: [OwnershipTypeEntity!]!
+  """
+  The Custom Ownership Types themselves
+  """
+  ownershipTypes: [OwnershipTypeEntity!]!
 }
-
 
 input CreateOwnershipTypeInput {
-    """
-    The name of the Custom Ownership Type
-    """
-    name: String!
+  """
+  The name of the Custom Ownership Type
+  """
+  name: String!
 
-    """
-    The description of the Custom Ownership Type
-    """
-    description: String!
+  """
+  The description of the Custom Ownership Type
+  """
+  description: String!
 }
 
-
 input UpdateOwnershipTypeInput {
-    """
-    The name of the Custom Ownership Type
-    """
-    name: String
+  """
+  The name of the Custom Ownership Type
+  """
+  name: String
 
-    """
-    The description of the Custom Ownership Type
-    """
-    description: String
+  """
+  The description of the Custom Ownership Type
+  """
+  description: String
 }
 
 """
 A standardized type of a user
 """
 type DataHubPersona {
-    """
-    The urn of the persona type
-    """
-    urn: String!
+  """
+  The urn of the persona type
+  """
+  urn: String!
 }
 
 """
 Describes a generic filter on a dataset
 """
 type DatasetFilter {
-    """
-    Type of partition
-    """
-    type: DatasetFilterType!
+  """
+  Type of partition
+  """
+  type: DatasetFilterType!
 
-    """
-    The raw query if using a SQL FilterType
-    """
-    sql: String
+  """
+  The raw query if using a SQL FilterType
+  """
+  sql: String
 }
 
 """
@@ -12612,70 +12627,69 @@ enum DatasetFilterType {
   SQL
 }
 
-
 """
 Input required to create or update a DatasetFilter
 """
 input DatasetFilterInput {
-    """
-    Type of partition
-    """
-    type: DatasetFilterType!
+  """
+  Type of partition
+  """
+  type: DatasetFilterType!
 
-    """
-    The raw query if using a SQL FilterType
-    """
-    sql: String
+  """
+  The raw query if using a SQL FilterType
+  """
+  sql: String
 }
 
 """
 An entity type registered in DataHub
 """
 type EntityTypeEntity implements Entity {
-    """
-    A primary key associated with the Query
-    """
-    urn: String!
+  """
+  A primary key associated with the Query
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Info about this type including its name
-    """
-    info: EntityTypeInfo!
+  """
+  Info about this type including its name
+  """
+  info: EntityTypeInfo!
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
 Properties about an individual entity type
 """
 type EntityTypeInfo {
-    """
-    The standard entity type
-    """
-    type: EntityType!
+  """
+  The standard entity type
+  """
+  type: EntityType!
 
-    """
-    The fully qualified name of the entity type. This includes its namespace
-    """
-    qualifiedName: String!
+  """
+  The fully qualified name of the entity type. This includes its namespace
+  """
+  qualifiedName: String!
 
-    """
-    The display name of this type
-    """
-    displayName: String
+  """
+  The display name of this type
+  """
+  displayName: String
 
-    """
-    The description of this type
-    """
-    description: String
+  """
+  The description of this type
+  """
+  description: String
 }
 
 """
@@ -12683,181 +12697,177 @@ A restricted entity that the user does not have full permissions to view.
 This entity type does not relate to an entity type in the database.
 """
 type Restricted implements Entity & EntityWithRelationships {
-    """
-    The primary key of the restricted entity
-    """
-    urn: String!
+  """
+  The primary key of the restricted entity
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 
-    """
-    Edges extending from this entity grouped by direction in the lineage graph
-    """
-    lineage(input: LineageInput!): EntityLineageResult
+  """
+  Edges extending from this entity grouped by direction in the lineage graph
+  """
+  lineage(input: LineageInput!): EntityLineageResult
 }
-
 
 """
 A Business Attribute, or a logical schema Field
 """
 type BusinessAttribute implements Entity {
-    """
-    The primary key of the Data Product
-    """
-    urn: String!
+  """
+  The primary key of the Data Product
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Properties about a Business Attribute
-    """
-    properties: BusinessAttributeInfo
+  """
+  Properties about a Business Attribute
+  """
+  properties: BusinessAttributeInfo
 
-    """
-    Ownership metadata of the Business Attribute
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the Business Attribute
+  """
+  ownership: Ownership
 
-    """
-    References to internal resources related to Business Attribute
-    """
-    institutionalMemory: InstitutionalMemory
+  """
+  References to internal resources related to Business Attribute
+  """
+  institutionalMemory: InstitutionalMemory
 
-    """
-    Status of the Dataset
-    """
-    status: Status
+  """
+  Status of the Dataset
+  """
+  status: Status
 
-    """
-    List of relationships between the source Entity and some destination entities with a given types
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  List of relationships between the source Entity and some destination entities with a given types
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
 Business Attribute type
 """
-
 type BusinessAttributeInfo {
+  """
+  name of the business attribute
+  """
+  name: String!
 
-    """
-    name of the business attribute
-    """
-    name: String!
+  """
+  description of business attribute
+  """
+  description: String
 
-    """
-    description of business attribute
-    """
-    description: String
+  """
+  Tags associated with the business attribute
+  """
+  tags: GlobalTags
 
-    """
-    Tags associated with the business attribute
-    """
-    tags: GlobalTags
+  """
+  Glossary terms associated with the business attribute
+  """
+  glossaryTerms: GlossaryTerms
 
-    """
-    Glossary terms associated with the business attribute
-    """
-    glossaryTerms: GlossaryTerms
+  """
+  Platform independent field type of the field
+  """
+  type: SchemaFieldDataType
 
-    """
-    Platform independent field type of the field
-    """
-    type: SchemaFieldDataType
+  """
+  A list of platform specific metadata tuples
+  """
+  customProperties: [CustomPropertiesEntry!]
 
-    """
-    A list of platform specific metadata tuples
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  An AuditStamp corresponding to the creation of this chart
+  """
+  created: AuditStamp!
 
-     """
-    An AuditStamp corresponding to the creation of this chart
-    """
-    created: AuditStamp!
+  """
+  An AuditStamp corresponding to the modification of this chart
+  """
+  lastModified: AuditStamp!
 
-    """
-    An AuditStamp corresponding to the modification of this chart
-    """
-    lastModified: AuditStamp!
-
-    """
-    An optional AuditStamp corresponding to the deletion of this chart
-    """
-    deleted: AuditStamp
+  """
+  An optional AuditStamp corresponding to the deletion of this chart
+  """
+  deleted: AuditStamp
 }
 
 """
 Input required for creating a BusinessAttribute.
 """
 input CreateBusinessAttributeInput {
-    """
-    Optional! A custom id to use as the primary key identifier. If not provided, a random UUID will be generated as the id.
-    """
-    id: String
+  """
+  Optional! A custom id to use as the primary key identifier. If not provided, a random UUID will be generated as the id.
+  """
+  id: String
 
-    """
-    name of the business attribute
-    """
-    name: String!
+  """
+  name of the business attribute
+  """
+  name: String!
 
-    """
-    description of business attribute
-    """
-    description: String
+  """
+  description of business attribute
+  """
+  description: String
 
-    """
-    Platform independent field type of the field
-    """
-    type: SchemaFieldDataType
-
+  """
+  Platform independent field type of the field
+  """
+  type: SchemaFieldDataType
 }
 
 input BusinessAttributeInfoInput {
-    """
-    name of the business attribute
-    """
-    name: String!
+  """
+  name of the business attribute
+  """
+  name: String!
 
-    """
-    description of business attribute
-    """
-    description: String
+  """
+  description of business attribute
+  """
+  description: String
 
-    """
-    Platform independent field type of the field
-    """
-    type: SchemaFieldDataType
+  """
+  Platform independent field type of the field
+  """
+  type: SchemaFieldDataType
 }
 
 """
 Input required to update Business Attribute
 """
 input UpdateBusinessAttributeInput {
-    """
-    name of the business attribute
-    """
-    name: String
+  """
+  name of the business attribute
+  """
+  name: String
 
-    """
-    business attribute description
-    """
-    description: String
+  """
+  business attribute description
+  """
+  description: String
 
-	"""
-	type
-    """
-    type: SchemaFieldDataType
+  """
+  type
+  """
+  type: SchemaFieldDataType
 }
 
 """
@@ -12865,237 +12875,235 @@ Input required to attach Business Attribute
 If businessAttributeUrn is null, then it will remove the business attribute from the resource
 """
 input AddBusinessAttributeInput {
-    """
-    The urn of the business attribute to add
-    """
-    businessAttributeUrn: String!
+  """
+  The urn of the business attribute to add
+  """
+  businessAttributeUrn: String!
 
-    """
-    resource urns to add the business attribute to
-    """
-    resourceUrn: [ResourceRefInput!]!
+  """
+  resource urns to add the business attribute to
+  """
+  resourceUrn: [ResourceRefInput!]!
 }
 
 """
 Business attributes attached to the metadata
 """
 type BusinessAttributes {
-    """
-    Business Attribute attached to the Metadata Entity
-    """
-    businessAttribute: BusinessAttributeAssociation
+  """
+  Business Attribute attached to the Metadata Entity
+  """
+  businessAttribute: BusinessAttributeAssociation
 }
 
 """
 Input required to attach business attribute to an entity
 """
 type BusinessAttributeAssociation {
-    """
-    Business Attribute itself
-    """
-    businessAttribute: BusinessAttribute!
+  """
+  Business Attribute itself
+  """
+  businessAttribute: BusinessAttribute!
 
-    """
-    Reference back to the associated urn for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the associated urn for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 Input provided when listing Business Attribute
 """
 input ListBusinessAttributesInput {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int
+  """
+  The starting offset of the result set returned
+  """
+  start: Int
 
-    """
-    The maximum number of Business Attributes to be returned in the result set
-    """
-    count: Int
+  """
+  The maximum number of Business Attributes to be returned in the result set
+  """
+  count: Int
 
-    """
-    Optional search query
-    """
-    query: String
+  """
+  Optional search query
+  """
+  query: String
 }
 
 """
 Input for linking a versioned entity to a Version Set
 """
 input LinkVersionInput {
-    """
-    The target version set
-    """
-    versionSet: String!
+  """
+  The target version set
+  """
+  versionSet: String!
 
-    """
-    The target versioned entity to link
-    """
-    linkedEntity: String!
+  """
+  The target versioned entity to link
+  """
+  linkedEntity: String!
 
-    """
-    Version Tag label for the version, should be unique within a Version Set
-    """
-    version: String!
+  """
+  Version Tag label for the version, should be unique within a Version Set
+  """
+  version: String!
 
-    """
-    Optional timestamp from the source system
-    """
-    sourceTimestamp: Long
+  """
+  Optional timestamp from the source system
+  """
+  sourceTimestamp: Long
 
-    """
-    Optional creator from the source system, will be converted to an Urn
-    """
-    sourceCreator: String
+  """
+  Optional creator from the source system, will be converted to an Urn
+  """
+  sourceCreator: String
 
-    """
-    Optional comment about the version
-    """
-    comment: String
+  """
+  Optional comment about the version
+  """
+  comment: String
 }
 
 """
 Input for unlinking a versioned entity from a Version Set
 """
 input UnlinkVersionInput {
-    """
-    The target version set
-    """
-    versionSet: String
+  """
+  The target version set
+  """
+  versionSet: String
 
-    """
-    The target versioned entity to unlink
-    """
-    unlinkedEntity: String
+  """
+  The target versioned entity to unlink
+  """
+  unlinkedEntity: String
 }
 
 """
 The result obtained when listing Business Attribute
 """
 type ListBusinessAttributesResult {
-    """
-    The starting offset of the result set returned
-    """
-    start: Int!
+  """
+  The starting offset of the result set returned
+  """
+  start: Int!
 
-    """
-    The number of Business Attributes in the returned result set
-    """
-    count: Int!
+  """
+  The number of Business Attributes in the returned result set
+  """
+  count: Int!
 
-    """
-    The total number of Business Attributes in the result set
-    """
-    total: Int!
+  """
+  The total number of Business Attributes in the result set
+  """
+  total: Int!
 
-    """
-    The Business Attributes
-    """
-    businessAttributes: [BusinessAttribute!]!
+  """
+  The Business Attributes
+  """
+  businessAttributes: [BusinessAttribute!]!
 }
 
 """
 A cron schedule
 """
 type CronSchedule {
-    """
-    A cron-formatted execution interval, as a cron string, e.g. 1 * * * *
-    """
-    cron: String!
+  """
+  A cron-formatted execution interval, as a cron string, e.g. 1 * * * *
+  """
+  cron: String!
 
-    """
-    Timezone in which the cron interval applies, e.g. America/Los_Angeles
-    """
-    timezone: String!
+  """
+  Timezone in which the cron interval applies, e.g. America/Los_Angeles
+  """
+  timezone: String!
 }
-
 
 """
 Properties describing a data process instance's execution metadata
 """
 type DataProcessInstanceProperties {
-    """
-    The display name of this process instance
-    """
-    name: String!
+  """
+  The display name of this process instance
+  """
+  name: String!
 
-    """
-    URL to view this process instance in the external system
-    """
-    externalUrl: String
+  """
+  URL to view this process instance in the external system
+  """
+  externalUrl: String
 
-    """
-    When this process instance was created
-    """
-    created: AuditStamp
+  """
+  When this process instance was created
+  """
+  created: AuditStamp
 
-    """
-    Additional custom properties specific to this process instance
-    """
-    customProperties: [CustomPropertiesEntry!]
+  """
+  Additional custom properties specific to this process instance
+  """
+  customProperties: [CustomPropertiesEntry!]
 }
 
 """
 Properties specific to an ML model training run instance
 """
 type MLTrainingRunProperties {
-    """
-    Unique identifier for this training run
-    """
-    id: String
+  """
+  Unique identifier for this training run
+  """
+  id: String
 
-    """
-    List of URLs to access training run outputs (e.g. model artifacts, logs)
-    """
-    outputUrls: [String]
-    
-    """
-    Hyperparameters used in this training run
-    """
-    hyperParams: [MLHyperParam]
+  """
+  List of URLs to access training run outputs (e.g. model artifacts, logs)
+  """
+  outputUrls: [String]
 
-    """
-    Performance metrics recorded during this training run
-    """
-    trainingMetrics: [MLMetric]
+  """
+  Hyperparameters used in this training run
+  """
+  hyperParams: [MLHyperParam]
+
+  """
+  Performance metrics recorded during this training run
+  """
+  trainingMetrics: [MLMetric]
 }
 
 extend type DataProcessInstance {
+  """
+  Additional read only properties associated with the Data Job
+  """
+  properties: DataProcessInstanceProperties
 
-    """
-    Additional read only properties associated with the Data Job
-    """
-    properties: DataProcessInstanceProperties
+  """
+  The specific instance of the data platform that this entity belongs to
+  """
+  dataPlatformInstance: DataPlatformInstance
 
-    """
-    The specific instance of the data platform that this entity belongs to
-    """
-    dataPlatformInstance: DataPlatformInstance
+  """
+  Sub Types that this entity implements
+  """
+  subTypes: SubTypes
 
-    """
-    Sub Types that this entity implements
-    """
-    subTypes: SubTypes
+  """
+  The parent container in which the entity resides
+  """
+  container: Container
 
-    """
-    The parent container in which the entity resides
-    """
-    container: Container
+  """
+  Standardized platform urn where the data process instance is defined
+  """
+  platform: DataPlatform!
 
-    """
-    Standardized platform urn where the data process instance is defined
-    """
-    platform: DataPlatform!
+  """
+  Recursively get the lineage of containers for this entity
+  """
+  parentContainers: ParentContainersResult
 
-    """
-    Recursively get the lineage of containers for this entity
-    """
-    parentContainers: ParentContainersResult
-
-    """
-    Additional properties when subtype is Training Run
-    """
-    mlTrainingRunProperties: MLTrainingRunProperties
+  """
+  Additional properties when subtype is Training Run
+  """
+  mlTrainingRunProperties: MLTrainingRunProperties
 }

--- a/datahub-graphql-core/src/main/resources/forms.graphql
+++ b/datahub-graphql-core/src/main/resources/forms.graphql
@@ -1,23 +1,23 @@
 extend type Mutation {
-    """
-    Remove a form from a given list of entities.
-    """
-    batchRemoveForm(input: BatchRemoveFormInput!): Boolean!
+  """
+  Remove a form from a given list of entities.
+  """
+  batchRemoveForm(input: BatchRemoveFormInput!): Boolean!
 
-    """
-    Create a new form based on the input
-    """
-    createForm(input: CreateFormInput!): Form!
+  """
+  Create a new form based on the input
+  """
+  createForm(input: CreateFormInput!): Form!
 
-    """
-    Delete a given form
-    """
-    deleteForm(input: DeleteFormInput!): Boolean!
+  """
+  Delete a given form
+  """
+  deleteForm(input: DeleteFormInput!): Boolean!
 
-    """
-    Update an existing form based on the input
-    """
-    updateForm(input: UpdateFormInput!): Form!
+  """
+  Update an existing form based on the input
+  """
+  updateForm(input: UpdateFormInput!): Form!
 }
 
 """
@@ -41,324 +41,323 @@ type Forms {
 }
 
 type FormAssociation {
-    """
-    The form related to the associated urn
-    """
-    form: Form!
+  """
+  The form related to the associated urn
+  """
+  form: Form!
 
-    """
-    Reference back to the urn with the form on it for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  Reference back to the urn with the form on it for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 
-    """
-    The prompt that still need to be completed for this form
-    """
-    incompletePrompts: [FormPromptAssociation!]
+  """
+  The prompt that still need to be completed for this form
+  """
+  incompletePrompts: [FormPromptAssociation!]
 
-    """
-    The prompt that are already completed for this form
-    """
-    completedPrompts: [FormPromptAssociation!]
+  """
+  The prompt that are already completed for this form
+  """
+  completedPrompts: [FormPromptAssociation!]
 }
 
 """
 Verification object that has been applied to the entity via a completed form.
 """
 type FormVerificationAssociation {
-    """
-    The form related to the associated urn
-    """
-    form: Form!
+  """
+  The form related to the associated urn
+  """
+  form: Form!
 
-    """
-    When this verification was applied to this entity
-    """
-    lastModified: ResolvedAuditStamp
+  """
+  When this verification was applied to this entity
+  """
+  lastModified: ResolvedAuditStamp
 }
 
 """
 A form that helps with filling out metadata on an entity
 """
 type FormPromptAssociation {
-    """
-    The unique id of the form prompt
-    """
-    id: String!
+  """
+  The unique id of the form prompt
+  """
+  id: String!
 
-    """
-    When and by whom this form prompt has last been modified
-    """
-    lastModified: ResolvedAuditStamp!
+  """
+  When and by whom this form prompt has last been modified
+  """
+  lastModified: ResolvedAuditStamp!
 
-    """
-    Optional information about the field-level prompt associations.
-    """
-    fieldAssociations: FormPromptFieldAssociations
+  """
+  Optional information about the field-level prompt associations.
+  """
+  fieldAssociations: FormPromptFieldAssociations
 }
 
 """
 Information about the field-level prompt associations.
 """
 type FormPromptFieldAssociations {
-    """
-    If this form prompt is for fields, this will contain a list of completed associations per field
-    """
-    completedFieldPrompts: [FieldFormPromptAssociation!]
+  """
+  If this form prompt is for fields, this will contain a list of completed associations per field
+  """
+  completedFieldPrompts: [FieldFormPromptAssociation!]
 
-    """
-    If this form prompt is for fields, this will contain a list of incomlete associations per field
-    """
-    incompleteFieldPrompts: [FieldFormPromptAssociation!]
+  """
+  If this form prompt is for fields, this will contain a list of incomlete associations per field
+  """
+  incompleteFieldPrompts: [FieldFormPromptAssociation!]
 }
 
 """
 An association for field-level form prompts
 """
 type FieldFormPromptAssociation {
-    """
-    The schema field path
-    """
-    fieldPath: String!
+  """
+  The schema field path
+  """
+  fieldPath: String!
 
-    """
-    When and by whom this form field-level prompt has last been modified
-    """
-    lastModified: ResolvedAuditStamp!
+  """
+  When and by whom this form field-level prompt has last been modified
+  """
+  lastModified: ResolvedAuditStamp!
 }
 
 """
 A form that helps with filling out metadata on an entity
 """
 type Form implements Entity {
-    """
-    A primary key associated with the Form
-    """
-    urn: String!
+  """
+  A primary key associated with the Form
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Information about this form
-    """
-    info: FormInfo!
+  """
+  Information about this form
+  """
+  info: FormInfo!
 
-    """
-    Ownership metadata of the form
-    """
-    ownership: Ownership
+  """
+  Ownership metadata of the form
+  """
+  ownership: Ownership
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
 The type of a form. This is optional on a form entity
 """
 enum FormType {
-    """
-    This form is used for "verifying" entities as a state for governance and compliance
-    """
-    VERIFICATION
+  """
+  This form is used for "verifying" entities as a state for governance and compliance
+  """
+  VERIFICATION
 
-    """
-    This form is used to help with filling out metadata on entities
-    """
-    COMPLETION
+  """
+  This form is used to help with filling out metadata on entities
+  """
+  COMPLETION
 }
 
 """
 Properties about an individual Form
 """
 type FormInfo {
-    """
-    The name of this form
-    """
-    name: String!
+  """
+  The name of this form
+  """
+  name: String!
 
-    """
-    The description of this form
-    """
-    description: String
+  """
+  The description of this form
+  """
+  description: String
 
-    """
-    The type of this form
-    """
-    type: FormType!
+  """
+  The type of this form
+  """
+  type: FormType!
 
-    """
-    The prompt for this form
-    """
-    prompts: [FormPrompt!]!
+  """
+  The prompt for this form
+  """
+  prompts: [FormPrompt!]!
 
-    """
-    The actors that are assigned to complete the forms for the associated entities.
-    """
-    actors: FormActorAssignment!
+  """
+  The actors that are assigned to complete the forms for the associated entities.
+  """
+  actors: FormActorAssignment!
 }
 
 """
 A prompt shown to the user to collect metadata about an entity
 """
 type FormPrompt {
-    """
-    The ID of this prompt. This will be globally unique.
-    """
-    id: String!
+  """
+  The ID of this prompt. This will be globally unique.
+  """
+  id: String!
 
-    """
-    The title of this prompt
-    """
-    title: String!
+  """
+  The title of this prompt
+  """
+  title: String!
 
-    """
-    The urn of the parent form that this prompt is part of
-    """
-    formUrn: String!
+  """
+  The urn of the parent form that this prompt is part of
+  """
+  formUrn: String!
 
-    """
-    The description of this prompt
-    """
-    description: String
+  """
+  The description of this prompt
+  """
+  description: String
 
-    """
-    The description of this prompt
-    """
-    type: FormPromptType!
+  """
+  The description of this prompt
+  """
+  type: FormPromptType!
 
-    """
-    Whether the prompt is required for the form to be considered completed.
-    """
-    required: Boolean!
+  """
+  Whether the prompt is required for the form to be considered completed.
+  """
+  required: Boolean!
 
-    """
-    The params for this prompt if type is STRUCTURED_PROPERTY
-    """
-    structuredPropertyParams: StructuredPropertyParams
+  """
+  The params for this prompt if type is STRUCTURED_PROPERTY
+  """
+  structuredPropertyParams: StructuredPropertyParams
 }
 
 """
 Enum of all form prompt types
 """
 enum FormPromptType {
-    """
-    A structured property form prompt type.
-    """
-    STRUCTURED_PROPERTY
-    """
-    A schema field-level structured property form prompt type.
-    """
-    FIELDS_STRUCTURED_PROPERTY
+  """
+  A structured property form prompt type.
+  """
+  STRUCTURED_PROPERTY
+  """
+  A schema field-level structured property form prompt type.
+  """
+  FIELDS_STRUCTURED_PROPERTY
 }
 
 """
 A prompt shown to the user to collect metadata about an entity
 """
 type StructuredPropertyParams {
-    """
-    The structured property required for the prompt on this entity
-    """
-    structuredProperty: StructuredPropertyEntity!
+  """
+  The structured property required for the prompt on this entity
+  """
+  structuredProperty: StructuredPropertyEntity!
 }
 
 """
 Input for responding to a singular prompt in a form
 """
 input SubmitFormPromptInput {
-    """
-    The unique ID of the prompt this input is responding to
-    """
-    promptId: String!
+  """
+  The unique ID of the prompt this input is responding to
+  """
+  promptId: String!
 
-    """
-    The urn of the form that this prompt is a part of
-    """
-    formUrn: String!
+  """
+  The urn of the form that this prompt is a part of
+  """
+  formUrn: String!
 
-    """
-    The type of prompt that this input is responding to
-    """
-    type: FormPromptType!
+  """
+  The type of prompt that this input is responding to
+  """
+  type: FormPromptType!
 
-    """
-    The fieldPath on a schema field that this prompt submission is association with.
-    This should be provided when the prompt is type FIELDS_STRUCTURED_PROPERTY
-    """
-    fieldPath: String
+  """
+  The fieldPath on a schema field that this prompt submission is association with.
+  This should be provided when the prompt is type FIELDS_STRUCTURED_PROPERTY
+  """
+  fieldPath: String
 
-    """
-    The structured property required for the prompt on this entity
-    """
-    structuredPropertyParams: StructuredPropertyInputParams
+  """
+  The structured property required for the prompt on this entity
+  """
+  structuredPropertyParams: StructuredPropertyInputParams
 }
-
 
 """
 Input for collecting structured property values to apply to entities
 """
 input PropertyValueInput {
-    """
-    The string value for this structured property
-    """
-    stringValue: String
+  """
+  The string value for this structured property
+  """
+  stringValue: String
 
-    """
-    The number value for this structured property
-    """
-    numberValue: Float
+  """
+  The number value for this structured property
+  """
+  numberValue: Float
 }
 
 """
 A prompt shown to the user to collect metadata about an entity
 """
 input StructuredPropertyInputParams {
-    """
-    The urn of the structured property being applied to an entity
-    """
-    structuredPropertyUrn: String!
+  """
+  The urn of the structured property being applied to an entity
+  """
+  structuredPropertyUrn: String!
 
-    """
-    The list of values you want to apply on this structured property to an entity
-    """
-    values: [PropertyValueInput!]!
+  """
+  The list of values you want to apply on this structured property to an entity
+  """
+  values: [PropertyValueInput!]!
 }
 
 """
 Input for batch assigning a form to different entities
 """
 input BatchAssignFormInput {
-    """
-    The urn of the form being assigned to entities
-    """
-    formUrn: String!
+  """
+  The urn of the form being assigned to entities
+  """
+  formUrn: String!
 
-    """
-    The entities that this form is being assigned to
-    """
-    entityUrns: [String!]!
+  """
+  The entities that this form is being assigned to
+  """
+  entityUrns: [String!]!
 }
 
 """
 Input for batch assigning a form to different entities
 """
 input CreateDynamicFormAssignmentInput {
-    """
-    The urn of the form being assigned to entities that match some criteria
-    """
-    formUrn: String!
+  """
+  The urn of the form being assigned to entities that match some criteria
+  """
+  formUrn: String!
 
-    """
-    A list of disjunctive criterion for the filter. (or operation to combine filters).
-    Entities that match this filter will have this form applied to them.
-    Currently, we only support a set of fields to filter on and they are:
-    (1) platform (2) subType (3) container (4) _entityType (5) domain
-    """
-    orFilters: [AndFilterInput!]!
+  """
+  A list of disjunctive criterion for the filter. (or operation to combine filters).
+  Entities that match this filter will have this form applied to them.
+  Currently, we only support a set of fields to filter on and they are:
+  (1) platform (2) subType (3) container (4) _entityType (5) domain
+  """
+  orFilters: [AndFilterInput!]!
 }
 
 type FormActorAssignment {
@@ -388,209 +387,208 @@ type FormActorAssignment {
 Input for verifying forms on entities
 """
 input VerifyFormInput {
-    """
-    The urn of the form being verified on an entity
-    """
-    formUrn: String!
+  """
+  The urn of the form being verified on an entity
+  """
+  formUrn: String!
 
-    """
-    The urn of the entity that is having a form verified on it
-    """
-    entityUrn: String!
+  """
+  The urn of the entity that is having a form verified on it
+  """
+  entityUrn: String!
 }
 
 """
 Input for batch removing a form from different entities
 """
 input BatchRemoveFormInput {
-    """
-    The urn of the form being removed from entities
-    """
-    formUrn: String!
+  """
+  The urn of the form being removed from entities
+  """
+  formUrn: String!
 
-    """
-    The entities that this form is being removed from
-    """
-    entityUrns: [String!]!
+  """
+  The entities that this form is being removed from
+  """
+  entityUrns: [String!]!
 }
 
 """
 Input for batch removing a form from different entities
 """
 input CreateFormInput {
-    """
-    Advanced: Optionally provide an ID to create a form urn from
-    """
-    id: String
+  """
+  Advanced: Optionally provide an ID to create a form urn from
+  """
+  id: String
 
-    """
-    The name of the form being created
-    """
-    name: String!
+  """
+  The name of the form being created
+  """
+  name: String!
 
-    """
-    The optional description of the form being created
-    """
-    description: String
+  """
+  The optional description of the form being created
+  """
+  description: String
 
-    """
-    The type of this form, whether it's verification or completion. Default is completion.
-    """
-    type: FormType
+  """
+  The type of this form, whether it's verification or completion. Default is completion.
+  """
+  type: FormType
 
-    """
-    The type of this form, whether it's verification or completion. Default is completion.
-    """
-    prompts: [CreatePromptInput!]
+  """
+  The type of this form, whether it's verification or completion. Default is completion.
+  """
+  prompts: [CreatePromptInput!]
 
-    """
-    Information on how this form should be assigned to users/groups
-    """
-    actors: FormActorAssignmentInput
+  """
+  Information on how this form should be assigned to users/groups
+  """
+  actors: FormActorAssignmentInput
 }
 
 """
 Input for creating form prompts
 """
 input CreatePromptInput {
-    """
-    Advanced: Optionally provide an ID to this prompt. All prompt IDs must be globally unique.
-    """
-    id: String
+  """
+  Advanced: Optionally provide an ID to this prompt. All prompt IDs must be globally unique.
+  """
+  id: String
 
-    """
-    The title of the prompt
-    """
-    title: String!
+  """
+  The title of the prompt
+  """
+  title: String!
 
-    """
-    The optional description of the prompt
-    """
-    description: String
+  """
+  The optional description of the prompt
+  """
+  description: String
 
-    """
-    The type of the prompt.
-    """
-    type: FormPromptType!
+  """
+  The type of the prompt.
+  """
+  type: FormPromptType!
 
-    """
-    The params required if this prompt type is STRUCTURED_PROPERTY or FIELDS_STRUCTURED_PROPERTY
-    """
-    structuredPropertyParams: StructuredPropertyParamsInput
+  """
+  The params required if this prompt type is STRUCTURED_PROPERTY or FIELDS_STRUCTURED_PROPERTY
+  """
+  structuredPropertyParams: StructuredPropertyParamsInput
 
-    """
-    Whether this prompt will be required or not. Default is false.
-    """
-    required: Boolean
-
+  """
+  Whether this prompt will be required or not. Default is false.
+  """
+  required: Boolean
 }
 
 """
 Input for assigning a form to actors
 """
 input FormActorAssignmentInput {
-    """
-    Whether this form will be applied to owners of associated entities or not. Default is true.
-    """
-    owners: Boolean
+  """
+  Whether this form will be applied to owners of associated entities or not. Default is true.
+  """
+  owners: Boolean
 
-    """
-    The optional list of user urns to assign this form to
-    """
-    users: [String!]
+  """
+  The optional list of user urns to assign this form to
+  """
+  users: [String!]
 
-    """
-    The optional list of group urns to assign this form to
-    """
-    groups: [String!]
+  """
+  The optional list of group urns to assign this form to
+  """
+  groups: [String!]
 }
 
 """
 Input for a structured property type prompt
 """
 input StructuredPropertyParamsInput {
-    """
-    The urn of the structured property for a given form prompt
-    """
-    urn: String!
+  """
+  The urn of the structured property for a given form prompt
+  """
+  urn: String!
 }
 
 """
 Input for updating a form
 """
 input UpdateFormInput {
-    """
-    The urn of the form being updated
-    """
-    urn: String!
+  """
+  The urn of the form being updated
+  """
+  urn: String!
 
-    """
-    The new name of the form
-    """
-    name: String
+  """
+  The new name of the form
+  """
+  name: String
 
-    """
-    The new description of the form
-    """
-    description: String
+  """
+  The new description of the form
+  """
+  description: String
 
-    """
-    The new type of the form
-    """
-    type: FormType
+  """
+  The new type of the form
+  """
+  type: FormType
 
-    """
-    The new prompts being added to this form
-    """
-    promptsToAdd: [CreatePromptInput!]
+  """
+  The new prompts being added to this form
+  """
+  promptsToAdd: [CreatePromptInput!]
 
-    """
-    The IDs of the prompts to remove from this form
-    """
-    promptsToRemove: [String!]
+  """
+  The IDs of the prompts to remove from this form
+  """
+  promptsToRemove: [String!]
 
-    """
-    Information on how this form should be assigned to users/groups
-    """
-    actors: FormActorAssignmentUpdateInput
+  """
+  Information on how this form should be assigned to users/groups
+  """
+  actors: FormActorAssignmentUpdateInput
 }
 
 """
 Update input for assigning a form to actors
 """
 input FormActorAssignmentUpdateInput {
-    """
-    Whether this form will be applied to owners of associated entities or not. Default is true.
-    """
-    owners: Boolean
+  """
+  Whether this form will be applied to owners of associated entities or not. Default is true.
+  """
+  owners: Boolean
 
-    """
-    The optional list of user urns to assign this form to
-    """
-    usersToAdd: [String!]
+  """
+  The optional list of user urns to assign this form to
+  """
+  usersToAdd: [String!]
 
-    """
-    The users being removed from being assigned to this form
-    """
-    usersToRemove: [String!]
+  """
+  The users being removed from being assigned to this form
+  """
+  usersToRemove: [String!]
 
-    """
-    The optional list of group urns to assign this form to
-    """
-    groupsToAdd: [String!]
+  """
+  The optional list of group urns to assign this form to
+  """
+  groupsToAdd: [String!]
 
-    """
-    The groups being removed from being assigned to this form
-    """
-    groupsToRemove: [String!]
+  """
+  The groups being removed from being assigned to this form
+  """
+  groupsToRemove: [String!]
 }
 
 """
 Input for deleting a form
 """
 input DeleteFormInput {
-    """
-    The urn of the form that is being deleted
-    """
-    urn: String!
+  """
+  The urn of the form that is being deleted
+  """
+  urn: String!
 }

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -6,10 +6,11 @@ extend type Mutation {
     """
     Input required to create a new incident
     """
-    input: RaiseIncidentInput!): String
+    input: RaiseIncidentInput!
+  ): String
 
   """
-  Update an existing incident for a resource (asset)
+  Update the status of an existing incident for a resource (asset)
   """
   updateIncidentStatus(
     """
@@ -20,7 +21,8 @@ extend type Mutation {
     """
     Input required to update the state of an existing incident
     """
-    input: UpdateIncidentStatusInput!): Boolean
+    input: UpdateIncidentStatusInput!
+  ): Boolean
 }
 
 """
@@ -177,7 +179,6 @@ enum IncidentType {
   CUSTOM
 }
 
-
 """
 Details about the status of an asset incident
 """
@@ -292,15 +293,16 @@ extend type Dataset {
     """
     Optional incident state to filter by, defaults to any state.
     """
-    state: IncidentState,
+    state: IncidentState
     """
     Optional start offset, defaults to 0.
     """
-    start: Int,
+    start: Int
     """
     Optional start offset, defaults to 20.
     """
-    count: Int): EntityIncidentsResult
+    count: Int
+  ): EntityIncidentsResult
 }
 
 extend type DataJob {
@@ -311,15 +313,16 @@ extend type DataJob {
     """
     Optional incident state to filter by, defaults to any state.
     """
-    state: IncidentState,
+    state: IncidentState
     """
     Optional start offset, defaults to 0.
     """
-    start: Int,
+    start: Int
     """
     Optional start offset, defaults to 20.
     """
-    count: Int): EntityIncidentsResult
+    count: Int
+  ): EntityIncidentsResult
 }
 
 extend type DataFlow {
@@ -330,15 +333,16 @@ extend type DataFlow {
     """
     Optional incident state to filter by, defaults to any state.
     """
-    state: IncidentState,
+    state: IncidentState
     """
     Optional start offset, defaults to 0.
     """
-    start: Int,
+    start: Int
     """
     Optional start offset, defaults to 20.
     """
-    count: Int): EntityIncidentsResult
+    count: Int
+  ): EntityIncidentsResult
 }
 
 extend type Dashboard {
@@ -349,15 +353,16 @@ extend type Dashboard {
     """
     Optional incident state to filter by, defaults to any state.
     """
-    state: IncidentState,
+    state: IncidentState
     """
     Optional start offset, defaults to 0.
     """
-    start: Int,
+    start: Int
     """
     Optional start offset, defaults to 20.
     """
-    count: Int): EntityIncidentsResult
+    count: Int
+  ): EntityIncidentsResult
 }
 
 extend type Chart {
@@ -368,13 +373,14 @@ extend type Chart {
     """
     Optional incident state to filter by, defaults to any state.
     """
-    state: IncidentState,
+    state: IncidentState
     """
     Optional start offset, defaults to 0.
     """
-    start: Int,
+    start: Int
     """
     Optional start offset, defaults to 20.
     """
-    count: Int): EntityIncidentsResult
+    count: Int
+  ): EntityIncidentsResult
 }

--- a/datahub-graphql-core/src/main/resources/ingestion.graphql
+++ b/datahub-graphql-core/src/main/resources/ingestion.graphql
@@ -15,7 +15,9 @@ extend type Query {
   """
   List all ingestion sources
   """
-  listIngestionSources(input: ListIngestionSourcesInput!): ListIngestionSourcesResult
+  listIngestionSources(
+    input: ListIngestionSourcesInput!
+  ): ListIngestionSourcesResult
 
   """
   Fetch a specific ingestion source
@@ -54,7 +56,10 @@ extend type Mutation {
   """
   Update an existing ingestion source
   """
-  updateIngestionSource(urn: String!, input: UpdateIngestionSourceInput!): String
+  updateIngestionSource(
+    urn: String!
+    input: UpdateIngestionSourceInput!
+  ): String
 
   """
   Delete an existing ingestion source
@@ -65,12 +70,16 @@ extend type Mutation {
   Create a request to execute an ingestion job
   input: Input required for creating an ingestion execution request
   """
-  createIngestionExecutionRequest(input: CreateIngestionExecutionRequestInput!): String
+  createIngestionExecutionRequest(
+    input: CreateIngestionExecutionRequestInput!
+  ): String
 
   """
   Cancel a running execution request, provided the urn of the original execution request
   """
-  cancelIngestionExecutionRequest(input: CancelIngestionExecutionRequestInput!): String
+  cancelIngestionExecutionRequest(
+    input: CancelIngestionExecutionRequestInput!
+  ): String
 
   """
   Create a request to execute a test ingestion connection job
@@ -152,7 +161,6 @@ type ExecutionRequestResult {
   A structured report for this Execution Request
   """
   structuredReport: StructuredReport
-
 }
 
 """
@@ -196,7 +204,6 @@ type ExecutionRequest {
   Result of the execution request
   """
   result: ExecutionRequestResult
-
 }
 
 """
@@ -353,7 +360,6 @@ type IngestionConfig {
 The runs associated with an Ingestion Source managed by DataHub
 """
 type IngestionRun {
-
   """
   The urn of the execution request associated with the user
   """
@@ -604,10 +610,10 @@ input UpdateSecretInput {
 Input arguments for retrieving the plaintext values of a set of secrets
 """
 input GetSecretValuesInput {
-   """
-   A list of secret names
-   """
-   secrets: [String!]!
+  """
+  A list of secret names
+  """
+  secrets: [String!]!
 }
 
 """
@@ -634,4 +640,3 @@ input RollbackIngestionInput {
   """
   runId: String!
 }
-

--- a/datahub-graphql-core/src/main/resources/properties.graphql
+++ b/datahub-graphql-core/src/main/resources/properties.graphql
@@ -1,170 +1,178 @@
 extend type Mutation {
-    """
-    Upsert structured properties onto a given asset
-    """
-    upsertStructuredProperties(input: UpsertStructuredPropertiesInput!): StructuredProperties!
+  """
+  Upsert structured properties onto a given asset
+  """
+  upsertStructuredProperties(
+    input: UpsertStructuredPropertiesInput!
+  ): StructuredProperties!
 
-    """
-    Upsert structured properties onto a given asset
-    """
-    removeStructuredProperties(input: RemoveStructuredPropertiesInput!): StructuredProperties!
+  """
+  Upsert structured properties onto a given asset
+  """
+  removeStructuredProperties(
+    input: RemoveStructuredPropertiesInput!
+  ): StructuredProperties!
 
-    """
-    Create a new structured property
-    """
-    createStructuredProperty(input: CreateStructuredPropertyInput!): StructuredPropertyEntity!
+  """
+  Create a new structured property
+  """
+  createStructuredProperty(
+    input: CreateStructuredPropertyInput!
+  ): StructuredPropertyEntity!
 
-    """
-    Update an existing structured property
-    """
-    updateStructuredProperty(input: UpdateStructuredPropertyInput!): StructuredPropertyEntity!
+  """
+  Update an existing structured property
+  """
+  updateStructuredProperty(
+    input: UpdateStructuredPropertyInput!
+  ): StructuredPropertyEntity!
 
-    """
-    Delete an existing structured property
-    """
-    deleteStructuredProperty(input: DeleteStructuredPropertyInput!): Boolean!
+  """
+  Delete an existing structured property
+  """
+  deleteStructuredProperty(input: DeleteStructuredPropertyInput!): Boolean!
 }
 
 """
 A structured property that can be shared between different entities
 """
 type StructuredPropertyEntity implements Entity {
-    """
-    A primary key associated with the structured property
-    """
-    urn: String!
+  """
+  A primary key associated with the structured property
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Whether or not this entity exists on DataHub
-    """
-    exists: Boolean
+  """
+  Whether or not this entity exists on DataHub
+  """
+  exists: Boolean
 
-    """
-    Definition of this structured property including its name
-    """
-    definition: StructuredPropertyDefinition!
+  """
+  Definition of this structured property including its name
+  """
+  definition: StructuredPropertyDefinition!
 
-    """
-    Definition of this structured property including its name
-    """
-    settings: StructuredPropertySettings
+  """
+  Definition of this structured property including its name
+  """
+  settings: StructuredPropertySettings
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
 Properties about an individual Query
 """
 type StructuredPropertyDefinition {
-    """
-    The fully qualified name of the property. This includes its namespace
-    """
-    qualifiedName: String!
+  """
+  The fully qualified name of the property. This includes its namespace
+  """
+  qualifiedName: String!
 
-    """
-    The display name of this structured property
-    """
-    displayName: String
+  """
+  The display name of this structured property
+  """
+  displayName: String
 
-    """
-    The description of this property
-    """
-    description: String
+  """
+  The description of this property
+  """
+  description: String
 
-    """
-    The cardinality of a Structured Property determining whether one or multiple values
-    can be applied to the entity from this property.
-    """
-    cardinality: PropertyCardinality
+  """
+  The cardinality of a Structured Property determining whether one or multiple values
+  can be applied to the entity from this property.
+  """
+  cardinality: PropertyCardinality
 
-    """
-    A list of allowed values that the property is allowed to take.
-    """
-    allowedValues: [AllowedValue!]
+  """
+  A list of allowed values that the property is allowed to take.
+  """
+  allowedValues: [AllowedValue!]
 
-    """
-    The type of this structured property
-    """
-    valueType: DataTypeEntity!
+  """
+  The type of this structured property
+  """
+  valueType: DataTypeEntity!
 
-    """
-    Allows for type specialization of the valueType to be more specific about which
-    entity types are allowed, for example.
-    """
-    typeQualifier: TypeQualifier
+  """
+  Allows for type specialization of the valueType to be more specific about which
+  entity types are allowed, for example.
+  """
+  typeQualifier: TypeQualifier
 
-    """
-    Entity types that this structured property can be applied to
-    """
-    entityTypes: [EntityTypeEntity!]!
+  """
+  Entity types that this structured property can be applied to
+  """
+  entityTypes: [EntityTypeEntity!]!
 
-    """
-    Whether or not this structured property is immutable
-    """
-    immutable: Boolean!
+  """
+  Whether or not this structured property is immutable
+  """
+  immutable: Boolean!
 
-    """
-    Audit stamp for when this structured property was created
-    """
-    created: ResolvedAuditStamp
+  """
+  Audit stamp for when this structured property was created
+  """
+  created: ResolvedAuditStamp
 
-    """
-    Audit stamp for when this structured property was last modified
-    """
-    lastModified: ResolvedAuditStamp
+  """
+  Audit stamp for when this structured property was last modified
+  """
+  lastModified: ResolvedAuditStamp
 }
 
 """
 Settings specific to a structured property entity
 """
 type StructuredPropertySettings {
-    """
-    Whether or not this asset should be hidden in the main application
-    """
-    isHidden: Boolean!
+  """
+  Whether or not this asset should be hidden in the main application
+  """
+  isHidden: Boolean!
 
-    """
-    Whether or not this asset should be displayed as a search filter
-    """
-    showInSearchFilters: Boolean!
+  """
+  Whether or not this asset should be displayed as a search filter
+  """
+  showInSearchFilters: Boolean!
 
-    """
-    Whether or not this asset should be displayed in the asset sidebar
-    """
-    showInAssetSummary: Boolean!
+  """
+  Whether or not this asset should be displayed in the asset sidebar
+  """
+  showInAssetSummary: Boolean!
 
-    """
-    Whether or not this asset should be displayed as an asset badge on other asset's headers
-    """
-    showAsAssetBadge: Boolean!
+  """
+  Whether or not this asset should be displayed as an asset badge on other asset's headers
+  """
+  showAsAssetBadge: Boolean!
 
-    """
-    Whether or not this asset should be displayed as a column in the schema field table in a Dataset's "Columns" tab.
-    """
-    showInColumnsTable: Boolean!
+  """
+  Whether or not this asset should be displayed as a column in the schema field table in a Dataset's "Columns" tab.
+  """
+  showInColumnsTable: Boolean!
 }
 
 """
 An entry for an allowed value for a structured property
 """
 type AllowedValue {
-    """
-    The allowed value
-    """
-    value: PropertyValue!
+  """
+  The allowed value
+  """
+  value: PropertyValue!
 
-    """
-    The description of this allowed value
-    """
-    description: String
+  """
+  The description of this allowed value
+  """
+  description: String
 }
 
 """
@@ -172,15 +180,15 @@ The cardinality of a Structured Property determining whether one or multiple val
 can be applied to the entity from this property.
 """
 enum PropertyCardinality {
-    """
-    Only one value of this property can applied to an entity
-    """
-    SINGLE
+  """
+  Only one value of this property can applied to an entity
+  """
+  SINGLE
 
-    """
-    Multiple values of this property can applied to an entity
-    """
-    MULTIPLE
+  """
+  Multiple values of this property can applied to an entity
+  """
+  MULTIPLE
 }
 
 """
@@ -188,30 +196,30 @@ Allows for type specialization of the valueType to be more specific about which
 entity types are allowed, for example.
 """
 type TypeQualifier {
-    """
-    The list of allowed entity types
-    """
-    allowedTypes: [EntityTypeEntity!]
+  """
+  The list of allowed entity types
+  """
+  allowedTypes: [EntityTypeEntity!]
 }
 
 """
 String property value
 """
 type StringValue {
-    """
-    The value of a string type property
-    """
-    stringValue: String!
+  """
+  The value of a string type property
+  """
+  stringValue: String!
 }
 
 """
 Numeric property value
 """
 type NumberValue {
-    """
-    The value of a number type property
-    """
-    numberValue: Float!
+  """
+  The value of a number type property
+  """
+  numberValue: Float!
 }
 
 """
@@ -223,80 +231,80 @@ union PropertyValue = StringValue | NumberValue
 An entry in an structured properties list represented as a tuple
 """
 type StructuredPropertiesEntry {
-    """
-    The key of the map entry
-    """
-    structuredProperty: StructuredPropertyEntity!
+  """
+  The key of the map entry
+  """
+  structuredProperty: StructuredPropertyEntity!
 
-    """
-    The values of the structured property for this entity
-    """
-    values: [PropertyValue]!
+  """
+  The values of the structured property for this entity
+  """
+  values: [PropertyValue]!
 
-    """
-    The optional entities associated with the values if the values are entity urns
-    """
-    valueEntities: [Entity]
+  """
+  The optional entities associated with the values if the values are entity urns
+  """
+  valueEntities: [Entity]
 
-    """
-    The urn of the entity this property came from for tracking purposes e.g. when sibling nodes are merged together
-    """
-    associatedUrn: String!
+  """
+  The urn of the entity this property came from for tracking purposes e.g. when sibling nodes are merged together
+  """
+  associatedUrn: String!
 }
 
 """
 Input for upserting structured properties on a given asset
 """
 input UpsertStructuredPropertiesInput {
-    """
-    The urn of the asset that we are updating
-    """
-    assetUrn: String!
+  """
+  The urn of the asset that we are updating
+  """
+  assetUrn: String!
 
-    """
-    The list of structured properties you want to upsert on this asset
-    """
-    structuredPropertyInputParams: [StructuredPropertyInputParams!]!
+  """
+  The list of structured properties you want to upsert on this asset
+  """
+  structuredPropertyInputParams: [StructuredPropertyInputParams!]!
 }
 
 """
 Input for removing structured properties on a given asset
 """
 input RemoveStructuredPropertiesInput {
-    """
-    The urn of the asset that we are removing properties from
-    """
-    assetUrn: String!
+  """
+  The urn of the asset that we are removing properties from
+  """
+  assetUrn: String!
 
-    """
-    The list of structured properties you want to remove from this asset
-    """
-    structuredPropertyUrns: [String!]!
+  """
+  The list of structured properties you want to remove from this asset
+  """
+  structuredPropertyUrns: [String!]!
 }
 
 """
 A data type registered in DataHub
 """
 type DataTypeEntity implements Entity {
-    """
-    A primary key associated with the Query
-    """
-    urn: String!
+  """
+  A primary key associated with the Query
+  """
+  urn: String!
 
-    """
-    A standard Entity Type
-    """
-    type: EntityType!
+  """
+  A standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    Info about this type including its name
-    """
-    info: DataTypeInfo!
+  """
+  Info about this type including its name
+  """
+  info: DataTypeInfo!
 
-    """
-    Granular API for querying edges extending from this entity
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Granular API for querying edges extending from this entity
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
@@ -338,224 +346,223 @@ enum StdDataType {
 Properties about an individual data type
 """
 type DataTypeInfo {
-    """
-    The standard data type
-    """
-    type: StdDataType!
+  """
+  The standard data type
+  """
+  type: StdDataType!
 
-    """
-    The fully qualified name of the type. This includes its namespace
-    """
-    qualifiedName: String!
+  """
+  The fully qualified name of the type. This includes its namespace
+  """
+  qualifiedName: String!
 
-    """
-    The display name of this type
-    """
-    displayName: String
+  """
+  The display name of this type
+  """
+  displayName: String
 
-    """
-    The description of this type
-    """
-    description: String
+  """
+  The description of this type
+  """
+  description: String
 }
 
 """
 Input for creating a new structured property entity
 """
 input CreateStructuredPropertyInput {
-    """
-    (Advanced) An optional unique ID to use when creating the urn of this entity
-    """
-    id: String
+  """
+  (Advanced) An optional unique ID to use when creating the urn of this entity
+  """
+  id: String
 
-    """
-    The unique fully qualified name of this structured property, dot delimited.
-    This will be required to match the ID of this structured property.
-    """
-    qualifiedName: String
+  """
+  The unique fully qualified name of this structured property, dot delimited.
+  This will be required to match the ID of this structured property.
+  """
+  qualifiedName: String
 
-    """
-    The optional display name for this property
-    """
-    displayName: String
+  """
+  The optional display name for this property
+  """
+  displayName: String
 
-    """
-    The optional description for this property
-    """
-    description: String
+  """
+  The optional description for this property
+  """
+  description: String
 
-    """
-    Whether the property will be mutable once it is applied or not. Default is false.
-    """
-    immutable: Boolean
+  """
+  Whether the property will be mutable once it is applied or not. Default is false.
+  """
+  immutable: Boolean
 
-    """
-    The urn of the value type that this structured property accepts.
-    For example: urn:li:dataType:datahub.string or urn:li:dataType:datahub.date
-    """
-    valueType: String!
+  """
+  The urn of the value type that this structured property accepts.
+  For example: urn:li:dataType:datahub.string or urn:li:dataType:datahub.date
+  """
+  valueType: String!
 
-    """
-    The optional input for specifying specific entity types as values
-    """
-    typeQualifier: TypeQualifierInput
+  """
+  The optional input for specifying specific entity types as values
+  """
+  typeQualifier: TypeQualifierInput
 
-    """
-    The optional input for specifying a list of allowed values
-    """
-    allowedValues: [AllowedValueInput!]
+  """
+  The optional input for specifying a list of allowed values
+  """
+  allowedValues: [AllowedValueInput!]
 
-    """
-    The optional input for specifying if one or multiple values can be applied.
-    Default is one value (single cardinality)
-    """
-    cardinality: PropertyCardinality
+  """
+  The optional input for specifying if one or multiple values can be applied.
+  Default is one value (single cardinality)
+  """
+  cardinality: PropertyCardinality
 
-    """
-    The list of entity types that this property can be applied to.
-    For example: ["urn:li:entityType:datahub.dataset"]
-    """
-    entityTypes: [String!]!
+  """
+  The list of entity types that this property can be applied to.
+  For example: ["urn:li:entityType:datahub.dataset"]
+  """
+  entityTypes: [String!]!
 
-    """
-    Settings for this structured property
-    """
-    settings: StructuredPropertySettingsInput
+  """
+  Settings for this structured property
+  """
+  settings: StructuredPropertySettingsInput
 }
 
 """
 Input for specifying specific entity types as values
 """
 input TypeQualifierInput {
-    """
-    The list of allowed entity types as urns (ie. ["urn:li:entityType:datahub.corpuser"])
-    """
-    allowedTypes: [String!]
+  """
+  The list of allowed entity types as urns (ie. ["urn:li:entityType:datahub.corpuser"])
+  """
+  allowedTypes: [String!]
 }
 
 """
 An input entry for an allowed value for a structured property
 """
 input AllowedValueInput {
-    """
-    The allowed string value if the value is of type string
-    Either this or numberValue is required.
-    """
-    stringValue: String
+  """
+  The allowed string value if the value is of type string
+  Either this or numberValue is required.
+  """
+  stringValue: String
 
-    """
-    The allowed number value if the value is of type number.
-    Either this or stringValue is required.
-    """
-    numberValue: Float
+  """
+  The allowed number value if the value is of type number.
+  Either this or stringValue is required.
+  """
+  numberValue: Float
 
-    """
-    The description of this allowed value
-    """
-    description: String
+  """
+  The description of this allowed value
+  """
+  description: String
 }
 
 """
 Input for updating an existing structured property entity
 """
 input UpdateStructuredPropertyInput {
-    """
-    The urn of the structured property being updated
-    """
-    urn: String!
+  """
+  The urn of the structured property being updated
+  """
+  urn: String!
 
-    """
-    The optional display name for this property
-    """
-    displayName: String
+  """
+  The optional display name for this property
+  """
+  displayName: String
 
-    """
-    The optional description for this property
-    """
-    description: String
+  """
+  The optional description for this property
+  """
+  description: String
 
-    """
-    Whether the property will be mutable once it is applied or not. Default is false.
-    """
-    immutable: Boolean
+  """
+  Whether the property will be mutable once it is applied or not. Default is false.
+  """
+  immutable: Boolean
 
-    """
-    The optional input for specifying specific entity types as values
-    """
-    typeQualifier: UpdateTypeQualifierInput
+  """
+  The optional input for specifying specific entity types as values
+  """
+  typeQualifier: UpdateTypeQualifierInput
 
-    """
-    Append to the list of allowed values for this property.
-    For backwards compatibility, this is append only.
-    """
-    newAllowedValues: [AllowedValueInput!]
+  """
+  Append to the list of allowed values for this property.
+  For backwards compatibility, this is append only.
+  """
+  newAllowedValues: [AllowedValueInput!]
 
-    """
-    Set to true if you want to change the cardinality of this structured property
-    to multiple. Cannot change from multiple to single for backwards compatibility reasons.
-    """
-    setCardinalityAsMultiple: Boolean
+  """
+  Set to true if you want to change the cardinality of this structured property
+  to multiple. Cannot change from multiple to single for backwards compatibility reasons.
+  """
+  setCardinalityAsMultiple: Boolean
 
-    """
-    Append to the list of entity types that this property can be applied to.
-    For backwards compatibility, this is append only.
-    """
-    newEntityTypes: [String!]
+  """
+  Append to the list of entity types that this property can be applied to.
+  For backwards compatibility, this is append only.
+  """
+  newEntityTypes: [String!]
 
-    """
-    Settings for this structured property
-    """
-    settings: StructuredPropertySettingsInput
+  """
+  Settings for this structured property
+  """
+  settings: StructuredPropertySettingsInput
 }
 
 """
 Input for updating specifying specific entity types as values
 """
 input UpdateTypeQualifierInput {
-    """
-    Append to the list of allowed entity types as urns for this property (ie. ["urn:li:entityType:datahub.corpuser"])
-    For backwards compatibility, this is append only.
-    """
-    newAllowedTypes: [String!]
+  """
+  Append to the list of allowed entity types as urns for this property (ie. ["urn:li:entityType:datahub.corpuser"])
+  For backwards compatibility, this is append only.
+  """
+  newAllowedTypes: [String!]
 }
 
 """
 Input for deleting a form
 """
 input DeleteStructuredPropertyInput {
-    """
-    The urn of the structured properties that is being deleted
-    """
-    urn: String!
+  """
+  The urn of the structured properties that is being deleted
+  """
+  urn: String!
 }
 
 """
 Settings for a structured property
 """
 input StructuredPropertySettingsInput {
-    """
-    Whether or not this asset should be hidden in the main application
-    """
-    isHidden: Boolean
+  """
+  Whether or not this asset should be hidden in the main application
+  """
+  isHidden: Boolean
 
-    """
-    Whether or not this asset should be displayed as a search filter
-    """
-    showInSearchFilters: Boolean
+  """
+  Whether or not this asset should be displayed as a search filter
+  """
+  showInSearchFilters: Boolean
 
-    """
-    Whether or not this asset should be displayed in the asset sidebar
-    """
-    showInAssetSummary: Boolean
+  """
+  Whether or not this asset should be displayed in the asset sidebar
+  """
+  showInAssetSummary: Boolean
 
-    """
-    Whether or not this asset should be displayed as an asset badge on other asset's headers
-    """
-    showAsAssetBadge: Boolean
+  """
+  Whether or not this asset should be displayed as an asset badge on other asset's headers
+  """
+  showAsAssetBadge: Boolean
 
-    """
-    Whether or not this asset should be displayed as a column in the schema field table in a Dataset's "Columns" tab.
-    """
-    showInColumnsTable: Boolean
+  """
+  Whether or not this asset should be displayed as a column in the schema field table in a Dataset's "Columns" tab.
+  """
+  showInColumnsTable: Boolean
 }
-

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -54,13 +54,18 @@ extend type Query {
   """
   Aggregate across DataHub entities
   """
-  aggregateAcrossEntities(input: AggregateAcrossEntitiesInput!): AggregateResults
+  aggregateAcrossEntities(
+    input: AggregateAcrossEntitiesInput!
+  ): AggregateResults
 
   """
   List Data Product assets for a given urn
   """
-  listDataProductAssets(urn: String!, input: SearchAcrossEntitiesInput!): SearchResults
-  
+  listDataProductAssets(
+    urn: String!
+    input: SearchAcrossEntitiesInput!
+  ): SearchResults
+
   """
   Browse for different entities by getting organizational groups and their
   aggregated counts + content. Uses browsePathsV2 aspect and replaces our old
@@ -97,7 +102,8 @@ input SearchInput {
   Deprecated in favor of the more expressive orFilters field
   Facet filters to apply to search results. These will be 'AND'-ed together.
   """
-  filters: [FacetFilterInput!]  @deprecated(reason: "Use `orFilters`- they are more expressive")
+  filters: [FacetFilterInput!]
+    @deprecated(reason: "Use `orFilters`- they are more expressive")
 
   """
   A list of disjunctive criterion for the filter. (or operation to combine filters)
@@ -113,7 +119,7 @@ input SearchInput {
 """
 Set of flags to control search behavior
 """
-input  SearchFlags {
+input SearchFlags {
   """
   Whether to skip cache
   """
@@ -239,7 +245,8 @@ input SearchAcrossEntitiesInput {
   Deprecated in favor of the more expressive orFilters field
   Facet filters to apply to search results. These will be 'AND'-ed together.
   """
-  filters: [FacetFilterInput!]  @deprecated(reason: "Use `orFilters`- they are more expressive")
+  filters: [FacetFilterInput!]
+    @deprecated(reason: "Use `orFilters`- they are more expressive")
 
   """
   A list of disjunctive criterion for the filter. (or operation to combine filters)
@@ -344,7 +351,6 @@ input ScrollAcrossEntitiesInput {
   searchFlags: SearchFlags
 }
 
-
 """
 Input arguments for a search query over the results of a multi-hop graph query
 """
@@ -383,7 +389,8 @@ input SearchAcrossLineageInput {
   Deprecated in favor of the more expressive orFilters field
   Facet filters to apply to search results. These will be 'AND'-ed together.
   """
-  filters: [FacetFilterInput!]  @deprecated(reason: "Use `orFilters`- they are more expressive")
+  filters: [FacetFilterInput!]
+    @deprecated(reason: "Use `orFilters`- they are more expressive")
 
   """
   A list of disjunctive criterion for the filter. (or operation to combine filters)
@@ -547,7 +554,7 @@ enum FilterOperator {
   GREATER_THAN
 
   """
-   Represent the relation greater than or equal to, e.g. ownerCount >= 5
+  Represent the relation greater than or equal to, e.g. ownerCount >= 5
   """
   GREATER_THAN_OR_EQUAL_TO
 
@@ -585,7 +592,6 @@ enum FilterOperator {
   Represent the relation: URN field matches any nested child or parent in addition to the given URN
   """
   RELATED_INCL
-
 }
 
 """
@@ -674,7 +680,6 @@ type AggregateResults {
 Results returned by issuing a search query
 """
 type ScrollResults {
-
   """
   Opaque ID to pass to the next request to the server
   """
@@ -814,19 +819,17 @@ type SearchAcrossLineageResult {
   Whether this relationship was ignored as a hop
   """
   ignoredAsHop: Boolean!
-
 }
 
 """
 An overview of the field that was matched in the entity search document
 """
 type EntityPath {
-    """
-    Path of entities between source and destination nodes
-    """
-    path: [Entity]
+  """
+  Path of entities between source and destination nodes
+  """
+  path: [Entity]
 }
-
 
 """
 An overview of the field that was matched in the entity search document
@@ -932,7 +935,6 @@ type SearchSuggestion {
   frequency: Int
 }
 
-
 """
 Input for performing an auto completion query against a single Metadata Entity
 """
@@ -961,7 +963,6 @@ input AutoCompleteInput {
   Faceted filters applied to autocomplete results
   """
   filters: [FacetFilterInput!]
-
 
   """
   A list of disjunctive criterion for the filter. (or operation to combine filters)
@@ -1093,7 +1094,8 @@ input BrowseInput {
   Deprecated in favor of the more expressive orFilters field
   Facet filters to apply to search results. These will be 'AND'-ed together.
   """
-  filters: [FacetFilterInput!]  @deprecated(reason: "Use `orFilters`- they are more expressive")
+  filters: [FacetFilterInput!]
+    @deprecated(reason: "Use `orFilters`- they are more expressive")
 
   """
   A list of disjunctive criterion for the filter. (or operation to combine filters)
@@ -1305,7 +1307,6 @@ type FreshnessStats {
   In case an index was consulted, this reflects the freshness of the index
   """
   systemFreshness: [SystemFreshness]
-
 }
 
 type SystemFreshness {
@@ -1470,20 +1471,17 @@ input SortCriterion {
 A grouping specification for search results.
 """
 input GroupingSpec {
-
   """
   A list of grouping criteria for grouping search results.
   There is no implied order in the grouping criteria.
   """
   groupingCriteria: [GroupingCriterion!]
-
 }
 
 """
 A single grouping criterion for grouping search results
 """
 input GroupingCriterion {
-
   """
   The base entity type that needs to be grouped
   e.g. schemaField
@@ -1496,5 +1494,4 @@ input GroupingCriterion {
   e.g. dataset, domain, etc.
   """
   groupingEntityType: EntityType!
-
 }

--- a/datahub-graphql-core/src/main/resources/tests.graphql
+++ b/datahub-graphql-core/src/main/resources/tests.graphql
@@ -2,40 +2,40 @@
 A metadata entity representing a DataHub Test
 """
 type Test implements Entity {
-    """
-    The primary key of the Test itself
-    """
-    urn: String!
+  """
+  The primary key of the Test itself
+  """
+  urn: String!
 
-    """
-    The standard Entity Type
-    """
-    type: EntityType!
+  """
+  The standard Entity Type
+  """
+  type: EntityType!
 
-    """
-    The name of the Test
-    """
-    name: String!
+  """
+  The name of the Test
+  """
+  name: String!
 
-    """
-    The category of the Test (user defined)
-    """
-    category: String!
+  """
+  The category of the Test (user defined)
+  """
+  category: String!
 
-    """
-    Description of the test
-    """
-    description: String
+  """
+  Description of the test
+  """
+  description: String
 
-    """
-    Definition for the test
-    """
-    definition: TestDefinition!
+  """
+  Definition for the test
+  """
+  definition: TestDefinition!
 
-    """
-    Unused for tests
-    """
-    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+  """
+  Unused for tests
+  """
+  relationships(input: RelationshipsInput!): EntityRelationshipsResult
 }
 
 """
@@ -53,15 +53,15 @@ type TestDefinition {
 The result type of a test that has been run
 """
 enum TestResultType {
-    """
-    The test succeeded.
-    """
-    SUCCESS
+  """
+  The test succeeded.
+  """
+  SUCCESS
 
-    """
-    The test failed.
-    """
-    FAILURE
+  """
+  The test failed.
+  """
+  FAILURE
 }
 
 """
@@ -95,10 +95,10 @@ type TestResult {
 }
 
 extend type Dataset {
-    """
-    The results of evaluating tests
-    """
-    testResults: TestResults
+  """
+  The results of evaluating tests
+  """
+  testResults: TestResults
 }
 
 extend type Query {

--- a/datahub-graphql-core/src/main/resources/timeline.graphql
+++ b/datahub-graphql-core/src/main/resources/timeline.graphql
@@ -1,170 +1,171 @@
 extend type Query {
-    """
-    Returns the most recent changes made to each column in a dataset at each dataset version.
-    """
-    getSchemaBlame(input: GetSchemaBlameInput!): GetSchemaBlameResult
+  """
+  Returns the most recent changes made to each column in a dataset at each dataset version.
+  """
+  getSchemaBlame(input: GetSchemaBlameInput!): GetSchemaBlameResult
 
-    """
-    Returns the list of schema versions for a dataset.
-    """
-    getSchemaVersionList(input: GetSchemaVersionListInput!): GetSchemaVersionListResult
+  """
+  Returns the list of schema versions for a dataset.
+  """
+  getSchemaVersionList(
+    input: GetSchemaVersionListInput!
+  ): GetSchemaVersionListResult
 }
 
 """
 Enum of types of changes
 """
 enum ChangeOperationType {
-    """
-    When an element is added
-    """
-    ADD
-    """
-    When an element is modified
-    """
-    MODIFY
-    """
-    When an element is removed
-    """
-    REMOVE
+  """
+  When an element is added
+  """
+  ADD
+  """
+  When an element is modified
+  """
+  MODIFY
+  """
+  When an element is removed
+  """
+  REMOVE
 }
 
 """
 Enum of CategoryTypes
 """
 enum ChangeCategoryType {
-    """
-    When documentation has been edited
-    """
-    DOCUMENTATION
-    """
-    When glossary terms have been added or removed
-    """
-    GLOSSARY_TERM
-    """
-    When ownership has been modified
-    """
-    OWNERSHIP
-    """
-    When technical schemas have been added or removed
-    """
-    TECHNICAL_SCHEMA
-    """
-    When tags have been added or removed
-    """
-    TAG
+  """
+  When documentation has been edited
+  """
+  DOCUMENTATION
+  """
+  When glossary terms have been added or removed
+  """
+  GLOSSARY_TERM
+  """
+  When ownership has been modified
+  """
+  OWNERSHIP
+  """
+  When technical schemas have been added or removed
+  """
+  TECHNICAL_SCHEMA
+  """
+  When tags have been added or removed
+  """
+  TAG
 }
 
 """
 Input for getting list of schema versions.
 """
 input GetSchemaVersionListInput {
-    """
-    The dataset urn
-    """
-    datasetUrn: String!
+  """
+  The dataset urn
+  """
+  datasetUrn: String!
 }
 
 """
 Schema changes computed at a specific version.
 """
 type GetSchemaVersionListResult {
-    """
-    Latest and current semantic version
-    """
-    latestVersion: SemanticVersionStruct
-    """
-    Selected semantic version
-    """
-    version: SemanticVersionStruct
-    """
-    All semantic versions. Absent when there are no versions.
-    """
-    semanticVersionList: [SemanticVersionStruct!]
+  """
+  Latest and current semantic version
+  """
+  latestVersion: SemanticVersionStruct
+  """
+  Selected semantic version
+  """
+  version: SemanticVersionStruct
+  """
+  All semantic versions. Absent when there are no versions.
+  """
+  semanticVersionList: [SemanticVersionStruct!]
 }
-
 
 """
 Input for getting schema changes computed at a specific version.
 """
 input GetSchemaBlameInput {
-    """
-    The dataset urn
-    """
-    datasetUrn: String!
-    """
-    Changes after this version are not shown. If not provided, this is the latestVersion.
-    """
-    version: String
+  """
+  The dataset urn
+  """
+  datasetUrn: String!
+  """
+  Changes after this version are not shown. If not provided, this is the latestVersion.
+  """
+  version: String
 }
 
 """
 Schema changes computed at a specific version.
 """
 type GetSchemaBlameResult {
-    """
-    Selected semantic version
-    """
-    version: SemanticVersionStruct
-    """
-    List of schema blame. Absent when there are no fields to return history for.
-    """
-    schemaFieldBlameList: [SchemaFieldBlame!]
+  """
+  Selected semantic version
+  """
+  version: SemanticVersionStruct
+  """
+  List of schema blame. Absent when there are no fields to return history for.
+  """
+  schemaFieldBlameList: [SchemaFieldBlame!]
 }
 
 """
 Blame for a single field
 """
 type SchemaFieldBlame {
-    """
-    Flattened name of a schema field
-    """
-    fieldPath: String!
-    """
-    Attributes identifying a field change
-    """
-    schemaFieldChange: SchemaFieldChange!
+  """
+  Flattened name of a schema field
+  """
+  fieldPath: String!
+  """
+  Attributes identifying a field change
+  """
+  schemaFieldChange: SchemaFieldChange!
 }
 
 """
 Attributes identifying a field change
 """
 type SchemaFieldChange {
-    """
-    The time at which the schema was updated
-    """
-    timestampMillis: Long!
-    """
-    The last semantic version that this schema was changed in
-    """
-    lastSemanticVersion: String!
-    """
-    Version stamp of the change
-    """
-    versionStamp: String!
-    """
-    The type of the change
-    """
-    changeType: ChangeOperationType!
-    """
-    Last column update, such as Added/Modified/Removed in v1.2.3.
-    """
-    lastSchemaFieldChange: String
+  """
+  The time at which the schema was updated
+  """
+  timestampMillis: Long!
+  """
+  The last semantic version that this schema was changed in
+  """
+  lastSemanticVersion: String!
+  """
+  Version stamp of the change
+  """
+  versionStamp: String!
+  """
+  The type of the change
+  """
+  changeType: ChangeOperationType!
+  """
+  Last column update, such as Added/Modified/Removed in v1.2.3.
+  """
+  lastSchemaFieldChange: String
 }
 
 """
 Properties identify a semantic version
 """
 type SemanticVersionStruct {
-    """
-    Semantic version of the change
-    """
-    semanticVersion: String
-    """
-    Semantic version timestamp
-    """
-    semanticVersionTimestamp: Long
-    """
-    Version stamp of the change
-    """
-    versionStamp: String
+  """
+  Semantic version of the change
+  """
+  semanticVersion: String
+  """
+  Semantic version timestamp
+  """
+  semanticVersionTimestamp: Long
+  """
+  Version stamp of the change
+  """
+  versionStamp: String
 }


### PR DESCRIPTION
In order to make all of our graphql files consistent, this PR reformats them using `prettier`. For the real diff, which the only diff here is a couple of changes to documentation, review this PR with whitespace turned off.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
