### PR TITLE
feat(versioning): Support entity versioning ingestion

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -968,8 +968,9 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                     // lock)
 
                     // Initial database state from database
-                    Map<String, Map<String, SystemAspect>> batchAspects =
+                    final Map<String, Map<String, SystemAspect>> batchAspects =
                         aspectDao.getLatestAspects(opContext, urnAspects, true);
+                    final Map<String, Map<String, SystemAspect>> updatedLatestAspects;
 
                     // read #2 (potentially)
                     final Map<String, Map<String, Long>> nextVersions =
@@ -989,7 +990,6 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                       // These items are new items from side effects
                       Map<String, Set<String>> sideEffects = updatedItems.getFirst();
 
-                      final Map<String, Map<String, SystemAspect>> updatedLatestAspects;
                       final Map<String, Map<String, Long>> updatedNextVersions;
 
                       Map<String, Map<String, SystemAspect>> newLatestAspects =
@@ -1024,6 +1024,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                               .collect(Collectors.toList());
                     } else {
                       changeMCPs = updatedItems.getSecond();
+                      updatedLatestAspects = batchAspects;
                     }
 
                     // No changes, return
@@ -1080,7 +1081,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                                     Latest aspect after possible in-memory mutation
                                   */
                                   final SystemAspect latestAspect =
-                                      batchAspects
+                                      updatedLatestAspects
                                           .getOrDefault(writeItem.getUrn().toString(), Map.of())
                                           .get(writeItem.getAspectName());
 
