### PR TITLE
fix(lineage): error message for edit lineage

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lineage/UpdateLineageResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/lineage/UpdateLineageResolver.java
@@ -222,16 +222,15 @@ public class UpdateLineageResolver implements DataFetcher<CompletableFuture<Bool
     if (!isAuthorized(context, upstreamUrn, editLineagePrivileges)) {
       throw new AuthorizationException(
           String.format(
-              "Unauthorized to edit %s lineage. Please contact your DataHub administrator.",
-              upstreamUrn.getEntityType()));
+              "Unauthorized to edit %s lineage for %s", upstreamUrn, upstreamUrn.getEntityType()));
     }
 
     Urn downstreamUrn = UrnUtils.getUrn(lineageEdge.getDownstreamUrn());
     if (!isAuthorized(context, downstreamUrn, editLineagePrivileges)) {
       throw new AuthorizationException(
           String.format(
-              "Unauthorized to edit %s lineage. Please contact your DataHub administrator.",
-              downstreamUrn.getEntityType()));
+              "Unauthorized to edit %s lineage for %s",
+              downstreamUrn, downstreamUrn.getEntityType()));
     }
   }
 

--- a/datahub-web-react/src/app/lineage/manage/ManageLineageModal.tsx
+++ b/datahub-web-react/src/app/lineage/manage/ManageLineageModal.tsx
@@ -107,8 +107,8 @@ export default function ManageLineageModal({
                     });
                 }
             })
-            .catch(() => {
-                message.error('Error updating lineage');
+            .catch((error) => {
+                message.error(error.message || 'Error updating lineage');
             });
     }
 

--- a/datahub-web-react/src/app/lineageV2/manualLineage/ManageLineageModal.tsx
+++ b/datahub-web-react/src/app/lineageV2/manualLineage/ManageLineageModal.tsx
@@ -17,6 +17,7 @@ import { useUpdateLineageMutation } from '../../../graphql/mutations.generated';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import updateNodeContext from './updateNodeContext';
 import { useOnClickExpandLineage } from '../LineageEntityNode/useOnClickExpandLineage';
+import { error } from 'console';
 
 const ModalFooter = styled.div`
     display: flex;
@@ -85,9 +86,8 @@ export default function ManageLineageModal({ node, direction, closeModal, refetc
                     });
                 }
             })
-            .catch((e) => {
-                message.error('Error updating lineage');
-                console.warn(e);
+            .catch((error) => {
+                message.error(error.message || 'Error updating lineage');
             });
     }
 

--- a/datahub-web-react/src/app/lineageV2/manualLineage/ManageLineageModal.tsx
+++ b/datahub-web-react/src/app/lineageV2/manualLineage/ManageLineageModal.tsx
@@ -17,7 +17,6 @@ import { useUpdateLineageMutation } from '../../../graphql/mutations.generated';
 import { useEntityRegistry } from '../../useEntityRegistry';
 import updateNodeContext from './updateNodeContext';
 import { useOnClickExpandLineage } from '../LineageEntityNode/useOnClickExpandLineage';
-import { error } from 'console';
 
 const ModalFooter = styled.div`
     display: flex;

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -49,11 +49,11 @@ COPY --from=binary /go/bin/dockerize /usr/local/bin
 ENV LD_LIBRARY_PATH="/lib:/lib64"
 
 FROM base AS prod-install
-COPY war.war /datahub/datahub-gms/bin/war.war
 COPY metadata-models/src/main/resources/entity-registry.yml /datahub/datahub-gms/resources/entity-registry.yml
 COPY docker/datahub-gms/start.sh /datahub/datahub-gms/scripts/start.sh
 COPY docker/monitoring/client-prometheus-config.yaml /datahub/datahub-gms/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-gms/scripts/start.sh
+COPY war.war /datahub/datahub-gms/bin/war.war
 
 FROM base AS dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docs/features/feature-guides/ui-lineage.md
+++ b/docs/features/feature-guides/ui-lineage.md
@@ -5,6 +5,8 @@ The UI shows the latest version of the data lineage. The time picker can be used
 
 ## Editing from Lineage Graph View
 
+Ensure that you have `Edit lineage` privilege on both upstream and downstream entities before you try to add upstream or downstream lineage. 
+
 The first place that you can edit data lineage for entities is from the Lineage Visualization screen. Click on the "Lineage" button on the top right of an entity's profile to get to this view.
 
 <p align="center">

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/DataHubAuthorizer.java
@@ -367,7 +367,7 @@ public class DataHubAuthorizer implements Authorizer {
           writeLock.unlock();
         }
 
-        log.debug(String.format("Successfully fetched %s policies.", total));
+        log.debug("Successfully fetched {} policies.", total);
       } catch (Exception e) {
         log.error(
             "Caught exception while loading Policy cache. Will retry on next scheduled attempt.",

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyEngine.java
@@ -191,11 +191,10 @@ public class PolicyEngine {
       return true;
     }
     if (policyResourceFilter == null) {
-      // No resource defined on the policy.
+      log.debug("No resource defined on the policy.");
       return true;
     }
     if (requestResource.isEmpty()) {
-      // Resource filter present in policy, but no resource spec provided.
       log.debug("Resource filter present in policy, but no resource spec provided.");
       return false;
     }

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyFetcher.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authorization/PolicyFetcher.java
@@ -81,7 +81,7 @@ public class PolicyFetcher {
   public PolicyFetchResult fetchPolicies(
       OperationContext opContext, String query, int count, @Nullable String scrollId, Filter filter)
       throws RemoteInvocationException, URISyntaxException {
-    log.debug(String.format("Batch fetching policies. count: %s, scroll: %s", count, scrollId));
+    log.debug("Batch fetching policies. count: {}, scroll: {}", count, scrollId);
 
     // First fetch all policy urns
     ScrollResult result =


### PR DESCRIPTION
- show proper error message in case user does not have privilege on upstream
- change some `log.debug(String.format` to `log.debug(` on java side
- move copying `war` to later as rest of items are less frequently changed. Will very slightly help with dev workflow for gms
- add note that you need privilege on both upstream and downstream entity when editing lineage.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
