### PR TITLE
fix(ci): remove platform from dataprocessinstance gql

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3108,16 +3108,17 @@ public class GmsGraphQLEngine {
                               ? dataProcessInstance.getDataPlatformInstance().getUrn()
                               : null;
                         }))
-                .dataFetcher(
-                    "platform",
-                    new LoadableTypeResolver<>(
-                        dataPlatformType,
-                        (env) -> {
-                          final DataProcessInstance dataProcessInstance = env.getSource();
-                          return dataProcessInstance.getPlatform() != null
-                              ? dataProcessInstance.getPlatform().getUrn()
-                              : null;
-                        }))
+                //                .dataFetcher(
+                //                    "platform",
+                //                    new LoadableTypeResolver<>(
+                //                        dataPlatformType,
+                //                        (env) -> {
+                //                          final DataProcessInstance dataProcessInstance =
+                // env.getSource();
+                //                          return dataProcessInstance.getPlatform() != null
+                //                              ? dataProcessInstance.getPlatform().getUrn()
+                //                              : null;
+                //                        }))
                 .dataFetcher("parentContainers", new ParentContainersResolver(entityClient))
                 .dataFetcher(
                     "container",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3108,17 +3108,6 @@ public class GmsGraphQLEngine {
                               ? dataProcessInstance.getDataPlatformInstance().getUrn()
                               : null;
                         }))
