### PR TITLE
fix: fixes mypy complaints about pkgresources

### DIFF
--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=71.1.0", "wheel"]
+requires = ["setuptools >= 71.1", "wheel"]
 
 [tool.ruff.lint.isort]
 section-order = ["future", "patch", "standard-library", "third-party", "first-party", "local-folder"]

--- a/metadata-ingestion/pyproject.toml
+++ b/metadata-ingestion/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=63.0.0", "wheel"]
+requires = ["setuptools>=71.1.0", "wheel"]
 
 [tool.ruff.lint.isort]
 section-order = ["future", "patch", "standard-library", "third-party", "first-party", "local-folder"]

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -555,7 +555,6 @@ all_exclude_plugins: Set[str] = {
 
 mypy_stubs = {
     "types-dataclasses",
-    "types-setuptools",
     "types-six",
     "types-python-dateutil",
     # We need to avoid 2.31.0.5 and 2.31.0.4 due to

--- a/metadata-ingestion/tests/unit/test_packaging.py
+++ b/metadata-ingestion/tests/unit/test_packaging.py
@@ -8,6 +8,6 @@ import datahub._version as datahub_version
 )
 def test_datahub_version():
     # Simply importing pkg_resources checks for unsatisfied dependencies.
-    import pkg_resources
+    import pkg_resources  # type: ignore[import-untyped]
 
     assert pkg_resources.get_distribution(datahub_version.__package_name__).version


### PR DESCRIPTION
From today we are pulling `types-setuptools==75.8.2.20250305`, and we are having this exception

```
tests/unit/test_packaging.py:11: error: Library stubs not installed for "pkg_resources"  [import-untyped]
tests/unit/test_packaging.py:11: note: Hint: "python3 -m pip install types-setuptools"
tests/unit/test_packaging.py:11: note: (or run "mypy --install-types" to install all missing stub packages)
tests/unit/test_packaging.py:11: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

which matches with this PR from yesterday https://github.com/python/typeshed/pull/13369

Stubs are not required since `setuptools>=71.1.0`

> [!NOTE]  
> Unfortunately only solved with the `ignore` mypy hint

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
