### PR TITLE
revert(ci): revert datahub-wheel build changes

### DIFF
--- a/.github/workflows/python-build-pages.yml
+++ b/.github/workflows/python-build-pages.yml
@@ -8,7 +8,7 @@ on:
       - "metadata-ingestion/**"
       - "metadata-ingestion-modules/**"
       - "metadata-models/**"
-  pull_request_target:
+  pull_request:
     branches:
       - "**"
     paths:
@@ -38,11 +38,7 @@ jobs:
           distribution: "zulu"
           java-version: 17
       - uses: gradle/actions/setup-gradle@v4
-      - uses: actions/checkout@v4
-        # Note: not using acryldata/sane-checkout-action because this is a
-        # pull_request_target event, and hence requires `ref`.
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: acryldata/sane-checkout-action@v3
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -58,17 +54,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Publish
-        # Cloudflare's pages-action does not support PRs from forks.
-        # See https://developers.cloudflare.com/pages/platform/known-issues/
-        # Based on the discussion here https://github.com/json-schema-org/website/issues/330
-        # we can use a direct upload to work around this limitation.
-        # See https://github.com/AdrianGonz97/refined-cf-pages-action#enabling-pr-previews-from-forks
-        uses: AdrianGonz97/refined-cf-pages-action@v1
+        uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ${{ vars.CLOUDFLARE_WHEELS_PROJECT_NAME }}
-          deploymentName: ${{ vars.CLOUDFLARE_WHEELS_PROJECT_NAME }}
           workingDirectory: python-build
           directory: site
           gitHubToken: ${{ github.token }}


### PR DESCRIPTION
In #12722 and https://github.com/datahub-project/datahub/pull/12730 I attempted to make the cloudflare pages builds work on PRs from forks. It turns out cloudflare's pages-action had issues with PRs from forks, and we started seeing errors (e.g.
https://github.com/datahub-project/datahub/actions/runs/13552436222/job/37879053347?pr=12732) when we tried an alternative action that used direct uploads.

Maybe in the future we'll revisit this, but for now it's not worth the effort.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
