### PR TITLE
fix(ui) Fix order of parent containers on v2 autocomplete item

### DIFF
--- a/datahub-web-react/src/app/searchV2/autoComplete/AutoCompleteEntity.tsx
+++ b/datahub-web-react/src/app/searchV2/autoComplete/AutoCompleteEntity.tsx
@@ -80,14 +80,11 @@ export default function AutoCompleteEntity({ query, entity, siblings, hasParentT
             .filter(Boolean) ?? [];
 
     const parentContainers = genericEntityProps?.parentContainers?.containers || [];
-    // Need to reverse parentContainers since it returns direct parent first.
-    const orderedParentContainers = [...parentContainers].reverse();
 
     const subtype = genericEntityProps?.subTypes?.typeNames?.[0];
 
     // Parent entities are either a) containers or b) entity-type specific parents (glossary nodes, domains, etc)
-    const parentEntities =
-        (orderedParentContainers?.length && orderedParentContainers) || getParentEntities(entity) || [];
+    const parentEntities = (parentContainers?.length && parentContainers) || getParentEntities(entity) || [];
 
     const showPlatforms = !!platforms.length;
     const showPlatformDivider = !!platforms.length && !!parentContainers.length;


### PR DESCRIPTION
Fixes the order of parent containers on autocomplete entity items in the V2 UI - we were reversing these containers in `AutoCompleteEntity` since we wanted to display the top level containers first. Well in the V2 UI we updated the `ParentContainers` component to also reverse these passed in entities, which resulted in reverting back to the wrong order. Now we are showing containers in the correct order.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
