### PR TITLE
fix(cli): avoid false positive cli upgrade suggestions

### DIFF
--- a/metadata-ingestion/src/datahub/upgrade/upgrade.py
+++ b/metadata-ingestion/src/datahub/upgrade/upgrade.py
@@ -55,11 +55,19 @@ async def get_client_version_stats():
         async with session.get(pypi_url) as resp:
             response_json = await resp.json()
             try:
-                releases = response_json.get("releases", [])
-                sorted_releases = sorted(releases.keys(), key=lambda x: Version(x))
-                latest_cli_release_string = [
-                    x for x in sorted_releases if "rc" not in x
-                ][-1]
+                releases = response_json.get("releases", {})
+                filtered_releases = {
+                    version: release_files
+                    for version, release_files in releases.items()
+                    if not all(
+                        release_file.get("yanked") for release_file in release_files
+                    )
+                    and "rc" not in version
+                }
+                sorted_releases = sorted(
+                    filtered_releases.keys(), key=lambda x: Version(x)
+                )
+                latest_cli_release_string = sorted_releases[-1]
                 latest_cli_release = Version(latest_cli_release_string)
                 current_version_info = releases.get(current_version_string)
                 current_version_date = None


### PR DESCRIPTION
Skips yanked releases when determining the latest CLI release. This is necessary because we previously released and yanked a 15.0.4 release.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
