### PR TITLE
feat(ingestion/snowflake):adds snowflake stored procedures as a new dataset 

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/common/subtypes.py
@@ -25,6 +25,7 @@ class DatasetSubTypes(StrEnum):
     NEO4J_NODE = "Neo4j Node"
     NEO4J_RELATIONSHIP = "Neo4j Relationship"
     SNOWFLAKE_STREAM = "Snowflake Stream"
+    SNOWFLAKE_PROCEDURE = "Snowflake Procedure"
 
     # TODO: Create separate entity...
     NOTEBOOK = "Notebook"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/constants.py
@@ -54,6 +54,7 @@ class SnowflakeObjectDomain(StrEnum):
     COLUMN = "column"
     ICEBERG_TABLE = "iceberg table"
     STREAM = "stream"
+    PROCEDURE = "procedure"
 
 
 GENERIC_PERMISSION_ERROR_KEY = "permission-error"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -103,6 +103,11 @@ class SnowflakeFilterConfig(SQLFilterConfig):
         description="Regex patterns for streams to filter in ingestion. Note: Defaults to table_pattern if not specified. Specify regex to match the entire view name in database.schema.view format. e.g. to match all views starting with customer in Customer database and public schema, use the regex 'Customer.public.customer.*'",
     )
 
+    procedure_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Regex patterns for procedures to filter in ingestion. Note: Defaults to table_pattern if not specified. Specify regex to match the entire procedure name in database.schema.procedure format. e.g. to match all procedures starting with customer in Customer database and public schema, use the regex 'Customer.public.customer.*'",
+    )
+
     match_fully_qualified_names: bool = Field(
         default=False,
         description="Whether `schema_pattern` is matched against fully qualified schema name `<catalog>.<schema>`.",
@@ -282,6 +287,11 @@ class SnowflakeV2Config(
     include_streams: bool = Field(
         default=True,
         description="If enabled, streams will be ingested as separate entities from tables/views.",
+    )
+
+    include_procedures: bool = Field(
+        default=True,
+        description="If enabled, procedures will be ingested as separate entities from tables/views.",
     )
 
     structured_property_pattern: AllowDenyPattern = Field(

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_lineage_v2.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field, validator
 
 from datahub.configuration.datetimes import parse_absolute_time
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.source.snowflake.snowflake_schema import SnowflakeProcedure
 from datahub.ingestion.api.closeable import Closeable
 from datahub.ingestion.source.aws.s3_util import make_s3_urn_for_lineage
 from datahub.ingestion.source.snowflake.constants import (
@@ -22,6 +21,7 @@ from datahub.ingestion.source.snowflake.snowflake_connection import (
 )
 from datahub.ingestion.source.snowflake.snowflake_query import SnowflakeQuery
 from datahub.ingestion.source.snowflake.snowflake_report import SnowflakeV2Report
+from datahub.ingestion.source.snowflake.snowflake_schema import SnowflakeProcedure
 from datahub.ingestion.source.snowflake.snowflake_utils import (
     SnowflakeCommonMixin,
     SnowflakeFilter,
@@ -30,9 +30,11 @@ from datahub.ingestion.source.snowflake.snowflake_utils import (
 from datahub.ingestion.source.state.redundant_run_skip_handler import (
     RedundantLineageRunSkipHandler,
 )
-from datahub.metadata.schema_classes import DatasetLineageTypeClass, UpstreamClass
-from datahub.sql_parsing.datajob import to_datajob_input_output
-from datahub.metadata.schema_classes import DataJobInputOutputClass
+from datahub.metadata.schema_classes import (
+    DataJobInputOutputClass,
+    DatasetLineageTypeClass,
+    UpstreamClass,
+)
 from datahub.sql_parsing.datajob import to_datajob_input_output
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.sql_parsing.split_statements import split_statements
@@ -549,7 +551,8 @@ class SnowflakeLineageExtractor(SnowflakeCommonMixin, Closeable):
     def close(self) -> None:
         pass
 
-    def parse_procedure_code(self,
+    def parse_procedure_code(
+        self,
         *,
         schema_resolver: SchemaResolver,
         default_db: Optional[str],
@@ -591,9 +594,9 @@ class SnowflakeLineageExtractor(SnowflakeCommonMixin, Closeable):
             ignore_extra_mcps=True,
         )
 
-
     # Is procedure handling generic enough to be added to SqlParsingAggregator?
-    def generate_procedure_lineage(self,
+    def generate_procedure_lineage(
+        self,
         *,
         schema_resolver: SchemaResolver,
         procedure: SnowflakeProcedure,

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_query.py
@@ -10,6 +10,7 @@ from datahub.utilities.prefix_batch_builder import PrefixGroup
 
 SHOW_VIEWS_MAX_PAGE_SIZE = 10000
 SHOW_STREAM_MAX_PAGE_SIZE = 10000
+SHOW_PROCEDURES_MAX_PAGE_SIZE = 10000
 
 
 def create_deny_regex_sql_filter(
@@ -982,3 +983,25 @@ WHERE table_schema='{schema_name}' AND {extra_clause}"""
             f"""FROM '{stream_pagination_marker}'""" if stream_pagination_marker else ""
         )
         return f"""SHOW STREAMS IN DATABASE {db_name} LIMIT {limit} {from_clause};"""
+
+    # @staticmethod
+    # def procedures_for_database(
+    #     db_name: str,
+    #     limit: int = SHOW_PROCEDURES_MAX_PAGE_SIZE,
+    #     procedure_pagination_marker: Optional[str] = None,
+    # ) -> str:
+    #     # SHOW PROCEDURES can return a maximum of 10000 rows.
+    #     # https://docs.snowflake.com/en/sql-reference/sql/show-procedures#usage-notes
+    #     assert limit <= SHOW_PROCEDURES_MAX_PAGE_SIZE
+
+    #     # To work around this, we paginate through the results using the FROM clause.
+    #     from_clause = (
+    #         f"""FROM '{procedure_pagination_marker}'"""
+    #         if procedure_pagination_marker
+    #         else ""
+    #     )
+    #     return f"""SHOW PROCEDURES IN DATABASE {db_name} LIMIT {limit} {from_clause};"""
+
+    @staticmethod
+    def procedures_for_database(db_name: str) -> str:
+        return f"""SELECT * FROM {db_name}.INFORMATION_SCHEMA.PROCEDURES;"""

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_report.py
@@ -105,6 +105,7 @@ class SnowflakeV2Report(
     databases_scanned: int = 0
     tags_scanned: int = 0
     streams_scanned: int = 0
+    procedures_scanned: int = 0
 
     include_usage_stats: bool = False
     include_operational_stats: bool = False
@@ -134,6 +135,7 @@ class SnowflakeV2Report(
     num_get_tags_on_columns_for_table_queries: int = 0
 
     num_get_streams_for_schema_queries: int = 0
+    num_get_procedures_for_schema_queries: int = 0
 
     rows_zero_objects_modified: int = 0
 
@@ -163,6 +165,8 @@ class SnowflakeV2Report(
             self.tags_scanned += 1
         elif ent_type == "stream":
             self.streams_scanned += 1
+        elif ent_type == "procedure":
+            self.procedures_scanned += 1
         else:
             raise KeyError(f"Unknown entity {ent_type}.")
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema.py
@@ -157,11 +157,18 @@ class SnowflakeStream:
 
 
 @dataclass
+class SnowflakeProcedureContainer:
+    name: str
+    database_name: str
+    schema_name: str
+
+@dataclass
 class SnowflakeProcedure:
     name: str  # PROCEDURE_NAME
     database_name: str  # PROCEDURE_CATALOG
     schema_name: str  # PROCEDURE_SCHEMA
     owner: str  # PROCEDURE_OWNER
+    entity: SnowflakeProcedureContainer
     argument_signature: Optional[str]  # ARGUMENT_SIGNATURE
     data_type: Optional[str]  # DATA_TYPE
     character_maximum_length: Optional[int]  # CHARACTER_MAXIMUM_LENGTH
@@ -181,6 +188,7 @@ class SnowflakeProcedure:
     )  # Procedures do not have columns, but we need to satisfy the type checker
     tags: Optional[List[SnowflakeTag]] = None
     column_tags: Dict[str, List[SnowflakeTag]] = field(default_factory=dict)
+    type: str = "STORED_PROCEDURE"
 
 
 class _SnowflakeTagCache:
@@ -753,6 +761,11 @@ class SnowflakeDataDictionary(SupportsAsObj):
                     database_name=procedure["PROCEDURE_CATALOG"],
                     schema_name=procedure["PROCEDURE_SCHEMA"],
                     owner=procedure["PROCEDURE_OWNER"],
+                    entity=SnowflakeProcedureContainer(
+                        name=procedure["PROCEDURE_NAME"],
+                        database_name=procedure["PROCEDURE_CATALOG"],
+                        schema_name=procedure["PROCEDURE_SCHEMA"],
+                    ),
                     argument_signature=procedure["ARGUMENT_SIGNATURE"],
                     data_type=procedure["DATA_TYPE"],
                     character_maximum_length=procedure["CHARACTER_MAXIMUM_LENGTH"],

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -1547,7 +1547,9 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
                 with self.report.new_stage(f"*: {LINEAGE_EXTRACTION}"):
                     self.generate_procedure_lineage(
                         procedure=procedure,
-                        procedure_job_urn=self.identifiers.gen_dataset_urn(procedure.name),
+                        procedure_job_urn=self.identifiers.gen_dataset_urn(
+                            procedure.name
+                        ),
                         is_temp_table=lambda _: False,
                         raise_=True,
                     )

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -1543,16 +1543,6 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
         try:
             yield from self.gen_dataset_workunits(procedure, schema_name, db_name)
 
-            if self.config.include_procedure_lineage:
-                with self.report.new_stage(f"*: {LINEAGE_EXTRACTION}"):
-                    self.generate_procedure_lineage(
-                        procedure=procedure,
-                        procedure_job_urn=self.identifiers.gen_dataset_urn(
-                            procedure.name
-                        ),
-                        is_temp_table=lambda _: False,
-                        raise_=True,
-                    )
         except Exception as e:
             self.structured_reporter.warning(
                 "Failed to process procedure:", procedure.name, exc=e

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_schema_gen.py
@@ -1008,6 +1008,11 @@ class SnowflakeSchemaGenerator(SnowflakeStructuredReportMixin):
                         SnowflakeObjectDomain.TABLE
                         if isinstance(table, SnowflakeTable)
                         else SnowflakeObjectDomain.VIEW
+                        if isinstance(table, SnowflakeView)
+                        else SnowflakeObjectDomain.PROCEDURE
+                        if isinstance(table, SnowflakeProcedure)
+                        else None
+
                     ),
                 )
                 if self.snowsight_url_builder

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -125,6 +125,7 @@ class SnowflakeFilter:
             SnowflakeObjectDomain.MATERIALIZED_VIEW,
             SnowflakeObjectDomain.ICEBERG_TABLE,
             SnowflakeObjectDomain.STREAM,
+            SnowflakeObjectDomain.PROCEDURE,
         ):
             return False
         if _is_sys_table(dataset_name):

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_utils.py
@@ -89,7 +89,12 @@ class SnowsightUrlBuilder:
         table_name: str,
         schema_name: str,
         db_name: str,
-        domain: Literal[SnowflakeObjectDomain.TABLE, SnowflakeObjectDomain.VIEW],
+        domain: Literal[
+            SnowflakeObjectDomain.TABLE,
+            SnowflakeObjectDomain.VIEW,
+            SnowflakeObjectDomain.STREAM,
+            SnowflakeObjectDomain.PROCEDURE,
+        ],
     ) -> Optional[str]:
         return f"{self.snowsight_base_url}#/data/databases/{db_name}/schemas/{schema_name}/{domain}/{table_name}/"
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -545,20 +545,32 @@ class SnowflakeV2Source(
             for schema in db.schemas
             for stream_name in schema.streams
         ]
+        discovered_procedures: List[str] = [
+            self.identifiers.get_dataset_identifier(
+                procedure_name, schema.name, db.name
+            )
+            for db in databases
+            for schema in db.schemas
+            for procedure_name in schema.procedures
+        ]
 
         if (
             len(discovered_tables) == 0
             and len(discovered_views) == 0
             and len(discovered_streams) == 0
+            and len(discovered_procedures) == 0
         ):
             self.structured_reporter.failure(
                 GENERIC_PERMISSION_ERROR_KEY,
-                "No tables/views/streams found. Please check permissions.",
+                "No tables/views/streams/procedures found. Please check permissions.",
             )
             return
 
         self.discovered_datasets = (
-            discovered_tables + discovered_views + discovered_streams
+            discovered_tables
+            + discovered_views
+            + discovered_streams
+            + discovered_procedures
         )
 
         if self.config.use_queries_v2:

--- a/metadata-ingestion/tests/integration/snowflake/common.py
+++ b/metadata-ingestion/tests/integration/snowflake/common.py
@@ -15,6 +15,7 @@ NUM_STREAMS = 1
 NUM_COLS = 10
 NUM_OPS = 10
 NUM_USAGE = 0
+NUM_PROCEDURES = 1
 
 
 def is_secure(view_idx):
@@ -181,6 +182,7 @@ def default_query_results(  # noqa: C901
     num_cols=NUM_COLS,
     num_ops=NUM_OPS,
     num_usages=NUM_USAGE,
+    num_procedures=NUM_PROCEDURES,
 ):
     if query == SnowflakeQuery.current_account():
         return [{"CURRENT_ACCOUNT()": "ABC12345"}]
@@ -338,6 +340,30 @@ def default_query_results(  # noqa: C901
                 "owner_role_type": "ROLE",
             }
             for stream_idx in range(1, num_streams + 1)
+        ]
+    elif query == SnowflakeQuery.procedures_for_database("TEST_DB"):
+        return [
+            {
+                "PROCEDURE_CATALOG": "TEST_DB",
+                "PROCEDURE_SCHEMA": "TEST_SCHEMA",
+                "PROCEDURE_NAME": f"PROCEDURE_{procedure_idx}",
+                "PROCEDURE_OWNER": "ACCOUNTADMIN",
+                "ARGUMENT_SIGNATURE": "() RETURN VARCHAR",
+                "DATA_TYPE": "VARCHAR",
+                "CHARACTER_MAXIMUM_LENGTH": 16777216,
+                "CHARACTER_OCTET_LENGTH": 16777216,
+                "NUMERIC_PRECISION": None,
+                "NUMERIC_PRECISION_RADIX": None,
+                "NUMERIC_SCALE": None,
+                "PROCEDURE_LANGUAGE": "SQL",
+                "PROCEDURE_DEFINITION": f"CREATE PROCEDURE PROCEDURE_{procedure_idx}() RETURNS VARCHAR LANGUAGE SQL AS SELECT 1",
+                "CREATED": datetime(2021, 6, 8, 0, 0, 0, 0, tzinfo=timezone.utc),
+                "LAST_ALTERED": datetime(2021, 6, 8, 0, 0, 0, 0, tzinfo=timezone.utc),
+                "COMMENT": f"Comment for Procedure {procedure_idx}",
+                "EXTERNAL_ACCESS_INTEGRATIONS": None,
+                "SECRETS": None,
+            }
+            for procedure_idx in range(1, num_procedures + 1)
         ]
     elif query in (
         SnowflakeQuery.use_database("TEST_DB"),

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_golden.json
@@ -25,7 +25,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -41,7 +41,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -57,7 +57,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -75,7 +75,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -95,7 +95,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -111,7 +111,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -128,7 +128,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -144,7 +144,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -175,7 +175,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -191,7 +191,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -207,7 +207,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -225,7 +225,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -245,7 +245,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -266,7 +266,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -282,7 +282,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -479,7 +479,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -508,7 +508,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -524,7 +524,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -542,7 +542,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -567,7 +567,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -583,7 +583,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -780,7 +780,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -809,7 +809,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -825,7 +825,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -843,7 +843,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -868,7 +868,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -884,7 +884,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1081,7 +1081,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1110,7 +1110,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1126,7 +1126,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1144,7 +1144,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1169,7 +1169,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1185,7 +1185,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1382,7 +1382,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1411,7 +1411,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1427,7 +1427,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1445,7 +1445,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1470,7 +1470,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1486,7 +1486,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1683,7 +1683,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1712,7 +1712,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1728,7 +1728,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1746,7 +1746,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1771,7 +1771,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1787,7 +1787,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -1984,7 +1984,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2013,7 +2013,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2029,7 +2029,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2047,7 +2047,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2072,7 +2072,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2088,7 +2088,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2285,7 +2285,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2314,7 +2314,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2330,7 +2330,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2348,7 +2348,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2373,7 +2373,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2389,7 +2389,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2586,7 +2586,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2615,7 +2615,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2631,7 +2631,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2649,7 +2649,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2674,7 +2674,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2690,7 +2690,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2887,7 +2887,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2916,7 +2916,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2932,7 +2932,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2950,7 +2950,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2975,7 +2975,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -2991,7 +2991,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3188,7 +3188,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3217,7 +3217,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3233,7 +3233,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3251,7 +3251,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3276,7 +3276,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3293,7 +3293,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3309,7 +3309,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3480,7 +3480,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3509,7 +3509,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3525,7 +3525,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3543,7 +3543,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3561,7 +3561,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3586,7 +3586,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3603,7 +3603,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3620,7 +3620,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3637,7 +3637,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3653,7 +3653,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3817,7 +3817,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3844,7 +3844,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3860,7 +3860,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3878,7 +3878,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3904,7 +3904,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3922,7 +3922,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3947,7 +3947,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -3963,7 +3963,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4166,7 +4166,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4202,7 +4202,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4218,7 +4218,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4236,296 +4236,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "status",
-    "aspect": {
-        "json": {
-            "removed": false
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "schemaMetadata",
-    "aspect": {
-        "json": {
-            "schemaName": "test_db.test_schema.stream_1",
-            "platform": "urn:li:dataPlatform:snowflake",
-            "version": 0,
-            "created": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "hash": "",
-            "platformSchema": {
-                "com.linkedin.schema.MySqlDDL": {
-                    "tableSchema": ""
-                }
-            },
-            "fields": [
-                {
-                    "fieldPath": "col_1",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.NumberType": {}
-                        }
-                    },
-                    "nativeDataType": "NUMBER(38,0)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_2",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_3",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_4",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_5",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_6",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_7",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_8",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_9",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "col_10",
-                    "nullable": false,
-                    "description": "Comment for column",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(255)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "metadata$action",
-                    "nullable": false,
-                    "description": "Type of DML operation (INSERT/DELETE)",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.StringType": {}
-                        }
-                    },
-                    "nativeDataType": "VARCHAR(10)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "metadata$isupdate",
-                    "nullable": false,
-                    "description": "Whether row is from UPDATE operation",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.BooleanType": {}
-                        }
-                    },
-                    "nativeDataType": "BOOLEAN",
-                    "recursive": false,
-                    "isPartOfKey": false
-                },
-                {
-                    "fieldPath": "metadata$row_id",
-                    "nullable": false,
-                    "description": "Unique row identifier",
-                    "type": {
-                        "type": {
-                            "com.linkedin.schema.NumberType": {}
-                        }
-                    },
-                    "nativeDataType": "NUMBER(38,0)",
-                    "recursive": false,
-                    "isPartOfKey": false
-                }
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "SOURCE_TYPE": "Table",
-                "TYPE": "DELTA",
-                "STALE": "false",
-                "MODE": "DEFAULT",
-                "OWNER_ROLE_TYPE": "ROLE",
-                "TABLE_NAME": "TEST_DB.TEST_SCHEMA.TABLE_1",
-                "BASE_TABLES": "TEST_DB.TEST_SCHEMA.TABLE_1",
-                "STALE_AFTER": "2021-06-22T00:00:00+00:00"
-            },
-            "externalUrl": "https://app.snowflake.com/ap-south-1.aws/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/STREAM_1/",
-            "name": "STREAM_1",
-            "qualifiedName": "TEST_DB.TEST_SCHEMA.STREAM_1",
-            "description": "Comment for Stream 1",
-            "created": {
-                "time": 1623110400000
-            },
-            "lastModified": {
-                "time": 1623110400000
-            },
-            "tags": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Snowflake Stream"
-            ]
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4550,7 +4261,151 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "test_db.test_schema.procedure_1",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.MySqlDDL": {
+                    "tableSchema": ""
+                }
+            },
+            "fields": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "PROCEDURE_DEFINITION": "CREATE PROCEDURE PROCEDURE_1() RETURNS VARCHAR LANGUAGE SQL AS SELECT 1",
+                "PROCEDURE_LANGUAGE": "SQL",
+                "PROCEDURE_OWNER": "ACCOUNTADMIN",
+                "PROCEDURE_CATALOG": "TEST_DB",
+                "PROCEDURE_SCHEMA": "TEST_SCHEMA",
+                "PROCEDURE_NAME": "PROCEDURE_1",
+                "LAST_ALTERED": "2021-06-08T00:00:00+00:00",
+                "COMMENT": "Comment for Procedure 1"
+            },
+            "externalUrl": "https://app.snowflake.com/ap-south-1.aws/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/PROCEDURE_1/",
+            "name": "PROCEDURE_1",
+            "qualifiedName": "TEST_DB.TEST_SCHEMA.PROCEDURE_1",
+            "description": "Comment for Procedure 1",
+            "created": {
+                "time": 1623110400000
+            },
+            "lastModified": {
+                "time": 1623110400000
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Snowflake Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+                    "urn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585"
+                },
+                {
+                    "id": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+                    "urn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4561,7 +4416,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516740,
+            "timestampMillis": 1738986635586,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4573,7 +4428,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4584,7 +4439,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516750,
+            "timestampMillis": 1738986635588,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4596,7 +4451,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4607,7 +4462,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516750,
+            "timestampMillis": 1738986635589,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4619,7 +4474,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4630,7 +4485,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516751,
+            "timestampMillis": 1738986635589,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4642,7 +4497,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4653,7 +4508,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516751,
+            "timestampMillis": 1738986635590,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4665,7 +4520,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4676,7 +4531,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516752,
+            "timestampMillis": 1738986635590,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4688,7 +4543,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4699,7 +4554,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516752,
+            "timestampMillis": 1738986635591,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4711,7 +4566,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4722,7 +4577,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516753,
+            "timestampMillis": 1738986635592,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4734,7 +4589,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4745,7 +4600,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516754,
+            "timestampMillis": 1738986635592,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4757,7 +4612,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4768,7 +4623,7 @@
     "aspectName": "datasetProfile",
     "aspect": {
         "json": {
-            "timestampMillis": 1738040516754,
+            "timestampMillis": 1738986635593,
             "partitionSpec": {
                 "partition": "FULL_TABLE_SNAPSHOT",
                 "type": "FULL_TABLE"
@@ -4780,7 +4635,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4954,7 +4809,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5133,7 +4988,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5161,7 +5016,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5220,7 +5075,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5236,7 +5091,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5388,7 +5243,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5416,7 +5271,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5469,7 +5324,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5485,7 +5340,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5637,7 +5492,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5665,7 +5520,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5715,7 +5570,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5731,7 +5586,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5883,7 +5738,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5911,7 +5766,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5964,7 +5819,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -5980,7 +5835,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6132,7 +5987,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6160,7 +6015,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6213,7 +6068,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6229,7 +6084,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6381,7 +6236,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6409,7 +6264,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6462,7 +6317,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6478,7 +6333,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6630,7 +6485,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6658,7 +6513,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6711,7 +6566,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6727,7 +6582,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6879,7 +6734,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6907,7 +6762,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6960,7 +6815,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -6976,7 +6831,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7128,7 +6983,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7156,7 +7011,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7209,7 +7064,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7225,7 +7080,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7377,7 +7232,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7405,7 +7260,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7458,7 +7313,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7474,7 +7329,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7626,7 +7481,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7647,14 +7502,14 @@
                 "actor": "urn:li:corpuser:_ingestion"
             },
             "lastModified": {
-                "time": 1738040516852,
+                "time": 1738986635699,
                 "actor": "urn:li:corpuser:_ingestion"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7737,7 +7592,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7753,7 +7608,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7905,7 +7760,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -7926,14 +7781,14 @@
                 "actor": "urn:li:corpuser:_ingestion"
             },
             "lastModified": {
-                "time": 1738040516859,
+                "time": 1738986635707,
                 "actor": "urn:li:corpuser:_ingestion"
             }
         }
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8016,7 +7871,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8032,181 +7887,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1654473600000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 0,
-            "totalSqlQueries": 0,
-            "topSqlQueries": [],
-            "userCounts": [],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1654473600000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 0,
-            "totalSqlQueries": 0,
-            "topSqlQueries": [],
-            "userCounts": [],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1654473600000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 0,
-            "totalSqlQueries": 0,
-            "topSqlQueries": [],
-            "userCounts": [],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1654473600000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 0,
-            "totalSqlQueries": 0,
-            "topSqlQueries": [],
-            "userCounts": [],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1654473600000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 0,
-            "totalSqlQueries": 0,
-            "topSqlQueries": [],
-            "userCounts": [],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
-        "lastRunId": "no-run-id-provided"
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetUsageStatistics",
-    "aspect": {
-        "json": {
-            "timestampMillis": 1654473600000,
-            "eventGranularity": {
-                "unit": "DAY",
-                "multiple": 1
-            },
-            "partitionSpec": {
-                "partition": "FULL_TABLE_SNAPSHOT",
-                "type": "FULL_TABLE"
-            },
-            "uniqueUserCount": 0,
-            "totalSqlQueries": 0,
-            "topSqlQueries": [],
-            "userCounts": [],
-            "fieldCounts": []
-        }
-    },
-    "systemMetadata": {
-        "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8235,13 +7916,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_8,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
@@ -8264,7 +7945,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8293,13 +7974,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_7,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
@@ -8322,13 +8003,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.stream_1,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
@@ -8351,13 +8032,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_3,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetUsageStatistics",
     "aspect": {
@@ -8380,7 +8061,65 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8409,7 +8148,152 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.view_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_10,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_5,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_6,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetUsageStatistics",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1654473600000,
+            "eventGranularity": {
+                "unit": "DAY",
+                "multiple": 1
+            },
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            },
+            "uniqueUserCount": 0,
+            "totalSqlQueries": 0,
+            "topSqlQueries": [],
+            "userCounts": [],
+            "fieldCounts": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8432,7 +8316,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8455,7 +8339,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8478,7 +8362,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8501,7 +8385,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8524,7 +8408,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8547,7 +8431,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8570,7 +8454,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8593,7 +8477,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8616,7 +8500,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8639,7 +8523,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8655,7 +8539,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8671,7 +8555,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8687,7 +8571,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8703,7 +8587,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8719,7 +8603,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8735,7 +8619,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8751,7 +8635,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8767,7 +8651,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8783,7 +8667,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8799,7 +8683,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8815,7 +8699,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8831,7 +8715,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8847,7 +8731,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8863,7 +8747,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8879,7 +8763,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8895,7 +8779,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8911,7 +8795,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8927,7 +8811,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8943,7 +8827,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -8959,7 +8843,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1615443388097,
-        "runId": "snowflake-2025_01_28-00_01_52-5vkne0",
+        "runId": "snowflake-2025_02_07-22_50_32-zu8dil",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_privatelink_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_privatelink_golden.json
@@ -4472,6 +4472,139 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "test_db.test_schema.procedure_1",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.MySqlDDL": {
+                    "tableSchema": ""
+                }
+            },
+            "fields": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "PATCH",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": [
+            {
+                "op": "add",
+                "path": "/name",
+                "value": "PROCEDURE_1"
+            },
+            {
+                "op": "add",
+                "path": "/description",
+                "value": "Comment for Procedure 1"
+            },
+            {
+                "op": "add",
+                "path": "/created",
+                "value": {
+                    "time": 1623110400000
+                }
+            },
+            {
+                "op": "add",
+                "path": "/lastModified",
+                "value": {
+                    "time": 1623110400000
+                }
+            },
+            {
+                "op": "add",
+                "path": "/qualifiedName",
+                "value": "TEST_DB.TEST_SCHEMA.PROCEDURE_1"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/PROCEDURE_DEFINITION",
+                "value": "CREATE PROCEDURE PROCEDURE_1() RETURNS VARCHAR LANGUAGE SQL AS SELECT 1"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/PROCEDURE_LANGUAGE",
+                "value": "SQL"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/PROCEDURE_OWNER",
+                "value": "ACCOUNTADMIN"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/PROCEDURE_CATALOG",
+                "value": "TEST_DB"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/PROCEDURE_SCHEMA",
+                "value": "TEST_SCHEMA"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/PROCEDURE_NAME",
+                "value": "PROCEDURE_1"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/LAST_ALTERED",
+                "value": "2021-06-08T00:00:00+00:00"
+            },
+            {
+                "op": "add",
+                "path": "/customProperties/COMMENT",
+                "value": "Comment for Procedure 1"
+            }
+        ]
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "query",
     "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Asnowflake%2Cinstance1.test_db.test_schema.view_1%2CPROD%29",
     "changeType": "UPSERT",
@@ -4496,6 +4629,22 @@
     "systemMetadata": {
         "lastObserved": 1654621200000,
         "runId": "snowflake-2022_06_07-17_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:eac598ee71ef1b5e24448d650c08aa5f"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4595,6 +4744,70 @@
     "systemMetadata": {
         "lastObserved": 1654621200000,
         "runId": "snowflake-2022_06_07-17_00_00",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Snowflake Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:snowflake",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,instance1)"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,instance1.test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,instance1)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,instance1)"
+                },
+                {
+                    "id": "urn:li:container:900b1327253068cb1537b1b3c807ddab",
+                    "urn": "urn:li:container:900b1327253068cb1537b1b3c807ddab"
+                },
+                {
+                    "id": "urn:li:container:eac598ee71ef1b5e24448d650c08aa5f",
+                    "urn": "urn:li:container:eac598ee71ef1b5e24448d650c08aa5f"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1654621200000,
+        "runId": "snowflake-2022_06_07-17_00_00-9p8aie",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/snowflake/snowflake_structured_properties_golden.json
+++ b/metadata-ingestion/tests/integration/snowflake/snowflake_structured_properties_golden.json
@@ -140,8 +140,7 @@
             "lastModified": {
                 "time": 1615443388097,
                 "actor": "urn:li:corpuser:datahub"
-            },
-            "filterStatus": "DISABLED"
+            }
         }
     },
     "systemMetadata": {
@@ -2993,8 +2992,7 @@
             "lastModified": {
                 "time": 1615443388097,
                 "actor": "urn:li:corpuser:datahub"
-            },
-            "filterStatus": "DISABLED"
+            }
         }
     },
     "systemMetadata": {
@@ -3334,8 +3332,7 @@
             "lastModified": {
                 "time": 1615443388097,
                 "actor": "urn:li:corpuser:datahub"
-            },
-            "filterStatus": "DISABLED"
+            }
         }
     },
     "systemMetadata": {
@@ -3364,8 +3361,7 @@
             "lastModified": {
                 "time": 1615443388097,
                 "actor": "urn:li:corpuser:datahub"
-            },
-            "filterStatus": "DISABLED"
+            }
         }
     },
     "systemMetadata": {
@@ -3394,8 +3390,7 @@
             "lastModified": {
                 "time": 1615443388097,
                 "actor": "urn:li:corpuser:datahub"
-            },
-            "filterStatus": "DISABLED"
+            }
         }
     },
     "systemMetadata": {
@@ -4171,6 +4166,91 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_36-j226q7",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "test_db.test_schema.procedure_1",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.MySqlDDL": {
+                    "tableSchema": ""
+                }
+            },
+            "fields": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_36-j226q7",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "PROCEDURE_DEFINITION": "CREATE PROCEDURE PROCEDURE_1() RETURNS VARCHAR LANGUAGE SQL AS SELECT 1",
+                "PROCEDURE_LANGUAGE": "SQL",
+                "PROCEDURE_OWNER": "ACCOUNTADMIN",
+                "PROCEDURE_CATALOG": "TEST_DB",
+                "PROCEDURE_SCHEMA": "TEST_SCHEMA",
+                "PROCEDURE_NAME": "PROCEDURE_1",
+                "LAST_ALTERED": "2021-06-08T00:00:00+00:00",
+                "COMMENT": "Comment for Procedure 1"
+            },
+            "externalUrl": "https://app.snowflake.com/ap-south-1.aws/abc12345/#/data/databases/TEST_DB/schemas/TEST_SCHEMA/view/PROCEDURE_1/",
+            "name": "PROCEDURE_1",
+            "qualifiedName": "TEST_DB.TEST_SCHEMA.PROCEDURE_1",
+            "description": "Comment for Procedure 1",
+            "created": {
+                "time": 1623110400000
+            },
+            "lastModified": {
+                "time": 1623110400000
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_36-j226q7",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "query",
     "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Asnowflake%2Ctest_db.test_schema.view_1%2CPROD%29",
     "changeType": "UPSERT",
@@ -4195,6 +4275,22 @@
     "systemMetadata": {
         "lastObserved": 1615443388097,
         "runId": "snowflake-2025_01_07-13_38_56-3fo398",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_36-j226q7",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -4282,6 +4378,24 @@
     }
 },
 {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Snowflake Procedure"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_36-j226q7",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
     "entityType": "query",
     "entityUrn": "urn:li:query:view_urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Asnowflake%2Ctest_db.test_schema.view_1%2CPROD%29",
     "changeType": "UPSERT",
@@ -4294,6 +4408,31 @@
     "systemMetadata": {
         "lastObserved": 1615443388097,
         "runId": "snowflake-2025_01_07-13_38_56-3fo398",
+        "lastRunId": "no-run-id-provided"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.procedure_1,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:5e359958be02ce647cd9ac196dbd4585",
+                    "urn": "urn:li:container:5e359958be02ce647cd9ac196dbd4585"
+                },
+                {
+                    "id": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c",
+                    "urn": "urn:li:container:94c696a054bab40b73e640a7f82e3b1c"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1615443388097,
+        "runId": "snowflake-2025_02_07-22_50_36-j226q7",
         "lastRunId": "no-run-id-provided"
     }
 },

--- a/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
+++ b/metadata-ingestion/tests/integration/snowflake/test_snowflake_failures.py
@@ -137,20 +137,15 @@ def test_snowflake_no_tables_causes_pipeline_failure(
         mock_connect.return_value = sf_connection
         sf_connection.cursor.return_value = sf_cursor
 
-        # Error in listing databases
-        no_tables_fn = query_permission_response_override(
+        # Mock all queries to return empty results
+        sf_cursor.execute.side_effect = query_permission_error_override(
             default_query_results,
-            [SnowflakeQuery.tables_for_schema("TEST_SCHEMA", "TEST_DB")],
-            [],
-        )
-        no_views_fn = query_permission_response_override(
-            no_tables_fn,
-            [SnowflakeQuery.show_views_for_database("TEST_DB")],
-            [],
-        )
-        sf_cursor.execute.side_effect = query_permission_response_override(
-            no_views_fn,
-            [SnowflakeQuery.streams_for_database("TEST_DB")],
+            [
+                SnowflakeQuery.tables_for_schema("TEST_SCHEMA", "TEST_DB"),
+                SnowflakeQuery.show_views_for_database("TEST_DB"),
+                SnowflakeQuery.streams_for_database("TEST_DB"),
+                SnowflakeQuery.procedures_for_database("TEST_DB"),
+            ],
             [],
         )
         pipeline = Pipeline(snowflake_pipeline_config)


### PR DESCRIPTION
adds stored procedures as a new dataset for Snowflake.

<img width="927" alt="Screenshot 2025-02-08 at 8 07 16 PM" src="https://github.com/user-attachments/assets/6a2e9384-9099-4dc1-8f42-a53057a45aad" />
<img width="858" alt="Screenshot 2025-02-08 at 8 21 18 PM" src="https://github.com/user-attachments/assets/ac9c9d86-1078-477c-8bb2-3ac7667e200e" />


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
