### PR TITLE
feat(models): adds subtypes to most entities in the model

### DIFF
--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -110,6 +110,7 @@ entities:
       - ownership
       - status
       - testResults
+      - subTypes
   - name: dataProcessInstance
     doc: DataProcessInstance represents an instance of a datajob/jobflow run
     keyAspect: dataProcessInstanceKey
@@ -211,6 +212,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: corpGroup
     doc: CorpGroup represents an identity of a group of users in the enterprise.
     keyAspect: corpGroupKey
@@ -225,6 +227,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: domain
     doc: A data domain within an organization.
     category: core
@@ -284,6 +287,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: glossaryNode
     category: core
     keyAspect: glossaryNodeKey
@@ -295,6 +299,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: dataHubIngestionSource
     category: internal
     keyAspect: dataHubIngestionSourceKey
@@ -369,6 +374,7 @@ entities:
       - forms
       - testResults
       - versionProperties
+      - subTypes
   - name: mlModelGroup
     category: core
     keyAspect: mlModelGroupKey
@@ -387,6 +393,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: mlModelDeployment
     category: core
     keyAspect: mlModelDeploymentKey
@@ -417,6 +424,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: mlFeature
     category: core
     keyAspect: mlFeatureKey
@@ -436,6 +444,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: mlPrimaryKey
     category: core
     keyAspect: mlPrimaryKeyKey
@@ -453,6 +462,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: telemetry
     category: internal
     keyAspect: telemetryKey
@@ -493,6 +503,7 @@ entities:
       - documentation
       - testResults
       - deprecation
+      - subTypes
   - name: globalSettings
     doc: Global settings for an the platform
     category: internal
@@ -521,6 +532,7 @@ entities:
     keyAspect: postKey
     aspects:
       - postInfo
+      - subTypes
   - name: dataHubStepState
     category: internal
     keyAspect: dataHubStepStateKey
@@ -566,6 +578,7 @@ entities:
       - structuredProperties
       - forms
       - testResults
+      - subTypes
   - name: ownershipType
     doc: Ownership Type represents a user-created ownership category for a person or group who is responsible for an asset.
     category: core


### PR DESCRIPTION
Subtypes are useful. Most entities should have them. 
This PR adds subtypes to most of the entities in the metadata model. 

This PR does NOT add support for GQL mapping or rendering these subtypes in the UI. 
That will be covered by a subsequent PR.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
