### PR TITLE
feat(sdk): add/remove methods + other small improvements

### DIFF
--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -16,7 +16,10 @@ disallow_untyped_defs = no
 
 # try to be a bit more strict in certain areas of the codebase
 [mypy-datahub]
-# Only for datahub's __init__.py - allow implicit reexport
+# Allow implicit reexport for datahub's __init__.py
+implicit_reexport = yes
+[mypy-datahub.sdk]
+# Allow implicit reexport for datahub.sdk's __init__.py
 implicit_reexport = yes
 [mypy-datahub.*]
 ignore_missing_imports = no

--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -70,6 +70,7 @@ filterwarnings =
     ignore:Did not recognize type:sqlalchemy.exc.SAWarning
     ignore::datahub.configuration.pydantic_migration_helpers.PydanticDeprecatedSince20
     ignore::datahub.configuration.common.ConfigurationWarning
+    ignore:The new datahub SDK:datahub.errors.ExperimentalWarning
 
 [coverage:run]
 # Because of some quirks in the way setup.cfg, coverage.py, pytest-cov,

--- a/metadata-ingestion/src/datahub/emitter/mcp_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mcp_builder.py
@@ -36,7 +36,7 @@ from datahub.metadata.schema_classes import (
     SubTypesClass,
     TagAssociationClass,
 )
-from datahub.metadata.urns import StructuredPropertyUrn
+from datahub.metadata.urns import ContainerUrn, StructuredPropertyUrn
 
 # In https://github.com/datahub-project/datahub/pull/11214, we added a
 # new env field to container properties. However, populating this field
@@ -86,6 +86,9 @@ class ContainerKey(DatahubKey):
 
     def property_dict(self) -> Dict[str, str]:
         return self.dict(by_alias=True, exclude_none=True)
+
+    def as_urn_typed(self) -> ContainerUrn:
+        return ContainerUrn.from_string(self.as_urn())
 
     def as_urn(self) -> str:
         return make_container_urn(guid=self.guid())

--- a/metadata-ingestion/src/datahub/sdk/_attribution.py
+++ b/metadata-ingestion/src/datahub/sdk/_attribution.py
@@ -5,6 +5,10 @@ from typing import Iterator
 
 from datahub.utilities.str_enum import StrEnum
 
+# TODO: This attribution setup is not the final form. I expect that once we have better
+# backend support for attribution and attribution-oriented patch, this will become a bit
+# more sophisticated.
+
 
 class KnownAttribution(StrEnum):
     INGESTION = "INGESTION"

--- a/metadata-ingestion/src/datahub/sdk/_entity.py
+++ b/metadata-ingestion/src/datahub/sdk/_entity.py
@@ -36,6 +36,8 @@ class Entity:
 
     def _init_from_graph(self, current_aspects: models.AspectBag) -> Self:
         self._prev_aspects = current_aspects
+
+        self._aspects = {}
         aspect: models._Aspect
         for aspect_name, aspect in (current_aspects or {}).items():  # type: ignore
             aspect_copy = type(aspect).from_obj(aspect.to_obj())

--- a/metadata-ingestion/src/datahub/sdk/_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_shared.py
@@ -291,6 +291,18 @@ class HasContainer(Entity):
             )
         )
 
+    @property
+    def browse_path(self) -> Optional[List[UrnOrStr]]:
+        if browse_path := self._get_aspect(models.BrowsePathsV2Class):
+            path: List[UrnOrStr] = []
+            for entry in browse_path.path:
+                if entry.urn:
+                    path.append(Urn.from_string(entry.urn))
+                else:
+                    path.append(entry.id)
+            return path
+        return None
+
 
 TagInputType: TypeAlias = Union[str, TagUrn, models.TagAssociationClass]
 TagsInputType: TypeAlias = List[TagInputType]

--- a/metadata-ingestion/src/datahub/sdk/_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_shared.py
@@ -87,6 +87,13 @@ class HasPlatformInstance(Entity):
         )
 
     @property
+    def platform(self) -> Optional[DataPlatformUrn]:
+        dataPlatform = self._get_aspect(models.DataPlatformInstanceClass)
+        if dataPlatform and dataPlatform.platform:
+            return DataPlatformUrn.from_string(dataPlatform.platform)
+        return None
+
+    @property
     def platform_instance(self) -> Optional[DataPlatformInstanceUrn]:
         dataPlatformInstance = self._get_aspect(models.DataPlatformInstanceClass)
         if dataPlatformInstance and dataPlatformInstance.instance:

--- a/metadata-ingestion/src/datahub/sdk/_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_shared.py
@@ -332,6 +332,12 @@ class HasContainer(Entity):
         )
 
     @property
+    def parent_container(self) -> Optional[ContainerUrn]:
+        if container := self._get_aspect(models.ContainerClass):
+            return ContainerUrn.from_string(container.container)
+        return None
+
+    @property
     def browse_path(self) -> Optional[List[UrnOrStr]]:
         if browse_path := self._get_aspect(models.BrowsePathsV2Class):
             path: List[UrnOrStr] = []

--- a/metadata-ingestion/src/datahub/sdk/_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_shared.py
@@ -312,8 +312,7 @@ class HasTags(Entity):
     __slots__ = ()
 
     def _ensure_tags(self) -> List[models.TagAssociationClass]:
-        tags = self._setdefault_aspect(models.GlobalTagsClass(tags=[])).tags
-        return tags
+        return self._setdefault_aspect(models.GlobalTagsClass(tags=[])).tags
 
     # TODO: Return a custom type with deserialized urns, instead of the raw aspect.
     @property
@@ -368,8 +367,9 @@ class HasTerms(Entity):
     __slots__ = ()
 
     def _ensure_terms(self) -> List[models.GlossaryTermAssociationClass]:
-        terms = self._setdefault_aspect(models.GlossaryTermsClass(terms=[])).terms
-        return terms
+        return self._setdefault_aspect(
+            models.GlossaryTermsClass(terms=[], auditStamp=self._terms_audit_stamp())
+        ).terms
 
     # TODO: Return a custom type with deserialized urns, instead of the raw aspect.
     @property

--- a/metadata-ingestion/src/datahub/sdk/_shared.py
+++ b/metadata-ingestion/src/datahub/sdk/_shared.py
@@ -355,6 +355,10 @@ TermsInputType: TypeAlias = List[TermInputType]
 class HasTerms(Entity):
     __slots__ = ()
 
