### PR TITLE
revert old change to backend MAU, fix frontend MAU

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetChartsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/resolver/GetChartsResolver.java
@@ -85,20 +85,8 @@ public final class GetChartsResolver implements DataFetcher<List<AnalyticsChartG
       final String title,
       final DateInterval interval) {
 
-    final DateRange dateRange;
-
-    // adjust month to show 1st of month rather than last day of previous month
-    if (interval == DateInterval.MONTH) {
-      dateRange =
-          new DateRange(
-              String.valueOf(beginning.plusDays(1).getMillis()), // Shift start by 1 day
-              String.valueOf(end.plusDays(1).getMillis()) // Shift end by 1 day
-              );
-    } else {
-      // week display starting Sundays
-      dateRange =
-          new DateRange(String.valueOf(beginning.getMillis()), String.valueOf(end.getMillis()));
-    }
+    final DateRange dateRange =
+        new DateRange(String.valueOf(beginning.getMillis()), String.valueOf(end.getMillis()));
 
     final List<NamedLine> timeSeriesLines =
         _analyticsService.getTimeseriesChart(

--- a/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
+++ b/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
@@ -84,6 +84,32 @@ export function computeLines(chartData: TimeSeriesChartType, insertBlankPoints: 
     return returnLines;
 }
 
+const formatAxisDate = (value: number, chartData: TimeSeriesChartType) => {
+    const date = new Date(value);
+
+    // force UTC
+    const utcDate = new Date(
+        Date.UTC(
+            date.getUTCFullYear(),
+            date.getUTCMonth(),
+            date.getUTCDate()
+        )
+    );
+    
+    return chartData.interval === 'MONTH'
+        ? utcDate.toLocaleDateString('en-US', { 
+            month: 'short', 
+            year: 'numeric',
+            timeZone: 'UTC'
+        })
+        : utcDate.toLocaleDateString('en-US', { 
+            year: 'numeric', 
+            month: 'short', 
+            day: 'numeric',
+            timeZone: 'UTC'
+        });
+};
+
 export const TimeSeriesChart = ({
     chartData,
     width,
@@ -117,6 +143,7 @@ export const TimeSeriesChart = ({
                     strokeWidth={style?.axisWidth}
                     tickLabelProps={{ fill: 'black', fontFamily: 'inherit', fontSize: 10 }}
                     numTicks={3}
+                    tickFormat={(value) => formatAxisDate(value, chartData)}
                 />
                 <Axis
                     orientation="right"
@@ -151,9 +178,10 @@ export const TimeSeriesChart = ({
                         tooltipData?.nearestDatum && (
                             <div>
                                 <div>
-                                    {new Date(
-                                        Number(accessors.xAccessor(tooltipData.nearestDatum.datum)),
-                                    ).toDateString()}
+                                    {formatAxisDate(
+                                        accessors.xAccessor(tooltipData.nearestDatum.datum),
+                                        chartData
+                                    )}
                                 </div>
                                 <div>{accessors.yAccessor(tooltipData.nearestDatum.datum)}</div>
                             </div>

--- a/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
+++ b/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
@@ -88,26 +88,20 @@ const formatAxisDate = (value: number, chartData: TimeSeriesChartType) => {
     const date = new Date(value);
 
     // force UTC
-    const utcDate = new Date(
-        Date.UTC(
-            date.getUTCFullYear(),
-            date.getUTCMonth(),
-            date.getUTCDate()
-        )
-    );
-    
+    const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+
     return chartData.interval === 'MONTH'
-        ? utcDate.toLocaleDateString('en-US', { 
-            month: 'short', 
-            year: 'numeric',
-            timeZone: 'UTC'
-        })
-        : utcDate.toLocaleDateString('en-US', { 
-            year: 'numeric', 
-            month: 'short', 
-            day: 'numeric',
-            timeZone: 'UTC'
-        });
+        ? utcDate.toLocaleDateString('en-US', {
+              month: 'short',
+              year: 'numeric',
+              timeZone: 'UTC',
+          })
+        : utcDate.toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+              timeZone: 'UTC',
+          });
 };
 
 export const TimeSeriesChart = ({
@@ -178,10 +172,7 @@ export const TimeSeriesChart = ({
                         tooltipData?.nearestDatum && (
                             <div>
                                 <div>
-                                    {formatAxisDate(
-                                        accessors.xAccessor(tooltipData.nearestDatum.datum),
-                                        chartData
-                                    )}
+                                    {formatAxisDate(accessors.xAccessor(tooltipData.nearestDatum.datum), chartData)}
                                 </div>
                                 <div>{accessors.yAccessor(tooltipData.nearestDatum.datum)}</div>
                             </div>

--- a/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
+++ b/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
@@ -87,21 +87,33 @@ export function computeLines(chartData: TimeSeriesChartType, insertBlankPoints: 
 const formatAxisDate = (value: number, chartData: TimeSeriesChartType) => {
     const date = new Date(value);
 
-    // force UTC
-    const utcDate = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
-
-    return chartData.interval === 'MONTH'
-        ? utcDate.toLocaleDateString('en-US', {
-              month: 'short',
-              year: 'numeric',
-              timeZone: 'UTC',
-          })
-        : utcDate.toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-              timeZone: 'UTC',
-          });
+    switch (chartData.interval) {
+        case 'MONTH':
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                year: 'numeric',
+                timeZone: 'UTC',
+            });
+        case 'WEEK':
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                timeZone: 'UTC',
+            });
+        case 'DAY':
+            return date.toLocaleDateString('en-US', {
+                weekday: 'short',
+                day: 'numeric',
+                timeZone: 'UTC',
+            });
+        default:
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                timeZone: 'UTC',
+            });
+    }
 };
 
 export const TimeSeriesChart = ({


### PR DESCRIPTION
I'm reverting the backend changes I made in Nov from this PR https://github.com/datahub-project/datahub/pull/11918/files

With my changes to the frontend, the MAU chart ticks now have just the month:
After:
![image](https://github.com/user-attachments/assets/ec2a6ee9-b939-473a-be89-66be2a90c5ad)
Before ticks would show (for Oct):
![image](https://github.com/user-attachments/assets/91269c30-6384-45b5-a640-2d5576fe1512)


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
