### PR TITLE
feat(snowflake): add missing pushdown_deny_usernames config to be used when use_queries_v2

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -308,6 +308,13 @@ class SnowflakeV2Config(
         " assertions CLI in snowflake",
     )
 
+    pushdown_deny_usernames: List[str] = Field(
+        default=[],
+        description="List of snowflake usernames which will not be considered for lineage/usage/queries extraction. "
+        "This is primarily useful for improving performance by filtering out users with extremely high query volumes. "
+        "Only applicable if `use_queries_v2` is enabled.",
+    )
+
     @validator("convert_urns_to_lowercase")
     def validate_convert_urns_to_lowercase(cls, v):
         if not v:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -567,6 +567,7 @@ class SnowflakeV2Source(
                         include_queries=self.config.include_queries,
                         include_query_usage_statistics=self.config.include_query_usage_statistics,
                         user_email_pattern=self.config.user_email_pattern,
+                        pushdown_deny_usernames=self.config.pushdown_deny_usernames,
                     ),
                     structured_report=self.report,
                     filters=self.filters,


### PR DESCRIPTION
The legacy `SnowflakeQueriesSource` inherits from `SnowflakeQueriesExtractorConfig` and so exposes the config param

https://github.com/datahub-project/datahub/blob/e2b1ed7530f1c4019d331aa98bf9782225a49b5c/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py#L113-L115

and then, uses it

https://github.com/datahub-project/datahub/blob/e2b1ed7530f1c4019d331aa98bf9782225a49b5c/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_queries.py#L330-L338

However, the `SnowflakeV2Source` doesn't 

https://github.com/datahub-project/datahub/blob/e2b1ed7530f1c4019d331aa98bf9782225a49b5c/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py#L182-L190

and so the proposal in this PR is to define the config param so it can be passed accordingly when instantiating the `SnowflakeQueriesExtractor` 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
