### PR TITLE
fix(ui) Properly get display name when downloading search results

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/search/downloadAsCsvUtil.ts
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/downloadAsCsvUtil.ts
@@ -33,6 +33,7 @@ export const getSearchCsvDownloadHeader = (sampleResult?: SearchResultInterface)
 };
 
 export const transformGenericEntityPropertiesToCsvRow = (
+    entityRegistry: EntityRegistry,
     properties: GenericEntityProperties | null,
     entityUrl: string,
     result: SearchResultInterface,
@@ -41,11 +42,11 @@ export const transformGenericEntityPropertiesToCsvRow = (
         // urn
         properties?.urn || '',
         // name
-        properties?.name || '',
+        entityRegistry.getDisplayName(result.entity.type, result.entity) || properties?.name || '',
         // type
         result.entity.type || '',
         // description
-        properties?.properties?.description || '',
+        properties?.properties?.description || properties?.editableProperties?.description || '',
         // user owners
         properties?.ownership?.owners
             ?.filter((owner) => owner.owner.type === EntityType.CorpUser)
@@ -98,6 +99,6 @@ export const transformResultsToCsvRow = (results: SearchResultInterface[], entit
     return results.map((result) => {
         const genericEntityProperties = entityRegistry.getGenericEntityProperties(result.entity.type, result.entity);
         const entityUrl = entityRegistry.getEntityUrl(result.entity.type, result.entity.urn);
-        return transformGenericEntityPropertiesToCsvRow(genericEntityProperties, entityUrl, result);
+        return transformGenericEntityPropertiesToCsvRow(entityRegistry, genericEntityProperties, entityUrl, result);
     });
 };

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/search/downloadAsCsvUtil.ts
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/search/downloadAsCsvUtil.ts
@@ -33,6 +33,7 @@ export const getSearchCsvDownloadHeader = (sampleResult?: SearchResultInterface)
 };
 
 export const transformGenericEntityPropertiesToCsvRow = (
+    entityRegistry: EntityRegistry,
     properties: GenericEntityProperties | null,
     entityUrl: string,
     result: SearchResultInterface,
@@ -41,7 +42,7 @@ export const transformGenericEntityPropertiesToCsvRow = (
         // urn
         properties?.urn || '',
         // name
-        properties?.name || '',
+        entityRegistry.getDisplayName(result.entity.type, result.entity) || properties?.name || '',
         // type
         result.entity.type || '',
         // description
@@ -98,6 +99,6 @@ export const transformResultsToCsvRow = (results: SearchResultInterface[], entit
     return results.map((result) => {
         const genericEntityProperties = entityRegistry.getGenericEntityProperties(result.entity.type, result.entity);
         const entityUrl = entityRegistry.getEntityUrl(result.entity.type, result.entity.urn);
-        return transformGenericEntityPropertiesToCsvRow(genericEntityProperties, entityUrl, result);
+        return transformGenericEntityPropertiesToCsvRow(entityRegistry, genericEntityProperties, entityUrl, result);
     });
 };


### PR DESCRIPTION
There was a report where downloading results with groups in them were not getting the display name of the asset properly. This fixes that in v1 and v2 UIs for all entity types.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