@@ -1145,8 +1146,9 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                                       // Only consider retention when there was a previous version
                                       .filter(
                                           result ->
-                                              batchAspects.containsKey(result.getUrn().toString())
-                                                  && batchAspects
+                                              updatedLatestAspects.containsKey(
+                                                      result.getUrn().toString())
+                                                  && updatedLatestAspects
                                                       .get(result.getUrn().toString())
                                                       .containsKey(
                                                           result.getRequest().getAspectName()))

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffect.java
@@ -1,0 +1,175 @@
+package com.linkedin.metadata.entity.versioning.sideeffects;
+
+import static com.linkedin.metadata.Constants.*;
+
+import com.datahub.util.RecordUtils;
+import com.linkedin.common.VersionProperties;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.SystemAspect;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.batch.MCLItem;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
+import com.linkedin.metadata.aspect.patch.PatchOperationType;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MCPSideEffect;
+import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
+import com.linkedin.metadata.entity.ebean.batch.PatchItemImpl;
+import com.linkedin.metadata.models.AspectSpec;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.versionset.VersionSetProperties;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Side effect that updates the isLatest property for the referenced versioned entity's Version
+ * Properties aspect.
+ */
+@Slf4j
+@Getter
+@Setter
+@Accessors(chain = true)
+public class VersionPropertiesSideEffect extends MCPSideEffect {
+  @Nonnull private AspectPluginConfig config;
+
+  @Override
+  protected Stream<ChangeMCP> applyMCPSideEffect(
+      Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
+    return changeMCPS.stream().flatMap(item -> upsertVersionSet(item, retrieverContext));
+  }
+
+  @Override
+  protected Stream<MCPItem> postMCPSideEffect(
+      Collection<MCLItem> mclItems, @Nonnull RetrieverContext retrieverContext) {
+    return Stream.of();
+  }
+
+  private static Stream<ChangeMCP> upsertVersionSet(
+      ChangeMCP changeMCP, @Nonnull RetrieverContext retrieverContext) {
+    Urn entityUrn = changeMCP.getUrn();
+
+    if (!VERSION_PROPERTIES_ASPECT_NAME.equals(changeMCP.getAspectName())) {
+      return Stream.empty();
+    }
+
+    VersionProperties versionProperties = changeMCP.getAspect(VersionProperties.class);
+    if (versionProperties == null) {
+      log.error("Unable to process version properties for urn: {}", changeMCP.getUrn());
+      return Stream.empty();
+    }
+
+    VersionSetProperties newVersionSetProperties =
+        new VersionSetProperties()
+            .setVersioningScheme(versionProperties.getVersioningScheme())
+            .setLatest(entityUrn);
+
+    Urn versionSetUrn = versionProperties.getVersionSet();
+    SystemAspect versionSetPropertiesAspect =
+        retrieverContext
+            .getAspectRetriever()
+            .getLatestSystemAspect(versionSetUrn, VERSION_SET_PROPERTIES_ASPECT_NAME);
+    if (versionSetPropertiesAspect != null) {
+      VersionSetProperties versionSetProperties =
+          RecordUtils.toRecordTemplate(
+              VersionSetProperties.class, versionSetPropertiesAspect.getRecordTemplate().data());
+      Urn prevLatest = versionSetProperties.getLatest();
+      if (prevLatest.equals(entityUrn)) {
+        return Stream.empty();
+      }
+
+      SystemAspect prevLatestVersionPropertiesAspect =
+          retrieverContext
+              .getAspectRetriever()
+              .getLatestSystemAspect(prevLatest, VERSION_PROPERTIES_ASPECT_NAME);
+      if (prevLatestVersionPropertiesAspect == null) {
+        return Stream.empty();
+      }
+
+      VersionProperties prevLatestVersionProperties =
+          RecordUtils.toRecordTemplate(
+              VersionProperties.class,
+              prevLatestVersionPropertiesAspect.getRecordTemplate().data());
+      if (versionProperties.getSortId().compareTo(prevLatestVersionProperties.getSortId()) <= 0) {
+        return Stream.empty();
+      }
+
+      // New version properties aspect is the latest
+      ChangeMCP updateVersionSetProperties =
+          ChangeItemImpl.builder()
+              .urn(versionSetUrn)
+              .aspectName(VERSION_SET_PROPERTIES_ASPECT_NAME)
+              .changeType(ChangeType.UPSERT)
+              .recordTemplate(newVersionSetProperties)
+              .auditStamp(changeMCP.getAuditStamp())
+              .systemMetadata(changeMCP.getSystemMetadata())
+              .build(retrieverContext.getAspectRetriever());
+
+      EntitySpec entitySpec =
+          retrieverContext
+              .getAspectRetriever()
+              .getEntityRegistry()
+              .getEntitySpec(prevLatest.getEntityType());
+      GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+      patchOp.setOp(PatchOperationType.ADD.getValue());
+      patchOp.setPath("/isLatest");
+      patchOp.setValue(false);
+      ChangeMCP updateOldLatestVersionProperties =
+          PatchItemImpl.builder()
+              .urn(prevLatest)
+              .entitySpec(entitySpec)
+              .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+              .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+              .patch(GenericJsonPatch.builder().patch(List.of(patchOp)).build().getJsonPatch())
+              .auditStamp(changeMCP.getAuditStamp())
+              .systemMetadata(changeMCP.getSystemMetadata())
+              .build(retrieverContext.getAspectRetriever().getEntityRegistry())
+              .applyPatch(prevLatestVersionProperties, retrieverContext.getAspectRetriever());
+
+      versionProperties.setIsLatest(true);
+      return Stream.of(updateVersionSetProperties, updateOldLatestVersionProperties);
+    }
+
+    // Version Set does not exist
+    final AspectSpec keyAspectSpec =
+        retrieverContext
+            .getAspectRetriever()
+            .getEntityRegistry()
+            .getEntitySpec(VERSION_SET_ENTITY_NAME)
+            .getKeyAspectSpec();
+    RecordTemplate versionSetKey =
+        EntityKeyUtils.convertUrnToEntityKey(versionSetUrn, keyAspectSpec);
+
+    ChangeMCP createVersionSetKey =
+        ChangeItemImpl.builder()
+            .urn(versionSetUrn)
+            .aspectName(VERSION_SET_KEY_ASPECT_NAME)
+            .changeType(ChangeType.UPSERT)
+            .recordTemplate(versionSetKey)
+            .auditStamp(changeMCP.getAuditStamp())
+            .systemMetadata(changeMCP.getSystemMetadata())
+            .build(retrieverContext.getAspectRetriever());
+
+    ChangeMCP createVersionSetProperties =
+        ChangeItemImpl.builder()
+            .urn(versionSetUrn)
+            .aspectName(VERSION_SET_PROPERTIES_ASPECT_NAME)
+            .changeType(ChangeType.UPSERT)
+            .recordTemplate(newVersionSetProperties)
+            .auditStamp(changeMCP.getAuditStamp())
+            .systemMetadata(changeMCP.getSystemMetadata())
+            .build(retrieverContext.getAspectRetriever());
+
+    versionProperties.setIsLatest(true);
+    return Stream.of(createVersionSetKey, createVersionSetProperties);
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionSetSideEffect.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionSetSideEffect.java
@@ -124,21 +124,26 @@ public class VersionSetSideEffect extends MCPSideEffect {
               .getEntitySpec(newLatest.getEntityType());
       VersionProperties newLatestProperties =
           RecordUtils.toRecordTemplate(VersionProperties.class, newLatestEntity.data());
-      GenericJsonPatch.PatchOp currentPatch = new GenericJsonPatch.PatchOp();
-      currentPatch.setOp(PatchOperationType.ADD.getValue());
-      currentPatch.setPath("/isLatest");
-      currentPatch.setValue(true);
-      mcpItems.add(
-          PatchItemImpl.builder()
-              .urn(newLatest)
-              .entitySpec(entitySpec)
-              .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
-              .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
-              .patch(GenericJsonPatch.builder().patch(List.of(currentPatch)).build().getJsonPatch())
-              .auditStamp(changeMCP.getAuditStamp())
-              .systemMetadata(changeMCP.getSystemMetadata())
-              .build(retrieverContext.getAspectRetriever().getEntityRegistry())
-              .applyPatch(newLatestProperties, retrieverContext.getAspectRetriever()));
+
+      if (Boolean.FALSE.equals(newLatestProperties.isIsLatest())) {
+        GenericJsonPatch.PatchOp currentPatch = new GenericJsonPatch.PatchOp();
+        currentPatch.setOp(PatchOperationType.ADD.getValue());
+        currentPatch.setPath("/isLatest");
+        currentPatch.setValue(true);
+        mcpItems.add(
+            PatchItemImpl.builder()
+                .urn(newLatest)
+                .entitySpec(entitySpec)
+                .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+                .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+                .patch(
+                    GenericJsonPatch.builder().patch(List.of(currentPatch)).build().getJsonPatch())
+                .auditStamp(changeMCP.getAuditStamp())
+                .systemMetadata(changeMCP.getSystemMetadata())
+                .build(retrieverContext.getAspectRetriever().getEntityRegistry())
+                .applyPatch(newLatestProperties, retrieverContext.getAspectRetriever()));
+      }
+
       return mcpItems.stream();
     }
     return Stream.empty();

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffectTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/versioning/sideeffects/VersionPropertiesSideEffectTest.java
@@ -1,0 +1,238 @@
+package com.linkedin.metadata.entity.versioning.sideeffects;
+
+import static com.linkedin.metadata.Constants.*;
+import static com.linkedin.metadata.search.elasticsearch.indexbuilder.SettingsBuilder.*;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.*;
+
+import com.linkedin.common.GlobalTags;
+import com.linkedin.common.TagAssociationArray;
+import com.linkedin.common.VersionProperties;
+import com.linkedin.common.VersionTag;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.SystemAspect;
+import com.linkedin.metadata.aspect.batch.MCPItem;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
+import com.linkedin.metadata.entity.ebean.batch.MCLItemImpl;
+import com.linkedin.metadata.key.VersionSetKey;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.utils.AuditStampUtils;
+import com.linkedin.test.metadata.aspect.MockAspectRetriever;
+import com.linkedin.test.metadata.aspect.TestEntityRegistry;
+import com.linkedin.versionset.VersionSetProperties;
+import com.linkedin.versionset.VersioningScheme;
+import io.datahubproject.metadata.context.RetrieverContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class VersionPropertiesSideEffectTest {
+  private static final TestEntityRegistry TEST_REGISTRY = new TestEntityRegistry();
+
+  private static final Urn HAS_PROPERTIES_VERSION_SET_URN =
+      UrnUtils.getUrn("urn:li:versionSet:(has-properties,dataset)");
+  private static final Urn MISSING_PROPERTIES_VERSION_SET_URN =
+      UrnUtils.getUrn("urn:li:versionSet:(missing-properties-exists,dataset)");
+  private static final Urn NOT_EXISTS_PROPERTIES_VERSION_SET_URN =
+      UrnUtils.getUrn("urn:li:versionSet:(does-not-exist,dataset)");
+
+  private static final Urn PREVIOUS_LATEST_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)");
+  private static final Urn ENTITY_URN =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDatasetV2,PROD)");
+
+  private static final AspectPluginConfig TEST_PLUGIN_CONFIG =
+      AspectPluginConfig.builder()
+          .className(VersionSetSideEffect.class.getName())
+          .enabled(true)
+          .supportedOperations(
+              List.of("CREATE", "PATCH", "CREATE_ENTITY", "UPSERT", "DELETE", "RESTATE"))
+          .supportedEntityAspectNames(
+              List.of(
+                  AspectPluginConfig.EntityAspectName.builder()
+                      .entityName(ALL)
+                      .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+                      .build()))
+          .build();
+
+  private MockAspectRetriever mockAspectRetriever;
+  private RetrieverContext retrieverContext;
+  private VersionPropertiesSideEffect sideEffect;
+
+  @BeforeMethod
+  public void setup() {
+    VersionSetProperties existingVersionSetProperties =
+        new VersionSetProperties()
+            .setLatest(PREVIOUS_LATEST_URN)
+            .setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING);
+    VersionSetKey existingVersionSetKey =
+        new VersionSetKey().setId("missing-properties-exists").setEntityType(DATASET_ENTITY_NAME);
+
+    Map<Urn, List<RecordTemplate>> data = new HashMap<>();
+    data.put(HAS_PROPERTIES_VERSION_SET_URN, List.of(existingVersionSetProperties));
+    data.put(MISSING_PROPERTIES_VERSION_SET_URN, List.of(existingVersionSetKey));
+    mockAspectRetriever = new MockAspectRetriever(data);
+    mockAspectRetriever.setEntityRegistry(TEST_REGISTRY);
+
+    retrieverContext =
+        RetrieverContext.builder()
+            .searchRetriever(mock(SearchRetriever.class))
+            .aspectRetriever(mockAspectRetriever)
+            .graphRetriever(mock(GraphRetriever.class))
+            .build();
+
+    sideEffect = new VersionPropertiesSideEffect();
+    sideEffect.setConfig(TEST_PLUGIN_CONFIG);
+  }
+
+  @Test
+  public void testCreateVersionSet() {
+    // Create version set if it does not exist
+    VersionProperties properties =
+        new VersionProperties()
+            .setVersionSet(NOT_EXISTS_PROPERTIES_VERSION_SET_URN)
+            .setVersioningScheme(VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB)
+            .setVersion(new VersionTag().setVersionTag("version"))
+            .setSortId("abc");
+
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(ENTITY_URN)
+            .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+            .entitySpec(entitySpec)
+            .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(properties)
+            .previousSystemAspect(mock(SystemAspect.class))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    // Run side effect
+    List<MCPItem> sideEffectResults =
+        sideEffect
+            .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+            .collect(Collectors.toList());
+
+    // Verify results
+    assertEquals(sideEffectResults.size(), 1, "Expected one upsert");
+
+    // Verify patch for previous latest version
+    MCPItem patched = sideEffectResults.get(0);
+    assertEquals(patched.getUrn(), NOT_EXISTS_PROPERTIES_VERSION_SET_URN);
+    VersionSetProperties versionSetProperties = patched.getAspect(VersionSetProperties.class);
+    assertNotNull(versionSetProperties);
+    assertEquals(versionSetProperties.getLatest(), ENTITY_URN);
+    assertEquals(
+        versionSetProperties.getVersioningScheme(),
+        VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB);
+  }
+
+  @Test
+  public void testVersionSetPropertiesExists() {
+    // Do nothing if version set properties already exists
+    VersionProperties properties =
+        new VersionProperties()
+            .setVersionSet(HAS_PROPERTIES_VERSION_SET_URN)
+            .setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING)
+            .setVersion(new VersionTag().setVersionTag("version"))
+            .setSortId("abc");
+
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(ENTITY_URN)
+            .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+            .entitySpec(entitySpec)
+            .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(properties)
+            .previousSystemAspect(mock(SystemAspect.class))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    // Run side effect
+    List<MCPItem> sideEffectResults =
+        sideEffect
+            .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+            .collect(Collectors.toList());
+
+    // Verify results
+    assertEquals(sideEffectResults.size(), 0, "Expected no operations");
+  }
+
+  @Test
+  public void testCreateVersionSetExists() {
+    // Create version set properties if entity exists but properties aspect does not
+    VersionProperties properties =
+        new VersionProperties()
+            .setVersionSet(MISSING_PROPERTIES_VERSION_SET_URN)
+            .setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING)
+            .setVersion(new VersionTag().setVersionTag("version"))
+            .setSortId("abc");
+
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(ENTITY_URN)
+            .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
+            .entitySpec(entitySpec)
+            .aspectSpec(entitySpec.getAspectSpec(VERSION_PROPERTIES_ASPECT_NAME))
+            .recordTemplate(properties)
+            .previousSystemAspect(mock(SystemAspect.class))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    // Run side effect
+    List<MCPItem> sideEffectResults =
+        sideEffect
+            .applyMCPSideEffect(Collections.singletonList(changeItem), retrieverContext)
+            .collect(Collectors.toList());
+
+    // Verify results
+    assertEquals(sideEffectResults.size(), 1, "Expected one upsert");
+
+    // Verify patch for previous latest version
+    MCPItem patched = sideEffectResults.get(0);
+    assertEquals(patched.getUrn(), MISSING_PROPERTIES_VERSION_SET_URN);
+    VersionSetProperties versionSetProperties = patched.getAspect(VersionSetProperties.class);
+    assertNotNull(versionSetProperties);
+    assertEquals(versionSetProperties.getLatest(), ENTITY_URN);
+    assertEquals(versionSetProperties.getVersioningScheme(), VersioningScheme.LEXICOGRAPHIC_STRING);
+  }
+
+  @Test
+  public void testNoChangesForNonVersionSetProperties() {
+    // Create some other type of aspect change
+    EntitySpec entitySpec = TEST_REGISTRY.getEntitySpec(DATASET_ENTITY_NAME);
+    ChangeItemImpl changeItem =
+        ChangeItemImpl.builder()
+            .urn(PREVIOUS_LATEST_URN)
+            .aspectName(GLOBAL_TAGS_ASPECT_NAME)
+            .entitySpec(entitySpec)
+            .aspectSpec(entitySpec.getAspectSpec(GLOBAL_TAGS_ASPECT_NAME))
+            .recordTemplate(new GlobalTags().setTags(new TagAssociationArray()))
+            .auditStamp(AuditStampUtils.createDefaultAuditStamp())
+            .build(mockAspectRetriever);
+
+    MCLItemImpl mclItem =
+        MCLItemImpl.builder().build(changeItem, null, null, retrieverContext.getAspectRetriever());
+
+    // Run side effect
+    List<MCPItem> sideEffectResults =
+        sideEffect
+            .postMCPSideEffect(Collections.singletonList(mclItem), retrieverContext)
+            .collect(Collectors.toList());
+
+    // Verify no changes for non-version set properties aspects
+    assertEquals(
+        sideEffectResults.size(), 0, "Expected no changes for non-version set properties aspect");
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/versioning/validation/VersionPropertiesValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/versioning/validation/VersionPropertiesValidatorTest.java
@@ -1,6 +1,6 @@
 package com.linkedin.metadata.entity.versioning.validation;
 
-import static com.linkedin.metadata.Constants.CHART_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -37,8 +37,12 @@ import org.testng.annotations.Test;
 public class VersionPropertiesValidatorTest {
 
   private static final String ENTITY_TYPE = "dataset";
-  private static final Urn TEST_VERSION_SET_URN =
-      UrnUtils.getUrn("urn:li:versionSet:(12356,dataset)");
+  private static final Urn MANAGED_VERSION_SET_URN =
+      UrnUtils.getUrn("urn:li:versionSet:(managed,dataset)");
+  private static final Urn LEXICOGRAPHIC_VERSION_SET_URN =
+      UrnUtils.getUrn("urn:li:versionSet:(lexicographic,dataset)");
+  private static final Urn ML_MODEL_VERSION_SET_URN =
+      UrnUtils.getUrn("urn:li:versionSet:(managed,mlModel)");
   private static final Urn TEST_ENTITY_URN =
       UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)");
 
@@ -55,17 +59,26 @@ public class VersionPropertiesValidatorTest {
         .thenReturn(new ScrollResult().setEntities(new SearchEntityArray()));
     mockGraphRetriever = Mockito.mock(GraphRetriever.class);
 
-    // Create version set key and properties
-    VersionSetKey versionSetKey = new VersionSetKey();
-    versionSetKey.setEntityType(ENTITY_TYPE);
-
-    VersionSetProperties versionSetProperties = new VersionSetProperties();
-    versionSetProperties.setVersioningScheme(VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB);
-
     // Initialize mock aspect retriever with version set data
     Map<Urn, List<RecordTemplate>> data = new HashMap<>();
-    data.put(TEST_VERSION_SET_URN, Arrays.asList(versionSetKey, versionSetProperties));
+    data.put(
+        MANAGED_VERSION_SET_URN,
+        Arrays.asList(
+            new VersionSetKey().setEntityType(DATASET_ENTITY_NAME),
+            new VersionSetProperties()
+                .setVersioningScheme(VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB)));
+    data.put(
+        LEXICOGRAPHIC_VERSION_SET_URN,
+        Arrays.asList(
+            new VersionSetKey().setEntityType(DATASET_ENTITY_NAME),
+            new VersionSetProperties().setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING)));
+    data.put(
+        ML_MODEL_VERSION_SET_URN,
+        Arrays.asList(
+            new VersionSetKey().setEntityType(ML_MODEL_ENTITY_NAME),
+            new VersionSetProperties().setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING)));
     mockAspectRetriever = new MockAspectRetriever(data);
