### PR TITLE
chore(): Bring latest incidents data model + GraphQL to OSS

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -204,6 +204,7 @@ import com.linkedin.datahub.graphql.resolvers.group.RemoveGroupResolver;
 import com.linkedin.datahub.graphql.resolvers.health.EntityHealthResolver;
 import com.linkedin.datahub.graphql.resolvers.incident.EntityIncidentsResolver;
 import com.linkedin.datahub.graphql.resolvers.incident.RaiseIncidentResolver;
+import com.linkedin.datahub.graphql.resolvers.incident.UpdateIncidentResolver;
 import com.linkedin.datahub.graphql.resolvers.incident.UpdateIncidentStatusResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.CancelIngestionExecutionRequestResolver;
 import com.linkedin.datahub.graphql.resolvers.ingest.execution.CreateIngestionExecutionRequestResolver;
@@ -1397,6 +1398,9 @@ public class GmsGraphQLEngine {
               .dataFetcher(
                   "updateIncidentStatus",
                   new UpdateIncidentStatusResolver(this.entityClient, this.entityService))
+              .dataFetcher(
+                  "updateIncident",
+                  new UpdateIncidentResolver(this.entityClient, this.entityService))
               .dataFetcher(
                   "createForm", new CreateFormResolver(this.entityClient, this.formService))
               .dataFetcher("deleteForm", new DeleteFormResolver(this.entityClient))

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/EntityIncidentsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/EntityIncidentsResolver.java
@@ -6,6 +6,7 @@ import com.linkedin.datahub.graphql.concurrency.GraphQLConcurrencyUtils;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.EntityIncidentsResult;
 import com.linkedin.datahub.graphql.generated.Incident;
+import com.linkedin.datahub.graphql.generated.IncidentPriority;
 import com.linkedin.datahub.graphql.types.incident.IncidentMapper;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.entity.client.EntityClient;
@@ -38,6 +39,9 @@ public class EntityIncidentsResolver
   static final String INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME = "entities.keyword";
   static final String INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME = "state";
   static final String CREATED_TIME_SEARCH_INDEX_FIELD_NAME = "created";
+  static final String INCIDENT_STAGE_SEARCH_INDEX_FIELD_NAME = "stage";
+  static final String INCIDENT_PRIORITY_SEARCH_INDEX_FIELD_NAME = "priority";
+  static final String INCIDENT_ASSIGNEES_SEARCH_INDEX_FIELD_NAME = "assignees";
 
   private final EntityClient _entityClient;
 
@@ -55,12 +59,18 @@ public class EntityIncidentsResolver
           final Integer start = environment.getArgumentOrDefault("start", 0);
           final Integer count = environment.getArgumentOrDefault("count", 20);
           final Optional<String> maybeState = Optional.ofNullable(environment.getArgument("state"));
-
+          final Optional<String> maybeStage = Optional.ofNullable(environment.getArgument("stage"));
+          final Optional<String> maybePriority =
+              Optional.ofNullable(environment.getArgument("priority"));
+          final Optional<List<String>> maybeAssigneeUrns =
+              Optional.ofNullable(environment.getArgument("assigneeUrns"));
           try {
             // Step 1: Fetch set of incidents associated with the target entity from the Search
             // Index!
             // We use the search index so that we can easily sort by the last updated time.
-            final Filter filter = buildIncidentsEntityFilter(entityUrn, maybeState);
+            final Filter filter =
+                buildIncidentsFilter(
+                    entityUrn, maybeState, maybeStage, maybePriority, maybeAssigneeUrns);
             final List<SortCriterion> sortCriteria = buildIncidentsSortCriteria();
             final SearchResult searchResult =
                 _entityClient.filter(
@@ -110,13 +120,33 @@ public class EntityIncidentsResolver
         "get");
   }
 
-  private Filter buildIncidentsEntityFilter(
-      final String entityUrn, final Optional<String> maybeState) {
-    final Map<String, String> criterionMap = new HashMap<>();
-    criterionMap.put(INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME, entityUrn);
+  private Filter buildIncidentsFilter(
+      final String entityUrn,
+      final Optional<String> maybeState,
+      final Optional<String> maybeStage,
+      final Optional<String> maybePriority,
+      final Optional<List<String>> maybeAssigneeUrns) {
+    final Map<String, List<String>> criterionMap = new HashMap<>();
+    criterionMap.put(
+        INCIDENT_ENTITIES_SEARCH_INDEX_FIELD_NAME, Collections.singletonList(entityUrn));
     maybeState.ifPresent(
-        incidentState -> criterionMap.put(INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME, incidentState));
-    return QueryUtils.newFilter(criterionMap);
+        incidentState ->
+            criterionMap.put(
+                INCIDENT_STATE_SEARCH_INDEX_FIELD_NAME, Collections.singletonList(incidentState)));
+    maybeStage.ifPresent(
+        incidentStage ->
+            criterionMap.put(
+                INCIDENT_STAGE_SEARCH_INDEX_FIELD_NAME, Collections.singletonList(incidentStage)));
+    maybePriority.ifPresent(
+        incidentPriority ->
+            criterionMap.put(
+                INCIDENT_PRIORITY_SEARCH_INDEX_FIELD_NAME,
+                Collections.singletonList(
+                    IncidentUtils.mapIncidentPriority(IncidentPriority.valueOf(incidentPriority))
+                        .toString())));
+    maybeAssigneeUrns.ifPresent(
+        assigneeUrns -> criterionMap.put(INCIDENT_ASSIGNEES_SEARCH_INDEX_FIELD_NAME, assigneeUrns));
+    return QueryUtils.newListsFilter(criterionMap);
   }
 
   private List<SortCriterion> buildIncidentsSortCriteria() {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtils.java
@@ -3,12 +3,40 @@ package com.linkedin.datahub.graphql.resolvers.incident;
 import com.datahub.authorization.ConjunctivePrivilegeGroup;
 import com.datahub.authorization.DisjunctivePrivilegeGroup;
 import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.generated.IncidentPriority;
+import com.linkedin.incident.IncidentAssignee;
+import com.linkedin.incident.IncidentAssigneeArray;
+import com.linkedin.incident.IncidentStage;
+import com.linkedin.incident.IncidentState;
+import com.linkedin.incident.IncidentStatus;
 import com.linkedin.metadata.authorization.PoliciesConfig;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class IncidentUtils {
+
+  public static List<Urn> stringsToUrns(List<String> urns) {
+    return urns.stream()
+        .map(
+            rawUrn -> {
+              try {
+                return Urn.createFromString(rawUrn);
+              } catch (Exception e) {
+                return null;
+              }
+            })
+        .filter(Objects::nonNull)
+        .distinct()
+        .toList();
+  }
 
   public static boolean isAuthorizedToEditIncidentForResource(
       final Urn resourceUrn, final QueryContext context) {
@@ -22,4 +50,61 @@ public class IncidentUtils {
     return AuthorizationUtils.isAuthorized(
         context, resourceUrn.getEntityType(), resourceUrn.toString(), orPrivilegeGroups);
   }
+
+  @Nullable
+  public static Integer mapIncidentPriority(@Nullable final IncidentPriority priority) {
+    if (priority == null) {
+      return null;
+    }
+    switch (priority) {
+      case LOW:
+        return 3;
+      case MEDIUM:
+        return 2;
+      case HIGH:
+        return 1;
+      case CRITICAL:
+        return 0;
+      default:
+        throw new IllegalArgumentException("Invalid incident priority: " + priority);
+    }
+  }
+
+  @Nullable
+  public static IncidentAssigneeArray mapIncidentAssignees(
+      @Nullable final List<String> assignees, @Nonnull final AuditStamp auditStamp) {
+    if (assignees == null) {
+      return null;
+    }
+    return new IncidentAssigneeArray(
+        assignees.stream()
+            .map(assignee -> createAssignee(assignee, auditStamp))
+            .collect(Collectors.toList()));
+  }
+
+  @Nonnull
+  public static IncidentStatus mapIncidentStatus(
+      @Nullable final com.linkedin.datahub.graphql.generated.IncidentStatusInput input,
+      @Nonnull final AuditStamp auditStamp) {
+    if (input == null) {
+      return new IncidentStatus().setState(IncidentState.ACTIVE).setLastUpdated(auditStamp);
+    }
+
+    IncidentStatus status = new IncidentStatus();
+    status.setState(IncidentState.valueOf(input.getState().toString()));
+    if (input.getStage() != null) {
+      status.setStage(IncidentStage.valueOf(input.getStage().toString()));
+    }
+    if (input.getMessage() != null) {
+      status.setMessage(input.getMessage());
+    }
+    return status;
+  }
+
+  private static IncidentAssignee createAssignee(
+      @Nonnull final String assigneeUrn, @Nonnull final AuditStamp auditStamp) {
+    return new IncidentAssignee().setActor(UrnUtils.getUrn(assigneeUrn)).setAssignedAt(auditStamp);
+  }
+
+  private IncidentUtils() {}
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentResolver.java
@@ -1,0 +1,143 @@
+package com.linkedin.datahub.graphql.resolvers.incident;
+
+import static com.linkedin.datahub.graphql.authorization.AuthorizationUtils.ALL_PRIVILEGES_GROUP;
+import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.*;
+import static com.linkedin.datahub.graphql.resolvers.mutate.MutationUtils.*;
+import static com.linkedin.metadata.Constants.*;
+
+import com.datahub.authorization.ConjunctivePrivilegeGroup;
+import com.datahub.authorization.DisjunctivePrivilegeGroup;
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.authorization.AuthorizationUtils;
+import com.linkedin.datahub.graphql.exception.AuthorizationException;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLErrorCode;
+import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
+import com.linkedin.datahub.graphql.generated.UpdateIncidentInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.metadata.authorization.PoliciesConfig;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.EntityUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+
+/** GraphQL Resolver that updates an incident's status */
+@RequiredArgsConstructor
+public class UpdateIncidentResolver implements DataFetcher<CompletableFuture<Boolean>> {
+
+  private final EntityClient _entityClient;
+  private final EntityService _entityService;
+
+  @Override
+  public CompletableFuture<Boolean> get(final DataFetchingEnvironment environment)
+      throws Exception {
+    final QueryContext context = environment.getContext();
+    final Urn incidentUrn = Urn.createFromString(environment.getArgument("urn"));
+    final UpdateIncidentInput input =
+        bindArgument(environment.getArgument("input"), UpdateIncidentInput.class);
+    return CompletableFuture.supplyAsync(
+        () -> {
+
+          // Check whether the incident exists.
+          final IncidentInfo info =
+              (IncidentInfo)
+                  EntityUtils.getAspectFromEntity(
+                      context.getOperationContext(),
+                      incidentUrn.toString(),
+                      INCIDENT_INFO_ASPECT_NAME,
+                      _entityService,
+                      null);
+
+          if (info != null) {
+            // Check whether the actor has permission to edit the incident.
+            verifyAuthorizationOrThrow(context, info, input);
+
+            final AuditStamp actorStamp =
+                new AuditStamp()
+                    .setActor(UrnUtils.getUrn(context.getActorUrn()))
+                    .setTime(System.currentTimeMillis());
+            updateIncidentInfo(info, input, actorStamp);
+            try {
+              // Finally, create the MetadataChangeProposal.
+              final MetadataChangeProposal proposal =
+                  buildMetadataChangeProposalWithUrn(incidentUrn, INCIDENT_INFO_ASPECT_NAME, info);
+              _entityClient.ingestProposal(context.getOperationContext(), proposal, false);
+              return true;
+            } catch (Exception e) {
+              throw new RuntimeException("Failed to update incident status!", e);
+            }
+          }
+          throw new DataHubGraphQLException(
+              "Failed to update incident. Incident does not exist.",
+              DataHubGraphQLErrorCode.NOT_FOUND);
+        });
+  }
+
+  private void verifyAuthorizationOrThrow(
+      QueryContext context, IncidentInfo info, UpdateIncidentInput input)
+      throws AuthorizationException, IllegalArgumentException {
+    final List<Urn> existingResourceUrns = info.getEntities();
+    for (Urn resourceUrn : existingResourceUrns) {
+      if (!isAuthorizedToUpdateIncident(resourceUrn, context)) {
+        throw new AuthorizationException(
+            "Unauthorized to perform this action. Please contact your DataHub administrator.");
+      }
+    }
+    if (input.getResourceUrns() != null) {
+      if (input.getResourceUrns().isEmpty()) {
+        throw new IllegalArgumentException("resourceUrns cannot be empty if provided");
+      }
+      final List<Urn> newResourceUrns = IncidentUtils.stringsToUrns(input.getResourceUrns());
+      for (Urn resourceUrn : newResourceUrns) {
+        if (!existingResourceUrns.contains(resourceUrn)) {
+          if (!isAuthorizedToUpdateIncident(resourceUrn, context)) {
+            throw new AuthorizationException(
+                "Unauthorized to perform this action. Please contact your DataHub administrator.");
+          }
+        }
+      }
+    }
+  }
+
+  private void updateIncidentInfo(
+      final IncidentInfo info, final UpdateIncidentInput input, final AuditStamp actorStamp) {
+    if (input.getTitle() != null) {
+      info.setTitle(input.getTitle());
+    }
+    if (input.getDescription() != null) {
+      info.setDescription(input.getDescription());
+    }
+    if (input.getPriority() != null) {
+      info.setPriority(IncidentUtils.mapIncidentPriority(input.getPriority()));
+    }
+    if (input.getAssigneeUrns() != null) {
+      info.setAssignees(IncidentUtils.mapIncidentAssignees(input.getAssigneeUrns(), actorStamp));
+    }
+    if (input.getStatus() != null) {
+      info.setStatus(IncidentUtils.mapIncidentStatus(input.getStatus(), actorStamp));
+    }
+    if (input.getResourceUrns() != null && !input.getResourceUrns().isEmpty()) {
+      info.setEntities(new UrnArray(IncidentUtils.stringsToUrns(input.getResourceUrns())));
+    }
+  }
+
+  private boolean isAuthorizedToUpdateIncident(final Urn resourceUrn, final QueryContext context) {
+    final DisjunctivePrivilegeGroup orPrivilegeGroups =
+        new DisjunctivePrivilegeGroup(
+            ImmutableList.of(
+                ALL_PRIVILEGES_GROUP,
+                new ConjunctivePrivilegeGroup(
+                    ImmutableList.of(PoliciesConfig.EDIT_ENTITY_INCIDENTS_PRIVILEGE.getType()))));
+    return AuthorizationUtils.isAuthorized(
+        context, resourceUrn.getEntityType(), resourceUrn.toString(), orPrivilegeGroups);
+  }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentStatusResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentStatusResolver.java
@@ -20,6 +20,7 @@ import com.linkedin.datahub.graphql.exception.DataHubGraphQLException;
 import com.linkedin.datahub.graphql.generated.UpdateIncidentStatusInput;
 import com.linkedin.entity.client.EntityClient;
 import com.linkedin.incident.IncidentInfo;
+import com.linkedin.incident.IncidentStage;
 import com.linkedin.incident.IncidentState;
 import com.linkedin.incident.IncidentStatus;
 import com.linkedin.metadata.authorization.PoliciesConfig;
@@ -72,6 +73,9 @@ public class UpdateIncidentStatusResolver implements DataFetcher<CompletableFutu
                               .setTime(System.currentTimeMillis())));
               if (input.getMessage() != null) {
                 info.getStatus().setMessage(input.getMessage());
+              }
+              if (input.getStage() != null) {
+                info.getStatus().setStage(IncidentStage.valueOf(input.getStage().name()));
               }
               try {
                 // Finally, create the MetadataChangeProposal.

--- a/datahub-graphql-core/src/main/resources/incident.graphql
+++ b/datahub-graphql-core/src/main/resources/incident.graphql
@@ -9,7 +9,7 @@ extend type Mutation {
     input: RaiseIncidentInput!): String
 
   """
-  Update an existing incident for a resource (asset)
+  Update the status of an existing incident for a resource (asset)
   """
   updateIncidentStatus(
     """
@@ -20,7 +20,21 @@ extend type Mutation {
     """
     Input required to update the state of an existing incident
     """
-    input: UpdateIncidentStatusInput!): Boolean
+    input: IncidentStatusInput!): Boolean
+
+  """
+  Update an existing data incident. Any fields that are omitted will simply not be updated.
+  """
+  updateIncident(
+    """
+    The urn for an existing incident
+    """
+    urn: String!
+
+    """
+    Input required to update an existing incident
+    """
+    input: UpdateIncidentInput!): Boolean
 }
 
 """
@@ -88,9 +102,14 @@ type Incident implements Entity {
   status: IncidentStatus!
 
   """
-  Optional priority of the incident. Lower value indicates higher priority.
+  Optional priority of the incident.
   """
-  priority: Int
+  priority: IncidentPriority
+
+  """
+  The users or groups are assigned to resolve the incident
+  """
+  assignees: [OwnerType!]
 
   """
   The entity that the incident is associated with.
@@ -101,6 +120,11 @@ type Incident implements Entity {
   The source of the incident, i.e. how it was generated
   """
   source: IncidentSource
+
+  """
+  An optional time at which the incident actually started (may be before the date it was raised).
+  """
+  startedAt: Long
 
   """
   The time at which the incident was initially created
@@ -130,6 +154,62 @@ enum IncidentState {
   The incident is resolved.
   """
   RESOLVED
+}
+
+"""
+The lifecycle stage of the incident.
+"""
+enum IncidentStage {
+  """
+  The impact and priority of the incident is being actively assessed.
+  """
+  TRIAGE
+
+  """
+  The incident root cause is being investigated.
+  """
+  INVESTIGATION
+
+  """
+  The incident is in the remediation stage.
+  """
+  WORK_IN_PROGRESS
+
+  """
+  The incident is in the resolved as completed stage.
+  """
+  FIXED
+
+  """
+  The incident is in the resolved with no action required state, e.g., the
+  incident was a false positive, or was expected.
+  """
+  NO_ACTION_REQUIRED
+}
+
+"""
+The priority of the incident
+"""
+enum IncidentPriority {
+  """
+  A low priority incident (P3)
+  """
+  LOW
+
+  """
+  A medium priority incident (P2)
+  """
+  MEDIUM
+
+  """
+  A high priority incident (P1)
+  """
+  HIGH
+
+  """
+  A critical priority incident (P0)
+  """
+  CRITICAL
 }
 
 """
@@ -186,6 +266,10 @@ type IncidentStatus {
   The state of the incident
   """
   state: IncidentState!
+  """
+  The lifecycle stage of the incident. Null means that no stage has been assigned.
+  """
+  stage: IncidentStage
   """
   An optional message associated with the status
   """
@@ -248,16 +332,75 @@ input RaiseIncidentInput {
   description: String
   """
   The resource (dataset, dashboard, chart, dataFlow, etc) that the incident is associated with.
+  This must be present if resourceUrns are not defined.
   """
-  resourceUrn: String!
+  resourceUrn: String
+  """
+  The resources (dataset, dashboard, chart, dataFlow, etc) that the incident is associated with.
+  This must be present and not empty if resourceUrn is not defined.
+  """
+  resourceUrns: [String!]
+  """
+  The time at which the incident actually started (may be before the date it was raised).
+  """
+  startedAt: Long
   """
   The source of the incident, i.e. how it was generated
   """
   source: IncidentSourceInput
   """
-  An optional priority for the incident. Lower value indicates a higher priority.
+  The status of the incident
   """
-  priority: Int
+  status: IncidentStatusInput
+  """
+  An optional priority for the incident.
+  """
+  priority: IncidentPriority
+  """
+  An optional set of user or group assignee urns
+  """
+  assigneeUrns: [String!]
+}
+
+"""
+Input required to update an existing incident.
+"""
+input UpdateIncidentInput {
+  """
+  An optional title associated with the incident
+  """
+  title: String
+
+  """
+  An optional description associated with the incident
+  """
+  description: String
+
+  """
+  An optional time at which the incident actually started (may be before the date it was raised).
+  """
+  startedAt: Long
+
+  """
+  The status of the incident
+  """
+  status: IncidentStatusInput
+
+  """
+  An optional priority for the incident.
+  """
+  priority: IncidentPriority
+
+  """
+  An optional set of resources that the incident is assigned to.
+  If defined, there must be at least one in the list.
+  """
+  resourceUrns: [String!]
+
+  """
+  An optional set of user or group assignee urns
+  """
+  assigneeUrns: [String!]
 }
 
 """
@@ -271,6 +414,26 @@ input IncidentSourceInput {
 }
 
 """
+Input required to create an incident status
+"""
+input IncidentStatusInput {
+  """
+  The state of the incident
+  """
+  state: IncidentState!
+
+  """
+  The lifecycle stage ofthe incident
+  """
+  stage: IncidentStage
+
+  """
+  An optional message associated with the status
+  """
+  message: String
+}
+
+"""
 Input required to update status of an existing incident
 """
 input UpdateIncidentStatusInput {
@@ -278,6 +441,10 @@ input UpdateIncidentStatusInput {
   The new state of the incident
   """
   state: IncidentState!
+  """
+  Optional - The new lifecycle stage of the incident
+  """
+  stage: IncidentStage
   """
   An optional message associated with the new state
   """
@@ -293,6 +460,18 @@ extend type Dataset {
     Optional incident state to filter by, defaults to any state.
     """
     state: IncidentState,
+    """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage,
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority,
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!],
     """
     Optional start offset, defaults to 0.
     """
@@ -313,6 +492,18 @@ extend type DataJob {
     """
     state: IncidentState,
     """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage,
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority,
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!],
+    """
     Optional start offset, defaults to 0.
     """
     start: Int,
@@ -331,6 +522,18 @@ extend type DataFlow {
     Optional incident state to filter by, defaults to any state.
     """
     state: IncidentState,
+    """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage,
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority,
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!],
     """
     Optional start offset, defaults to 0.
     """
@@ -351,6 +554,18 @@ extend type Dashboard {
     """
     state: IncidentState,
     """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage,
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority,
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!],
+    """
     Optional start offset, defaults to 0.
     """
     start: Int,
@@ -369,6 +584,18 @@ extend type Chart {
     Optional incident state to filter by, defaults to any state.
     """
     state: IncidentState,
+    """
+    Optional incident stage to filter by, defaults to any state.
+    """
+    stage: IncidentStage,
+    """
+    Optional incident priority to filter by, defaults to any state.
+    """
+    priority: IncidentPriority,
+    """
+    Optional assignee urns for an incident.
+    """
+    assigneeUrns: [String!],
     """
     Optional start offset, defaults to 0.
     """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentInfoMatcher.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentInfoMatcher.java
@@ -1,0 +1,112 @@
+package com.linkedin.datahub.graphql.resolvers.incident;
+
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.mxe.GenericAspect;
+import com.linkedin.mxe.MetadataChangeProposal;
+import org.mockito.ArgumentMatcher;
+
+public class IncidentInfoMatcher implements ArgumentMatcher<MetadataChangeProposal> {
+
+  private MetadataChangeProposal left;
+
+  public IncidentInfoMatcher(MetadataChangeProposal left) {
+    this.left = left;
+  }
+
+  @Override
+  public boolean matches(MetadataChangeProposal right) {
+    return left.getEntityType().equals(right.getEntityType())
+        && left.getAspectName().equals(right.getAspectName())
+        && left.getChangeType().equals(right.getChangeType())
+        && incidentInfoMatches(left.getAspect(), right.getAspect());
+  }
+
+  private boolean incidentInfoMatches(GenericAspect left, GenericAspect right) {
+    IncidentInfo leftProps =
+        GenericRecordUtils.deserializeAspect(
+            left.getValue(), "application/json", IncidentInfo.class);
+
+    IncidentInfo rightProps =
+        GenericRecordUtils.deserializeAspect(
+            right.getValue(), "application/json", IncidentInfo.class);
+
+    // Verify optional fields.
+    if (leftProps.hasDescription()) {
+      if (!leftProps.getDescription().equals(rightProps.getDescription())) {
+        return false;
+      }
+    }
+
+    if (leftProps.hasTitle()) {
+      if (!leftProps.getTitle().equals(rightProps.getTitle())) {
+        return false;
+      }
+    }
+
+    if (leftProps.hasType()) {
+      if (!leftProps.getType().equals(rightProps.getType())) {
+        return false;
+      }
+    }
+
+    if (leftProps.hasAssignees() && leftProps.getAssignees().size() > 0) {
+      if (!((Integer) leftProps.getAssignees().size()).equals(rightProps.getAssignees().size())) {
+        return false;
+      }
+      // Just verify the first mapping
+      if (!leftProps
+          .getAssignees()
+          .get(0)
+          .getActor()
+          .equals(rightProps.getAssignees().get(0).getActor())) {
+        return false;
+      }
+    }
+
+    if (leftProps.hasPriority()) {
+      if (!leftProps.getPriority().equals(rightProps.getPriority())) {
+        return false;
+      }
+    }
+
+    if (leftProps.hasEntities()) {
+      if (!leftProps.getEntities().equals(rightProps.getEntities())) {
+        return false;
+      }
+    }
+
+    if (leftProps.getStatus().hasStage()) {
+      if (!leftProps.getStatus().getStage().equals(rightProps.getStatus().getStage())) {
+        return false;
+      }
+    }
+
+    if (leftProps.getStatus().hasState()) {
+      if (!leftProps.getStatus().getState().equals(rightProps.getStatus().getState())) {
+        return false;
+      }
+    }
+
+    if (leftProps.getStatus().hasMessage()) {
+      if (!leftProps.getStatus().getMessage().equals(rightProps.getStatus().getMessage())) {
+        return false;
+      }
+    }
+
+    if (leftProps.getSource().hasType()) {
+      if (!leftProps.getSource().getType().equals(rightProps.getSource().getType())) {
+        return false;
+      }
+    }
+
+    if (leftProps.getSource().hasSourceUrn()) {
+      if (!leftProps.getSource().getSourceUrn().equals(rightProps.getSource().getSourceUrn())) {
+        return false;
+      }
+    }
+
+    // All fields match!
+    return true;
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtilsTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/IncidentUtilsTest.java
@@ -1,0 +1,106 @@
+package com.linkedin.datahub.graphql.resolvers.incident;
+
+import static org.testng.Assert.*;
+
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.generated.IncidentPriority;
+import com.linkedin.datahub.graphql.generated.IncidentStatusInput;
+import com.linkedin.incident.IncidentAssigneeArray;
+import com.linkedin.incident.IncidentStage;
+import com.linkedin.incident.IncidentState;
+import com.linkedin.incident.IncidentStatus;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class IncidentUtilsTest {
+
+  private static final Urn TEST_USER_URN = UrnUtils.getUrn("urn:li:corpuser:test");
+
+  @Test
+  public void testMapIncidentPriorityWithNull() {
+    assertNull(IncidentUtils.mapIncidentPriority(null));
+  }
+
+  @Test
+  public void testMapIncidentPriorityWithLow() {
+    assertEquals(IncidentUtils.mapIncidentPriority(IncidentPriority.LOW), Integer.valueOf(3));
+  }
+
+  @Test
+  public void testMapIncidentPriorityWithMedium() {
+    assertEquals(IncidentUtils.mapIncidentPriority(IncidentPriority.MEDIUM), Integer.valueOf(2));
+  }
+
+  @Test
+  public void testMapIncidentPriorityWithHigh() {
+    assertEquals(IncidentUtils.mapIncidentPriority(IncidentPriority.HIGH), Integer.valueOf(1));
+  }
+
+  @Test
+  public void testMapIncidentPriorityWithCritical() {
+    assertEquals(IncidentUtils.mapIncidentPriority(IncidentPriority.CRITICAL), Integer.valueOf(0));
+  }
+
+  @Test
+  public void testMapIncidentAssigneesWithNullAssignees() {
+    AuditStamp stamp = new AuditStamp();
+    stamp.setActor(TEST_USER_URN);
+    stamp.setTime(System.currentTimeMillis());
+    assertNull(IncidentUtils.mapIncidentAssignees(null, stamp));
+  }
+
+  @Test
+  public void testMapIncidentAssigneesWithEmptyAssignees() {
+    AuditStamp stamp = new AuditStamp();
+    stamp.setActor(TEST_USER_URN);
+    stamp.setTime(System.currentTimeMillis());
+    IncidentAssigneeArray result =
+        IncidentUtils.mapIncidentAssignees(Collections.emptyList(), stamp);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void testMapIncidentAssigneesWithValidAssignees() {
+    AuditStamp stamp = new AuditStamp();
+    stamp.setActor(TEST_USER_URN);
+    stamp.setTime(System.currentTimeMillis());
+    List<String> assignees = Arrays.asList("urn:li:corpuser:1", "urn:li:corpuser:2");
+    IncidentAssigneeArray result = IncidentUtils.mapIncidentAssignees(assignees, stamp);
+    assertNotNull(result);
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(0).getActor().toString(), "urn:li:corpuser:1");
+    assertEquals(result.get(1).getActor().toString(), "urn:li:corpuser:2");
+  }
+
+  @Test
+  public void testMapIncidentStatusWithNullInput() {
+    AuditStamp stamp = new AuditStamp();
+    stamp.setActor(TEST_USER_URN);
+    stamp.setTime(System.currentTimeMillis());
+    IncidentStatus status = IncidentUtils.mapIncidentStatus(null, stamp);
+    assertNotNull(status);
+    assertEquals(status.getState(), IncidentState.ACTIVE);
+    assertEquals(status.getLastUpdated(), stamp);
+  }
+
+  @Test
+  public void testMapIncidentStatusWithValidInput() {
+    IncidentStatusInput input = new IncidentStatusInput();
+    input.setState(com.linkedin.datahub.graphql.generated.IncidentState.RESOLVED);
+    input.setStage(com.linkedin.datahub.graphql.generated.IncidentStage.INVESTIGATION);
+    input.setMessage("Issue resolved");
+
+    AuditStamp stamp = new AuditStamp();
+    stamp.setActor(TEST_USER_URN);
+    stamp.setTime(System.currentTimeMillis());
+    IncidentStatus status = IncidentUtils.mapIncidentStatus(input, stamp);
+
+    assertEquals(status.getState(), IncidentState.RESOLVED);
+    assertEquals(status.getStage(), IncidentStage.INVESTIGATION);
+    assertEquals(status.getMessage(), "Issue resolved");
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/RaiseIncidentResolverTest.java
@@ -1,0 +1,225 @@
+package com.linkedin.datahub.graphql.resolvers.incident;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.metadata.Constants.INCIDENT_INFO_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.IncidentPriority;
+import com.linkedin.datahub.graphql.generated.RaiseIncidentInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.incident.IncidentAssignee;
+import com.linkedin.incident.IncidentAssigneeArray;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.incident.IncidentSource;
+import com.linkedin.incident.IncidentSourceType;
+import com.linkedin.incident.IncidentStage;
+import com.linkedin.incident.IncidentState;
+import com.linkedin.incident.IncidentStatus;
+import com.linkedin.incident.IncidentType;
+import com.linkedin.metadata.entity.AspectUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class RaiseIncidentResolverTest {
+
+  private static final Urn TEST_INCIDENT_URN = UrnUtils.getUrn("urn:li:incident:TEST");
+
+  @Test
+  public void testGetSuccessAllFields() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setTitle("Title");
+    testInput.setDescription("Description");
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.SQL);
+    testInput.setResourceUrn("urn:li:dataset:(test,test,test)");
+    Long incidentStartedAtMillis = System.currentTimeMillis();
+    testInput.setStartedAt(incidentStartedAtMillis);
+    testInput.setStatus(
+        new com.linkedin.datahub.graphql.generated.IncidentStatusInput(
+            com.linkedin.datahub.graphql.generated.IncidentState.ACTIVE,
+            com.linkedin.datahub.graphql.generated.IncidentStage.INVESTIGATION,
+            "Message"));
+    testInput.setAssigneeUrns(ImmutableList.of("urn:li:corpuser:test"));
+    testInput.setSource(
+        new com.linkedin.datahub.graphql.generated.IncidentSourceInput(
+            com.linkedin.datahub.graphql.generated.IncidentSourceType.MANUAL));
+    testInput.setPriority(IncidentPriority.CRITICAL);
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+    String result = resolver.get(mockEnv).get();
+
+    Assert.assertEquals(result, TEST_INCIDENT_URN.toString());
+
+    IncidentInfo expectedInfo = new IncidentInfo();
+    expectedInfo.setTitle("Title");
+    expectedInfo.setDescription("Description");
+    expectedInfo.setType(IncidentType.SQL);
+    expectedInfo.setEntities(
+        new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:dataset:(test,test,test)"))));
+    expectedInfo.setStartedAt(incidentStartedAtMillis);
+    expectedInfo.setStatus(
+        new IncidentStatus()
+            .setState(IncidentState.ACTIVE)
+            .setStage(IncidentStage.INVESTIGATION)
+            .setMessage("Message"));
+    expectedInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(new AuditStamp()))));
+    expectedInfo.setPriority(0);
+    expectedInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    // Verify entity client
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(OperationContext.class),
+            Mockito.argThat(
+                new IncidentInfoMatcher(
+                    AspectUtils.buildMetadataChangeProposal(
+                        TEST_INCIDENT_URN, INCIDENT_INFO_ASPECT_NAME, expectedInfo))),
+            Mockito.anyBoolean());
+  }
+
+  @Test
+  public void testCustomTypeRequired() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.CUSTOM);
+    testInput.setResourceUrn("urn:li:dataset:(test,test,test)");
+    testInput.setTitle("Title");
+    testInput.setDescription("Description");
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+
+    try {
+      resolver.get(mockEnv).get();
+      Assert.fail("Expected exception was not thrown");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(
+          "customType is required: Failed to create incident.", e.getCause().getMessage());
+    }
+  }
+
+  @Test
+  public void testGetFailRequiredFields() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.SQL);
+    testInput.setResourceUrns(Collections.emptyList());
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+    Exception exception =
+        Assert.expectThrows(
+            RuntimeException.class,
+            () -> {
+              resolver.get(mockEnv).get();
+            });
+
+    Assert.assertEquals(
+        exception.getMessage(), "At least 1 resource urn must be defined to raise an incident.");
+  }
+
+  @Test
+  public void testGetSuccessRequiredFields() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    RaiseIncidentInput testInput = new RaiseIncidentInput();
+    testInput.setType(com.linkedin.datahub.graphql.generated.IncidentType.SQL);
+    testInput.setResourceUrn("urn:li:dataset:(test,test,test)");
+    testInput.setResourceUrns(
+        List.of(
+            "urn:li:dataset:(test,test,test)",
+            "urn:li:dataset:(test,test,test2)",
+            "urn:li:dataset:(test,test,test3)"));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    RaiseIncidentResolver resolver = new RaiseIncidentResolver(mockClient);
+    String result = resolver.get(mockEnv).get();
+
+    Assert.assertEquals(result, TEST_INCIDENT_URN.toString());
+
+    IncidentInfo expectedInfo = new IncidentInfo();
+    expectedInfo.setType(IncidentType.SQL);
+    expectedInfo.setEntities(
+        new UrnArray(
+            IncidentUtils.stringsToUrns(
+                ImmutableList.of(
+                    "urn:li:dataset:(test,test,test)",
+                    "urn:li:dataset:(test,test,test2)",
+                    "urn:li:dataset:(test,test,test3)"))));
+    expectedInfo.setStatus(new IncidentStatus().setState(IncidentState.ACTIVE));
+    expectedInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    // Verify entity client
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(OperationContext.class),
+            Mockito.argThat(
+                new IncidentInfoMatcher(
+                    AspectUtils.buildMetadataChangeProposal(
+                        TEST_INCIDENT_URN, INCIDENT_INFO_ASPECT_NAME, expectedInfo))),
+            Mockito.anyBoolean());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/incident/UpdateIncidentResolverTest.java
@@ -1,0 +1,278 @@
+package com.linkedin.datahub.graphql.resolvers.incident;
+
+import static com.linkedin.datahub.graphql.TestUtils.getMockAllowContext;
+import static com.linkedin.metadata.Constants.INCIDENT_INFO_ASPECT_NAME;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.UrnArray;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.IncidentPriority;
+import com.linkedin.datahub.graphql.generated.UpdateIncidentInput;
+import com.linkedin.entity.client.EntityClient;
+import com.linkedin.incident.IncidentAssignee;
+import com.linkedin.incident.IncidentAssigneeArray;
+import com.linkedin.incident.IncidentInfo;
+import com.linkedin.incident.IncidentSource;
+import com.linkedin.incident.IncidentSourceType;
+import com.linkedin.incident.IncidentStage;
+import com.linkedin.incident.IncidentState;
+import com.linkedin.incident.IncidentStatus;
+import com.linkedin.incident.IncidentType;
+import com.linkedin.metadata.entity.AspectUtils;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.mxe.MetadataChangeProposal;
+import graphql.schema.DataFetchingEnvironment;
+import io.datahubproject.metadata.context.OperationContext;
+import java.util.List;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class UpdateIncidentResolverTest {
+
+  private static final Urn TEST_INCIDENT_URN = UrnUtils.getUrn("urn:li:incident:TEST");
+
+  @Test
+  public void testGetSuccessAllFields() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    IncidentInfo existingInfo = new IncidentInfo();
+    existingInfo.setTitle("Title");
+    existingInfo.setDescription("Description");
+    existingInfo.setType(IncidentType.SQL);
+    existingInfo.setEntities(
+        new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:dataset:(test,test,test)"))));
+    existingInfo.setStatus(
+        new IncidentStatus()
+            .setState(IncidentState.ACTIVE)
+            .setStage(IncidentStage.INVESTIGATION)
+            .setMessage("Message"));
+    existingInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(new AuditStamp()))));
+    existingInfo.setPriority(0);
+    existingInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    EntityService mockEntityService = Mockito.mock(EntityService.class);
+    Mockito.when(
+            mockEntityService.getAspect(
+                any(OperationContext.class),
+                Mockito.eq(TEST_INCIDENT_URN),
+                Mockito.eq(INCIDENT_INFO_ASPECT_NAME),
+                Mockito.eq(0L)))
+        .thenReturn(existingInfo);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateIncidentInput testInput = new UpdateIncidentInput();
+    testInput.setTitle("New Title");
+    testInput.setDescription("New Description");
+    final Long incidentStartedAtNew = 10L;
+    testInput.setStartedAt(incidentStartedAtNew);
+    testInput.setStatus(
+        new com.linkedin.datahub.graphql.generated.IncidentStatusInput(
+            com.linkedin.datahub.graphql.generated.IncidentState.RESOLVED,
+            com.linkedin.datahub.graphql.generated.IncidentStage.FIXED,
+            "Message 2"));
+    testInput.setAssigneeUrns(ImmutableList.of("urn:li:corpuser:test", "urn:li:corpuser:test2"));
+    testInput.setPriority(IncidentPriority.LOW);
+    testInput.setResourceUrns(List.of("urn:li:dataset:(test,test,test2)"));
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_INCIDENT_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    UpdateIncidentResolver resolver = new UpdateIncidentResolver(mockClient, mockEntityService);
+    Boolean result = resolver.get(mockEnv).get();
+
+    Assert.assertTrue(result);
+
+    IncidentInfo expectedInfo = new IncidentInfo();
+    expectedInfo.setTitle("New Title");
+    expectedInfo.setDescription("New Description");
+    expectedInfo.setType(IncidentType.SQL);
+    expectedInfo.setEntities(
+        new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:dataset:(test,test,test2)"))));
+    expectedInfo.setStartedAt(incidentStartedAtNew);
+    expectedInfo.setStatus(
+        new IncidentStatus()
+            .setState(IncidentState.RESOLVED)
+            .setStage(IncidentStage.FIXED)
+            .setMessage("Message 2"));
+    expectedInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(new AuditStamp()),
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test2"))
+                    .setAssignedAt(new AuditStamp()))));
+    expectedInfo.setPriority(3);
+    expectedInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    // Verify entity client
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(OperationContext.class),
+            Mockito.argThat(
+                new IncidentInfoMatcher(
+                    AspectUtils.buildMetadataChangeProposal(
+                        TEST_INCIDENT_URN, INCIDENT_INFO_ASPECT_NAME, expectedInfo))),
+            Mockito.anyBoolean());
+  }
+
+  @Test
+  public void testGetSuccessRequiredFields() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    IncidentInfo existingInfo = new IncidentInfo();
+    existingInfo.setTitle("Title");
+    existingInfo.setDescription("Description");
+    existingInfo.setType(IncidentType.SQL);
+    existingInfo.setEntities(
+        new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:dataset:(test,test,test)"))));
+    existingInfo.setStatus(
+        new IncidentStatus()
+            .setState(IncidentState.ACTIVE)
+            .setStage(IncidentStage.INVESTIGATION)
+            .setMessage("Message"));
+    existingInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(new AuditStamp()))));
+    existingInfo.setPriority(0);
+    existingInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    EntityService mockEntityService = Mockito.mock(EntityService.class);
+    Mockito.when(
+            mockEntityService.getAspect(
+                any(OperationContext.class),
+                Mockito.eq(TEST_INCIDENT_URN),
+                Mockito.eq(INCIDENT_INFO_ASPECT_NAME),
+                Mockito.eq(0L)))
+        .thenReturn(existingInfo);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateIncidentInput testInput = new UpdateIncidentInput();
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_INCIDENT_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    UpdateIncidentResolver resolver = new UpdateIncidentResolver(mockClient, mockEntityService);
+    Boolean result = resolver.get(mockEnv).get();
+
+    Assert.assertTrue(result);
+
+    IncidentInfo expectedInfo = new IncidentInfo();
+    expectedInfo.setTitle("Title");
+    expectedInfo.setDescription("Description");
+    expectedInfo.setType(IncidentType.SQL);
+    expectedInfo.setEntities(
+        new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:dataset:(test,test,test)"))));
+    expectedInfo.setStatus(
+        new IncidentStatus()
+            .setState(IncidentState.ACTIVE)
+            .setStage(IncidentStage.INVESTIGATION)
+            .setMessage("Message"));
+    expectedInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(new AuditStamp()))));
+    expectedInfo.setPriority(0);
+    expectedInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    // Verify entity client
+    Mockito.verify(mockClient, Mockito.times(1))
+        .ingestProposal(
+            any(OperationContext.class),
+            Mockito.argThat(
+                new IncidentInfoMatcher(
+                    AspectUtils.buildMetadataChangeProposal(
+                        TEST_INCIDENT_URN, INCIDENT_INFO_ASPECT_NAME, expectedInfo))),
+            Mockito.anyBoolean());
+  }
+
+  @Test
+  public void testGetFailureIncidentDoesNotExist() throws Exception {
+    EntityClient mockClient = Mockito.mock(EntityClient.class);
+    Mockito.when(
+            mockClient.ingestProposal(
+                any(OperationContext.class),
+                Mockito.any(MetadataChangeProposal.class),
+                Mockito.anyBoolean()))
+        .thenReturn(TEST_INCIDENT_URN.toString());
+
+    IncidentInfo existingInfo = new IncidentInfo();
+    existingInfo.setTitle("Title");
+    existingInfo.setDescription("Description");
+    existingInfo.setType(IncidentType.SQL);
+    existingInfo.setEntities(
+        new UrnArray(ImmutableList.of(UrnUtils.getUrn("urn:li:dataset:(test,test,test)"))));
+    existingInfo.setStatus(
+        new IncidentStatus()
+            .setState(IncidentState.ACTIVE)
+            .setStage(IncidentStage.INVESTIGATION)
+            .setMessage("Message"));
+    existingInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(new AuditStamp()))));
+    existingInfo.setPriority(0);
+    existingInfo.setSource(new IncidentSource().setType(IncidentSourceType.MANUAL));
+
+    EntityService mockEntityService = Mockito.mock(EntityService.class);
+    Mockito.when(
+            mockEntityService.getAspect(
+                any(OperationContext.class),
+                Mockito.eq(TEST_INCIDENT_URN),
+                Mockito.eq(INCIDENT_INFO_ASPECT_NAME),
+                Mockito.eq(0L)))
+        .thenReturn(null);
+
+    // Execute resolver
+    QueryContext mockContext = getMockAllowContext();
+    DataFetchingEnvironment mockEnv = Mockito.mock(DataFetchingEnvironment.class);
+    Mockito.when(mockEnv.getContext()).thenReturn(mockContext);
+
+    UpdateIncidentInput testInput = new UpdateIncidentInput();
+
+    Mockito.when(mockEnv.getArgument(Mockito.eq("urn"))).thenReturn(TEST_INCIDENT_URN.toString());
+    Mockito.when(mockEnv.getArgument(Mockito.eq("input"))).thenReturn(testInput);
+
+    UpdateIncidentResolver resolver = new UpdateIncidentResolver(mockClient, mockEntityService);
+
+    Assert.assertThrows(() -> resolver.get(mockEnv).get());
+  }
+}

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentMapperTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/types/incident/IncidentMapperTest.java
@@ -2,13 +2,14 @@ package com.linkedin.datahub.graphql.types.incident;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.GlobalTags;
 import com.linkedin.common.TagAssociationArray;
-import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.TagUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.common.urn.UrnUtils;
@@ -39,6 +40,7 @@ public class IncidentMapperTest {
 
   @Test
   public void testMap() throws Exception {
+    // This is your existing full test that sets up many fields.
     EntityResponse entityResponse = new EntityResponse();
     Urn urn = Urn.createFromString("urn:li:incident:1");
     Urn userUrn = Urn.createFromString("urn:li:corpuser:test");
@@ -57,6 +59,7 @@ public class IncidentMapperTest {
     incidentInfo.setCustomType("Custom Type");
     incidentInfo.setTitle("Test Incident", SetMode.IGNORE_NULL);
     incidentInfo.setDescription("This is a test incident", SetMode.IGNORE_NULL);
+    // Set priority HIGH (1 -> HIGH)
     incidentInfo.setPriority(1, SetMode.IGNORE_NULL);
     incidentInfo.setAssignees(
         new IncidentAssigneeArray(
@@ -67,7 +70,8 @@ public class IncidentMapperTest {
                 new IncidentAssignee()
                     .setActor(UrnUtils.getUrn("urn:li:corpGroup:test2"))
                     .setAssignedAt(lastStatus))));
-    incidentInfo.setEntities(new UrnArray(Collections.singletonList(urn)));
+    // TODO: Support multiple entities per incident.
+    incidentInfo.setEntities(new com.linkedin.common.UrnArray(Collections.singletonList(urn)));
     Long incidentStartedAt = 10L;
     incidentInfo.setStartedAt(incidentStartedAt);
 
@@ -94,10 +98,9 @@ public class IncidentMapperTest {
     GlobalTags tags = new GlobalTags();
     tags.setTags(
         new TagAssociationArray(
-            new TagAssociationArray(
-                Collections.singletonList(
-                    new com.linkedin.common.TagAssociation()
-                        .setTag(TagUrn.createFromString("urn:li:tag:test"))))));
+            ImmutableList.of(
+                new com.linkedin.common.TagAssociation()
+                    .setTag(TagUrn.createFromString("urn:li:tag:test")))));
     envelopedTagsAspect.setValue(new Aspect(tags.data()));
 
     entityResponse.setAspects(
@@ -141,5 +144,166 @@ public class IncidentMapperTest {
     assertEquals(incident.getTags().getTags().size(), 1);
     assertEquals(
         incident.getTags().getTags().get(0).getTag().getUrn().toString(), "urn:li:tag:test");
+  }
+
+  // --- Additional tests for priority mapping ---
+
+  @Test
+  public void testMappingPriorityLow() throws Exception {
+    // Priority 3 should map to LOW
+    EntityResponse entityResponse = createBaseEntityResponse();
+    setIncidentPriority(entityResponse, 3);
+    Incident incident = IncidentMapper.map(null, entityResponse);
+    assertEquals(
+        incident.getPriority(), IncidentPriority.LOW, "Priority 3 should be mapped to LOW");
+  }
+
+  @Test
+  public void testMappingPriorityMedium() throws Exception {
+    // Priority 2 should map to MEDIUM
+    EntityResponse entityResponse = createBaseEntityResponse();
+    setIncidentPriority(entityResponse, 2);
+    Incident incident = IncidentMapper.map(null, entityResponse);
+    assertEquals(
+        incident.getPriority(), IncidentPriority.MEDIUM, "Priority 2 should be mapped to MEDIUM");
+  }
+
+  @Test
+  public void testMappingPriorityHigh() throws Exception {
+    // Priority 1 should map to HIGH
+    EntityResponse entityResponse = createBaseEntityResponse();
+    setIncidentPriority(entityResponse, 1);
+    Incident incident = IncidentMapper.map(null, entityResponse);
+    assertEquals(
+        incident.getPriority(), IncidentPriority.HIGH, "Priority 1 should be mapped to HIGH");
+  }
+
+  @Test
+  public void testMappingPriorityCritical() throws Exception {
+    // Priority 0 should map to CRITICAL
+    EntityResponse entityResponse = createBaseEntityResponse();
+    setIncidentPriority(entityResponse, 0);
+    Incident incident = IncidentMapper.map(null, entityResponse);
+    assertEquals(
+        incident.getPriority(),
+        IncidentPriority.CRITICAL,
+        "Priority 0 should be mapped to CRITICAL");
+  }
+
+  @Test
+  public void testMappingInvalidPriority() throws Exception {
+    // An invalid priority (e.g., 5) should result in a null mapping.
+    EntityResponse entityResponse = createBaseEntityResponse();
+    setIncidentPriority(entityResponse, 5);
+    Incident incident = IncidentMapper.map(null, entityResponse);
+    assertNull(
+        incident.getPriority(), "Invalid priority value should result in a null priority mapping");
+  }
+
+  // --- Additional tests for assignee mapping (CorpUser vs CorpGroup) ---
+
+  @Test
+  public void testMappingAssigneesMapping() throws Exception {
+    // Create an incident with one corp user and one corp group
+    EntityResponse entityResponse = createBaseEntityResponse();
+    EnvelopedAspect incidentAspect =
+        entityResponse.getAspects().get(Constants.INCIDENT_INFO_ASPECT_NAME);
+    IncidentInfo incidentInfo = new IncidentInfo(incidentAspect.getValue().data());
+
+    AuditStamp auditStamp = new AuditStamp();
+    auditStamp.setTime(2000L);
+    // Set explicit assignees
+    IncidentAssignee corpUserAssignee =
+        new IncidentAssignee()
+            .setActor(UrnUtils.getUrn("urn:li:corpuser:testUser"))
+            .setAssignedAt(auditStamp);
+    IncidentAssignee corpGroupAssignee =
+        new IncidentAssignee()
+            .setActor(UrnUtils.getUrn("urn:li:corpGroup:testGroup"))
+            .setAssignedAt(auditStamp);
+    incidentInfo.setAssignees(
+        new IncidentAssigneeArray(ImmutableList.of(corpUserAssignee, corpGroupAssignee)));
+    incidentAspect.setValue(new Aspect(incidentInfo.data()));
+
+    Incident incident = IncidentMapper.map(null, entityResponse);
+    assertNotNull(incident.getAssignees());
+    assertEquals(incident.getAssignees().size(), 2);
+    assertTrue(
+        incident.getAssignees().get(0) instanceof CorpUser,
+        "Expected first assignee to be a CorpUser");
+    assertTrue(
+        incident.getAssignees().get(1) instanceof CorpGroup,
+        "Expected second assignee to be a CorpGroup");
+    assertEquals(((CorpUser) incident.getAssignees().get(0)).getUrn(), "urn:li:corpuser:testUser");
+    assertEquals(
+        ((CorpGroup) incident.getAssignees().get(1)).getUrn(), "urn:li:corpGroup:testGroup");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testMappingInvalidAssignee() throws Exception {
+    // Create an incident with an invalid assignee type.
+    EntityResponse entityResponse = createBaseEntityResponse();
+    EnvelopedAspect incidentAspect =
+        entityResponse.getAspects().get(Constants.INCIDENT_INFO_ASPECT_NAME);
+    IncidentInfo incidentInfo = new IncidentInfo(incidentAspect.getValue().data());
+
+    // Use an actor URN that does not correspond to a corp user or corp group.
+    IncidentAssignee invalidAssignee =
+        new IncidentAssignee().setActor(UrnUtils.getUrn("urn:li:invalid:entity"));
+    incidentInfo.setAssignees(new IncidentAssigneeArray(ImmutableList.of(invalidAssignee)));
+    incidentAspect.setValue(new Aspect(incidentInfo.data()));
+
+    // This call should throw IllegalArgumentException.
+    IncidentMapper.map(null, entityResponse);
+  }
+
+  // --- Helper methods for creating a minimal base EntityResponse ---
+
+  /** Creates a minimal EntityResponse with a basic IncidentInfo aspect. */
+  private EntityResponse createBaseEntityResponse() throws Exception {
+    EntityResponse entityResponse = new EntityResponse();
+    Urn urn = Urn.createFromString("urn:li:incident:1");
+    Urn userUrn = Urn.createFromString("urn:li:corpuser:test");
+    entityResponse.setUrn(urn);
+
+    EnvelopedAspect envelopedIncidentInfo = new EnvelopedAspect();
+    IncidentInfo incidentInfo = new IncidentInfo();
+
+    AuditStamp auditStamp = new AuditStamp();
+    auditStamp.setTime(1000L);
+    auditStamp.setActor(userUrn);
+    incidentInfo.setCreated(auditStamp);
+    incidentInfo.setType(IncidentType.FIELD);
+    incidentInfo.setTitle("Base Incident", SetMode.IGNORE_NULL);
+    incidentInfo.setDescription("Base incident description", SetMode.IGNORE_NULL);
+    // Default priority; tests will override this.
+    incidentInfo.setPriority(1, SetMode.IGNORE_NULL);
+    // Provide a default assignee (corp user) so mapping works.
+    incidentInfo.setAssignees(
+        new IncidentAssigneeArray(
+            ImmutableList.of(
+                new IncidentAssignee()
+                    .setActor(UrnUtils.getUrn("urn:li:corpuser:test"))
+                    .setAssignedAt(auditStamp))));
+    incidentInfo.setEntities(new com.linkedin.common.UrnArray(Collections.singletonList(urn)));
+
+    envelopedIncidentInfo.setValue(new Aspect(incidentInfo.data()));
+
+    EnvelopedAspectMap aspects =
+        new EnvelopedAspectMap(
+            ImmutableMap.of(Constants.INCIDENT_INFO_ASPECT_NAME, envelopedIncidentInfo));
+    entityResponse.setAspects(aspects);
+    return entityResponse;
+  }
+
+  /**
+   * Updates the priority value on the IncidentInfo aspect contained in the given EntityResponse.
+   */
+  private void setIncidentPriority(EntityResponse entityResponse, int priority) throws Exception {
+    EnvelopedAspect incidentAspect =
+        entityResponse.getAspects().get(Constants.INCIDENT_INFO_ASPECT_NAME);
+    IncidentInfo incidentInfo = new IncidentInfo(incidentAspect.getValue().data());
+    incidentInfo.setPriority(priority, SetMode.IGNORE_NULL);
+    incidentAspect.setValue(new Aspect(incidentInfo.data()));
   }
 }

--- a/datahub-web-react/src/graphql/incident.graphql
+++ b/datahub-web-react/src/graphql/incident.graphql
@@ -9,6 +9,7 @@ fragment incidentsFields on EntityIncidentsResult {
         customType
         title
         description
+        startedAt
         status {
             state
             message

--- a/datahub-web-react/src/graphql/mutations.graphql
+++ b/datahub-web-react/src/graphql/mutations.graphql
@@ -106,7 +106,7 @@ mutation raiseIncident($input: RaiseIncidentInput!) {
     raiseIncident(input: $input)
 }
 
-mutation updateIncidentStatus($urn: String!, $input: UpdateIncidentStatusInput!) {
+mutation updateIncidentStatus($urn: String!, $input: IncidentStatusInput!) {
     updateIncidentStatus(urn: $urn, input: $input)
 }
 

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -24,6 +24,9 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - #12408: The `platform` field in the DataPlatformInstance GraphQL type is removed. Clients need to retrieve the platform via the optional `dataPlatformInstance` field.
 
+- #12671: The `priority` field of the Incident entity is changed from an integer to an enum. This field was previously completely unused in UI and API, so this change should not affect existing deployments.
+
+
 ### Known Issues
 
 - #12601: Jetty 12 introduces a stricter handling of url encoding. We are currently applying a workaround to prevent a regression, while technically breaking the official specifications.

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentAssignee.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentAssignee.pdl
@@ -1,0 +1,26 @@
+namespace com.linkedin.incident
+
+import com.linkedin.common.Urn
+import com.linkedin.common.AuditStamp
+
+/**
+ * The incident assignee type.
+ * This is in a record so that we can add additional fields if we need to later (e.g.
+ * the type of the assignee.
+ */
+record IncidentAssignee {
+  /**
+  * The user or group assigned to the incident.
+  */
+  @Searchable = {
+    "addToFilters": true,
+    "filterNameOverride": "Assignee",
+    "fieldName": "assignees"
+  }
+  actor: Urn
+
+  /**
+  * The time & actor responsible for assiging the assignee.
+  */
+  assignedAt: AuditStamp
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentInfo.pdl
@@ -2,6 +2,7 @@ namespace com.linkedin.incident
 
 import com.linkedin.common.AuditStamp
 import com.linkedin.common.EntityReference
+import com.linkedin.common.Time
 import com.linkedin.common.Urn
 
 /**
@@ -57,12 +58,19 @@ record IncidentInfo {
 
   /**
   * A numeric severity or priority for the incident. On the UI we will translate this into something easy to understand.
+  * Currently supported: 0 - CRITICAL, 1 - HIGH, 2 - MED, 3 - LOW
+  * (We probably should have modeled as an enum)
   */
   @Searchable = {
     "addToFilters": true,
     "filterNameOverride": "Priority"
   }
   priority: optional int = 0
+
+  /**
+   * The parties assigned with resolving the incident
+   */
+  assignees: optional array[IncidentAssignee]
 
   /**
    * The current status of an incident, i.e. active or inactive.
@@ -73,6 +81,17 @@ record IncidentInfo {
    * The source of an incident, i.e. how it was generated.
    */
   source: optional IncidentSource
+
+  /**
+   * The time at which the incident actually started (may be before the date it was raised).
+   */
+  @Searchable = {
+    "/time": {
+        "fieldName": "startedAt",
+        "fieldType": "COUNT"
+      }
+  }
+  startedAt: optional Time
 
   /**
    * The time at which the request was initially created

--- a/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentStatus.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/incident/IncidentStatus.pdl
@@ -7,7 +7,7 @@ import com.linkedin.common.AuditStamp
  */
 record IncidentStatus {
   /**
-  * The state of the incident
+  * The top-level state of the incident, whether it's active or resolved.
   */
   @Searchable = {
     "addToFilters": true,
@@ -22,6 +22,38 @@ record IncidentStatus {
      * The incident is resolved.
      */
     RESOLVED
+  }
+
+  /**
+   * The lifecycle stage for the incident - Null means no stage was assigned yet.
+   * In the future, we may add CUSTOM here with a customStage string field for user-defined stages.
+   */
+  @Searchable = {
+    "addToFilters": true,
+    "filterNameOverride": "Stage"
+  }
+  stage: optional enum IncidentStage {
+    /**
+     * The impact and priority of the incident is being actively assessed.
+     */
+    TRIAGE
+    /**
+     * The incident root cause is being investigated.
+     */
+    INVESTIGATION
+    /**
+     * The incident is in the remediation stage.
+     */
+    WORK_IN_PROGRESS
+    /**
+     * The incident is in the resolved as completed stage.
+     */
+    FIXED
+    /**
+     * The incident is in the resolved with no action required state, e.g. the
+     * incident was a false positive, or was expected.
+     */
+    NO_ACTION_REQUIRED
   }
 
   /**

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
@@ -33,8 +33,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.CollectionUtils;
 import javax.validation.constraints.Null;
+import org.apache.commons.collections.CollectionUtils;
 
 public class QueryUtils {
 

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
@@ -7,6 +7,7 @@ import com.datahub.util.ModelUtils;
 import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.aspect.AspectVersion;
 import com.linkedin.metadata.config.DataHubAppConfiguration;
 import com.linkedin.metadata.models.EntitySpec;
@@ -33,12 +34,50 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
+import javax.validation.constraints.Null;
 
 public class QueryUtils {
 
   public static final Filter EMPTY_FILTER = new Filter().setOr(new ConjunctiveCriterionArray());
 
   private QueryUtils() {}
+
+  // Creates new Criterion with field and value, using EQUAL condition.
+  @Nonnull
+  public static Criterion newCriterion(@Nonnull String field, @Nonnull String value) {
+    return newCriterion(field, value, Condition.EQUAL);
+  }
+
+  // Creates new Criterion with field, value and condition.
+  @Nonnull
+  public static Criterion newCriterion(
+      @Nonnull String field, @Nonnull String value, @Nonnull Condition condition) {
+    return new Criterion()
+        .setField(field)
+        .setValue(value)
+        .setValues(new StringArray(ImmutableList.of(value)))
+        .setCondition(condition);
+  }
+
+  // Creates new Criterion with field and value, using EQUAL condition.
+  @Nullable
+  public static Criterion newCriterion(@Nonnull String field, @Nonnull List<String> values) {
+    return newCriterion(field, values, Condition.EQUAL);
+  }
+
+  // Creates new Criterion with field, value and condition.
+  @Null
+  public static Criterion newCriterion(
+      @Nonnull String field, @Nonnull List<String> values, @Nonnull Condition condition) {
+    if (values.isEmpty()) {
+      return null;
+    }
+    return new Criterion()
+        .setField(field)
+        .setValue(values.get(0)) // Hack! This is due to bad modeling.
+        .setValues(new StringArray(values))
+        .setCondition(condition);
+  }
 
   // Creates new Filter from a map of Criteria by removing null-valued Criteria and using EQUAL
   // condition (default).
@@ -51,6 +90,25 @@ public class QueryUtils {
         params.entrySet().stream()
             .filter(e -> Objects.nonNull(e.getValue()))
             .map(e -> buildCriterion(e.getKey(), Condition.EQUAL, e.getValue()))
+            .collect(Collectors.toCollection(CriterionArray::new));
+    return new Filter()
+        .setOr(
+            new ConjunctiveCriterionArray(
+                ImmutableList.of(new ConjunctiveCriterion().setAnd(criteria))));
+  }
+
+  // Creates new Filter from a map of Criteria by removing null-valued Criteria and using EQUAL
+  // condition (default).
+  @Nonnull
+  public static Filter newListsFilter(@Nullable Map<String, List<String>> params) {
+    if (params == null) {
+      return EMPTY_FILTER;
+    }
+    CriterionArray criteria =
+        params.entrySet().stream()
+            .filter(e -> Objects.nonNull(e.getValue()))
+            .map(e -> newCriterion(e.getKey(), e.getValue()))
+            .filter(Objects::nonNull)
             .collect(Collectors.toCollection(CriterionArray::new));
     return new Filter()
         .setOr(

--- a/metadata-service/services/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
+++ b/metadata-service/services/src/main/java/com/linkedin/metadata/search/utils/QueryUtils.java
@@ -43,23 +43,6 @@ public class QueryUtils {
   private QueryUtils() {}
 
   // Creates new Criterion with field and value, using EQUAL condition.
-  @Nonnull
-  public static Criterion newCriterion(@Nonnull String field, @Nonnull String value) {
-    return newCriterion(field, value, Condition.EQUAL);
-  }
-
-  // Creates new Criterion with field, value and condition.
-  @Nonnull
-  public static Criterion newCriterion(
-      @Nonnull String field, @Nonnull String value, @Nonnull Condition condition) {
-    return new Criterion()
-        .setField(field)
-        .setValue(value)
-        .setValues(new StringArray(ImmutableList.of(value)))
-        .setCondition(condition);
-  }
-
-  // Creates new Criterion with field and value, using EQUAL condition.
   @Nullable
   public static Criterion newCriterion(@Nonnull String field, @Nonnull List<String> values) {
     return newCriterion(field, values, Condition.EQUAL);

--- a/metadata-service/services/src/test/java/com/linkedin/metadata/search/utils/QueryUtilsTest.java
+++ b/metadata-service/services/src/test/java/com/linkedin/metadata/search/utils/QueryUtilsTest.java
@@ -1,0 +1,181 @@
+package com.linkedin.metadata.search.utils;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.Filter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class QueryUtilsTest {
+
+  @Test
+  public void testNewCriterionEmptyValues() {
+    List<String> emptyList = Collections.emptyList();
+    // Should return null when the values list is empty.
+    Criterion crit = QueryUtils.newCriterion("testField", emptyList);
+    Assert.assertNull(crit, "Expected null when values list is empty");
+  }
+
+  @Test
+  public void testNewCriterionWithValues() {
+    List<String> values = Arrays.asList("val1", "val2");
+    Criterion crit = QueryUtils.newCriterion("testField", values);
+    Assert.assertNotNull(crit, "Criterion should not be null");
+    Assert.assertEquals(crit.getField(), "testField", "Field name should match");
+    Assert.assertEquals(crit.getValue(), "val1", "Value should be set to the first element");
+    // Assuming StringArray has a method getElements() returning a List<String>
+    Assert.assertEquals(
+        crit.getValues(), new StringArray(values), "Values should match the input list");
+    Assert.assertEquals(
+        crit.getCondition(), Condition.EQUAL, "Condition should be EQUAL by default");
+  }
+
+  @Test
+  public void testNewCriterionWithProvidedCondition() {
+    List<String> values = Arrays.asList("val1");
+    // Here we explicitly pass the condition (using EQUAL in this case)
+    Criterion crit = QueryUtils.newCriterion("field", values, Condition.EQUAL);
+    Assert.assertNotNull(crit, "Criterion should not be null");
+    Assert.assertEquals(crit.getField(), "field", "Field name should match");
+    Assert.assertEquals(crit.getValue(), "val1", "Value should be the first element");
+    Assert.assertEquals(
+        crit.getValues(), new StringArray(values), "Values should match the input list");
+    Assert.assertEquals(
+        crit.getCondition(), Condition.EQUAL, "Condition should match the provided condition");
+  }
+
+  @Test
+  public void testNewFilterWithNullMap() {
+    // When params is null, the returned filter should be the EMPTY_FILTER
+    Filter filter = QueryUtils.newFilter((Map<String, String>) null);
+    Assert.assertSame(filter, QueryUtils.EMPTY_FILTER, "Expected EMPTY_FILTER when params is null");
+  }
+
+  @Test
+  public void testNewFilterWithEmptyMap() {
+    // When an empty map is provided, we expect a filter whose inner criteria list is empty.
+    Filter filter = QueryUtils.newFilter(new HashMap<>());
+    Assert.assertNotNull(filter.getOr(), "Filter 'or' clause should not be null");
+    Assert.assertEquals(filter.getOr().size(), 1, "Expected one conjunctive criterion");
+    ConjunctiveCriterion cc = filter.getOr().get(0);
+    Assert.assertNotNull(cc.getAnd(), "ConjunctiveCriterion 'and' clause should not be null");
+    Assert.assertTrue(cc.getAnd().isEmpty(), "Expected empty criteria list for empty params map");
+  }
+
+  @Test
+  public void testNewFilterWithValidEntry() {
+    Map<String, String> params = new HashMap<>();
+    params.put("field1", "value1");
+    Filter filter = QueryUtils.newFilter(params);
+
+    // Verify the internal structure: one ConjunctiveCriterion containing one Criterion.
+    Assert.assertNotNull(filter.getOr(), "Filter 'or' clause should not be null");
+    Assert.assertEquals(filter.getOr().size(), 1, "Expected one conjunctive criterion");
+    ConjunctiveCriterion cc = filter.getOr().get(0);
+    Assert.assertNotNull(cc.getAnd(), "ConjunctiveCriterion 'and' clause should not be null");
+    Assert.assertEquals(cc.getAnd().size(), 1, "Expected one criterion in the filter");
+    Criterion crit = cc.getAnd().get(0);
+    Assert.assertEquals(crit.getField(), "field1", "Field name should match");
+    Assert.assertEquals(crit.getValue(), "", "Value should be empty string");
+    Assert.assertEquals(
+        crit.getValues(),
+        new StringArray(Collections.singletonList("value1")),
+        "Values should contain the provided value");
+    Assert.assertEquals(crit.getCondition(), Condition.EQUAL, "Condition should be EQUAL");
+  }
+
+  @Test
+  public void testNewListsFilterWithNullMap() {
+    // When params is null, the returned filter should be the EMPTY_FILTER.
+    Filter filter = QueryUtils.newListsFilter(null);
+    Assert.assertSame(filter, QueryUtils.EMPTY_FILTER, "Expected EMPTY_FILTER when params is null");
+  }
+
+  @Test
+  public void testNewListsFilterWithEmptyMap() {
+    Filter filter = QueryUtils.newListsFilter(new HashMap<>());
+    Assert.assertNotNull(filter.getOr(), "Filter 'or' clause should not be null");
+    Assert.assertEquals(filter.getOr().size(), 1, "Expected one conjunctive criterion");
+    ConjunctiveCriterion cc = filter.getOr().get(0);
+    Assert.assertNotNull(cc.getAnd(), "ConjunctiveCriterion 'and' clause should not be null");
+    Assert.assertTrue(cc.getAnd().isEmpty(), "Expected empty criteria list for empty params map");
+  }
+
+  @Test
+  public void testNewListsFilterWithValidEntry() {
+    Map<String, List<String>> params = new HashMap<>();
+    params.put("field2", Arrays.asList("a", "b"));
+    Filter filter = QueryUtils.newListsFilter(params);
+
+    Assert.assertNotNull(filter.getOr(), "Filter 'or' clause should not be null");
+    Assert.assertEquals(filter.getOr().size(), 1, "Expected one conjunctive criterion");
+    ConjunctiveCriterion cc = filter.getOr().get(0);
+    Assert.assertNotNull(cc.getAnd(), "ConjunctiveCriterion 'and' clause should not be null");
+    Assert.assertEquals(cc.getAnd().size(), 1, "Expected one criterion in the filter");
+    Criterion crit = cc.getAnd().get(0);
+    Assert.assertEquals(crit.getField(), "field2", "Field name should match");
+    Assert.assertEquals(
+        crit.getValue(), "a", "Value should be set to the first element of the list");
+    Assert.assertEquals(
+        crit.getValues(),
+        new StringArray(Arrays.asList("a", "b")),
+        "Values should match the input list");
+    Assert.assertEquals(crit.getCondition(), Condition.EQUAL, "Condition should be EQUAL");
+  }
+
+  @Test
+  public void testNewFilterWithFieldAndValue() {
+    // This method is just a convenience overload that should be equivalent
+    // to newFilter(Collections.singletonMap(field, value))
+    Filter filter = QueryUtils.newFilter("field3", "value3");
+
+    Assert.assertNotNull(filter.getOr(), "Filter 'or' clause should not be null");
+    Assert.assertEquals(filter.getOr().size(), 1, "Expected one conjunctive criterion");
+    ConjunctiveCriterion cc = filter.getOr().get(0);
+    Assert.assertNotNull(cc.getAnd(), "ConjunctiveCriterion 'and' clause should not be null");
+    Assert.assertEquals(cc.getAnd().size(), 1, "Expected one criterion in the filter");
+    Criterion crit = cc.getAnd().get(0);
+    Assert.assertEquals(crit.getField(), "field3", "Field name should match");
+    Assert.assertEquals(
+        crit.getValues(),
+        new StringArray(Collections.singletonList("value3")),
+        "Values should contain the provided value");
+    Assert.assertEquals(crit.getValue(), "", "Value should be empty string");
+    Assert.assertEquals(crit.getCondition(), Condition.EQUAL, "Condition should be EQUAL");
+  }
+
+  @Test
+  public void testNewFilterWithCriterion() {
+    // Create a Criterion manually and then build a filter from it.
+    List<String> values = Arrays.asList("x", "y");
+    Criterion crit =
+        new Criterion()
+            .setField("field4")
+            .setValue("x")
+            .setValues(new StringArray(values))
+            .setCondition(Condition.EQUAL);
+    Filter filter = QueryUtils.newFilter(crit);
+
+    Assert.assertNotNull(filter.getOr(), "Filter 'or' clause should not be null");
+    Assert.assertEquals(filter.getOr().size(), 1, "Expected one conjunctive criterion");
+    ConjunctiveCriterion cc = filter.getOr().get(0);
+    Assert.assertNotNull(cc.getAnd(), "ConjunctiveCriterion 'and' clause should not be null");
+    Assert.assertEquals(cc.getAnd().size(), 1, "Expected one criterion in the filter");
+    Criterion critFromFilter = cc.getAnd().get(0);
+    Assert.assertEquals(critFromFilter.getField(), "field4", "Field name should match");
+    Assert.assertEquals(critFromFilter.getValue(), "x", "Value should match");
+    Assert.assertEquals(
+        critFromFilter.getValues(),
+        new StringArray(values),
+        "Values should match the original list");
+    Assert.assertEquals(
+        critFromFilter.getCondition(), Condition.EQUAL, "Condition should be EQUAL");
+  }
+}

--- a/smoke-test/tests/incidents/incidents_test.py
+++ b/smoke-test/tests/incidents/incidents_test.py
@@ -121,7 +121,7 @@ def test_raise_resolve_incident(auth_session):
                 "title": "test title 2",
                 "description": "test description 2",
                 "resourceUrn": TEST_DATASET_URN,
-                "priority": 0,
+                "priority": "CRITICAL",
             }
         },
     }
@@ -226,7 +226,7 @@ def test_raise_resolve_incident(auth_session):
     assert new_incident["title"] == "test title 2"
     assert new_incident["description"] == "test description 2"
     assert new_incident["status"]["state"] == "RESOLVED"
-    assert new_incident["priority"] == 0
+    assert new_incident["priority"] == "CRITICAL"
 
     delete_json = {"urn": new_incident_urn}
 

--- a/smoke-test/tests/incidents/incidents_test.py
+++ b/smoke-test/tests/incidents/incidents_test.py
@@ -141,7 +141,7 @@ def test_raise_resolve_incident(auth_session):
 
     # Resolve the incident.
     update_incident_status = {
-        "query": """mutation updateIncidentStatus($urn: String!, $input: UpdateIncidentStatusInput!) {\n
+        "query": """mutation updateIncidentStatus($urn: String!, $input: IncidentStatusInput!) {\n
             updateIncidentStatus(urn: $urn, input: $input)
         }""",
         "variables": {


### PR DESCRIPTION
In this PR, we bring our new changes for the Incidents V2 model to the Open Source repository. 

# Changes
1. Add support for stage, priority, assignee, resources to incident model PDL
2. Introduce new update incident resolver
3. Evolve existing endpoints to support new fields
4. Unit tests

# Note that 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
