### PR TITLE
fix(structuredProps) Add validation for allowedTypes and harden API for invalid types

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/entitytype/EntityTypeUrnMapper.java
@@ -111,4 +111,8 @@ public class EntityTypeUrnMapper {
     }
     return ENTITY_NAME_TO_ENTITY_TYPE_URN.get(name);
   }
+
+  public static boolean isValidEntityType(String entityTypeUrn) {
+    return ENTITY_TYPE_URN_TO_NAME.containsKey(entityTypeUrn);
+  }
 }


### PR DESCRIPTION
Previously, if someone used our API they could put invalid `allowedTypes` inside of our `typeQualifier` map. This would result in a busted graphql API because we try to hydrate an entity type entity that doesn't exist. So I took two steps to fix this problem:

1. Harden our graphql API to filter out invalid types. This isn't a perfect solution, but in the case someone had already gotten an invalid type in there, we now won't crash the whole UI. However going forward they should never be in this position because of number 2:
2. Add validation on the property definition validator to ensure that these allowedTypes are valid entity types urns.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
