### PR TITLE
fix(url-encoding): fix regression in url encoding

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -22,6 +22,10 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - #12408: The `platform` field in the DataPlatformInstance GraphQL type is removed. Clients need to retrieve the platform via the optional `dataPlatformInstance` field.
 
+### Known Issues
+
+- #12601: Jetty 12 introduces a stricter handling of url encoding. We are currently applying a workaround to prevent a regression, while technically breaking the official specifications.
+
 ### Potential Downtime
 
 ### Deprecations

--- a/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
+++ b/metadata-service/war/src/main/java/com/linkedin/gms/CommonApplicationConfig.java
@@ -2,7 +2,10 @@ package com.linkedin.gms;
 
 import com.linkedin.metadata.spring.YamlPropertySourceFactory;
 import java.lang.management.ManagementFactory;
+import java.util.Set;
 import javax.management.MBeanServer;
+import org.eclipse.jetty.ee10.servlet.ServletHandler;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -65,12 +68,26 @@ public class CommonApplicationConfig {
   @Bean
   public WebServerFactoryCustomizer<JettyServletWebServerFactory> jettyCustomizer() {
     return factory -> {
+
       // Configure HTTP
       factory.addServerCustomizers(
           server -> {
+
             // HTTP Configuration
             HttpConfiguration httpConfig = new HttpConfiguration();
             httpConfig.setRequestHeaderSize(32768);
+
+            // See https://github.com/jetty/jetty.project/issues/11890
+            // Configure URI compliance to allow encoded slashes
+            httpConfig.setUriCompliance(
+                UriCompliance.from(
+                    Set.of(
+                        UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR,
+                        UriCompliance.Violation.AMBIGUOUS_PATH_ENCODING)));
+            // set this for Servlet 6+
+            server
+                .getContainedBeans(ServletHandler.class)
+                .forEach(handler -> handler.setDecodeAmbiguousURIs(true));
 
             // HTTP Connector
             ServerConnector connector =

--- a/smoke-test/tests/openapi/v3/entities.json
+++ b/smoke-test/tests/openapi/v3/entities.json
@@ -22,6 +22,13 @@
   },
   {
     "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset%2FEntityV3%2CPROD%29",
+      "description": "Remove test dataset with %2F",
+      "method": "delete"
+    }
+  },
+  {
+    "request": {
       "url": "/openapi/v3/entity/dataset",
       "params": {
         "createIfNotExists": "false",
@@ -154,6 +161,97 @@
             }
           }
         ]
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset",
+      "params": {
+        "async": "false"
+      },
+      "description": "Create dataset with %2F",
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,dataset/EntityV3,PROD)",
+          "datasetProperties": {
+            "value": {
+              "name": "dataset/EntityV3",
+              "qualifiedName": "entities.dataset/EntityV3",
+              "customProperties": {},
+              "tags": []
+            }
+          },
+          "status": {
+            "value": {
+              "removed": false
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset%2FEntityV3%2CPROD%29",
+      "method": "get",
+      "description": "Get dataset with %2F",
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,dataset/EntityV3,PROD)",
+          "datasetProperties": {
+            "value": {
+              "name": "dataset/EntityV3",
+              "qualifiedName": "entities.dataset/EntityV3",
+              "customProperties": {},
+              "tags": []
+            }
+          },
+          "status": {
+            "value": {
+              "removed": false
+            }
+          }
+        }
+      ]
+    },
+    "response": {
+      "json": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:test,dataset/EntityV3,PROD)",
+        "browsePathsV2": {
+          "value": {
+            "path": [
+              {
+                "id": "Default"
+              }
+            ]
+          }
+        },
+        "datasetKey": {
+          "value": {
+            "name": "dataset/EntityV3",
+            "platform": "urn:li:dataPlatform:test",
+            "origin": "PROD"
+          }
+        },
+        "dataPlatformInstance": {
+          "value": {
+            "platform": "urn:li:dataPlatform:test"
+          }
+        },
+        "datasetProperties": {
+          "value": {
+            "name": "dataset/EntityV3",
+            "customProperties": {},
+            "qualifiedName": "entities.dataset/EntityV3",
+            "tags": []
+          }
+        },
+        "status": {
+          "value": {
+            "removed": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This bug is encountered when using url encoding on the url path `/` => `%2F`

workaround: https://github.com/jetty/jetty.project/issues/11890


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
