### PR TITLE
fix(graphql): removed duplicated entity in EntityTypeUrnMapper

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapper.java
@@ -77,9 +77,6 @@ public class EntityTypeUrnMapper {
           .put(
               Constants.BUSINESS_ATTRIBUTE_ENTITY_NAME,
               "urn:li:entityType:datahub.businessAttribute")
-          .put(
-              Constants.DATA_PROCESS_INSTANCE_ENTITY_NAME,
-              "urn:li:entityType:datahub.dataProcessInstance")
           .build();
 
   private static final Map<String, String> ENTITY_TYPE_URN_TO_NAME =

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeMapperTest.java
@@ -1,0 +1,20 @@
+package com.linkedin.datahub.graphql.types.entitytype;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.metadata.Constants;
+import org.testng.annotations.Test;
+
+public class EntityTypeMapperTest {
+
+  @Test
+  public void testGetType() throws Exception {
+    assertEquals(EntityTypeMapper.getType(Constants.DATASET_ENTITY_NAME), EntityType.DATASET);
+  }
+
+  @Test
+  public void testGetName() throws Exception {
+    assertEquals(EntityTypeMapper.getName(EntityType.DATASET), Constants.DATASET_ENTITY_NAME);
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapperTest.java
@@ -1,0 +1,30 @@
+package com.linkedin.datahub.graphql.types.entitytype;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.metadata.Constants;
+import org.testng.annotations.Test;
+
+public class EntityTypeUrnMapperTest {
+
+  @Test
+  public void testGetName() throws Exception {
+    assertEquals(
+        EntityTypeUrnMapper.getName("urn:li:entityType:datahub.dataset"),
+        Constants.DATASET_ENTITY_NAME);
+  }
+
+  @Test
+  public void testGetEntityType() throws Exception {
+    assertEquals(
+        EntityTypeUrnMapper.getEntityType("urn:li:entityType:datahub.dataset"), EntityType.DATASET);
+  }
+
+  @Test
+  public void testGetEntityTypeUrn() throws Exception {
+    assertEquals(
+        EntityTypeUrnMapper.getEntityTypeUrn(Constants.DATASET_ENTITY_NAME),
+        "urn:li:entityType:datahub.dataset");
+  }
+}


### PR DESCRIPTION
When I tried to create a structured property using the new UI in v0.15.0, I noticed, that it does not work because there is a duplicated entry in the EntityTypeUrnMapper:

Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.IllegalArgumentException: Multiple entries with same key: dataProcessInstance=urn:li:entityType:datahub.dataProcessInstance and dataProcessInstance=urn:li:entityType:datahub.dataProcessInstance [in thread "ForkJoinPool.commonPool-worker-325"]

The duplicated entry was added with #12263.

I have also added some simple tests of EntityTypeUrnMapperTest (and EntityTypeMapperTest) to make sure that duplicated entries will be noticed in the future there. I have not tested the tests locally, we will see whether they work in the CI pipeline.


## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
