### PR TITLE
fix(tracing): handle noop mcl

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/utils/SystemMetadataUtils.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/utils/SystemMetadataUtils.java
@@ -4,12 +4,14 @@ import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
 
 import com.datahub.util.RecordUtils;
 import com.linkedin.data.template.SetMode;
+import com.linkedin.data.template.StringMap;
 import com.linkedin.mxe.SystemMetadata;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SystemMetadataUtils {
+  private static final String NO_OP_KEY = "isNoOp";
 
   private SystemMetadataUtils() {}
 
@@ -41,5 +43,26 @@ public class SystemMetadataUtils {
       return createDefaultSystemMetadata();
     }
     return RecordUtils.toRecordTemplate(SystemMetadata.class, jsonSystemMetadata);
+  }
+
+  public static boolean isNoOp(@Nullable SystemMetadata systemMetadata) {
+    if (systemMetadata != null
+        && systemMetadata.hasProperties()
+        && systemMetadata.getProperties() != null) {
+      return Boolean.parseBoolean(systemMetadata.getProperties().getOrDefault(NO_OP_KEY, "false"));
+    }
+
+    return false;
+  }
+
+  @Nullable
+  public static SystemMetadata setNoOp(@Nullable SystemMetadata systemMetadata, boolean isNoOp) {
+    if (systemMetadata != null) {
+      if (!systemMetadata.hasProperties() || systemMetadata.getProperties() == null) {
+        systemMetadata.setProperties(new StringMap());
+      }
+      systemMetadata.getProperties().put(NO_OP_KEY, String.valueOf(isNoOp));
+    }
+    return systemMetadata;
   }
 }

