### PR TITLE
feat(ui): Update ExternalUrlButton to include self-hosted gitlab URLs

### DIFF
--- a/datahub-web-react/src/app/entity/shared/ExternalUrlButton.tsx
+++ b/datahub-web-react/src/app/entity/shared/ExternalUrlButton.tsx
@@ -5,7 +5,7 @@ import UrlButton from './UrlButton';
 
 const GITHUB_LINK = 'github.com';
 const GITHUB = 'GitHub';
-const GITLAB_LINK = 'gitlab.com';
+const GITLAB_LINK = 'gitlab.';
 const GITLAB = 'GitLab';
 
 interface Props {

--- a/datahub-web-react/src/app/entityV2/shared/utils.ts
+++ b/datahub-web-react/src/app/entityV2/shared/utils.ts
@@ -103,7 +103,7 @@ export function getExternalUrlDisplayName(entity: GenericEntityProperties | null
     // Scoping these constants
     const GITHUB_LINK = 'github.com';
     const GITHUB_NAME = 'GitHub';
-    const GITLAB_LINK = 'gitlab.com';
+    const GITLAB_LINK = 'gitlab.';
     const GITLAB_NAME = 'GitLab';
 
     const externalUrl = entity?.properties?.externalUrl;


### PR DESCRIPTION
Update ExternalUrlButton to include self-hosted gitlab URLs. `gitlab.com` is not part of the URL for self hosted Gitlab instances. `gitlab.` will help us cover it 
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
