### PR TITLE
fix(ui) Show editable field info for fields based on exact fieldPath version

### DIFF
--- a/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/utils.ts
+++ b/datahub-web-react/src/app/entityV2/dataset/profile/schema/utils/utils.ts
@@ -69,6 +69,11 @@ export function pathMatchesNewPath(fieldPathA?: string | null, fieldPathB?: stri
     return fieldPathA === fieldPathB || fieldPathA === downgradeV2FieldPath(fieldPathB);
 }
 
+// should use pathMatchesExact when rendering editable info so the user edits the correct field
+export function pathMatchesExact(fieldPathA?: string | null, fieldPathB?: string | null) {
+    return fieldPathA === fieldPathB;
+}
+
 // group schema fields by fieldPath and grouping for hierarchy in schema table
 export function groupByFieldPath(
     schemaRows?: Array<SchemaField>,

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/AboutFieldTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/components/SchemaFieldDrawer/AboutFieldTab.tsx
@@ -10,7 +10,7 @@ import {
     UsageQueryResult,
 } from '../../../../../../../../types.generated';
 import { useMutationUrn } from '../../../../../../../entity/shared/EntityContext';
-import { pathMatchesNewPath } from '../../../../../../dataset/profile/schema/utils/utils';
+import { pathMatchesExact } from '../../../../../../dataset/profile/schema/utils/utils';
 import NotesSection from '../../../../../notes/NotesSection';
 import FieldDescription from './FieldDescription';
 import { FieldDetails } from './FieldDetails';
@@ -55,7 +55,7 @@ export function AboutFieldTab({ properties }: AboutFieldTabProps) {
             : undefined;
     const editableFieldInfo = properties.editableSchemaMetadata?.editableSchemaFieldInfo.find(
         (candidateEditableFieldInfo) =>
-            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, expandedField?.fieldPath),
+            pathMatchesExact(candidateEditableFieldInfo.fieldPath, expandedField?.fieldPath),
     );
 
     const notes = properties.notes?.sort((a, b) => moment(b.lastModified.time).diff(moment(a.lastModified.time))) || [];

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useDescriptionRenderer.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { EditableSchemaMetadata, SchemaField, SubResourceType } from '../../../../../../../types.generated';
 import DescriptionField from '../../../../../dataset/profile/schema/components/SchemaDescriptionField';
-import { pathMatchesNewPath } from '../../../../../dataset/profile/schema/utils/utils';
+import { pathMatchesExact } from '../../../../../dataset/profile/schema/utils/utils';
 import { useUpdateDescriptionMutation } from '../../../../../../../graphql/mutations.generated';
 import { useMutationUrn, useRefetch } from '../../../../../../entity/shared/EntityContext';
 import { useSchemaRefetch } from '../SchemaContext';
@@ -31,7 +31,7 @@ export default function useDescriptionRenderer(
 
     return (description: string | undefined, record: SchemaField, index: number): JSX.Element => {
         const editableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find((candidateEditableFieldInfo) =>
-            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+            pathMatchesExact(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         );
         const { schemaFieldEntity } = record;
         const { displayedDescription, sanitizedDescription, isPropagated, sourceDetail } = extractFieldDescription(

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useExtractFieldDescriptionInfo.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useExtractFieldDescriptionInfo.ts
@@ -1,4 +1,4 @@
-import { pathMatchesNewPath } from '@src/app/entityV2/dataset/profile/schema/utils/utils';
+import { pathMatchesExact } from '@src/app/entityV2/dataset/profile/schema/utils/utils';
 import { EditableSchemaMetadata, SchemaField } from '@src/types.generated';
 import { getFieldDescriptionDetails } from './getFieldDescriptionDetails';
 import { sanitizeRichText } from '../../../Documentation/components/editor/utils';
@@ -8,7 +8,7 @@ export default function useExtractFieldDescriptionInfo(
 ) {
     return (record: SchemaField, description: string | undefined | null = null) => {
         const editableFieldInfoB = editableSchemaMetadata?.editableSchemaFieldInfo.find((candidateEditableFieldInfo) =>
-            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+            pathMatchesExact(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         );
         const { displayedDescription, isPropagated, sourceDetail } = getFieldDescriptionDetails({
             schemaFieldEntity: record.schemaFieldEntity,

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useExtractFieldGlossaryTermsInfo.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useExtractFieldGlossaryTermsInfo.ts
@@ -1,4 +1,4 @@
-import { pathMatchesNewPath } from '@src/app/entityV2/dataset/profile/schema/utils/utils';
+import { pathMatchesExact } from '@src/app/entityV2/dataset/profile/schema/utils/utils';
 import { EditableSchemaMetadata, GlossaryTerms, SchemaField } from '@src/types.generated';
 
 export default function useExtractFieldGlossaryTermsInfo(
@@ -6,7 +6,7 @@ export default function useExtractFieldGlossaryTermsInfo(
 ) {
     return (record: SchemaField, defaultUneditableTerms: GlossaryTerms | null = null) => {
         const editableTerms = editableSchemaMetadata?.editableSchemaFieldInfo.find((candidateEditableFieldInfo) =>
-            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+            pathMatchesExact(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         )?.glossaryTerms;
 
         const uneditableTerms = defaultUneditableTerms || record?.glossaryTerms;

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useExtractFieldTagsInfo.ts
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useExtractFieldTagsInfo.ts
@@ -1,10 +1,10 @@
-import { pathMatchesNewPath } from '@src/app/entityV2/dataset/profile/schema/utils/utils';
+import { pathMatchesExact } from '@src/app/entityV2/dataset/profile/schema/utils/utils';
 import { EditableSchemaMetadata, GlobalTags, SchemaField } from '@src/types.generated';
 
 export default function useExtractFieldTagsInfo(editableSchemaMetadata: EditableSchemaMetadata | null | undefined) {
     return (record: SchemaField, defaultUneditableTags: GlobalTags | null = null) => {
         const editableTags = editableSchemaMetadata?.editableSchemaFieldInfo.find((candidateEditableFieldInfo) =>
-            pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+            pathMatchesExact(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         )?.globalTags;
 
         const uneditableTags = defaultUneditableTags || record?.globalTags;

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRendererFeatureTable.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRendererFeatureTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EditableSchemaMetadata, EntityType, GlobalTags, SchemaField } from '../../../../../../../types.generated';
 import TagTermGroup from '../../../../../../sharedV2/tags/TagTermGroup';
-import { pathMatchesNewPath } from '../../../../../dataset/profile/schema/utils/utils';
+import { pathMatchesExact } from '../../../../../dataset/profile/schema/utils/utils';
 import { useEntityData, useRefetch } from '../../../../../../entity/shared/EntityContext';
 
 export default function useTagsAndTermsRendererFeatureTable(
@@ -15,7 +15,7 @@ export default function useTagsAndTermsRendererFeatureTable(
 
     const tagAndTermRender = (tags: GlobalTags, record: SchemaField, rowIndex: number | undefined) => {
         const relevantEditableFieldInfo = editableSchemaMetadata?.editableSchemaFieldInfo.find(
-            (candidateEditableFieldInfo) => pathMatchesNewPath(candidateEditableFieldInfo.fieldPath, record.fieldPath),
+            (candidateEditableFieldInfo) => pathMatchesExact(candidateEditableFieldInfo.fieldPath, record.fieldPath),
         );
 
         return (


### PR DESCRIPTION
We had a bug where if ingestion originally had a v1 fieldPath for a column, then a user adds a tag or a term, this adds a v1 fieldPath in editableSchemaMetadata with this tag/term.
Then if ingestion switches to v2 fieldPath, so whenever we add a tag or term, it adds it under editableSchemaMetadata with the v2 fieldPath.
However, the bug here is that we render the editable info for a field for whichever version of the fieldPath we find first in editableSchemaMetadata - so if we find v2 fieldPath first, we render that always. so we never show the new edits to the v2 field path.

My fix here is that for where we display editable info for a field, it should always match exactly what is coming from schemaMetadata either v1 or v2. That way when you edit a field, it always shows your current edits.

This means there's a possible bug if ingestion switches back and forth between v1 and v2 field paths, we will show the editable info of whatever the current version is. so ideally we don't switch back and forth between the two. But this is better than we currently have

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
