### PR TITLE
fix(ui): better experience for analytics charts

### DIFF
--- a/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
+++ b/datahub-web-react/src/app/analyticsDashboard/components/TimeSeriesChart.tsx
@@ -84,6 +84,38 @@ export function computeLines(chartData: TimeSeriesChartType, insertBlankPoints: 
     return returnLines;
 }
 
+const formatAxisDate = (value: number, chartData: TimeSeriesChartType) => {
+    const date = new Date(value);
+
+    switch (chartData.interval) {
+        case 'MONTH':
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                year: 'numeric',
+                timeZone: 'UTC',
+            });
+        case 'WEEK':
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                timeZone: 'UTC',
+            });
+        case 'DAY':
+            return date.toLocaleDateString('en-US', {
+                weekday: 'short',
+                day: 'numeric',
+                timeZone: 'UTC',
+            });
+        default:
+            return date.toLocaleDateString('en-US', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+                timeZone: 'UTC',
+            });
+    }
+};
+
 export const TimeSeriesChart = ({
     chartData,
     width,
@@ -117,6 +149,7 @@ export const TimeSeriesChart = ({
                     strokeWidth={style?.axisWidth}
                     tickLabelProps={{ fill: 'black', fontFamily: 'inherit', fontSize: 10 }}
                     numTicks={3}
+                    tickFormat={(value) => formatAxisDate(value, chartData)}
                 />
                 <Axis
                     orientation="right"
@@ -151,9 +184,7 @@ export const TimeSeriesChart = ({
                         tooltipData?.nearestDatum && (
                             <div>
                                 <div>
-                                    {new Date(
-                                        Number(accessors.xAccessor(tooltipData.nearestDatum.datum)),
-                                    ).toDateString()}
+                                    {formatAxisDate(accessors.xAccessor(tooltipData.nearestDatum.datum), chartData)}
                                 </div>
                                 <div>{accessors.yAccessor(tooltipData.nearestDatum.datum)}</div>
                             </div>


### PR DESCRIPTION
Combined with this PR, should fix the analytics charts https://github.com/datahub-project/datahub/pull/12461

Charts for these three currently look like this. They have the full date which isn't necessary. 
![image](https://github.com/user-attachments/assets/179cdbe8-5a80-4c29-a796-73a934d194c5)
![image](https://github.com/user-attachments/assets/37c5d7cd-537a-4777-845d-0331e0277d64)
![image](https://github.com/user-attachments/assets/fbc1e74d-633b-40fe-9629-1df15d1d0458)

After these changes, the charts look like this, without the full month/day/year:

![image](https://github.com/user-attachments/assets/cd289831-f5ca-4342-98f7-a679bb60811f)
![image](https://github.com/user-attachments/assets/71406e75-31dd-4d7f-a678-74a29ff22120)
![image](https://github.com/user-attachments/assets/f99138b9-cc64-461a-9b7f-266fd7148701)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