+    def _ensure_terms(self) -> List[models.GlossaryTermAssociationClass]:
+        terms = self._setdefault_aspect(models.GlossaryTermsClass(terms=[])).terms
+        return terms
+
     # TODO: Return a custom type with deserialized urns, instead of the raw aspect.
     @property
     def terms(self) -> Optional[List[models.GlossaryTermAssociationClass]]:
@@ -388,6 +392,24 @@ class HasTerms(Entity):
                 ],
                 auditStamp=self._terms_audit_stamp(),
             )
+        )
+
+    @classmethod
+    def _terms_key(self, term: models.GlossaryTermAssociationClass) -> str:
+        return term.urn
+
+    def add_term(self, term: TermInputType) -> None:
+        add_list_unique(
+            self._ensure_terms(),
+            self._terms_key,
+            self._parse_glossary_term_association_class(term),
+        )
+
+    def remove_term(self, term: TermInputType) -> None:
+        remove_list_unique(
+            self._ensure_terms(),
+            self._terms_key,
+            self._parse_glossary_term_association_class(term),
         )
 
 

--- a/metadata-ingestion/src/datahub/sdk/_utils.py
+++ b/metadata-ingestion/src/datahub/sdk/_utils.py
@@ -20,7 +20,9 @@ def add_list_unique(lst: List[T], key: Callable[[T], K], item: T) -> None:
     lst.append(item)
 
 
-def remove_list_unique(lst: List[T], key: Callable[[T], K], item: T) -> None:
+def remove_list_unique(
+    lst: List[T], key: Callable[[T], K], item: T, *, missing_ok: bool = True
+) -> None:
     # Poor man's patch implementation.
     item_key = key(item)
     removed = False
@@ -29,5 +31,5 @@ def remove_list_unique(lst: List[T], key: Callable[[T], K], item: T) -> None:
             lst.pop(i)
             removed = True
             # Tricky: no break. In case there's already duplicates, we want to remove all of them.
-    if not removed:
-        raise ItemNotFoundError(f"Item {item} not found in list")
+    if not removed and not missing_ok:
+        raise ItemNotFoundError(f"Cannot remove item {item} from list: not found")

--- a/metadata-ingestion/src/datahub/sdk/_utils.py
+++ b/metadata-ingestion/src/datahub/sdk/_utils.py
@@ -1,0 +1,33 @@
+from typing import Any, Callable, List, Protocol, TypeVar
+
+from datahub.errors import ItemNotFoundError
+
+
+class _SupportsEq(Protocol):
+    def __eq__(self, other: Any) -> bool: ...
+
+
+T = TypeVar("T")
+K = TypeVar("K", bound=_SupportsEq)
+
+
+def add_list_unique(lst: List[T], key: Callable[[T], K], item: T) -> None:
+    item_key = key(item)
+    for i, existing in enumerate(lst):
+        if key(existing) == item_key:
+            lst[i] = item
+            return
+    lst.append(item)
+
+
+def remove_list_unique(lst: List[T], key: Callable[[T], K], item: T) -> None:
+    # Poor man's patch implementation.
+    item_key = key(item)
+    removed = False
+    for i, existing in enumerate(lst):
+        if key(existing) == item_key:
+            lst.pop(i)
+            removed = True
+            # Tricky: no break. In case there's already duplicates, we want to remove all of them.
+    if not removed:
+        raise ItemNotFoundError(f"Item {item} not found in list")

