### PR TITLE
fix(lineage) Support views and sorting in impact analysis

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -1026,7 +1026,8 @@ public class GmsGraphQLEngine {
                     new ScrollAcrossEntitiesResolver(this.entityClient, this.viewService))
                 .dataFetcher(
                     "searchAcrossLineage",
-                    new SearchAcrossLineageResolver(this.entityClient, this.entityRegistry))
+                    new SearchAcrossLineageResolver(
+                        this.entityClient, this.entityRegistry, this.viewService))
                 .dataFetcher(
                     "scrollAcrossLineage", new ScrollAcrossLineageResolver(this.entityClient))
                 .dataFetcher(

--- a/datahub-graphql-core/src/main/resources/search.graphql
+++ b/datahub-graphql-core/src/main/resources/search.graphql
@@ -417,6 +417,16 @@ input SearchAcrossLineageInput {
   Flags controlling the lineage query
   """
   lineageFlags: LineageFlags
+
+  """
+  Optional - A View to apply when generating results
+  """
+  viewUrn: String
+
+  """
+  Optional - Information on how to sort this search result
+  """
+  sortInput: SearchSortInput
 }
 
 """

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/ScrollAcrossLineageResolverTest.java
@@ -31,6 +31,7 @@ import com.linkedin.metadata.search.LineageSearchEntity;
 import com.linkedin.metadata.search.LineageSearchEntityArray;
 import com.linkedin.metadata.search.MatchedFieldArray;
 import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.service.ViewService;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.InputStream;
@@ -76,7 +77,7 @@ public class ScrollAcrossLineageResolverTest {
     InputStream inputStream = ClassLoader.getSystemResourceAsStream("entity-registry.yml");
     EntityRegistry entityRegistry = new ConfigEntityRegistry(inputStream);
     SearchAcrossLineageResolver resolver =
-        new SearchAcrossLineageResolver(_entityClient, entityRegistry);
+        new SearchAcrossLineageResolver(_entityClient, entityRegistry, mock(ViewService.class));
     assertTrue(resolver._allEntities.contains("dataset"));
     assertTrue(resolver._allEntities.contains("dataFlow"));
     // Test for case sensitivity

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolverTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/resolvers/search/SearchAcrossLineageResolverTest.java
@@ -22,6 +22,7 @@ import com.linkedin.metadata.search.LineageSearchEntityArray;
 import com.linkedin.metadata.search.LineageSearchResult;
 import com.linkedin.metadata.search.MatchedFieldArray;
 import com.linkedin.metadata.search.SearchResultMetadata;
+import com.linkedin.metadata.service.ViewService;
 import graphql.schema.DataFetchingEnvironment;
 import io.datahubproject.metadata.context.OperationContext;
 import java.io.InputStream;
@@ -48,6 +49,7 @@ public class SearchAcrossLineageResolverTest {
   private SearchAcrossLineageResolver _resolver;
 
   private EntityRegistry _entityRegistry;
+  private ViewService _viewService;
 
   @BeforeMethod
   public void setupTest() {
@@ -56,7 +58,8 @@ public class SearchAcrossLineageResolverTest {
     _authentication = mock(Authentication.class);
 
     _entityRegistry = mock(EntityRegistry.class);
-    _resolver = new SearchAcrossLineageResolver(_entityClient, _entityRegistry);
+    _viewService = mock(ViewService.class);
+    _resolver = new SearchAcrossLineageResolver(_entityClient, _entityRegistry, _viewService);
   }
 
   @Test
@@ -64,7 +67,7 @@ public class SearchAcrossLineageResolverTest {
     InputStream inputStream = ClassLoader.getSystemResourceAsStream("entity-registry.yml");
     EntityRegistry entityRegistry = new ConfigEntityRegistry(inputStream);
     SearchAcrossLineageResolver resolver =
-        new SearchAcrossLineageResolver(_entityClient, entityRegistry);
+        new SearchAcrossLineageResolver(_entityClient, entityRegistry, _viewService);
     assertTrue(resolver._allEntities.contains("dataset"));
     assertTrue(resolver._allEntities.contains("dataFlow"));
     // Test for case sensitivity
@@ -115,7 +118,7 @@ public class SearchAcrossLineageResolverTest {
             eq(QUERY),
             eq(null),
             any(),
-            eq(null),
+            eq(Collections.emptyList()),
             eq(START),
             eq(COUNT)))
         .thenReturn(lineageSearchResult);

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/FilterUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/FilterUtils.java
@@ -1,0 +1,130 @@
+package com.linkedin.metadata.utils.elasticsearch;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.Criterion;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.utils.CriterionUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class FilterUtils {
+
+  /**
+   * Combines two {@link Filter} instances in a conjunction and returns a new instance of {@link
+   * Filter} in disjunctive normal form.
+   *
+   * @param baseFilter the filter to apply the view to
+   * @param viewFilter the view filter, null if it doesn't exist
+   * @return a new instance of {@link Filter} representing the applied view.
+   */
+  @Nonnull
+  public static Filter combineFilters(
+      @Nullable final Filter baseFilter, @Nonnull final Filter viewFilter) {
+    final Filter finalBaseFilter =
+        baseFilter == null
+            ? new Filter().setOr(new ConjunctiveCriterionArray(Collections.emptyList()))
+            : baseFilter;
+
+    // Join the filter conditions in Disjunctive Normal Form.
+    return combineFiltersInConjunction(finalBaseFilter, viewFilter);
+  }
+
+  /**
+   * Joins two filters in conjunction by reducing to Disjunctive Normal Form.
+   *
+   * @param filter1 the first filter in the pair
+   * @param filter2 the second filter in the pair
+   *     <p>This method supports either Filter format, where the "or" field is used, instead of
+   *     criteria. If the criteria filter is used, then it will be converted into an "OR" before
+   *     returning the new filter.
+   * @return the result of joining the 2 filters in a conjunction (AND)
+   *     <p>How does it work? It basically cross-products the conjunctions inside of each Filter
+   *     clause.
+   *     <p>Example Inputs: filter1 -> { or: [ { and: [ { field: tags, condition: EQUAL, values:
+   *     ["urn:li:tag:tag"] } ] }, { and: [ { field: glossaryTerms, condition: EQUAL, values:
+   *     ["urn:li:glossaryTerm:term"] } ] } ] } filter2 -> { or: [ { and: [ { field: domain,
+   *     condition: EQUAL, values: ["urn:li:domain:domain"] }, ] }, { and: [ { field: glossaryTerms,
+   *     condition: EQUAL, values: ["urn:li:glossaryTerm:term2"] } ] } ] } Example Output: { or: [ {
+   *     and: [ { field: tags, condition: EQUAL, values: ["urn:li:tag:tag"] }, { field: domain,
+   *     condition: EQUAL, values: ["urn:li:domain:domain"] } ] }, { and: [ { field: tags,
+   *     condition: EQUAL, values: ["urn:li:tag:tag"] }, { field: glossaryTerms, condition: EQUAL,
+   *     values: ["urn:li:glosaryTerm:term2"] } ] }, { and: [ { field: glossaryTerm, condition:
+   *     EQUAL, values: ["urn:li:glossaryTerm:term"] }, { field: domain, condition: EQUAL, values:
+   *     ["urn:li:domain:domain"] } ] }, { and: [ { field: glossaryTerm, condition: EQUAL, values:
+   *     ["urn:li:glossaryTerm:term"] }, { field: glossaryTerms, condition: EQUAL, values:
+   *     ["urn:li:glosaryTerm:term2"] } ] }, ] }
+   */
+  @Nonnull
+  private static Filter combineFiltersInConjunction(
+      @Nonnull final Filter filter1, @Nonnull final Filter filter2) {
+
+    final Filter finalFilter1 = convertToV2Filter(filter1);
+    final Filter finalFilter2 = convertToV2Filter(filter2);
+
+    // If either filter is empty, simply return the other filter.
+    if (!finalFilter1.hasOr() || finalFilter1.getOr().size() == 0) {
+      return finalFilter2;
+    }
+    if (!finalFilter2.hasOr() || finalFilter2.getOr().size() == 0) {
+      return finalFilter1;
+    }
+
+    // Iterate through the base filter, then cross-product with filter 2 conditions.
+    final Filter result = new Filter();
+    final List<ConjunctiveCriterion> newDisjunction = new ArrayList<>();
+    for (ConjunctiveCriterion conjunction1 : finalFilter1.getOr()) {
+      for (ConjunctiveCriterion conjunction2 : finalFilter2.getOr()) {
+        final List<Criterion> joinedCriterion = new ArrayList<>(conjunction1.getAnd());
+        joinedCriterion.addAll(conjunction2.getAnd());
+        ConjunctiveCriterion newConjunction =
+            new ConjunctiveCriterion().setAnd(new CriterionArray(joinedCriterion));
+        newDisjunction.add(newConjunction);
+      }
+    }
+    result.setOr(new ConjunctiveCriterionArray(newDisjunction));
+    return result;
+  }
+
+  @Nonnull
+  private static Filter convertToV2Filter(@Nonnull Filter filter) {
+    if (filter.hasOr()) {
+      return filter;
+    } else if (filter.hasCriteria()) {
+      // Convert criteria to an OR
+      return new Filter()
+          .setOr(
+              new ConjunctiveCriterionArray(
+                  ImmutableList.of(new ConjunctiveCriterion().setAnd(filter.getCriteria()))));
+    }
+    throw new IllegalArgumentException(
+        String.format(
+            "Illegal filter provided! Neither 'or' nor 'criteria' fields were populated for filter %s",
+            filter));
+  }
+
+  @Nonnull
+  public static Filter createValuesFilter(
+      @Nonnull final String fieldName, @Nonnull final List<String> values) {
+    Filter filter = new Filter();
+    CriterionArray criterionArray = new CriterionArray();
+
+    StringArray valuesArray = new StringArray();
+    valuesArray.addAll(values);
+    Criterion criterion = CriterionUtils.buildCriterion(fieldName, Condition.EQUAL, valuesArray);
+
+    criterionArray.add(criterion);
+    filter.setOr(
+        new ConjunctiveCriterionArray(
+            ImmutableList.of(new ConjunctiveCriterion().setAnd(criterionArray))));
+
+    return filter;
+  }
+}

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/FilterUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/FilterUtilsTest.java
@@ -1,0 +1,213 @@
+package com.linkedin.metadata.utils;
+
+import static com.linkedin.metadata.utils.CriterionUtils.buildCriterion;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.metadata.query.filter.Condition;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterion;
+import com.linkedin.metadata.query.filter.ConjunctiveCriterionArray;
+import com.linkedin.metadata.query.filter.CriterionArray;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.utils.elasticsearch.FilterUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FilterUtilsTest {
+
+  @Test
+  public static void testApplyViewToFilterNullBaseFilter() {
+
+    Filter viewFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(
+                            new CriterionArray(
+                                ImmutableList.of(
+                                    buildCriterion("field", Condition.EQUAL, "test"))))));
+
+    Filter result = FilterUtils.combineFilters(null, viewFilter);
+    Assert.assertEquals(viewFilter, result);
+  }
+
+  @Test
+  public static void testApplyViewToFilterComplexBaseFilter() {
+    Filter baseFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    ImmutableList.of(
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                                        buildCriterion("field2", Condition.EQUAL, "test2")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field3", Condition.EQUAL, "test3"),
+                                        buildCriterion("field4", Condition.EQUAL, "test4")))))));
+
+    Filter viewFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    new ConjunctiveCriterion()
+                        .setAnd(
+                            new CriterionArray(
+                                ImmutableList.of(
+                                    buildCriterion("field", Condition.EQUAL, "test"))))));
+
+    Filter result = FilterUtils.combineFilters(baseFilter, viewFilter);
+
+    Filter expectedResult =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    ImmutableList.of(
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                                        buildCriterion("field2", Condition.EQUAL, "test2"),
+                                        buildCriterion("field", Condition.EQUAL, "test")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field3", Condition.EQUAL, "test3"),
+                                        buildCriterion("field4", Condition.EQUAL, "test4"),
+                                        buildCriterion("field", Condition.EQUAL, "test")))))));
+
+    Assert.assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public static void testApplyViewToFilterComplexViewFilter() {
+    Filter baseFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    ImmutableList.of(
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                                        buildCriterion("field2", Condition.EQUAL, "test2")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field3", Condition.EQUAL, "test3"),
+                                        buildCriterion("field4", Condition.EQUAL, "test4")))))));
+
+    Filter viewFilter =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    ImmutableList.of(
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("viewField1", Condition.EQUAL, "viewTest1"),
+                                        buildCriterion(
+                                            "viewField2", Condition.EQUAL, "viewTest2")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("viewField3", Condition.EQUAL, "viewTest3"),
+                                        buildCriterion(
+                                            "viewField4", Condition.EQUAL, "viewTest4")))))));
+
+    Filter result = FilterUtils.combineFilters(baseFilter, viewFilter);
+
+    Filter expectedResult =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    ImmutableList.of(
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                                        buildCriterion("field2", Condition.EQUAL, "test2"),
+                                        buildCriterion("viewField1", Condition.EQUAL, "viewTest1"),
+                                        buildCriterion(
+                                            "viewField2", Condition.EQUAL, "viewTest2")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                                        buildCriterion("field2", Condition.EQUAL, "test2"),
+                                        buildCriterion("viewField3", Condition.EQUAL, "viewTest3"),
+                                        buildCriterion(
+                                            "viewField4", Condition.EQUAL, "viewTest4")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field3", Condition.EQUAL, "test3"),
+                                        buildCriterion("field4", Condition.EQUAL, "test4"),
+                                        buildCriterion("viewField1", Condition.EQUAL, "viewTest1"),
+                                        buildCriterion(
+                                            "viewField2", Condition.EQUAL, "viewTest2")))),
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field3", Condition.EQUAL, "test3"),
+                                        buildCriterion("field4", Condition.EQUAL, "test4"),
+                                        buildCriterion("viewField3", Condition.EQUAL, "viewTest3"),
+                                        buildCriterion(
+                                            "viewField4", Condition.EQUAL, "viewTest4")))))));
+
+    Assert.assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public static void testApplyViewToFilterV1Filter() {
+    Filter baseFilter =
+        new Filter()
+            .setCriteria(
+                new CriterionArray(
+                    ImmutableList.of(
+                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                        buildCriterion("field2", Condition.EQUAL, "test2"))));
+
+    Filter viewFilter =
+        new Filter()
+            .setCriteria(
+                new CriterionArray(
+                    ImmutableList.of(
+                        buildCriterion("viewField1", Condition.EQUAL, "viewTest1"),
+                        buildCriterion("viewField2", Condition.EQUAL, "viewTest2"))));
+
+    Filter result = FilterUtils.combineFilters(baseFilter, viewFilter);
+
+    Filter expectedResult =
+        new Filter()
+            .setOr(
+                new ConjunctiveCriterionArray(
+                    ImmutableList.of(
+                        new ConjunctiveCriterion()
+                            .setAnd(
+                                new CriterionArray(
+                                    ImmutableList.of(
+                                        buildCriterion("field1", Condition.EQUAL, "test1"),
+                                        buildCriterion("field2", Condition.EQUAL, "test2"),
+                                        buildCriterion("viewField1", Condition.EQUAL, "viewTest1"),
+                                        buildCriterion(
+                                            "viewField2", Condition.EQUAL, "viewTest2")))))));
+
+    Assert.assertEquals(expectedResult, result);
+  }
+}


### PR DESCRIPTION
This was a bug from bringing over the V2 UI where the backend wasn't built to support views and sorting while the UI was. This PR adds support for those functionalities in impact analysis. In order to do that I created a new utils class with associated tests.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
