### PR TITLE
feat(cli): add extra pip and debug flag

### DIFF
--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -352,27 +352,6 @@ def deploy(
         extra_args_dict.append({"key": "extra_pip_requirements", "value": extra_pip})
         variables["input"]["config"]["extraArgs"] = extra_args_dict
 
-    # """
-    # {
-    #   "urn": "urn:li:dataHubIngestionSource:0ba905ad-5aca-4943-9ae7-e093be99535d",
-    #   "input": {
-    #     "type": "demo-data",
-    #     "name": "demo",
-    #     "config": {
-    #       "recipe": "{\"source\":{\"type\":\"demo-data\",\"config\":{}}}",
-    #       "executorId": "default",
-    #       "debugMode": true,
-    #       "extraArgs": [
-    #         {
-    #           "key": "extra_pip_requirements",
-    #           "value": "[\"memray\"]"
-    #         }
-    #       ]
-    #     }
-    #   }
-    # }
-    # """
-
     # The updateIngestionSource endpoint can actually do upserts as well.
     graphql_query: str = textwrap.dedent(
         """

--- a/metadata-ingestion/src/datahub/utilities/ingest_utils.py
+++ b/metadata-ingestion/src/datahub/utilities/ingest_utils.py
@@ -1,0 +1,106 @@
+import json
+import logging
+from typing import Optional
+
+import click
+
+from datahub.configuration.common import ConfigModel
+from datahub.configuration.config_loader import load_config_file
+from datahub.emitter.mce_builder import datahub_guid
+
+logger = logging.getLogger(__name__)
+
+
+def _make_ingestion_urn(name: str) -> str:
+    guid = datahub_guid(
+        {
+            "name": name,
+        }
+    )
+    return f"urn:li:dataHubIngestionSource:deploy-{guid}"
+
+
+class DeployOptions(ConfigModel):
+    name: str
+    schedule: Optional[str] = None
+    time_zone: str = "UTC"
+    cli_version: Optional[str] = None
+    executor_id: str = "default"
+
+
+def deploy_source_vars(
+    name: Optional[str],
+    config: str,
+    urn: Optional[str],
+    executor_id: str,
+    cli_version: Optional[str],
+    schedule: Optional[str],
+    time_zone: str,
+    extra_pip: Optional[str],
+    debug: bool = False,
+) -> dict:
+    pipeline_config = load_config_file(
+        config,
+        allow_stdin=True,
+        allow_remote=True,
+        resolve_env_vars=False,
+    )
+
+    deploy_options_raw = pipeline_config.pop("deployment", None)
+    if deploy_options_raw is not None:
+        deploy_options = DeployOptions.parse_obj(deploy_options_raw)
+
+        if name:
+            logger.info(f"Overriding deployment name {deploy_options.name} with {name}")
+            deploy_options.name = name
+    else:
+        if not name:
+            raise click.UsageError(
+                "Either --name must be set or deployment_name specified in the config"
+            )
+        deploy_options = DeployOptions(name=name)
+
+    # Use remaining CLI args to override deploy_options
+    if schedule:
+        deploy_options.schedule = schedule
+    if time_zone:
+        deploy_options.time_zone = time_zone
+    if cli_version:
+        deploy_options.cli_version = cli_version
+    if executor_id:
+        deploy_options.executor_id = executor_id
+
+    logger.info(f"Using {repr(deploy_options)}")
+
+    if not urn:
+        # When urn/name is not specified, we will generate a unique urn based on the deployment name.
+        urn = _make_ingestion_urn(deploy_options.name)
+        logger.info(f"Using recipe urn: {urn}")
+
+    variables: dict = {
+        "urn": urn,
+        "input": {
+            "name": deploy_options.name,
+            "type": pipeline_config["source"]["type"],
+            "config": {
+                "recipe": json.dumps(pipeline_config),
+                "executorId": deploy_options.executor_id,
+                "debugMode": debug,
+                "version": deploy_options.cli_version,
+            },
+        },
+    }
+
+    if deploy_options.schedule is not None:
+        variables["input"]["schedule"] = {
+            "interval": deploy_options.schedule,
+            "timezone": deploy_options.time_zone,
+        }
+    if extra_pip is not None:
+        extra_args_list = (
+            variables.get("input", {}).get("config", {}).get("extraArgs", [])
+        )
+        extra_args_list.append({"key": "extra_pip_requirements", "value": extra_pip})
+        variables["input"]["config"]["extraArgs"] = extra_args_list
+
+    return variables

--- a/metadata-ingestion/tests/unit/utilities/sample_demo.dhub.yaml
+++ b/metadata-ingestion/tests/unit/utilities/sample_demo.dhub.yaml
@@ -1,0 +1,3 @@
+source:
+  type: demo-data
+  config: {}

--- a/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
+++ b/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
@@ -27,7 +27,7 @@ def test_deploy_source_vars():
 
     deploy_vars = deploy_source_vars(
         name,
-        config,
+        str(config),
         urn,
         executor_id,
         cli_version,

--- a/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
+++ b/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
@@ -19,8 +19,8 @@ def test_deploy_source_vars():
     config = pathlib.Path(__file__).parent / "sample_demo.dhub.yaml"
     urn = None
     executor_id = "default"
-    cli_version = None
-    schedule = None
+    cli_version = "0.15.0.1"
+    schedule = "5 4 * * *"
     time_zone = "UTC"
     extra_pip = '["pandas"]'
     debug = False
@@ -40,12 +40,16 @@ def test_deploy_source_vars():
         "urn": "urn:li:dataHubIngestionSource:deploy-2b895b6efaa28b818284e5c696a18799",
         "input": {
             "name": "test",
+            "schedule": {
+                "interval": "5 4 * * *",
+                "timezone": "UTC",
+            },
             "type": "demo-data",
             "config": {
                 "recipe": '{"source": {"type": "demo-data", "config": {}}}',
                 "debugMode": False,
                 "executorId": "default",
-                "version": None,
+                "version": "0.15.0.1",
                 "extraArgs": [{"key": "extra_pip_requirements", "value": '["pandas"]'}],
             },
         },

--- a/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
+++ b/metadata-ingestion/tests/unit/utilities/test_ingest_utils.py
@@ -1,0 +1,52 @@
+import pathlib
+
+from datahub.utilities.ingest_utils import (
+    _make_ingestion_urn,
+    deploy_source_vars,
+)
+
+
+def test_make_ingestion_urn():
+    name = "test"
+    urn = _make_ingestion_urn(name)
+    assert (
+        urn == "urn:li:dataHubIngestionSource:deploy-2b895b6efaa28b818284e5c696a18799"
+    )
+
+
+def test_deploy_source_vars():
+    name = "test"
+    config = pathlib.Path(__file__).parent / "sample_demo.dhub.yaml"
+    urn = None
+    executor_id = "default"
+    cli_version = None
+    schedule = None
+    time_zone = "UTC"
+    extra_pip = '["pandas"]'
+    debug = False
+
+    deploy_vars = deploy_source_vars(
+        name,
+        config,
+        urn,
+        executor_id,
+        cli_version,
+        schedule,
+        time_zone,
+        extra_pip,
+        debug,
+    )
+    assert deploy_vars == {
+        "urn": "urn:li:dataHubIngestionSource:deploy-2b895b6efaa28b818284e5c696a18799",
+        "input": {
+            "name": "test",
+            "type": "demo-data",
+            "config": {
+                "recipe": '{"source": {"type": "demo-data", "config": {}}}',
+                "debugMode": False,
+                "executorId": "default",
+                "version": None,
+                "extraArgs": [{"key": "extra_pip_requirements", "value": '["pandas"]'}],
+            },
+        },
+    }


### PR DESCRIPTION
Allows these options
```
datahub ingest deploy --urn "$URN"  -c ../tmp/demo.dhub.yaml --name demo --extra-pip '["memray"]' --debug true
```

New options allowed are
```
--extra-pip '["memray"]' --debug true
```

Changed the graphql call to be similar to what we do in the UI which makes it easier to change. Add tests by moving code out of `ingest_cli.py` file. Otherwise there were no tests

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