--- a/metadata-ingestion/src/datahub/sdk/container.py
+++ b/metadata-ingestion/src/datahub/sdk/container.py
@@ -56,9 +56,7 @@ class Container(
         self,
         /,
         # Identity.
-        # TODO: We need to strongly recommend against passing ContainerUrn?
-        # Maybe we should just allow an incorrect type annotation?
-        container_key: ContainerKey | ContainerUrn,
+        container_key: ContainerKey,
         *,
         # Container attributes.
         display_name: str,
@@ -77,6 +75,8 @@ class Container(
         terms: Optional[TermsInputType] = None,
         domain: Optional[DomainInputType] = None,
     ):
+        # Hack: while the type annotations say container_key is always a ContainerKey,
+        # we allow ContainerUrn to make the graph-based constructor work.
         if isinstance(container_key, ContainerUrn):
             urn = container_key
         else:
@@ -141,7 +141,8 @@ class Container(
     @classmethod
     def _new_from_graph(cls, urn: Urn, current_aspects: models.AspectBag) -> Self:
         assert isinstance(urn, ContainerUrn)
-        entity = cls(urn, display_name="__dummy_value__")
+
+        entity = cls(urn, display_name="__dummy_value__", parent_container=None)  # type: ignore[arg-type]
         return entity._init_from_graph(current_aspects)
 
     def _ensure_container_props(

--- a/metadata-ingestion/src/datahub/sdk/container.py
+++ b/metadata-ingestion/src/datahub/sdk/container.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, Optional, Type, Union
+from typing import Dict, Optional, Type
 
 from typing_extensions import Self
 
@@ -68,7 +68,7 @@ class Container(
         created: Optional[datetime] = None,
         last_modified: Optional[datetime] = None,
         # Standard aspects.
-        parent_container: Union[Auto, ParentContainerInputType, None] = auto,
+        parent_container: Auto | ParentContainerInputType | None = auto,
         subtype: Optional[str] = None,
         owners: Optional[OwnersInputType] = None,
         tags: Optional[TagsInputType] = None,

--- a/metadata-ingestion/src/datahub/sdk/dataset.py
+++ b/metadata-ingestion/src/datahub/sdk/dataset.py
@@ -35,6 +35,7 @@ from datahub.sdk._shared import (
     make_time_stamp,
     parse_time_stamp,
 )
+from datahub.utilities.sentinels import Unset, unset
 
 SchemaFieldInputType: TypeAlias = Union[
     Tuple[str, str],  # (name, type)
@@ -351,7 +352,7 @@ class Dataset(
         created: Optional[datetime] = None,
         last_modified: Optional[datetime] = None,
         # Standard aspects.
-        parent_container: Optional[ParentContainerInputType] = None,
+        parent_container: ParentContainerInputType | Unset = unset,
         subtype: Optional[str] = None,
         owners: Optional[OwnersInputType] = None,
         tags: Optional[TagsInputType] = None,
@@ -392,10 +393,10 @@ class Dataset(
         if last_modified is not None:
             self.set_last_modified(last_modified)
 
+        if parent_container is not unset:
+            self._set_container(parent_container)
         if subtype is not None:
             self.set_subtype(subtype)
-        if parent_container is not None:
-            self._set_container(parent_container)
         if owners is not None:
             self.set_owners(owners)
         if tags is not None:

--- a/metadata-ingestion/src/datahub/sdk/dataset.py
+++ b/metadata-ingestion/src/datahub/sdk/dataset.py
@@ -336,7 +336,7 @@ class SchemaField:
 
         return terms
 
-    def set_terms(self, terms: List[models.GlossaryTermAssociationClass]) -> None:
+    def set_terms(self, terms: TermsInputType) -> None:
         parsed_terms = [
             self._parent._parse_glossary_term_association_class(term) for term in terms
         ]

--- a/metadata-ingestion/src/datahub/sdk/dataset.py
+++ b/metadata-ingestion/src/datahub/sdk/dataset.py
@@ -19,7 +19,6 @@ from datahub.metadata.urns import DatasetUrn, SchemaFieldUrn, Urn
 from datahub.sdk._attribution import is_ingestion_attribution
 from datahub.sdk._entity import Entity
 from datahub.sdk._shared import (
-    ContainerInputType,
     DatasetUrnOrStr,
     DomainInputType,
     HasContainer,
@@ -30,6 +29,7 @@ from datahub.sdk._shared import (
     HasTags,
     HasTerms,
     OwnersInputType,
+    ParentContainerInputType,
     TagsInputType,
     TermsInputType,
     make_time_stamp,
@@ -37,7 +37,6 @@ from datahub.sdk._shared import (
 )
 
 SchemaFieldInputType: TypeAlias = Union[
-    str,
     Tuple[str, str],  # (name, type)
     Tuple[str, str, str],  # (name, type, description)
     models.SchemaFieldClass,
@@ -352,8 +351,8 @@ class Dataset(
         created: Optional[datetime] = None,
         last_modified: Optional[datetime] = None,
         # Standard aspects.
+        parent_container: Optional[ParentContainerInputType] = None,
         subtype: Optional[str] = None,
-        container: Optional[ContainerInputType] = None,
         owners: Optional[OwnersInputType] = None,
         tags: Optional[TagsInputType] = None,
         terms: Optional[TermsInputType] = None,
@@ -395,8 +394,8 @@ class Dataset(
 
         if subtype is not None:
             self.set_subtype(subtype)
-        if container is not None:
-            self._set_container(container)
+        if parent_container is not None:
+            self._set_container(parent_container)
         if owners is not None:
             self.set_owners(owners)
         if tags is not None:
@@ -536,14 +535,6 @@ class Dataset(
                 ),
                 nativeDataType=field_type,
                 description=description,
-            )
-        elif isinstance(schema_field_input, str):
-            # TODO: Not sure this branch makes sense - we should probably just require types?
-            return models.SchemaFieldClass(
-                fieldPath=schema_field_input,
-                type=models.SchemaFieldDataTypeClass(models.NullTypeClass()),
-                nativeDataType="unknown",
-                description=None,
             )
         else:
             assert_never(schema_field_input)

--- a/metadata-ingestion/src/datahub/sdk/main_client.py
+++ b/metadata-ingestion/src/datahub/sdk/main_client.py
@@ -41,10 +41,24 @@ class DataHubClient:
 
     @classmethod
     def from_env(cls) -> "DataHubClient":
+        """Initialize a DataHubClient from the environment variables or ~/.datahubenv file.
+
+        This will first check DATAHUB_GMS_URL and DATAHUB_GMS_TOKEN. If not present,
+        it will read credentials from ~/.datahubenv. That file can be created using
+        the `datahub init` command.
+
+        If you're looking to specify the server/token in code, use the
+        DataHubClient(server=..., token=...) constructor instead.
+
+        Returns:
+            A DataHubClient instance.
+        """
+
         # Inspired by the DockerClient.from_env() method.
         # TODO: This one also reads from ~/.datahubenv, so the "from_env" name might be a bit confusing.
         # That file is part of the "environment", but is not a traditional "env variable".
         graph = get_default_graph()
+
         return cls(graph=graph)
 
     @property
@@ -54,3 +68,6 @@ class DataHubClient:
     @property
     def resolve(self) -> ResolverClient:
         return ResolverClient(self)
+
+    # TODO: search client
+    # TODO: lineage client

--- a/metadata-ingestion/src/datahub/specific/dataset.py
+++ b/metadata-ingestion/src/datahub/specific/dataset.py
@@ -15,6 +15,7 @@ from datahub.metadata.schema_classes import (
     UpstreamClass as Upstream,
     UpstreamLineageClass as UpstreamLineage,
 )
+from datahub.metadata.urns import DatasetUrn, TagUrn, Urn
 from datahub.specific.aspect_helpers.custom_properties import HasCustomPropertiesPatch
 from datahub.specific.aspect_helpers.ownership import HasOwnershipPatch
 from datahub.specific.aspect_helpers.structured_properties import (
@@ -22,8 +23,6 @@ from datahub.specific.aspect_helpers.structured_properties import (
 )
 from datahub.specific.aspect_helpers.tags import HasTagsPatch
 from datahub.specific.aspect_helpers.terms import HasTermsPatch
-from datahub.utilities.urns.tag_urn import TagUrn
-from datahub.utilities.urns.urn import Urn
 
 _Parent = TypeVar("_Parent", bound=MetadataPatchProposal)
 
@@ -104,12 +103,12 @@ class DatasetPatchBuilder(
 ):
     def __init__(
         self,
-        urn: str,
+        urn: Union[str, DatasetUrn],
         system_metadata: Optional[SystemMetadataClass] = None,
         audit_header: Optional[KafkaAuditHeaderClass] = None,
     ) -> None:
         super().__init__(
-            urn, system_metadata=system_metadata, audit_header=audit_header
+            str(urn), system_metadata=system_metadata, audit_header=audit_header
         )
 
     @classmethod

--- a/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
+++ b/metadata-ingestion/src/datahub/utilities/file_backed_collections.py
@@ -10,13 +10,11 @@ import tempfile
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from types import TracebackType
 from typing import (
     Any,
     Callable,
     Dict,
-    Final,
     Generic,
     Iterator,
     List,
@@ -31,6 +29,7 @@ from typing import (
 )
 
 from datahub.ingestion.api.closeable import Closeable
+from datahub.utilities.sentinels import Unset, unset
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -57,16 +56,6 @@ _DEFAULT_MEMORY_CACHE_EVICTION_BATCH_SIZE = 150
 SqliteValue = Union[int, float, str, bytes, datetime, None]
 
 _VT = TypeVar("_VT")
-
-
-class Unset(Enum):
-    token = 0
-
-
-# It's pretty annoying to create a true sentinel that works with typing.
-# https://peps.python.org/pep-0484/#support-for-singleton-types-in-unions
-# Can't wait for https://peps.python.org/pep-0661/
-_unset: Final = Unset.token
 
 
 class ConnectionWrapper:
@@ -372,7 +361,7 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
         self,
         /,
         key: str,
-        default: Union[_VT, Unset] = _unset,
+        default: Union[_VT, Unset] = unset,
     ) -> _VT:
         # If key is in the dictionary, this is similar to __getitem__ + mark_dirty.
         # If key is not in the dictionary, this is similar to __setitem__.
@@ -383,7 +372,7 @@ class FileBackedDict(MutableMapping[str, _VT], Closeable, Generic[_VT]):
             self.mark_dirty(key)
             return value
         except KeyError:
-            if default is _unset:
+            if default is unset:
                 raise
 
             self[key] = default

--- a/metadata-ingestion/src/datahub/utilities/sentinels.py
+++ b/metadata-ingestion/src/datahub/utilities/sentinels.py
@@ -13,3 +13,10 @@ class Unset(Enum):
 
 
 unset: Final = Unset.token
+
+
+class Auto(Enum):
+    token = 0
+
+
+auto: Final = Auto.token

--- a/metadata-ingestion/src/datahub/utilities/sentinels.py
+++ b/metadata-ingestion/src/datahub/utilities/sentinels.py
@@ -1,0 +1,15 @@
+from enum import Enum
+from typing import Final
+
+# It's pretty annoying to create a true sentinel that works with typing.
+# This approach using enums is inspired by:
+# https://peps.python.org/pep-0484/#support-for-singleton-types-in-unions
+#
+# Can't wait for https://peps.python.org/pep-0661/
+
+
+class Unset(Enum):
+    token = 0
+
+
+unset: Final = Unset.token

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_browse_path_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_browse_path_golden.json
@@ -1,0 +1,50 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,MY_DB.MY_SCHEMA.MY_TABLE,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:snowflake"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,MY_DB.MY_SCHEMA.MY_TABLE,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:64b0c379202fccb5aa45b25c56a81dab"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,MY_DB.MY_SCHEMA.MY_TABLE,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "Folders"
+                },
+                {
+                    "id": "urn:li:container:bdeef79e1e511095dbdb7563b5f4b3f4",
+                    "urn": "urn:li:container:bdeef79e1e511095dbdb7563b5f4b3f4"
+                },
+                {
+                    "id": "Subfolder"
+                },
+                {
+                    "id": "urn:li:container:64b0c379202fccb5aa45b25c56a81dab",
+                    "urn": "urn:li:container:64b0c379202fccb5aa45b25c56a81dab"
+                }
+            ]
+        }
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_dataset_complex_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_dataset_complex_golden.json
@@ -110,19 +110,6 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
@@ -150,6 +137,19 @@
                     "id": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056",
                     "urn": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
                 }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
             ]
         }
     }

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_dataset_ingestion_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_dataset_ingestion_golden.json
@@ -117,19 +117,6 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
         "json": {
@@ -157,6 +144,19 @@
                     "id": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056",
                     "urn": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
                 }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
             ]
         }
     }

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_owners_add_remove_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_owners_add_remove_golden.json
@@ -1,0 +1,34 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,db.schema.table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:redshift"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:redshift,db.schema.table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpGroup:group@datahubproject.io",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_tags_add_remove_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_tags_add_remove_golden.json
@@ -1,0 +1,279 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:snowflake",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "field1",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "field2",
+                    "nullable": false,
+                    "description": "field2 description",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "int64",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "editableDatasetProperties",
+    "aspect": {
+        "json": {
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "description": "test"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "key1": "value1",
+                "key2": "value2"
+            },
+            "externalUrl": "https://example.com",
+            "name": "MY_TABLE",
+            "qualifiedName": "MY_DB.MY_SCHEMA.MY_TABLE",
+            "created": {
+                "time": 1735787045000
+            },
+            "lastModified": {
+                "time": 1736391846000
+            },
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
+                },
+                {
+                    "id": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c",
+                    "urn": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c"
+                },
+                {
+                    "id": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056",
+                    "urn": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:admin@datahubproject.io",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:tag2"
+                },
+                {
+                    "tag": "urn:li:tag:tag3"
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:AccountBalance"
+                }
+            ],
+            "auditStamp": {
+                "time": 0,
+                "actor": "urn:li:corpuser:__ingestion"
+            }
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+        "json": {
+            "domains": [
+                "urn:li:domain:Marketing"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "editableSchemaMetadata",
+    "aspect": {
+        "json": {
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "editableSchemaFieldInfo": [
+                {
+                    "fieldPath": "field1",
+                    "description": "field1 description",
+                    "globalTags": {
+                        "tags": [
+                            {
+                                "tag": "urn:li:tag:field1_tag2"
+                            },
+                            {
+                                "tag": "urn:li:tag:field1_tag3"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "fieldPath": "field2",
+                    "glossaryTerms": {
+                        "terms": [
+                            {
+                                "urn": "urn:li:glossaryTerm:field2_term1"
+                            },
+                            {
+                                "urn": "urn:li:glossaryTerm:field2_term2"
+                            }
+                        ],
+                        "auditStamp": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:__ingestion"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_tags_add_remove_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_tags_add_remove_golden.json
@@ -1,25 +1,24 @@
 [
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:snowflake",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
         "json": {
             "schemaName": "",
-            "platform": "urn:li:dataPlatform:snowflake",
+            "platform": "urn:li:dataPlatform:bigquery",
             "version": 0,
             "created": {
                 "time": 0,
@@ -65,119 +64,7 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "editableDatasetProperties",
-    "aspect": {
-        "json": {
-            "created": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "description": "test"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "key1": "value1",
-                "key2": "value2"
-            },
-            "externalUrl": "https://example.com",
-            "name": "MY_TABLE",
-            "qualifiedName": "MY_DB.MY_SCHEMA.MY_TABLE",
-            "created": {
-                "time": 1735787045000
-            },
-            "lastModified": {
-                "time": 1736391846000
-            },
-            "tags": []
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
-                },
-                {
-                    "id": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c",
-                    "urn": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c"
-                },
-                {
-                    "id": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056",
-                    "urn": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:admin@datahubproject.io",
-                    "type": "TECHNICAL_OWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            }
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "globalTags",
     "aspect": {
@@ -195,39 +82,7 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "glossaryTerms",
-    "aspect": {
-        "json": {
-            "terms": [
-                {
-                    "urn": "urn:li:glossaryTerm:AccountBalance"
-                }
-            ],
-            "auditStamp": {
-                "time": 0,
-                "actor": "urn:li:corpuser:__ingestion"
-            }
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "domains",
-    "aspect": {
-        "json": {
-            "domains": [
-                "urn:li:domain:Marketing"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "editableSchemaMetadata",
     "aspect": {
@@ -243,7 +98,6 @@
             "editableSchemaFieldInfo": [
                 {
                     "fieldPath": "field1",
-                    "description": "field1 description",
                     "globalTags": {
                         "tags": [
                             {
@@ -253,23 +107,6 @@
                                 "tag": "urn:li:tag:field1_tag3"
                             }
                         ]
-                    }
-                },
-                {
-                    "fieldPath": "field2",
-                    "glossaryTerms": {
-                        "terms": [
-                            {
-                                "urn": "urn:li:glossaryTerm:field2_term1"
-                            },
-                            {
-                                "urn": "urn:li:glossaryTerm:field2_term2"
-                            }
-                        ],
-                        "auditStamp": {
-                            "time": 0,
-                            "actor": "urn:li:corpuser:__ingestion"
-                        }
                     }
                 }
             ]

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_terms_add_remove_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_terms_add_remove_golden.json
@@ -1,0 +1,279 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:snowflake",
+            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "",
+            "platform": "urn:li:dataPlatform:snowflake",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.Schemaless": {}
+            },
+            "fields": [
+                {
+                    "fieldPath": "field1",
+                    "nullable": false,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "field2",
+                    "nullable": false,
+                    "description": "field2 description",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NullType": {}
+                        }
+                    },
+                    "nativeDataType": "int64",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "editableDatasetProperties",
+    "aspect": {
+        "json": {
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "description": "test"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "key1": "value1",
+                "key2": "value2"
+            },
+            "externalUrl": "https://example.com",
+            "name": "MY_TABLE",
+            "qualifiedName": "MY_DB.MY_SCHEMA.MY_TABLE",
+            "created": {
+                "time": 1735787045000
+            },
+            "lastModified": {
+                "time": 1736391846000
+            },
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)",
+                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
+                },
+                {
+                    "id": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c",
+                    "urn": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c"
+                },
+                {
+                    "id": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056",
+                    "urn": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "ownership",
+    "aspect": {
+        "json": {
+            "owners": [
+                {
+                    "owner": "urn:li:corpuser:admin@datahubproject.io",
+                    "type": "TECHNICAL_OWNER"
+                }
+            ],
+            "ownerTypes": {},
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            }
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "globalTags",
+    "aspect": {
+        "json": {
+            "tags": [
+                {
+                    "tag": "urn:li:tag:tag1"
+                },
+                {
+                    "tag": "urn:li:tag:tag2"
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "glossaryTerms",
+    "aspect": {
+        "json": {
+            "terms": [
+                {
+                    "urn": "urn:li:glossaryTerm:Sensitive"
+                }
+            ],
+            "auditStamp": {
+                "time": 0,
+                "actor": "urn:li:corpuser:__ingestion"
+            }
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+        "json": {
+            "domains": [
+                "urn:li:domain:Marketing"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "editableSchemaMetadata",
+    "aspect": {
+        "json": {
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "editableSchemaFieldInfo": [
+                {
+                    "fieldPath": "field1",
+                    "description": "field1 description",
+                    "globalTags": {
+                        "tags": [
+                            {
+                                "tag": "urn:li:tag:field1_tag1"
+                            },
+                            {
+                                "tag": "urn:li:tag:field1_tag2"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "fieldPath": "field2",
+                    "glossaryTerms": {
+                        "terms": [
+                            {
+                                "urn": "urn:li:glossaryTerm:field2_term1"
+                            },
+                            {
+                                "urn": "urn:li:glossaryTerm:field2_term2"
+                            }
+                        ],
+                        "auditStamp": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:__ingestion"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_terms_add_remove_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_terms_add_remove_golden.json
@@ -260,10 +260,10 @@
                     "glossaryTerms": {
                         "terms": [
                             {
-                                "urn": "urn:li:glossaryTerm:field2_term1"
+                                "urn": "urn:li:glossaryTerm:field2_term2"
                             },
                             {
-                                "urn": "urn:li:glossaryTerm:field2_term2"
+                                "urn": "urn:li:glossaryTerm:PII"
                             }
                         ],
                         "auditStamp": {

--- a/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_terms_add_remove_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/dataset_golden/test_terms_add_remove_golden.json
@@ -1,25 +1,24 @@
 [
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
         "json": {
-            "platform": "urn:li:dataPlatform:snowflake",
-            "instance": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
+            "platform": "urn:li:dataPlatform:bigquery"
         }
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
         "json": {
             "schemaName": "",
-            "platform": "urn:li:dataPlatform:snowflake",
+            "platform": "urn:li:dataPlatform:bigquery",
             "version": 0,
             "created": {
                 "time": 0,
@@ -65,137 +64,7 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "editableDatasetProperties",
-    "aspect": {
-        "json": {
-            "created": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            },
-            "description": "test"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "datasetProperties",
-    "aspect": {
-        "json": {
-            "customProperties": {
-                "key1": "value1",
-                "key2": "value2"
-            },
-            "externalUrl": "https://example.com",
-            "name": "MY_TABLE",
-            "qualifiedName": "MY_DB.MY_SCHEMA.MY_TABLE",
-            "created": {
-                "time": 1735787045000
-            },
-            "lastModified": {
-                "time": 1736391846000
-            },
-            "tags": []
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "container",
-    "aspect": {
-        "json": {
-            "container": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "browsePathsV2",
-    "aspect": {
-        "json": {
-            "path": [
-                {
-                    "id": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)",
-                    "urn": "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
-                },
-                {
-                    "id": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c",
-                    "urn": "urn:li:container:37d6500021cda2a0aa7ae1900eab5a9c"
-                },
-                {
-                    "id": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056",
-                    "urn": "urn:li:container:66c5ac35f0bfc521dee6f7d9533a8056"
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "subTypes",
-    "aspect": {
-        "json": {
-            "typeNames": [
-                "Table"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "ownership",
-    "aspect": {
-        "json": {
-            "owners": [
-                {
-                    "owner": "urn:li:corpuser:admin@datahubproject.io",
-                    "type": "TECHNICAL_OWNER"
-                }
-            ],
-            "ownerTypes": {},
-            "lastModified": {
-                "time": 0,
-                "actor": "urn:li:corpuser:unknown"
-            }
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "globalTags",
-    "aspect": {
-        "json": {
-            "tags": [
-                {
-                    "tag": "urn:li:tag:tag1"
-                },
-                {
-                    "tag": "urn:li:tag:tag2"
-                }
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "glossaryTerms",
     "aspect": {
@@ -214,20 +83,7 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
-    "changeType": "UPSERT",
-    "aspectName": "domains",
-    "aspect": {
-        "json": {
-            "domains": [
-                "urn:li:domain:Marketing"
-            ]
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,my_instance.my_db.my_schema.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,proj.dataset.table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "editableSchemaMetadata",
     "aspect": {
@@ -241,20 +97,6 @@
                 "actor": "urn:li:corpuser:unknown"
             },
             "editableSchemaFieldInfo": [
-                {
-                    "fieldPath": "field1",
-                    "description": "field1 description",
-                    "globalTags": {
-                        "tags": [
-                            {
-                                "tag": "urn:li:tag:field1_tag1"
-                            },
-                            {
-                                "tag": "urn:li:tag:field1_tag2"
-                            }
-                        ]
-                    }
-                },
                 {
                     "fieldPath": "field2",
                     "glossaryTerms": {

--- a/metadata-ingestion/tests/unit/sdk_v2/entity_client_goldens/test_container_update_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/entity_client_goldens/test_container_update_golden.json
@@ -1,0 +1,15 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:ff645a51ee3284db4355c6b1b7aec6de",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "name": "test_db",
+            "description": "updated description"
+        }
+    }
+}
+]

--- a/metadata-ingestion/tests/unit/sdk_v2/entity_client_goldens/test_dataset_update_golden.json
+++ b/metadata-ingestion/tests/unit/sdk_v2/entity_client_goldens/test_dataset_update_golden.json
@@ -3,17 +3,6 @@
     "entityType": "dataset",
     "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
     "changeType": "UPSERT",
-    "aspectName": "dataPlatformInstance",
-    "aspect": {
-        "json": {
-            "platform": "urn:li:dataPlatform:snowflake"
-        }
-    }
-},
-{
-    "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,test_db.test_schema.table_1,PROD)",
-    "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
         "json": {

--- a/metadata-ingestion/tests/unit/sdk_v2/test_container.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_container.py
@@ -42,6 +42,7 @@ def test_container_basic() -> None:
     assert c.platform is not None
     assert c.platform.platform_name == "bigquery"
     assert c.platform_instance is None
+    assert c.browse_path == []
     assert c.tags is None
     assert c.terms is None
     assert c.created is None
@@ -72,6 +73,9 @@ def test_container_complex() -> None:
         database="MY_DB",
         schema="MY_SCHEMA",
     )
+    db_key = schema_key.parent_key()
+    assert db_key is not None
+
     created = datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     updated = datetime(2025, 1, 9, 3, 4, 6, tzinfo=timezone.utc)
 
@@ -107,7 +111,12 @@ def test_container_complex() -> None:
         str(c.platform_instance)
         == "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
     )
-    assert c.subtype == "Schema"
+    assert c.browse_path == [
+        c.platform_instance,
+        db_key.as_urn_typed(),
+    ]
+
+    # Properties.
     assert c.description == "test"
     assert c.display_name == "MY_SCHEMA"
     assert c.qualified_name == "MY_DB.MY_SCHEMA"
@@ -124,6 +133,7 @@ def test_container_complex() -> None:
     }
 
     # Check standard aspects.
+    assert c.subtype == "Schema"
     assert c.domain == DomainUrn("Marketing")
     assert c.tags is not None
     assert len(c.tags) == 2

--- a/metadata-ingestion/tests/unit/sdk_v2/test_container.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_container.py
@@ -39,6 +39,8 @@ def test_container_basic() -> None:
     assert str(c.urn) in repr(c)
 
     # Check most attributes.
+    assert c.platform is not None
+    assert c.platform.platform_name == "bigquery"
     assert c.platform_instance is None
     assert c.tags is None
     assert c.terms is None
@@ -98,6 +100,8 @@ def test_container_complex() -> None:
         ],
         domain=DomainUrn("Marketing"),
     )
+    assert c.platform is not None
+    assert c.platform.platform_name == "snowflake"
     assert c.platform_instance is not None
     assert (
         str(c.platform_instance)

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -221,6 +221,10 @@ def test_tags_add_remove() -> None:
     assert_entity_golden(d, _GOLDEN_DIR / "test_tags_add_remove_golden.json")
 
 
+# TODO: We should have add/remove/set tests where there's tags/terms
+# in both base and editable entries for a schema field.
+
+
 def _term_names(
     terms: Optional[List[models.GlossaryTermAssociationClass]],
 ) -> List[str]:
@@ -240,5 +244,15 @@ def test_terms_add_remove() -> None:
     for _ in range(2):
         d.remove_term(GlossaryTermUrn("AccountBalance"))
         assert _term_names(d.terms) == ["Sensitive"]
+
+    # Test field term add/remove flows.
+    field = d["field2"]
+    assert _term_names(field.terms) == ["field2_term1", "field2_term2"]
+    for _ in range(2):
+        field.add_term(GlossaryTermUrn("PII"))
+        assert _term_names(field.terms) == ["field2_term1", "field2_term2", "PII"]
+    for _ in range(2):
+        field.remove_term(GlossaryTermUrn("field2_term1"))
+        assert _term_names(field.terms) == ["field2_term2", "PII"]
 
     assert_entity_golden(d, _GOLDEN_DIR / "test_terms_add_remove_golden.json")

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -82,8 +82,8 @@ def _build_complex_dataset() -> Dataset:
     updated = datetime(2025, 1, 9, 3, 4, 6, tzinfo=timezone.utc)
 
     d = Dataset(
-        platform="snowflake",
-        platform_instance="my_instance",
+        platform=schema.platform,
+        platform_instance=schema.instance,
         name="my_db.my_schema.my_table",
         parent_container=schema,
         subtype=DatasetSubTypes.TABLE,

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -44,6 +44,7 @@ def test_dataset_basic(pytestconfig: pytest.Config) -> None:
     assert d.platform is not None
     assert d.platform.platform_name == "bigquery"
     assert d.platform_instance is None
+    assert d.browse_path is None
     assert d.tags is None
     assert d.terms is None
     assert d.created is None
@@ -77,6 +78,8 @@ def _build_complex_dataset() -> Dataset:
         database="MY_DB",
         schema="MY_SCHEMA",
     )
+    db = schema.parent_key()
+    assert db is not None
 
     created = datetime(2025, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
     updated = datetime(2025, 1, 9, 3, 4, 6, tzinfo=timezone.utc)
@@ -113,6 +116,7 @@ def _build_complex_dataset() -> Dataset:
         ],
         domain=DomainUrn("Marketing"),
     )
+
     assert d.platform is not None
     assert d.platform.platform_name == "snowflake"
     assert d.platform_instance is not None
@@ -120,7 +124,14 @@ def _build_complex_dataset() -> Dataset:
         str(d.platform_instance)
         == "urn:li:dataPlatformInstance:(urn:li:dataPlatform:snowflake,my_instance)"
     )
-    assert d.subtype == "Table"
+    assert schema.parent_key() is not None
+    assert d.browse_path == [
+        d.platform_instance,
+        db.as_urn_typed(),
+        schema.as_urn_typed(),
+    ]
+
+    # Properties.
     assert d.description == "test"
     assert d.display_name == "MY_TABLE"
     assert d.qualified_name == "MY_DB.MY_SCHEMA.MY_TABLE"
@@ -130,6 +141,7 @@ def _build_complex_dataset() -> Dataset:
     assert d.custom_properties == {"key1": "value1", "key2": "value2"}
 
     # Check standard aspects.
+    assert d.subtype == "Table"
     assert d.domain == DomainUrn("Marketing")
     assert d.tags is not None
     assert len(d.tags) == 2

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -19,6 +19,7 @@ from datahub.metadata.urns import (
     Urn,
 )
 from datahub.sdk._attribution import KnownAttribution, change_default_attribution
+from datahub.sdk._shared import UrnOrStr
 from datahub.sdk.dataset import Dataset
 from tests.test_helpers.sdk_v2_helpers import assert_entity_golden
 
@@ -342,3 +343,29 @@ def test_owners_add_remove() -> None:
         assert _owner_names(d.owners) == [(group, technical)]
 
     assert_entity_golden(d, _GOLDEN_DIR / "test_owners_add_remove_golden.json")
+
+
+def test_browse_path() -> None:
+    schema = SchemaKey(
+        platform="snowflake",
+        database="MY_DB",
+        schema="MY_SCHEMA",
+    )
+    db = schema.parent_key()
+    assert db is not None
+
+    path: list[UrnOrStr] = [
+        "Folders",
+        db.as_urn_typed(),
+        "Subfolder",
+        schema.as_urn_typed(),
+    ]
+    d = Dataset(
+        platform="snowflake",
+        name="MY_DB.MY_SCHEMA.MY_TABLE",
+        parent_container=path,
+    )
+    assert d.parent_container == schema.as_urn_typed()
+    assert d.browse_path == path
+
+    assert_entity_golden(d, _GOLDEN_DIR / "test_browse_path_golden.json")

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -41,6 +41,8 @@ def test_dataset_basic(pytestconfig: pytest.Config) -> None:
     assert str(d.urn) in repr(d)
 
     # Check most attributes.
+    assert d.platform is not None
+    assert d.platform.platform_name == "bigquery"
     assert d.platform_instance is None
     assert d.tags is None
     assert d.terms is None
@@ -111,6 +113,8 @@ def _build_complex_dataset() -> Dataset:
         ],
         domain=DomainUrn("Marketing"),
     )
+    assert d.platform is not None
+    assert d.platform.platform_name == "snowflake"
     assert d.platform_instance is not None
     assert (
         str(d.platform_instance)

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -354,7 +354,7 @@ def test_browse_path() -> None:
     db = schema.parent_key()
     assert db is not None
 
-    path: list[UrnOrStr] = [
+    path: List[UrnOrStr] = [
         "Folders",
         db.as_urn_typed(),
         "Subfolder",

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -195,7 +195,16 @@ def _tag_names(tags: Optional[List[models.TagAssociationClass]]) -> List[str]:
 
 
 def test_tags_add_remove() -> None:
-    d = _build_complex_dataset()
+    d = Dataset(
+        platform="bigquery",
+        name="proj.dataset.table",
+        schema=[
+            ("field1", "string"),
+            ("field2", "int64", "field2 description"),
+        ],
+        tags=[TagUrn("tag1"), TagUrn("tag2")],
+    )
+    d["field1"].set_tags([TagUrn("field1_tag1"), TagUrn("field1_tag2")])
 
     # For each loop - the second iteration should be a no-op.
 
@@ -234,7 +243,18 @@ def _term_names(
 
 
 def test_terms_add_remove() -> None:
-    d = _build_complex_dataset()
+    d = Dataset(
+        platform="bigquery",
+        name="proj.dataset.table",
+        schema=[
+            ("field1", "string"),
+            ("field2", "int64", "field2 description"),
+        ],
+        terms=[GlossaryTermUrn("AccountBalance")],
+    )
+    d["field2"].set_terms(
+        [GlossaryTermUrn("field2_term1"), GlossaryTermUrn("field2_term2")]
+    )
 
     # Test term add/remove flows.
     assert _term_names(d.terms) == ["AccountBalance"]

--- a/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_dataset.py
@@ -83,7 +83,7 @@ def _build_complex_dataset() -> Dataset:
         platform="snowflake",
         platform_instance="my_instance",
         name="my_db.my_schema.my_table",
-        container=schema,
+        parent_container=schema,
         subtype=DatasetSubTypes.TABLE,
         schema=[
             ("field1", "string"),

--- a/metadata-ingestion/tests/unit/sdk_v2/test_entity_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_entity_client.py
@@ -73,7 +73,7 @@ def test_dataset_creation(
         platform="snowflake",
         name="test_db.test_schema.table_1",
         env="prod",
-        container=schema,
+        parent_container=schema,
         schema=[
             ("col1", "string"),
             ("col2", "int"),

--- a/metadata-ingestion/tests/unit/sdk_v2/test_entity_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_entity_client.py
@@ -116,6 +116,30 @@ def test_dataset_read_modify_write(
     )
 
 
+def test_container_read_modify_write(
+    pytestconfig: pytest.Config, client: DataHubClient, mock_graph: Mock
+) -> None:
+    database_key = DatabaseKey(platform="snowflake", database="test_db")
+    container_urn = database_key.as_urn_typed()
+
+    # Setup mocks for the container.
+    mock_graph.exists.return_value = True
+    mock_graph.get_entity_semityped.return_value = {
+        "containerProperties": models.ContainerPropertiesClass(
+            name="test_db",
+        )
+    }
+
+    # Get and update the container
+    container = client.entities.get(container_urn)
+    container.set_description("updated description")
+
+    client.entities.update(container)
+    assert_client_golden(
+        pytestconfig, client, _GOLDEN_DIR / "test_container_update_golden.json"
+    )
+
+
 def test_create_existing_dataset_fails(client: DataHubClient, mock_graph: Mock) -> None:
     mock_graph.exists.return_value = True
 

--- a/metadata-ingestion/tests/unit/sdk_v2/test_entity_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_entity_client.py
@@ -28,11 +28,7 @@ def client(mock_graph: Mock) -> DataHubClient:
     return DataHubClient(graph=mock_graph)
 
 
-def assert_client_golden(
-    pytestconfig: pytest.Config,
-    client: DataHubClient,
-    golden_path: pathlib.Path,
-) -> None:
+def assert_client_golden(client: DataHubClient, golden_path: pathlib.Path) -> None:
     mcps = client._graph.emit_mcps.call_args[0][0]  # type: ignore
     mce_helpers.check_goldens_stream(
         outputs=mcps,
@@ -41,9 +37,7 @@ def assert_client_golden(
     )
 
 
-def test_container_creation_flow(
-    pytestconfig: pytest.Config, client: DataHubClient, mock_graph: Mock
-) -> None:
+def test_container_creation_flow(client: DataHubClient, mock_graph: Mock) -> None:
     # Create database and schema containers
     db = DatabaseKey(platform="snowflake", database="test_db")
     schema = SchemaKey(**db.dict(), schema="test_schema")
@@ -53,20 +47,14 @@ def test_container_creation_flow(
 
     # Test database container creation
     client.entities.upsert(db_container)
-    assert_client_golden(
-        pytestconfig, client, _GOLDEN_DIR / "test_container_db_golden.json"
-    )
+    assert_client_golden(client, _GOLDEN_DIR / "test_container_db_golden.json")
 
     # Test schema container creation
     client.entities.upsert(schema_container)
-    assert_client_golden(
-        pytestconfig, client, _GOLDEN_DIR / "test_container_schema_golden.json"
-    )
+    assert_client_golden(client, _GOLDEN_DIR / "test_container_schema_golden.json")
 
 
-def test_dataset_creation(
-    pytestconfig: pytest.Config, client: DataHubClient, mock_graph: Mock
-) -> None:
+def test_dataset_creation(client: DataHubClient, mock_graph: Mock) -> None:
     schema = SchemaKey(platform="snowflake", database="test_db", schema="test_schema")
 
     dataset = Dataset(
@@ -83,14 +71,10 @@ def test_dataset_creation(
     )
 
     client.entities.create(dataset)
-    assert_client_golden(
-        pytestconfig, client, _GOLDEN_DIR / "test_dataset_creation_golden.json"
-    )
+    assert_client_golden(client, _GOLDEN_DIR / "test_dataset_creation_golden.json")
 
 
-def test_dataset_read_modify_write(
-    pytestconfig: pytest.Config, client: DataHubClient, mock_graph: Mock
-) -> None:
+def test_dataset_read_modify_write(client: DataHubClient, mock_graph: Mock) -> None:
     # Setup mock for existing dataset
     mock_graph.exists.return_value = True
     dataset_urn = DatasetUrn(
@@ -111,14 +95,10 @@ def test_dataset_read_modify_write(
     dataset.set_description("updated description")
 
     client.entities.update(dataset)
-    assert_client_golden(
-        pytestconfig, client, _GOLDEN_DIR / "test_dataset_update_golden.json"
-    )
+    assert_client_golden(client, _GOLDEN_DIR / "test_dataset_update_golden.json")
 
 
-def test_container_read_modify_write(
-    pytestconfig: pytest.Config, client: DataHubClient, mock_graph: Mock
-) -> None:
+def test_container_read_modify_write(client: DataHubClient, mock_graph: Mock) -> None:
     database_key = DatabaseKey(platform="snowflake", database="test_db")
     container_urn = database_key.as_urn_typed()
 
@@ -135,9 +115,7 @@ def test_container_read_modify_write(
     container.set_description("updated description")
 
     client.entities.update(container)
-    assert_client_golden(
-        pytestconfig, client, _GOLDEN_DIR / "test_container_update_golden.json"
-    )
+    assert_client_golden(client, _GOLDEN_DIR / "test_container_update_golden.json")
 
 
 def test_create_existing_dataset_fails(client: DataHubClient, mock_graph: Mock) -> None:


### PR DESCRIPTION
- Add special sentinel values for unset and auto, in a way that works with type checking
- Refactor container / browse path init code
- Rename `container` -> `parent_container` in constructors
- Add getter for platform
- Add getter for parent container and browse path
- Add add/remove tag/term methods on both entities and schema fields
- Add add/remove owners methods for all entity types


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
