### PR TITLE
feat(build): use `pull_request_target` for datahub-wheels

### DIFF
--- a/.github/workflows/python-build-pages.yml
+++ b/.github/workflows/python-build-pages.yml
@@ -8,7 +8,7 @@ on:
       - "metadata-ingestion/**"
       - "metadata-ingestion-modules/**"
       - "metadata-models/**"
-  pull_request:
+  pull_request_target:
     branches:
       - "**"
     paths:
@@ -38,7 +38,11 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/actions/setup-gradle@v4
-      - uses: acryldata/sane-checkout-action@v3
+      - uses: actions/checkout@v4
+        # Note: not using acryldata/sane-checkout-action because this is a
+        # pull_request_target event, and hence requires `ref`.
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"


### PR DESCRIPTION
This PR won't have any datahub-wheels. But PRs after this one will have it.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
