### PR TITLE
fix(): Enable V2 UI in quickstart by default

### DIFF
--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -26,6 +26,7 @@ MAE_CONSUMER_ENABLED=true
 MCE_CONSUMER_ENABLED=true
 PE_CONSUMER_ENABLED=true
 UI_INGESTION_ENABLED=true
+THEME_V2_DEFAULT=true
 
 # Uncomment to disable Metadata Service Authentication
 # METADATA_SERVICE_AUTH_ENABLED=false

--- a/docker/profiles/docker-compose.gms.yml
+++ b/docker/profiles/docker-compose.gms.yml
@@ -350,6 +350,16 @@ services:
     depends_on:
       system-update-quickstart:
         condition: service_completed_successfully
+  datahub-gms-quickstart-consumers-legacy-ui:
+    <<: *datahub-gms-service
+    profiles:
+      - quickstart-consumers-legacy-ui
+    environment:
+      <<: *datahub-gms-env
+      THEME_V2_DEFAULT: false  # Override the environment variable for the ui default.
+    depends_on:
+      system-update-quickstart:
+        condition: service_completed_successfully
   datahub-gms-debug:
     <<: *datahub-gms-service-dev
     profiles:
@@ -412,6 +422,13 @@ services:
       - quickstart-consumers
     depends_on:
       datahub-gms-quickstart-consumers:
+        condition: service_healthy
+  datahub-mae-consumer-quickstart-consumers-legacy-ui:
+    <<: *datahub-mae-consumer-service
+    profiles:
+      - quickstart-consumers-legacy-ui
+    depends_on:
+      datahub-gms-quickstart-consumers-legacy-ui:
         condition: service_healthy
   datahub-mae-consumer-quickstart-consumers-dev:
     <<: *datahub-mae-consumer-service-dev

--- a/docker/quickstart/docker-compose-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-m1.quickstart.yml
@@ -103,6 +103,7 @@ services:
     - NEO4J_URI=bolt://neo4j
     - NEO4J_USERNAME=neo4j
     - PE_CONSUMER_ENABLED=true
+    - THEME_V2_DEFAULT=true
     - UI_INGESTION_ENABLED=true
     healthcheck:
       interval: 1s

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -103,6 +103,7 @@ services:
     - NEO4J_URI=bolt://neo4j
     - NEO4J_USERNAME=neo4j
     - PE_CONSUMER_ENABLED=true
+    - THEME_V2_DEFAULT=true
     - UI_INGESTION_ENABLED=true
     healthcheck:
       interval: 1s

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps.yaml
@@ -12,6 +12,13 @@ bootstrap:
       async: false
       mcps_location: "bootstrap_mcps/root-user.yaml"
 
+    - name: root-user-editable-info
+      version: v1
+      blocking: true
+      optional: true
+      async: false
+      mcps_location: "bootstrap_mcps/root-user-editable-info.yaml"
+
     - name: data-platforms
       version: v2
       blocking: true

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user-editable-info.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user-editable-info.yaml
@@ -1,0 +1,8 @@
+- entityUrn: urn:li:corpuser:datahub
+  entityType: corpuser
+  aspectName: corpUserEditableInfo
+  changeType: CREATE
+  aspect:
+    teams: []
+    skills: []
+    pictureLink: "https://media.licdn.com/dms/image/v2/D4E10AQHWZxgp69mYEg/image-shrink_800/B4EZS8_IkWHoAk-/0/1738337455407?e=2147483647&v=beta&t=GNcym7ZKnu5tPO4n4gV6XaGPPU0JfNvjH3QoNKR2sro"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
@@ -6,11 +6,3 @@
     active: true
     displayName: DataHub
     title: DataHub Root User
-- entityUrn: urn:li:corpuser:datahub
-  entityType: corpuser
-  aspectName: corpUserEditableInfo
-  changeType: UPSERT
-  aspect:
-    teams: []
-    skills: []
-    pictureLink: "https://media.licdn.com/dms/image/v2/D4E10AQHWZxgp69mYEg/image-shrink_800/B4EZS8_IkWHoAk-/0/1738337455407?e=2147483647&v=beta&t=GNcym7ZKnu5tPO4n4gV6XaGPPU0JfNvjH3QoNKR2sro"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
@@ -6,3 +6,11 @@
     active: true
     displayName: DataHub
     title: DataHub Root User
+- entityUrn: urn:li:corpuser:datahub
+  entityType: corpuser
+  aspectName: corpUserEditableInfo
+  changeType: UPSERT
+  aspect:
+    teams: []
+    skills: []
+    pictureLink: "https://media.licdn.com/dms/image/v2/D4E10AQHWZxgp69mYEg/image-shrink_800/B4EZS8_IkWHoAk-/0/1738337455407?e=2147483647&v=beta&t=GNcym7ZKnu5tPO4n4gV6XaGPPU0JfNvjH3QoNKR2sro"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
@@ -6,3 +6,11 @@
     active: true
     displayName: DataHub
     title: DataHub Root User
+- entityUrn: urn:li:corpuser:datahub
+  entityType: corpuser
+  aspectName: corpUserEditableInfo
+  changeType: UPSERT
+  aspect:
+    teams: []
+    skills: []
+    pictureLink: "https://media.licdn.com/dms/image/v2/D4E10AQHWZxgp69mYEg/image-shrink_800/B4EZS8_IkW[…]47483647&v=beta&t=GNcym7ZKnu5tPO4n4gV6XaGPPU0JfNvjH3QoNKR2sro"

--- a/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
+++ b/metadata-service/configuration/src/main/resources/bootstrap_mcps/root-user.yaml
@@ -6,11 +6,3 @@
     active: true
     displayName: DataHub
     title: DataHub Root User
-- entityUrn: urn:li:corpuser:datahub
-  entityType: corpuser
-  aspectName: corpUserEditableInfo
-  changeType: UPSERT
-  aspect:
-    teams: []
-    skills: []
-    pictureLink: "https://media.licdn.com/dms/image/v2/D4E10AQHWZxgp69mYEg/image-shrink_800/B4EZS8_IkW[…]47483647&v=beta&t=GNcym7ZKnu5tPO4n4gV6XaGPPU0JfNvjH3QoNKR2sro"

--- a/smoke-test/run-quickstart.sh
+++ b/smoke-test/run-quickstart.sh
@@ -26,4 +26,4 @@ DATAHUB_SEARCH_IMAGE="$DATAHUB_SEARCH_IMAGE" DATAHUB_SEARCH_TAG="$DATAHUB_SEARCH
 XPACK_SECURITY_ENABLED="$XPACK_SECURITY_ENABLED" ELASTICSEARCH_USE_SSL="$ELASTICSEARCH_USE_SSL" \
 USE_AWS_ELASTICSEARCH="$USE_AWS_ELASTICSEARCH" \
 DATAHUB_VERSION=${DATAHUB_VERSION} \
-docker compose --project-directory ../docker/profiles --profile quickstart-consumers up -d --quiet-pull --wait --wait-timeout 900
+docker compose --project-directory ../docker/profiles --profile quickstart-consumers-legacy-ui up -d --quiet-pull --wait --wait-timeout 900


### PR DESCRIPTION
- Enable V2 UI in quickstart by default! 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
