### PR TITLE
fix(filters) Fix autocomplete for platforms and improve advanced search builder

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EntityValueMenu.tsx
@@ -28,8 +28,7 @@ export default function EntityValueMenu({
     className,
 }: Props) {
     const entityRegistry = useEntityRegistry();
-    const isSearchable =
-        field.entityTypes?.length && field.entityTypes.every((t) => entityRegistry.getEntity(t).isSearchEnabled());
+    const isSearchable = !!field.entityTypes?.length;
     const { displayName } = field;
 
     // Ideally we would not have staged values, and filters would update automatically.
@@ -43,7 +42,8 @@ export default function EntityValueMenu({
     const finalSearchOptions = [...localSearchOptions, ...deduplicateOptions(localSearchOptions, searchOptions)];
 
     // Compute the final options to show to the user.
-    const finalOptions = searchQuery ? finalSearchOptions : defaultOptions;
+    const finalDefaultOptions = defaultOptions.length ? defaultOptions : searchOptions;
+    const finalOptions = searchQuery ? finalSearchOptions : finalDefaultOptions;
 
     // Finally, create the option set.
     // TODO: Add an option set for "no x".


### PR DESCRIPTION
Our advanced search builder which is used when clicking "+add filter" in the search experience and when building view filters was broken in one way and not optimal in another.
1. Platforms were not able to be searched for using auto-complete. So platform filters in views were completely broken. I added autocomplete functionality for it on the backend so things are good now.
2. We didn't do an initial search for dropdowns that should show some initial data, so it required that you type something in the search bar before you see any results. Now i add that initial search to pre-populate data.

**screenshots of it working now:**
<img width="906" alt="image" src="https://github.com/user-attachments/assets/6c183bec-6231-431d-8680-f76f318d1ef8" />

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/80afb9ba-6864-4ebc-9d79-c9d2f4488f52" />


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
