### PR TITLE
feat(ingest/s3): add table filtering

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/s3/source.py
@@ -966,6 +966,16 @@ class S3Source(StatefulIngestionSourceBase):
                     for f in list_folders(
                         bucket_name, f"{folder}", self.source_config.aws_config
                     ):
+                        table_name = f.split("/")[-1]
+                        if path_spec.is_allowed_table(table_name):
+                            logger.debug(
+                                f"Table '{table_name}' not allowed and skipping"
+                            )
+                            self.report.report_file_dropped(
+                                self.create_s3_path(bucket_name, f)
+                            )
+                            continue
+
                         dirs_to_process = []
                         logger.info(f"Processing folder: {f}")
                         if path_spec.traversal_method == FolderTraversalMethod.ALL:

--- a/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
+++ b/metadata-ingestion/tests/unit/data_lake/test_path_spec.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import pytest
 
 from datahub.ingestion.source.data_lake_common.path_spec import PathSpec
@@ -29,3 +31,111 @@ def test_allowed_ignores_depth_mismatch(
 
     # act, assert
     assert path_spec.allowed(s3_uri) == expected
+
+
+@pytest.mark.parametrize(
+    "s3_uri, allowed_tables, expected",
+    [
+        ("s3://bucket/table-1/p1/test.csv", None, True),
+        ("s3://bucket/table-1/p1/test.csv", [], True),
+        ("s3://bucket/table-1/p1/test.csv", ["table-1"], True),
+        ("s3://bucket/table-2/p1/test.csv", ["table-1"], False),
+    ],
+)
+def test_allowed_allowed_tables(
+    s3_uri: str, allowed_tables: List[str], expected: bool
+) -> None:
+    # arrange
+    path_spec = PathSpec(
+        include="s3://bucket/{table}/{partition0}/*.csv",
+        allowed_tables=allowed_tables,
+    )
+
+    # act, assert
+    assert path_spec.allowed(s3_uri) == expected
+
+
+@pytest.mark.parametrize(
+    "s3_uri, allowed_tables, expected",
+    [
+        ("s3://bucket/table-1/p1/", None, True),
+        ("s3://bucket/table-1/p1/", [], True),
+        ("s3://bucket/table-1/p1/", ["table-1"], True),
+        ("s3://bucket/table-2/p1/", ["table-1"], False),
+    ],
+)
+def test_dir_allowed_allowed_tables(
+    s3_uri: str, allowed_tables: List[str], expected: bool
+) -> None:
+    # arrange
+    path_spec = PathSpec(
+        include="s3://bucket/{table}/{partition0}/*.csv",
+        allowed_tables=allowed_tables,
+    )
+
+    # act, assert
+    assert path_spec.dir_allowed(s3_uri) == expected
+
+
+@pytest.mark.parametrize(
+    "include, s3_uri, expected",
+    [
+        (
+            "s3://bucket/{table}/{partition0}/*.csv",
+            "s3://bucket/table/p1/test.csv",
+            "table",
+        ),
+        (
+            "s3://bucket/data1/{partition0}/test.csv",
+            "s3://bucket/data1/p1/test.csv",
+            None,
+        ),
+    ],
+)
+def test_get_table_name(include: str, s3_uri: str, expected: Optional[str]) -> None:
+    # arrange
+    path_spec = PathSpec(
+        include=include,
+    )
+
+    # act, assert
+    assert path_spec._get_table_name(s3_uri) == expected
+
+
+@pytest.mark.parametrize(
+    "s3_uri",
+    [
+        "s3://bucket/dir/",
+        "s3://bucket/dir",
+    ],
+)
+def test_get_table_name_raises_error_table_not_found(s3_uri: str) -> None:
+    # arrange
+    path_spec = PathSpec(include="s3://bucket/dir1/{table}/{partition0}/*.csv")
+
+    # act, assert
+    with pytest.raises(ValueError) as e:
+        path_spec._get_table_name(s3_uri)
+    assert str(e.value) == f"Table not found in path: {s3_uri}"
+
+
+@pytest.mark.parametrize(
+    "table_name, allowed_tables, expected",
+    [
+        ("table", ["table"], True),
+        ("table", ["table-123"], False),
+        ("table", [], True),
+        ("table", None, True),
+    ],
+)
+def test_is_allowed_tables(
+    table_name: str, allowed_tables: str, expected: bool
+) -> None:
+    # arrange
+    path_spec = PathSpec(
+        include="s3://bucket/{table}/{partition0}/*.csv",
+        allowed_tables=allowed_tables,
+    )
+
+    # act, assert
+    assert path_spec.is_allowed_table(table_name) == expected


### PR DESCRIPTION
Add table name filtering to the s3 ingestion.

Datahub trying ingest all folders in `path_spec.include` and this noisily triggers the warning messages that says `skips this path`.

Also, it is not able to ingest some specific tables from a path which contains many folders. While we have the ignore_patterns property, it is not a proper way to ingest specific tables because the ignore_patterns getting wordy.

For the purpose of ingest specific tables, I add table name filtering feature.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