+    mockAspectRetriever.setEntityRegistry(new TestEntityRegistry());
 
     retrieverContext =
         io.datahubproject.metadata.context.RetrieverContext.builder()
@@ -78,7 +91,8 @@ public class VersionPropertiesValidatorTest {
   @Test
   public void testValidVersionProperties() {
     VersionProperties properties = new VersionProperties();
-    properties.setVersionSet(TEST_VERSION_SET_URN);
+    properties.setVersionSet(MANAGED_VERSION_SET_URN);
+    properties.setVersioningScheme(VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB);
     properties.setSortId("ABCDEFGH"); // Valid 8-char uppercase alpha
     properties.setVersion(new VersionTag().setVersionTag("123"));
 
@@ -93,7 +107,8 @@ public class VersionPropertiesValidatorTest {
   @Test
   public void testInvalidSortId() {
     VersionProperties properties = new VersionProperties();
-    properties.setVersionSet(TEST_VERSION_SET_URN);
+    properties.setVersionSet(MANAGED_VERSION_SET_URN);
+    properties.setVersioningScheme(VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB);
     properties.setSortId("123"); // Invalid - not 8 chars, not alpha
     properties.setVersion(new VersionTag().setVersionTag("123"));
 
@@ -108,12 +123,30 @@ public class VersionPropertiesValidatorTest {
   }
 
   @Test
-  public void testNonexistentVersionSet() {
-    Urn nonexistentUrn = UrnUtils.getUrn("urn:li:versionSet:(nonexistent,dataset)");
-
+  public void testSortIdValidLexicographic() {
     VersionProperties properties = new VersionProperties();
-    properties.setVersionSet(nonexistentUrn);
+    properties.setVersionSet(LEXICOGRAPHIC_VERSION_SET_URN);
+    properties.setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING);
+    properties.setSortId("123");
+    properties.setVersion(new VersionTag().setVersionTag("123"));
+
+    Stream<AspectValidationException> validationResult =
+        VersionPropertiesValidator.validatePropertiesUpserts(
+            TestMCP.ofOneUpsertItem(TEST_ENTITY_URN, properties, new TestEntityRegistry()),
+            retrieverContext);
+
+    var exceptions = validationResult.findAny();
+    Assert.assertTrue(
+        exceptions.isEmpty(), exceptions.map(AspectValidationException::getMessage).orElse(null));
+  }
+
+  @Test
+  public void testVersioningSchemeMismatch() {
+    VersionProperties properties = new VersionProperties();
+    properties.setVersionSet(MANAGED_VERSION_SET_URN);
+    properties.setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING);
     properties.setSortId("ABCDEFGH");
+    properties.setVersion(new VersionTag().setVersionTag("123"));
 
     Stream<AspectValidationException> validationResult =
         VersionPropertiesValidator.validatePropertiesUpserts(
@@ -122,31 +155,38 @@ public class VersionPropertiesValidatorTest {
 
     AspectValidationException exception = validationResult.findAny().get();
     Assert.assertNotNull(exception);
-    Assert.assertTrue(exception.getMessage().contains("Version Set specified does not exist"));
+    Assert.assertTrue(
+        exception.getMessage().contains("Versioning Scheme does not match Version Set properties"));
+  }
+
+  @Test
+  public void testNonexistentVersionSet() {
+    // Non-existent version set gets created by VersionPropertiesSideEffect
+    Urn nonexistentUrn = UrnUtils.getUrn("urn:li:versionSet:(nonexistent,dataset)");
+
+    VersionProperties properties = new VersionProperties();
+    properties.setVersionSet(nonexistentUrn);
+    properties.setSortId("abc");
+    properties.setVersion(new VersionTag().setVersionTag("123"));
+
+    Stream<AspectValidationException> validationResult =
+        VersionPropertiesValidator.validatePropertiesUpserts(
+            TestMCP.ofOneUpsertItem(TEST_ENTITY_URN, properties, new TestEntityRegistry()),
+            retrieverContext);
+
+    var exceptions = validationResult.findAny();
+    Assert.assertTrue(
+        exceptions.isEmpty(), exceptions.map(AspectValidationException::getMessage).orElse(null));
   }
 
   @Test
   public void testEntityTypeMismatch() {
-    // Create version set with different entity type
-    VersionSetKey wrongTypeKey = new VersionSetKey();
-    wrongTypeKey.setEntityType(CHART_ENTITY_NAME);
-
     VersionSetProperties versionSetProperties = new VersionSetProperties();
-    versionSetProperties.setVersioningScheme(VersioningScheme.ALPHANUMERIC_GENERATED_BY_DATAHUB);
-
-    Map<Urn, List<RecordTemplate>> data = new HashMap<>();
-    data.put(TEST_VERSION_SET_URN, Arrays.asList(wrongTypeKey, versionSetProperties));
-    mockAspectRetriever = new MockAspectRetriever(data);
-
-    retrieverContext =
-        io.datahubproject.metadata.context.RetrieverContext.builder()
-            .aspectRetriever(mockAspectRetriever)
-            .searchRetriever(mockSearchRetriever)
-            .graphRetriever(mockGraphRetriever)
-            .build();
+    versionSetProperties.setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING);
 
     VersionProperties properties = new VersionProperties();
-    properties.setVersionSet(TEST_VERSION_SET_URN);
+    properties.setVersionSet(ML_MODEL_VERSION_SET_URN);
+    properties.setVersioningScheme(VersioningScheme.LEXICOGRAPHIC_STRING);
     properties.setSortId("ABCDEFGH");
     properties.setVersion(new VersionTag().setVersionTag("123"));
 
@@ -164,7 +204,7 @@ public class VersionPropertiesValidatorTest {
   @Test
   public void testIsLatestFieldSpecified() {
     VersionProperties properties = new VersionProperties();
-    properties.setVersionSet(TEST_VERSION_SET_URN);
+    properties.setVersionSet(MANAGED_VERSION_SET_URN);
     properties.setSortId("ABCDEFGH");
     properties.setIsLatest(true); // Should not be specified
 

--- a/metadata-models/src/main/pegasus/com/linkedin/common/VersionProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/VersionProperties.pdl
@@ -1,5 +1,7 @@
 namespace com.linkedin.common
 
+import com.linkedin.versionset.VersioningScheme
+
 /**
  * Properties about a versioned asset i.e. dataset, ML Model, etc.
  */
@@ -55,6 +57,12 @@ record VersionProperties {
     "fieldName": "versionSortId"
   }
   sortId: string
+
+  /**
+   * What versioning scheme `sortId` belongs to.
+   * Defaults to a plain string that is lexicographically sorted.
+   */
+  versioningScheme: VersioningScheme = "LEXICOGRAPHIC_STRING"
 
   /**
    * Timestamp reflecting when this asset version was created in the source system.

--- a/metadata-models/src/main/pegasus/com/linkedin/versionset/VersionSetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/versionset/VersionSetProperties.pdl
@@ -18,7 +18,5 @@ record VersionSetProperties includes CustomProperties {
   /**
    * What versioning scheme is being utilized for the versioned entities sort criterion. Static once set
    */
-  versioningScheme: enum VersioningScheme {
-    ALPHANUMERIC_GENERATED_BY_DATAHUB
-  }
+  versioningScheme: VersioningScheme
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/versionset/VersioningScheme.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/versionset/VersioningScheme.pdl
@@ -1,0 +1,13 @@
+namespace com.linkedin.versionset
+
+enum VersioningScheme {
+  /**
+   * String sorted lexicographically.
+   */
+  LEXICOGRAPHIC_STRING,
+
+  /**
+   * String managed by DataHub. Currently, an 8 character alphabetical string.
+   */
+  ALPHANUMERIC_GENERATED_BY_DATAHUB
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -13,6 +13,7 @@ import com.linkedin.metadata.aspect.validation.FieldPathValidator;
 import com.linkedin.metadata.aspect.validation.UrnAnnotationValidator;
 import com.linkedin.metadata.aspect.validation.UserDeleteValidator;
 import com.linkedin.metadata.dataproducts.sideeffects.DataProductUnsetSideEffect;
+import com.linkedin.metadata.entity.versioning.sideeffects.VersionPropertiesSideEffect;
 import com.linkedin.metadata.entity.versioning.sideeffects.VersionSetSideEffect;
 import com.linkedin.metadata.entity.versioning.validation.VersionPropertiesValidator;
 import com.linkedin.metadata.entity.versioning.validation.VersionSetPropertiesValidator;
@@ -224,6 +225,24 @@ public class SpringStandardPluginConfiguration {
                         AspectPluginConfig.EntityAspectName.builder()
                             .entityName(VERSION_SET_ENTITY_NAME)
                             .aspectName(VERSION_SET_PROPERTIES_ASPECT_NAME)
+                            .build()))
+                .build());
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "featureFlags.entityVersioning", havingValue = "true")
+  public MCPSideEffect versionPropertiesSideEffect() {
+    return new VersionPropertiesSideEffect()
+        .setConfig(
+            AspectPluginConfig.builder()
+                .className(VersionPropertiesSideEffect.class.getName())
+                .enabled(true)
+                .supportedOperations(List.of(UPSERT, UPDATE, PATCH, CREATE, CREATE_ENTITY))
+                .supportedEntityAspectNames(
+                    List.of(
+                        AspectPluginConfig.EntityAspectName.builder()
+                            .entityName(ALL)
+                            .aspectName(VERSION_PROPERTIES_ASPECT_NAME)
                             .build()))
                 .build());
   }

--- a/smoke-test/tests/entity_versioning/test_versioning_ingest.py
+++ b/smoke-test/tests/entity_versioning/test_versioning_ingest.py
@@ -1,13 +1,12 @@
-import time
-
 import pytest
+
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DataHubGraph
 from datahub.metadata.schema_classes import *
 from datahub.metadata.urns import DatasetUrn, VersionSetUrn
 
-OLD_LATEST_URN = DatasetUrn("v", f"vol")
-ENTITY_URN = DatasetUrn("v", f"vi")
+OLD_LATEST_URN = DatasetUrn("v", "versioning_old_latest")
+ENTITY_URN = DatasetUrn("v", "versioning_entity")
 EXISTS_VERSION_SET_URN = VersionSetUrn("exists", DatasetUrn.ENTITY_TYPE)
 NOT_EXISTS_VERSION_SET_URN = VersionSetUrn("not-exists", DatasetUrn.ENTITY_TYPE)
 

--- a/smoke-test/tests/entity_versioning/test_versioning_ingest.py
+++ b/smoke-test/tests/entity_versioning/test_versioning_ingest.py
@@ -1,0 +1,178 @@
+import time
+
+import pytest
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.graph.client import DataHubGraph
+from datahub.metadata.schema_classes import *
+from datahub.metadata.urns import DatasetUrn, VersionSetUrn
+
+OLD_LATEST_URN = DatasetUrn("v", f"vol")
+ENTITY_URN = DatasetUrn("v", f"vi")
+EXISTS_VERSION_SET_URN = VersionSetUrn("exists", DatasetUrn.ENTITY_TYPE)
+NOT_EXISTS_VERSION_SET_URN = VersionSetUrn("not-exists", DatasetUrn.ENTITY_TYPE)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def ingest_cleanup_data(graph_client: DataHubGraph):
+    try:
+        graph_client.emit(
+            MetadataChangeProposalWrapper(
+                entityUrn=OLD_LATEST_URN.urn(),
+                aspect=VersionPropertiesClass(
+                    versionSet=EXISTS_VERSION_SET_URN.urn(),
+                    version=VersionTagClass(versionTag="first"),
+                    sortId="abc",
+                    versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+                ),
+            )
+        )
+        yield
+    finally:
+        pass
+        graph_client.hard_delete_entity(EXISTS_VERSION_SET_URN.urn())
+        graph_client.hard_delete_entity(NOT_EXISTS_VERSION_SET_URN.urn())
+        graph_client.hard_delete_entity(ENTITY_URN.urn())
+        graph_client.hard_delete_entity(OLD_LATEST_URN.urn())
+
+
+def test_ingest_version_properties(graph_client: DataHubGraph):
+    graph_client.emit(
+        MetadataChangeProposalWrapper(
+            entityUrn=ENTITY_URN.urn(),
+            aspect=VersionPropertiesClass(
+                versionSet=NOT_EXISTS_VERSION_SET_URN.urn(),
+                version=VersionTagClass(versionTag="first"),
+                sortId="abc",
+                versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+            ),
+        )
+    )
+    version_set_properties = graph_client.get_aspect(
+        NOT_EXISTS_VERSION_SET_URN.urn(), VersionSetPropertiesClass
+    )
+    assert version_set_properties.latest == ENTITY_URN.urn()
+    assert (
+        version_set_properties.versioningScheme
+        == VersioningSchemeClass.LEXICOGRAPHIC_STRING
+    )
+
+    assert graph_client.get_aspect(ENTITY_URN.urn(), VersionPropertiesClass).isLatest
+
+
+def test_ingest_version_properties_alphanumeric(graph_client: DataHubGraph):
+    graph_client.emit(
+        MetadataChangeProposalWrapper(
+            entityUrn=ENTITY_URN.urn(),
+            aspect=VersionPropertiesClass(
+                versionSet=NOT_EXISTS_VERSION_SET_URN.urn(),
+                version=VersionTagClass(versionTag="first"),
+                sortId="abc",
+                versioningScheme=VersioningSchemeClass.ALPHANUMERIC_GENERATED_BY_DATAHUB,
+            ),
+        )
+    )
+    assert graph_client.get_aspect(ENTITY_URN.urn(), VersionPropertiesClass).isLatest
+    version_set_properties = graph_client.get_aspect(
+        NOT_EXISTS_VERSION_SET_URN.urn(), VersionSetPropertiesClass
+    )
+    assert version_set_properties.latest == ENTITY_URN.urn()
+    assert (
+        version_set_properties.versioningScheme
+        == VersioningSchemeClass.ALPHANUMERIC_GENERATED_BY_DATAHUB
+    )
+
+
+def test_ingest_version_properties_version_set_new_latest(graph_client: DataHubGraph):
+    assert graph_client.get_aspect(
+        OLD_LATEST_URN.urn(), VersionPropertiesClass
+    ).isLatest
+    graph_client.emit(
+        MetadataChangeProposalWrapper(
+            entityUrn=ENTITY_URN.urn(),
+            aspect=VersionPropertiesClass(
+                versionSet=EXISTS_VERSION_SET_URN.urn(),
+                version=VersionTagClass(versionTag="second"),
+                sortId="bbb",
+                versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+            ),
+        )
+    )
+    assert not graph_client.get_aspect(
+        OLD_LATEST_URN.urn(), VersionPropertiesClass
+    ).isLatest
+    version_set_properties = graph_client.get_aspect(
+        EXISTS_VERSION_SET_URN.urn(), VersionSetPropertiesClass
+    )
+    assert version_set_properties.latest == ENTITY_URN.urn()
+    assert graph_client.get_aspect(ENTITY_URN.urn(), VersionPropertiesClass).isLatest
+
+
+def test_ingest_version_properties_version_set_not_latest(graph_client: DataHubGraph):
+    graph_client.emit(
+        MetadataChangeProposalWrapper(
+            entityUrn=ENTITY_URN.urn(),
+            aspect=VersionPropertiesClass(
+                versionSet=EXISTS_VERSION_SET_URN.urn(),
+                version=VersionTagClass(versionTag="zero"),
+                sortId="aaa",
+                versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+            ),
+        )
+    )
+    assert not graph_client.get_aspect(
+        ENTITY_URN.urn(), VersionPropertiesClass
+    ).isLatest
+    assert graph_client.get_aspect(
+        OLD_LATEST_URN.urn(), VersionPropertiesClass
+    ).isLatest
+    version_set_properties = graph_client.get_aspect(
+        EXISTS_VERSION_SET_URN.urn(), VersionSetPropertiesClass
+    )
+    assert version_set_properties.latest == OLD_LATEST_URN.urn()
+
+
+def test_ingest_many_versions(graph_client: DataHubGraph):
+    for i in range(20):
+        graph_client.emit(
+            MetadataChangeProposalWrapper(
+                entityUrn=DatasetUrn("v", f"entity_{i}").urn(),
+                aspect=VersionPropertiesClass(
+                    versionSet=NOT_EXISTS_VERSION_SET_URN.urn(),
+                    version=VersionTagClass(versionTag=f"v{i}"),
+                    sortId=str(i).zfill(2),
+                    versioningScheme=VersioningSchemeClass.LEXICOGRAPHIC_STRING,
+                ),
+            )
+        )
+    expected_latest_urn = DatasetUrn("v", f"entity_{i}")
+    assert graph_client.get_aspect(
+        expected_latest_urn.urn(), VersionPropertiesClass
+    ).isLatest
+    version_set_properties = graph_client.get_aspect(
+        NOT_EXISTS_VERSION_SET_URN.urn(), VersionSetPropertiesClass
+    )
+    assert version_set_properties.latest == expected_latest_urn.urn()
+    assert (
+        version_set_properties.versioningScheme
+        == VersioningSchemeClass.LEXICOGRAPHIC_STRING
+    )
+    result = graph_client.execute_graphql(
+        """
+            query getVersions($urn: String!) {
+              versionSet(urn: $urn) {
+                versionsSearch(input: {query: "*", count: 20, searchFlags: {skipCache: true}}) {
+                  searchResults {
+                    entity {
+                      urn
+                    }
+                  }
+                }
+              }
+            }
+        """,
+        variables={"urn": NOT_EXISTS_VERSION_SET_URN.urn()},
+    )
+    assert result["versionSet"]["versionsSearch"]["searchResults"] == [
+        {"entity": {"urn": DatasetUrn("v", f"entity_{i}").urn()}}
+        for i in reversed(range(20))
+    ]


### PR DESCRIPTION
- Create LEXICOGRAPHIC_STRING versioning scheme 
- Create versionPropertiesSideEffect that creates / updates version set latest
  * Unlink no longer creates version set

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
