### PR TITLE
Feat(ingestion/dbt): Add database and schema filtering to dbt

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/RecipeForm/dbt_cloud.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/RecipeForm/dbt_cloud.tsx
@@ -233,6 +233,62 @@ export const NODE_DENY: RecipeField = {
     section: 'Nodes',
 };
 
+const databaseAllowFieldPath = 'source.config.database_name_pattern.allow';
+export const DATABASE_ALLOW: RecipeField = {
+    name: 'database_name_pattern.allow',
+    label: 'Allow Database Patterns',
+    tooltip:
+        'Only include specific dbt Databases by providing their name, or a Regular Expression (REGEX). If not provided, all Databases will be included.',
+    placeholder: 'database_name',
+    type: FieldType.LIST,
+    buttonLabel: 'Add pattern',
+    fieldPath: databaseAllowFieldPath,
+    rules: null,
+    section: 'Databases',
+};
+
+const databaseDenyFieldPath = 'source.config.database_name_pattern.deny';
+export const DATABASE_DENY: RecipeField = {
+    name: 'database_name_pattern.deny',
+    label: 'Deny Database Patterns',
+    tooltip:
+        'Exclude specific dbt Databases by providing their name, or a Regular Expression (REGEX). If not provided, all Databases will be included. Deny patterns always take precedence over Allow patterns.',
+    placeholder: 'database_name',
+    type: FieldType.LIST,
+    buttonLabel: 'Add pattern',
+    fieldPath: databaseDenyFieldPath,
+    rules: null,
+    section: 'Databases',
+};
+
+const schemaAllowFieldPath = 'source.config.schema_name_pattern.allow';
+export const SCHEMA_ALLOW: RecipeField = {
+    name: 'schema_name_pattern.allow',
+    label: 'Allow Schema Patterns',
+    tooltip:
+        'Only include specific dbt Schemas by providing their name, or a Regular Expression (REGEX). If not provided, all Schemas will be included.',
+    placeholder: 'schema_name',
+    type: FieldType.LIST,
+    buttonLabel: 'Add pattern',
+    fieldPath: schemaAllowFieldPath,
+    rules: null,
+    section: 'Schemas',
+};
+
+const schemaDenyFieldPath = 'source.config.schema_name_pattern.deny';
+export const SCHEMA_DENY: RecipeField = {
+    name: 'schema_name_pattern.deny',
+    label: 'Deny Schema Patterns',
+    tooltip:
+        'Exclude specific dbt Schemas by providing their name, or a Regular Expression (REGEX). If not provided, all Schemas will be included. Deny patterns always take precedence over Allow patterns.',
+    placeholder: 'schema_name',
+    type: FieldType.LIST,
+    buttonLabel: 'Add pattern',
+    fieldPath: schemaDenyFieldPath,
+    rules: null,
+    section: 'Schemas',
+};
+
 export const METADATA_ENDPOINT: RecipeField = {
     name: 'metadata_endpoint',
     label: 'Custom Metadata Endpoint URL',

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -992,20 +992,25 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             all_nodes_map,
         )
 
-    def _is_allowed_node(self, key: str) -> bool:
-        return self.config.node_name_pattern.allowed(key)
+    def _is_allowed_node(self, dbt_name: str) -> bool:
+        return self.config.node_name_pattern.allowed(dbt_name)
+        
+    def _is_allowed_database(self, database: Optional[str]) -> bool:
+        return self.config.database_name_pattern.allowed(database or "")
+        
+    def _is_allowed_schema(self, schema: Optional[str]) -> bool:
+        return self.config.schema_name_pattern.allowed(schema or "")
+    
+    def _is_allowed(self, node: DBTNode) -> bool:
+        return self._is_allowed_node(node.dbt_name) and self._is_allowed_database(node.database) and self._is_allowed_schema(node.schema)
 
     def _filter_nodes(self, all_nodes: List[DBTNode]) -> List[DBTNode]:
         nodes = []
         for node in all_nodes:
-            key = node.dbt_name
-
-            if not self._is_allowed_node(key):
-                self.report.nodes_filtered.append(key)
+            if not self._is_allowed(node):
+                self.report.nodes_filtered.append(node.dbt_name)
                 continue
-
             nodes.append(node)
-
         return nodes
 
     @staticmethod
@@ -1036,8 +1041,8 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             cll_nodes.add(dbt_name)
             schema_nodes.add(dbt_name)
 
-        for dbt_name in all_nodes_map.keys():
-            if self._is_allowed_node(dbt_name):
+        for dbt_name, node in all_nodes_map.items():
+            if self._is_allowed(node):
                 add_node_to_cll_list(dbt_name)
 
         return schema_nodes, cll_nodes

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -281,6 +281,14 @@ class DBTCommonConfig(
         default=AllowDenyPattern.allow_all(),
         description="regex patterns for dbt model names to filter in ingestion.",
     )
+    database_name_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="regex patterns for dbt database names to filter in ingestion.",
+    )
+    schema_name_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="regex patterns for dbt schema names to filter in ingestion.",
+    )
     meta_mapping: Dict = Field(
         default={},
         description="mapping rules that will be executed against dbt meta properties. Refer to the section below on dbt meta automated mappings.",


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

This feature allows for filtering of nodes included based on database and/or schema, in addition to the node name filtering that is allowed now.

As an example, from the [dbt_manifest.json:](https://github.com/datahub-project/datahub/blob/47134c272bd82ff8d00b6a30c725fbde4165335c/metadata-ingestion/tests/integration/dbt/dbt_manifest.json#L3899)

```json
"source.sample_dbt.pagila.payment_p2020_05": {
    // ... other properties omitted ...
    "database": "pagila",
    // ... other properties omitted ...
    "schema": "public"
    // ... other properties omitted ...
}
```

We could now provide "public" in the `schema_name_pattern` to either include or exclude this node, and others in the "public" schema. 

Somewhat related to #12411.