-                //                .dataFetcher(
-                //                    "platform",
-                //                    new LoadableTypeResolver<>(
-                //                        dataPlatformType,
-                //                        (env) -> {
-                //                          final DataProcessInstance dataProcessInstance =
-                // env.getSource();
-                //                          return dataProcessInstance.getPlatform() != null
-                //                              ? dataProcessInstance.getPlatform().getUrn()
-                //                              : null;
-                //                        }))
                 .dataFetcher("parentContainers", new ParentContainersResolver(entityClient))
                 .dataFetcher(
                     "container",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceMapper.java
@@ -79,10 +79,6 @@ public class DataProcessInstanceMapper implements ModelMapper<EntityResponse, Da
           DataPlatformInstance dataPlatformInstance = new DataPlatformInstance(dataMap);
           dataProcessInstance.setDataPlatformInstance(
               DataPlatformInstanceAspectMapper.map(context, dataPlatformInstance));
-          //          DataPlatform dataPlatform = new DataPlatform();
-          //          dataPlatform.setUrn(dataPlatformInstance.getPlatform().toString());
-          //          dataPlatform.setType(EntityType.DATA_PLATFORM);
-          //          dataProcessInstance.setPlatform(dataPlatform);
         });
     mappingHelper.mapToResult(
         SUB_TYPES_ASPECT_NAME,

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceMapper.java
@@ -8,7 +8,6 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.DataMap;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.QueryContext;
-import com.linkedin.datahub.graphql.generated.DataPlatform;
 import com.linkedin.datahub.graphql.generated.DataProcessInstance;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.types.common.mappers.AuditStampMapper;
@@ -80,10 +79,10 @@ public class DataProcessInstanceMapper implements ModelMapper<EntityResponse, Da
           DataPlatformInstance dataPlatformInstance = new DataPlatformInstance(dataMap);
           dataProcessInstance.setDataPlatformInstance(
               DataPlatformInstanceAspectMapper.map(context, dataPlatformInstance));
-          DataPlatform dataPlatform = new DataPlatform();
-          dataPlatform.setUrn(dataPlatformInstance.getPlatform().toString());
-          dataPlatform.setType(EntityType.DATA_PLATFORM);
-          dataProcessInstance.setPlatform(dataPlatform);
+          //          DataPlatform dataPlatform = new DataPlatform();
+          //          dataPlatform.setUrn(dataPlatformInstance.getPlatform().toString());
+          //          dataPlatform.setType(EntityType.DATA_PLATFORM);
+          //          dataProcessInstance.setPlatform(dataPlatform);
         });
     mappingHelper.mapToResult(
         SUB_TYPES_ASPECT_NAME,

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -13030,11 +13030,6 @@ extend type DataProcessInstance {
     container: Container
 
     """
-    Standardized platform urn where the data process instance is defined
-    """
-    platform: DataPlatform!
-
-    """
     Recursively get the lineage of containers for this entity
     """
     parentContainers: ParentContainersResult

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/dataprocessinst/mappers/DataProcessInstanceMapperTest.java
@@ -80,9 +80,10 @@ public class DataProcessInstanceMapperTest {
     DataProcessInstance instance = DataProcessInstanceMapper.map(null, entityResponse);
 
     assertNotNull(instance.getDataPlatformInstance());
-    assertNotNull(instance.getPlatform());
-    assertEquals(instance.getPlatform().getUrn(), TEST_PLATFORM_URN);
-    assertEquals(instance.getPlatform().getType(), EntityType.DATA_PLATFORM);
+    assertNotNull(instance.getDataPlatformInstance().getPlatform());
+    assertEquals(instance.getDataPlatformInstance().getPlatform().getUrn(), TEST_PLATFORM_URN);
+    assertEquals(
+        instance.getDataPlatformInstance().getPlatform().getType(), EntityType.DATA_PLATFORM);
   }
 
   @Test

--- a/datahub-web-react/src/app/entity/dataProcessInstance/DataProcessInstanceEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataProcessInstance/DataProcessInstanceEntity.tsx
@@ -202,7 +202,8 @@ export class DataProcessInstanceEntity implements Entity<DataProcessInstance> {
                 subType={data.subTypes?.typeNames?.[0]}
                 description=""
                 platformName={
-                    data?.dataPlatformInstance?.platform?.properties?.displayName || capitalizeFirstLetterOnly(data?.dataPlatformInstance?.platform?.name)
+                    data?.dataPlatformInstance?.platform?.properties?.displayName ||
+                    capitalizeFirstLetterOnly(data?.dataPlatformInstance?.platform?.name)
                 }
                 platformLogo={data.dataPlatformInstance?.platform?.properties?.logoUrl}
                 platformInstanceId={data.dataPlatformInstance?.instanceId}

--- a/datahub-web-react/src/app/entity/dataProcessInstance/DataProcessInstanceEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataProcessInstance/DataProcessInstanceEntity.tsx
@@ -161,6 +161,7 @@ export class DataProcessInstanceEntity implements Entity<DataProcessInstance> {
         return {
             name,
             externalUrl,
+            platform: processInstance?.dataPlatformInstance?.platform,
         };
     };
 
@@ -201,9 +202,9 @@ export class DataProcessInstanceEntity implements Entity<DataProcessInstance> {
                 subType={data.subTypes?.typeNames?.[0]}
                 description=""
                 platformName={
-                    data?.platform?.properties?.displayName || capitalizeFirstLetterOnly(data?.platform?.name)
+                    data?.dataPlatformInstance?.platform?.properties?.displayName || capitalizeFirstLetterOnly(data?.dataPlatformInstance?.platform?.name)
                 }
-                platformLogo={data.platform.properties?.logoUrl}
+                platformLogo={data.dataPlatformInstance?.platform?.properties?.logoUrl}
                 platformInstanceId={data.dataPlatformInstance?.instanceId}
                 owners={null}
                 globalTags={null}
@@ -231,8 +232,8 @@ export class DataProcessInstanceEntity implements Entity<DataProcessInstance> {
             name: this.displayName(entity),
             type: EntityType.DataProcessInstance,
             subtype: entity?.subTypes?.typeNames?.[0],
-            icon: entity?.platform?.properties?.logoUrl || undefined,
-            platform: entity?.platform,
+            icon: entity?.dataPlatformInstance?.platform?.properties?.logoUrl || undefined,
+            platform: entity?.dataPlatformInstance?.platform,
             container: entity?.container,
             //            health: entity?.health || undefined,
         };

--- a/datahub-web-react/src/graphql/dataProcessInstance.graphql
+++ b/datahub-web-react/src/graphql/dataProcessInstance.graphql
@@ -67,9 +67,6 @@ fragment processInstanceRelationshipResults on EntityRelationshipsResult {
 fragment dataProcessInstanceFields on DataProcessInstance {
     urn
     type
-    platform {
-        ...platformFields
-    }
     parentContainers {
         ...parentContainersFields
     }
@@ -125,9 +122,6 @@ query getDataProcessInstance($urn: String!) {
     dataProcessInstance(urn: $urn) {
         urn
         type
-        platform {
-            ...platformFields
-        }
         parentContainers {
             ...parentContainersFields
         }

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -20,6 +20,8 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Breaking Changes
 
+- #12408: The `platform` field in the DataPlatformInstance GraphQL type is removed. Clients need to retrieve the platform via the optional `dataPlatformInstance` field.
+
 ### Potential Downtime
 
 ### Deprecations

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -1800,6 +1800,19 @@
   },
   {
     "auditHeader": null,
+    "entityType": "dataProcessInstance",
+    "entityUrn": "urn:li:dataProcessInstance:c39d6e424c70a1b3e8982535c68b5b5888",
+    "entityKeyAspect": null,
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+      "json": {
+        "platform": "urn:li:dataPlatform:airflow"
+      }
+    }
+  },
+  {
+    "auditHeader": null,
     "proposedSnapshot": {
       "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
         "urn": "urn:li:mlFeature:(cypress-test-2,some-cypress-feature-1)",

--- a/smoke-test/tests/cypress/data.json
+++ b/smoke-test/tests/cypress/data.json
@@ -1800,19 +1800,6 @@
   },
   {
     "auditHeader": null,
-    "entityType": "dataProcessInstance",
-    "entityUrn": "urn:li:dataProcessInstance:c39d6e424c70a1b3e8982535c68b5b5888",
-    "entityKeyAspect": null,
-    "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-      "json": {
-        "platform": "urn:li:dataPlatform:airflow"
-      }
-    }
-  },
-  {
-    "auditHeader": null,
     "proposedSnapshot": {
       "com.linkedin.pegasus2avro.metadata.snapshot.MLFeatureSnapshot": {
         "urn": "urn:li:mlFeature:(cypress-test-2,some-cypress-feature-1)",

--- a/smoke-test/tests/data_process_instance/test_data_process_instance.py
+++ b/smoke-test/tests/data_process_instance/test_data_process_instance.py
@@ -210,13 +210,6 @@ def test_search_dpi(auth_session, ingest_cleanup_data):
                                     name
                                 }
                             }
-                            platform {
-                                urn
-                                name
-                                properties {
-                                    type
-                                }
-                            }
                             subTypes {
                                 typeNames
                             }


### PR DESCRIPTION
DataProcessInstance has a similar issue with DataJob - no direct mandatory relationship to a DataPlatform. The relationship is optional through the `dataPlatformInstance` aspect. 
It can also be inferred through the parentTemplate (essentially a relationship to a DataJob or a DataFlow etc.) 

- This PR removes the requirement that the DataProcessInstance graphql type should always return a dataPlatform that is filled out. It also technically makes a backwards incompatible change to the GraphQL type - but since this was a recent commit, and it only affects readers - I think the change is okay to make. 

- We will need a second PR to add the wiring for the parentTemplate to get sent back via the GraphQL type system - for clients (e.g. UI) to render a platform via the dataPlatformInstance or the parentTemplate - whichever is available. 


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
