### PR TITLE
fix(mssql): use include_lineage flag from config

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py
@@ -466,7 +466,7 @@ class SQLServerSource(SQLAlchemySource):
         yield from self.construct_job_workunits(
             data_job,
             # For stored procedure lineage is ingested later
-            include_lineage=False,
+            override_include_lineage=False,
         )
 
     @staticmethod
@@ -627,7 +627,7 @@ class SQLServerSource(SQLAlchemySource):
     def construct_job_workunits(
         self,
         data_job: MSSQLDataJob,
-        include_lineage: bool = True,
+        override_include_lineage: Option[bool] = None,
     ) -> Iterable[MetadataWorkUnit]:
         yield MetadataChangeProposalWrapper(
             entityUrn=data_job.urn,
@@ -641,7 +641,12 @@ class SQLServerSource(SQLAlchemySource):
                 aspect=data_platform_instance_aspect,
             ).as_workunit()
 
-        if include_lineage:
+        effective_include_lineage = (
+            override_include_lineage
+            if override_include_lineage is not None
+            else self.config.include_lineage
+        )
+        if effective_include_lineage:
             yield MetadataChangeProposalWrapper(
                 entityUrn=data_job.urn,
                 aspect=data_job.as_datajob_input_output_aspect,


### PR DESCRIPTION
Note there is a call to `construct_job_workunits` that was not passing any value, which led to lineage being included regardless of the config.

https://github.com/datahub-project/datahub/blob/e6d56394781b86efbb374e09db9d7e347bbca17b/metadata-ingestion/src/datahub/ingestion/source/sql/mssql/source.py#L395-L399

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