--- a/entity-registry/src/test/java/com/linkedin/metadata/utils/SystemMetadataUtilsTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/utils/SystemMetadataUtilsTest.java
@@ -1,0 +1,120 @@
+package com.linkedin.metadata.utils;
+
+import static com.linkedin.metadata.Constants.DEFAULT_RUN_ID;
+import static org.testng.Assert.*;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.mxe.SystemMetadata;
+import org.testng.annotations.Test;
+
+public class SystemMetadataUtilsTest {
+
+  @Test
+  public void testCreateDefaultSystemMetadata() {
+    SystemMetadata metadata = SystemMetadataUtils.createDefaultSystemMetadata();
+
+    assertNotNull(metadata);
+    assertEquals(metadata.getRunId(), DEFAULT_RUN_ID);
+    assertTrue(metadata.hasLastObserved());
+    assertTrue(metadata.getLastObserved() > 0);
+  }
+
+  @Test
+  public void testCreateDefaultSystemMetadataWithRunId() {
+    String customRunId = "custom-run-id";
+    SystemMetadata metadata = SystemMetadataUtils.createDefaultSystemMetadata(customRunId);
+
+    assertNotNull(metadata);
+    assertEquals(metadata.getRunId(), customRunId);
+    assertTrue(metadata.hasLastObserved());
+    assertTrue(metadata.getLastObserved() > 0);
+  }
+
+  @Test
+  public void testGenerateSystemMetadataIfEmpty() {
+    // Test with null input
+    SystemMetadata nullMetadata = SystemMetadataUtils.generateSystemMetadataIfEmpty(null);
+    assertNotNull(nullMetadata);
+    assertEquals(nullMetadata.getRunId(), DEFAULT_RUN_ID);
+    assertTrue(nullMetadata.hasLastObserved());
+
+    // Test with existing metadata
+    SystemMetadata existingMetadata =
+        new SystemMetadata().setRunId("existing-run").setLastObserved(1234567890L);
+    SystemMetadata result = SystemMetadataUtils.generateSystemMetadataIfEmpty(existingMetadata);
+
+    assertEquals(result.getRunId(), "existing-run");
+    assertEquals(result.getLastObserved(), 1234567890L);
+  }
+
+  @Test
+  public void testParseSystemMetadata() {
+    // Test null input
+    SystemMetadata nullResult = SystemMetadataUtils.parseSystemMetadata(null);
+    assertNotNull(nullResult);
+    assertEquals(nullResult.getRunId(), DEFAULT_RUN_ID);
+
+    // Test empty string input
+    SystemMetadata emptyResult = SystemMetadataUtils.parseSystemMetadata("");
+    assertNotNull(emptyResult);
+    assertEquals(emptyResult.getRunId(), DEFAULT_RUN_ID);
+
+    // Test valid JSON input
+    String validJson = "{\"runId\":\"test-run\",\"lastObserved\":1234567890}";
+    SystemMetadata jsonResult = SystemMetadataUtils.parseSystemMetadata(validJson);
+    assertNotNull(jsonResult);
+    assertEquals(jsonResult.getRunId(), "test-run");
+    assertEquals(jsonResult.getLastObserved(), 1234567890L);
+  }
+
+  @Test
+  public void testIsNoOp() {
+    // Test null metadata
+    assertFalse(SystemMetadataUtils.isNoOp(null));
+
+    // Test metadata without properties
+    SystemMetadata emptyMetadata = new SystemMetadata();
+    assertFalse(SystemMetadataUtils.isNoOp(emptyMetadata));
+
+    // Test metadata with isNoOp=true
+    SystemMetadata noOpMetadata = new SystemMetadata();
+    StringMap properties = new StringMap();
+    properties.put("isNoOp", "true");
+    noOpMetadata.setProperties(properties);
+    assertTrue(SystemMetadataUtils.isNoOp(noOpMetadata));
+
+    // Test metadata with isNoOp=false
+    properties.put("isNoOp", "false");
+    assertFalse(SystemMetadataUtils.isNoOp(noOpMetadata));
+  }
+
+  @Test
+  public void testSetNoOp() {
+    // Test with null metadata
+    assertNull(SystemMetadataUtils.setNoOp(null, true));
+
+    // Test setting noOp to true
+    SystemMetadata metadata = new SystemMetadata();
+    SystemMetadata result = SystemMetadataUtils.setNoOp(metadata, true);
+    assertNotNull(result);
+    assertTrue(result.hasProperties());
+    assertNotNull(result.getProperties());
+    assertEquals(result.getProperties().get("isNoOp"), "true");
+
+    // Test setting noOp to false
+    result = SystemMetadataUtils.setNoOp(metadata, false);
+    assertNotNull(result);
+    assertTrue(result.hasProperties());
+    assertNotNull(result.getProperties());
+    assertEquals(result.getProperties().get("isNoOp"), "false");
+
+    // Test with existing properties
+    StringMap existingProps = new StringMap();
+    existingProps.put("otherKey", "value");
+    metadata.setProperties(existingProps);
+    result = SystemMetadataUtils.setNoOp(metadata, true);
+    assertNotNull(result);
+    assertEquals(result.getProperties().get("otherKey"), "value");
+    assertEquals(result.getProperties().get("isNoOp"), "true");
+  }
+}

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -97,6 +97,7 @@ dependencies {
   testImplementation externalDependency.springBootTest
   testImplementation spec.product.pegasus.restliServer
   testImplementation externalDependency.ebeanTest
+  testImplementation externalDependency.opentelemetrySdk
 
   // logback >=1.3 required due to `testcontainers` only
   testImplementation 'ch.qos.logback:logback-classic:1.4.7'

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -76,6 +76,7 @@ import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.EntityApiUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.metadata.utils.PegasusUtils;
+import com.linkedin.metadata.utils.SystemMetadataUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataAuditOperation;
 import com.linkedin.mxe.MetadataChangeLog;
@@ -2050,7 +2051,8 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
       Urn entityUrn,
       AuditStamp auditStamp,
       AspectSpec aspectSpec) {
-    boolean isNoOp = Objects.equals(oldAspect, newAspect);
+    boolean isNoOp =
+        SystemMetadataUtils.isNoOp(newSystemMetadata) || Objects.equals(oldAspect, newAspect);
     if (!isNoOp || alwaysEmitChangeLog || shouldAspectEmitChangeLog(aspectSpec)) {
       log.info("Producing MCL for ingested aspect {}, urn {}", aspectSpec.getName(), entityUrn);
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EntityServiceTest.java
@@ -1352,6 +1352,7 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
     EntityAspect readAspectDao2 = _aspectDao.getAspect(entityUrn.toString(), aspectName, 0);
 
     assertTrue(DataTemplateUtil.areEqual(writeAspect2, readAspect2));
+    SystemMetadataUtils.setNoOp(expectedMetadata2, false);
     assertTrue(
         DataTemplateUtil.areEqual(
             SystemMetadataUtils.parseSystemMetadata(readAspectDao2.getSystemMetadata()),
@@ -1393,7 +1394,9 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
     SystemMetadata metadata2 =
         AspectGenerationUtils.createSystemMetadata(1635792689, "run-456", null, "2");
     SystemMetadata expectedMetadata2 =
-        AspectGenerationUtils.createSystemMetadata(1635792689, "run-456", "run-123", "2");
+        SystemMetadataUtils.setNoOp(
+            AspectGenerationUtils.createSystemMetadata(1635792689, "run-456", "run-123", "2"),
+            false);
 
     List<ChangeItemImpl> items =
         List.of(
@@ -1594,6 +1597,7 @@ public abstract class EntityServiceTest<T_AD extends AspectDao, T_RS extends Ret
             SystemMetadataUtils.parseSystemMetadata(readAspectDao2.getSystemMetadata()),
             metadata1));
 
+    SystemMetadataUtils.setNoOp(expectedMetadata2, true);
     assertTrue(
         DataTemplateUtil.areEqual(
             SystemMetadataUtils.parseSystemMetadata(readAspectDao2.getSystemMetadata()),


### PR DESCRIPTION
Handle expected tracing output when no change to record template AND the trace id matches. The difference is that in this case the downstream storage change in ES is also an expected NO_OP.

Also prevent duplicate equality checks when determining the no op state.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
