### PR TITLE
fix(ingest): move json-schema deps out of base package

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -51,8 +51,6 @@ framework_common = {
     "ijson",
     "click-spinner",
     "requests_file",
-    "jsonref",
-    "jsonschema",
     "ruamel.yaml",
 }
 
@@ -264,6 +262,11 @@ postgres_common = {
     "GeoAlchemy2",
 }
 
+json_schema_common = {
+    "jsonref",
+    "jsonschema",
+}
+
 s3_base = {
     *aws_common,
     "more-itertools>=8.12.0",
@@ -451,8 +454,8 @@ plugins: Dict[str, Set[str]] = {
     | {"psycopg2-binary", "pymysql>=1.0.2"},
     "iceberg": iceberg_common,
     "iceberg-catalog": aws_common,
-    "json-schema": set(),
-    "kafka": kafka_common | kafka_protobuf,
+    "json-schema": json_schema_common,
+    "kafka": kafka_common | kafka_protobuf | json_schema_common,
     "kafka-connect": sql_common | {"requests", "JPype1"},
     "ldap": {"python-ldap>=2.4"},
     "looker": looker_common,


### PR DESCRIPTION
A simple `pip install acryl-datahub` does not need jsonschema/jsonref.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
