### PR TITLE
fix(test): move reading env variable inside method

### DIFF
--- a/smoke-test/tests/consistency_utils.py
+++ b/smoke-test/tests/consistency_utils.py
@@ -27,15 +27,13 @@ def infer_kafka_broker_container() -> str:
     return lines[0]
 
 
-KAFKA_BROKER_CONTAINER: str = str(
-    os.getenv("KAFKA_BROKER_CONTAINER", infer_kafka_broker_container())
-)
-
-
 def wait_for_writes_to_sync(max_timeout_in_sec: int = 120) -> None:
     if USE_STATIC_SLEEP:
         time.sleep(ELASTICSEARCH_REFRESH_INTERVAL_SECONDS)
         return
+    KAFKA_BROKER_CONTAINER: str = str(
+        os.getenv("KAFKA_BROKER_CONTAINER", infer_kafka_broker_container())
+    )
     start_time = time.time()
     # get offsets
     lag_zero = False


### PR DESCRIPTION
In case we try to run this in a kubernetes environment this causes failures

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
