### PR TITLE
Fix platform instance support on Druid ingestion

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -26,6 +26,8 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 - #12671: The `priority` field of the Incident entity is changed from an integer to an enum. This field was previously completely unused in UI and API, so this change should not affect existing deployments.
 
+- #12716: Fix the `platform_instance` being added twice to the URN. If you want to have the previous behavior back, you need to add your platform_instance twice (i.e. `plat.plat`).
+
 
 ### Known Issues
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/druid.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/druid.py
@@ -50,11 +50,7 @@ class DruidConfig(BasicSQLAlchemyConfig):
     """
 
     def get_identifier(self, schema: str, table: str) -> str:
-        return (
-            f"{self.platform_instance}.{table}"
-            if self.platform_instance
-            else f"{table}"
-        )
+        return f"{table}"
 
 
 @platform_name("Druid")

--- a/metadata-ingestion/tests/integration/druid/golden/druid_mces.json
+++ b/metadata-ingestion/tests/integration/druid/golden/druid_mces.json
@@ -18,7 +18,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -34,7 +34,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -51,7 +51,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -69,7 +69,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -90,7 +90,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -106,7 +106,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -130,7 +130,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -146,7 +146,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -163,7 +163,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -181,7 +181,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -206,7 +206,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -222,7 +222,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -246,7 +246,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -262,7 +262,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -279,7 +279,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -297,7 +297,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
@@ -322,13 +322,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
@@ -338,14 +338,14 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.segments,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.segments,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.common.Status": {
@@ -362,7 +362,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "my_druid.segments",
+                        "schemaName": "segments",
                         "platform": "urn:li:dataPlatform:druid",
                         "version": 0,
                         "created": {
@@ -616,13 +616,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -633,13 +633,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -651,13 +651,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -680,13 +680,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.server_segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.server_segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
@@ -696,14 +696,14 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.server_segments,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.server_segments,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.common.Status": {
@@ -720,7 +720,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "my_druid.server_segments",
+                        "schemaName": "server_segments",
                         "platform": "urn:li:dataPlatform:druid",
                         "version": 0,
                         "created": {
@@ -770,13 +770,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.server_segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.server_segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -787,13 +787,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.server_segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.server_segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -805,13 +805,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.server_segments,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.server_segments,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -834,13 +834,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.servers,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.servers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
@@ -850,14 +850,14 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.servers,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.servers,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.common.Status": {
@@ -874,7 +874,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "my_druid.servers",
+                        "schemaName": "servers",
                         "platform": "urn:li:dataPlatform:druid",
                         "version": 0,
                         "created": {
@@ -1020,13 +1020,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.servers,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.servers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1037,13 +1037,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.servers,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.servers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -1055,13 +1055,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.servers,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.servers,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -1084,13 +1084,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.supervisors,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.supervisors,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
@@ -1100,14 +1100,14 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.supervisors,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.supervisors,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.common.Status": {
@@ -1124,7 +1124,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "my_druid.supervisors",
+                        "schemaName": "supervisors",
                         "platform": "urn:li:dataPlatform:druid",
                         "version": 0,
                         "created": {
@@ -1246,13 +1246,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.supervisors,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.supervisors,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1263,13 +1263,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.supervisors,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.supervisors,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -1281,13 +1281,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.supervisors,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.supervisors,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -1310,13 +1310,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.tasks,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.tasks,PROD)",
     "changeType": "UPSERT",
     "aspectName": "container",
     "aspect": {
@@ -1326,14 +1326,14 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.tasks,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.tasks,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.common.Status": {
@@ -1350,7 +1350,7 @@
                 },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-                        "schemaName": "my_druid.tasks",
+                        "schemaName": "tasks",
                         "platform": "urn:li:dataPlatform:druid",
                         "version": 0,
                         "created": {
@@ -1544,13 +1544,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.tasks,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.tasks,PROD)",
     "changeType": "UPSERT",
     "aspectName": "dataPlatformInstance",
     "aspect": {
@@ -1561,13 +1561,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.tasks,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.tasks,PROD)",
     "changeType": "UPSERT",
     "aspectName": "subTypes",
     "aspect": {
@@ -1579,13 +1579,13 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.my_druid.tasks,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:druid,my_druid.tasks,PROD)",
     "changeType": "UPSERT",
     "aspectName": "browsePathsV2",
     "aspect": {
@@ -1608,7 +1608,7 @@
     },
     "systemMetadata": {
         "lastObserved": 1740387600000,
-        "runId": "druid-2025_02_24-09_00_00-p8a5zq",
+        "runId": "druid-2025_02_24-09_00_00-er4usx",
         "lastRunId": "no-run-id-provided"
     }
 }

--- a/metadata-ingestion/tests/unit/test_druid_source.py
+++ b/metadata-ingestion/tests/unit/test_druid_source.py
@@ -8,6 +8,6 @@ def test_druid_uri():
 
 
 def test_druid_get_identifier():
-    config = DruidConfig.parse_obj({})
+    config = DruidConfig.parse_obj({"host_port": "localhost:8082"})
 
     assert config.get_identifier("schema", "table") == "table"

--- a/metadata-ingestion/tests/unit/test_druid_source.py
+++ b/metadata-ingestion/tests/unit/test_druid_source.py
@@ -5,3 +5,9 @@ def test_druid_uri():
     config = DruidConfig.parse_obj({"host_port": "localhost:8082"})
 
     assert config.get_sql_alchemy_url() == "druid://localhost:8082/druid/v2/sql/"
+
+
+def test_druid_get_identifier():
+    config = DruidConfig.parse_obj({})
+
+    assert config.get_identifier("schema", "table") == "table"


### PR DESCRIPTION
If the platform instance was specified in a Druid ingestion, it was always set twice, because it was overrided in the get_identifier, and then added again down the line (see https://github.com/datahub-project/datahub/issues/11639).
This may break existing users that already rely on the broken platform instance implementation, but they could still manually set it to the old pattern in their dhub file.


## Checklist

- [ x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ x] Links to related issues (if applicable)
https://github.com/datahub-project/datahub/issues/11639
https://github.com/datahub-project/datahub/issues/12546
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [x] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
