### PR TITLE
fix(build): build improvements to help with incremental builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
+
 buildscript {
   ext.jdkVersionDefault = 17
   ext.javaClassVersionDefault = 11
@@ -396,25 +399,56 @@ configure(subprojects.findAll {! it.name.startsWith('spark-lineage')}) {
   }
 }
 
+apply plugin: 'com.gorylenko.gradle-git-properties'
+gitProperties {
+  keys = ['git.commit.id','git.commit.id.describe','git.commit.time']
+  // using any tags (not limited to annotated tags) for "git.commit.id.describe" property
+  // see http://ajoberstar.org/grgit/grgit-describe.html for more info about the describe method and available parameters
+  // 'it' is an instance of org.ajoberstar.grgit.Grgit
+  customProperty 'git.commit.id.describe', { it.describe(tags: true) }
+  gitPropertiesResourceDir = rootProject.buildDir
+  failOnNoGitDirectory = false
+}
+
+def gitPropertiesGenerated = false
+
+apply from: 'gradle/versioning/versioning-global.gradle'
+
+tasks.register("generateGitPropertiesGlobal", com.gorylenko.GenerateGitPropertiesTask) {
+  doFirst {
+    if (!gitPropertiesGenerated) {
+      println "Generating git.properties"
+      gitPropertiesGenerated = true
+    } else {
+      // Skip actual execution if already run
+      onlyIf { false }
+    }
+  }
+}
+
 subprojects {
 
   apply plugin: 'maven-publish'
-  apply plugin: 'com.gorylenko.gradle-git-properties'
   apply plugin: 'com.diffplug.spotless'
 
-  gitProperties {
-    keys = ['git.commit.id','git.commit.id.describe','git.commit.time']
-    // using any tags (not limited to annotated tags) for "git.commit.id.describe" property
-    // see http://ajoberstar.org/grgit/grgit-describe.html for more info about the describe method and available parameters
-    // 'it' is an instance of org.ajoberstar.grgit.Grgit
-    customProperty 'git.commit.id.describe', { it.describe(tags: true) }
-    failOnNoGitDirectory = false
+  def gitPropertiesTask = tasks.register("copyGitProperties", Copy) {
+    dependsOn rootProject.tasks.named("generateGitPropertiesGlobal")
+    def sourceFile = file("${rootProject.buildDir}/git.properties")
+    from sourceFile
+    into "$project.buildDir/resources/main"
   }
 
   plugins.withType(JavaPlugin).configureEach {
+    project.tasks.named(JavaPlugin.CLASSES_TASK_NAME).configure{
+      dependsOn gitPropertiesTask
+    }
     if (project.name == 'datahub-web-react') {
       return
     }
+    /* TODO: evaluate ignoring jar timestamps for increased caching (compares checksum instead)
+    jar {
+      preserveFileTimestamps = false
+    }*/
 
     dependencies {
       implementation externalDependency.annotationApi

--- a/datahub-web-react/build.gradle
+++ b/datahub-web-react/build.gradle
@@ -111,14 +111,13 @@ task yarnBuild(type: YarnTask, dependsOn: [yarnInstall, yarnGenerate]) {
   outputs.dir('dist')
 }
 
-task cleanExtraDirs {
+clean {
   delete 'node_modules/.yarn-integrity'
   delete 'dist'
   delete 'tmp'
   delete 'just'
   delete fileTree(dir: 'src', include: '*.generated.ts')
 }
-clean.finalizedBy(cleanExtraDirs)
 
 configurations {
   assets

--- a/gradle/versioning/versioning-global.gradle
+++ b/gradle/versioning/versioning-global.gradle
@@ -1,0 +1,101 @@
+/**
+ Applies a consistent versioning scheme to all projects using this script
+
+Uses git tags to mint versions by default. 
+git tags can be of a few forms:
+- short sha (typical for a PR or a commit) (e.g. 38960ae)
+- versioned tags (typical for a release) (e.g. v0.8.45, v0.8.45.1, v0.8.45rc1, v0.8.45.1rc4)
+
+Produces the following variables and supports token replacement
+- version: server version amenable for creating jars
+- fullVersion: full version string 
+- cliMajorVersion: cli version amenable for binding to server as a default
+  0.8.44 or 0.8.44-1 (for clean tags) or 0.8.45-SNAPSHOT (for unclean repositories)
+
+ All inference can be overridden by passing in the releaseVersion property
+ e.g. -PreleaseVersion=0.2.3.4 will set the jar version to 0.2.3-4
+
+ **/
+
+import groovy.json.JsonBuilder
+
+def detailedVersionString = "0.0.0-unknown-SNAPSHOT"
+def cliMajorVersion = "0.15.0" // base default cli major version
+def snapshotVersion = false
+def javaVersion = ""
+
+if (project.hasProperty("releaseVersion")) {
+  version = releaseVersion
+  detailedVersionString = releaseVersion
+} else {
+  try {
+      // apply this plugin in a try-catch block so that we can handle cases without .git directory
+      apply plugin: "com.palantir.git-version"
+      def details = versionDetails()
+      detailedVersionString = gitVersion()
+      version = details.lastTag
+      version = version.startsWith("v")? version.substring(1): version
+      def suffix = details.isCleanTag? "": "-SNAPSHOT"
+      snapshotVersion = ! details.isCleanTag
+    }
+    catch (Exception e) {
+          e.printStackTrace()
+          // last fall back
+          version = detailedVersionString
+    }
+}
+
+// trim version if it is of size 4 to size 3
+def versionParts = version.tokenize(".")
+cliMajorVersion = version
+if (versionParts.size() > 3) {
+  // at-least 4 part version
+  // we check if the 4th part is a .0 in which case we want to create a release
+  if ((versionParts.size() == 4) && (versionParts[3] == '0')) {
+    versionParts = versionParts[0..2]
+  }
+  version = versionParts[0..2].join('.')
+  if (versionParts.size() > 3) {
+      version = version + "-" + versionParts[3..versionParts.size()-1].join('-')
+  }
+}
+
+if (snapshotVersion) {
+    if (versionParts[versionParts.size()-1].isInteger()) {
+      def base_version = versionParts[0..versionParts.size()-2].join('.')
+      version = base_version + '.' + (versionParts[versionParts.size()-1].toInteger()+1).toString() + "-SNAPSHOT"
+      cliMajorVersion = base_version + "." + versionParts[versionParts.size()-1]
+    } else {
+      // we are unable to part the last token as an integer, so we just append SNAPSHOT to this version
+      version = versionParts[0..versionParts.size()-1].join('.') + '-SNAPSHOT'
+      cliMajorVersion = versionParts[0..versionParts.size()-1].join('.')
+    }
+
+    // differences from metadata-integration/java/versioning.gradle
+    if (versionParts[versionParts.size()-1].isInteger()) {
+      javaVersion = versionParts[0..versionParts.size()-2].join('.') + '.' + (versionParts[versionParts.size()-1].toInteger()+1).toString() + "-SNAPSHOT"
+    } else {
+      // we are unable to part the last token as an integer, so we just append SNAPSHOT to this version
+      javaVersion = versionParts[0..versionParts.size()-1].join('.') + '-SNAPSHOT'
+    }
+}
+
+// Note: No task, we want this executed during config phase, once for rootProject.
+def data = [
+    fullVersion: detailedVersionString,
+    cliMajorVersion: cliMajorVersion,
+    version: version,
+    javaVersion: javaVersion
+]
+
+// Convert to JSON
+def jsonBuilder = new JsonBuilder(data)
+def outputFile = file("${rootProject.buildDir}/version.json")
+
+// Ensure buildDir exists
+rootProject.buildDir.mkdirs()
+
+// Write to file
+outputFile.text = jsonBuilder.toPrettyString()
+
+println "git.properties JSON data written to ${outputFile}"

--- a/gradle/versioning/versioning.gradle
+++ b/gradle/versioning/versioning.gradle
@@ -1,79 +1,23 @@
-/**
- Applies a consistent versioning scheme to all projects using this script
-
-Uses git tags to mint versions by default. 
-git tags can be of a few forms:
-- short sha (typical for a PR or a commit) (e.g. 38960ae)
-- versioned tags (typical for a release) (e.g. v0.8.45, v0.8.45.1, v0.8.45rc1, v0.8.45.1rc4)
-
-Produces the following variables and supports token replacement
-- version: server version amenable for creating jars
-- fullVersion: full version string 
-- cliMajorVersion: cli version amenable for binding to server as a default
-  0.8.44 or 0.8.44-1 (for clean tags) or 0.8.45-SNAPSHOT (for unclean repositories)
-
- All inference can be overridden by passing in the releaseVersion property
- e.g. -PreleaseVersion=0.2.3.4 will set the jar version to 0.2.3-4
-
- **/
-
-
+import groovy.json.JsonSlurper
 import org.apache.tools.ant.filters.ReplaceTokens
+
 
 def detailedVersionString = "0.0.0-unknown-SNAPSHOT"
 def cliMajorVersion = "0.15.0" // base default cli major version
-def snapshotVersion = false
-if (project.hasProperty("releaseVersion")) {
-  version = releaseVersion
-  detailedVersionString = releaseVersion
-} else {
-  try {
-      // apply this plugin in a try-catch block so that we can handle cases without .git directory
-      apply plugin: "com.palantir.git-version"
-      def details = versionDetails()
-      detailedVersionString = gitVersion()
-      version = details.lastTag
-      version = version.startsWith("v")? version.substring(1): version
-      def suffix = details.isCleanTag? "": "-SNAPSHOT"
-      snapshotVersion = ! details.isCleanTag
-    }
-    catch (Exception e) {
-          e.printStackTrace()
-          // last fall back
-          version = detailedVersionString
-    }
-}
 
-// trim version if it is of size 4 to size 3
-def versionParts = version.tokenize(".")
-cliMajorVersion = version
-if (versionParts.size() > 3) {
-  // at-least 4 part version
-  // we check if the 4th part is a .0 in which case we want to create a release
-  if ((versionParts.size() == 4) && (versionParts[3] == '0')) {
-    versionParts = versionParts[0..2]
-  }
-  version = versionParts[0..2].join('.')
-  if (versionParts.size() > 3) {
-      version = version + "-" + versionParts[3..versionParts.size()-1].join('-')
-  }
-}
+def inputFile = file("${rootProject.buildDir}/version.json")
 
-if (snapshotVersion) {
-    if (versionParts[versionParts.size()-1].isInteger()) {
-      def base_version = versionParts[0..versionParts.size()-2].join('.')
-      version = base_version + '.' + (versionParts[versionParts.size()-1].toInteger()+1).toString() + "-SNAPSHOT"
-      cliMajorVersion = base_version + "." + versionParts[versionParts.size()-1]
-    } else {
-      // we are unable to part the last token as an integer, so we just append SNAPSHOT to this version
-      version = versionParts[0..versionParts.size()-1].join('.') + '-SNAPSHOT'
-      cliMajorVersion = versionParts[0..versionParts.size()-1].join('.')
-  }
-}
+task readJsonData {
+  if (inputFile.exists()) {
+    def jsonSlurper = new JsonSlurper()
+    def data = jsonSlurper.parse(inputFile)
 
-processResources {
-  filter(ReplaceTokens, tokens:[fullVersion: detailedVersionString])
-  filter(ReplaceTokens, tokens:[cliMajorVersion: cliMajorVersion])
+    detailedVersionString = data.fullVersion
+    cliMajorVersion = data.cliMajorVersion
+    version = data.version
+  } else {
+    println "git.properties JSON file not found: ${inputFile.path}"
+  }
 }
 
 task printVersionDetails() {
@@ -81,3 +25,9 @@ task printVersionDetails() {
   println("cliMajorVersion=" + cliMajorVersion)
   println("version=" +  version)
 }
+
+processResources {
+  filter(ReplaceTokens, tokens:[fullVersion: detailedVersionString])
+  filter(ReplaceTokens, tokens:[cliMajorVersion: cliMajorVersion])
+}
+

--- a/metadata-events/mxe-schemas/build.gradle
+++ b/metadata-events/mxe-schemas/build.gradle
@@ -31,7 +31,7 @@ task renameNamespace(type: Exec, dependsOn: copyOriginalAvsc) {
 build.dependsOn renameNamespace
 
 clean {
-  project.delete('src/main/pegasus')
-  project.delete('src/mainGeneratedAvroSchema/avro')
-  project.delete('src/renamed/avro')
+  delete 'src/main/pegasus'
+  delete 'src/mainGeneratedAvroSchema/avro'
+  delete 'src/renamed/avro'
 }

--- a/metadata-events/mxe-schemas/build.gradle
+++ b/metadata-events/mxe-schemas/build.gradle
@@ -19,13 +19,15 @@ generateDataTemplate.dependsOn copyMetadataModels
 mainCopySchemas.dependsOn copyMetadataModels
 pegasus.main.generationModes = [PegasusGenerationMode.PEGASUS, PegasusGenerationMode.AVRO]
 
-task copyOriginalAvsc(type: Copy, dependsOn: generateAvroSchema) {
+task renameNamespace(type: Copy, dependsOn: generateAvroSchema) {
   from("src/mainGeneratedAvroSchema/avro")
   into file("src/renamed/avro")
-}
 
-task renameNamespace(type: Exec, dependsOn: copyOriginalAvsc) {
-  commandLine 'bash', './rename-namespace.sh'
+  doLast {
+    project.exec {
+      commandLine 'bash', './rename-namespace.sh'
+    }
+  }
 }
 
 build.dependsOn renameNamespace

--- a/metadata-events/mxe-utils-avro/build.gradle
+++ b/metadata-events/mxe-utils-avro/build.gradle
@@ -36,5 +36,5 @@ compileJava.dependsOn copyOriginalMXESchemas
 processResources.dependsOn copyOriginalMXESchemas
 
 clean {
-  project.delete("src/main/resources/avro")
+  delete "src/main/resources/avro"
 }

--- a/metadata-integration/java/versioning.gradle
+++ b/metadata-integration/java/versioning.gradle
@@ -1,60 +1,30 @@
-/**
- Applies a consistent versioning scheme to all projects using this script
-  -PreleaseVersion=0.2.3.4 will set the jar version to 0.2.3-4
-
-  Not providing a property will make it use git tags to mint either a version like:
-  0.8.44 or 0.8.44-1 (for clean tags) or 0.8.45-SNAPSHOT (for unclean repositories)
-
- **/
-
-
+import groovy.json.JsonSlurper
 import org.apache.tools.ant.filters.ReplaceTokens
 
+
 def detailedVersionString = "0.0.0-unknown-SNAPSHOT"
-def snapshotVersion = false
-if (project.hasProperty("releaseVersion")) {
-  version = releaseVersion
-  detailedVersionString = releaseVersion
-} else {
-  try {
-      // apply this plugin in a try-catch block so that we can handle cases without .git directory
-      apply plugin: "com.palantir.git-version"
-      def details = versionDetails()
-      detailedVersionString = gitVersion()
-      version = details.lastTag
-      version = version.startsWith("v")? version.substring(1): version
-      def suffix = details.isCleanTag? "": "-SNAPSHOT"
-      snapshotVersion = ! details.isCleanTag
-    }
-    catch (Exception e) {
-          e.printStackTrace()
-          // last fall back
-          version = detailedVersionString
-      }
+def cliMajorVersion = "0.15.0" // base default cli major version
+
+task readJsonData {
+  def inputFile = file("${rootProject.buildDir}/version.json")
+
+  if (inputFile.exists()) {
+    def jsonSlurper = new JsonSlurper()
+    def data = jsonSlurper.parse(inputFile)
+
+    detailedVersionString = data.fullVersion
+    cliMajorVersion = data.cliMajorVersion
+    version = data.javaVersion
+  } else {
+    println "JSON file not found: ${inputFile.path}"
   }
-    // trim version if it is of size 4 to size 3
-    def versionParts = version.tokenize(".")
-    if (versionParts.size() > 3) {
-      // at-least 4 part version
-      // we check if the 4th part is a .0 in which case we want to create a release
-      if ((versionParts.size() == 4) && (versionParts[3] == '0')) {
-        versionParts = versionParts[0..2]
-      }
-      version = versionParts[0..2].join('.')
-      if (versionParts.size() > 3) {
-          version = version + "-" + versionParts[3..versionParts.size()-1].join('-')
-      }
-    }
+}
 
-    if (snapshotVersion) {
-        if (versionParts[versionParts.size()-1].isInteger()) {
-          version = versionParts[0..versionParts.size()-2].join('.') + '.' + (versionParts[versionParts.size()-1].toInteger()+1).toString() + "-SNAPSHOT"
-        } else {
-          // we are unable to part the last token as an integer, so we just append SNAPSHOT to this version
-          version = versionParts[0..versionParts.size()-1].join('.') + '-SNAPSHOT'
-      }
-    }
+processResources {
+  filter(ReplaceTokens, tokens:[fullVersion: detailedVersionString])
+}
 
-    processResources {
-      filter(ReplaceTokens, tokens:[fullVersion: detailedVersionString])
-    }
+task printVersionDetails() {
+  println("fullVersion=" + detailedVersionString)
+  println("version=" +  version)
+}

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -159,5 +159,7 @@ tasks.withType(Test) {
 }
 
 clean {
-  project.delete("$projectDir/generated")
+  //TODO: Is this really needed? dont see generated folder in projectDir. It is in build, but that doest need explicit clean
+  delete "$projectDir/generated"
 }
+

--- a/metadata-jobs/mae-consumer/build.gradle
+++ b/metadata-jobs/mae-consumer/build.gradle
@@ -64,5 +64,5 @@ compileJava.dependsOn avroSchemaSources
 processResources.dependsOn avroSchemaSources
 
 clean {
-    project.delete("src/main/resources/avro")
+    delete "src/main/resources/avro"
 }

--- a/metadata-jobs/mce-consumer/build.gradle
+++ b/metadata-jobs/mce-consumer/build.gradle
@@ -58,5 +58,5 @@ compileJava.dependsOn avroSchemaSources
 processResources.dependsOn avroSchemaSources
 
 clean {
-    project.delete("src/main/resources/avro")
+    delete "src/main/resources/avro"
 }

--- a/metadata-jobs/pe-consumer/build.gradle
+++ b/metadata-jobs/pe-consumer/build.gradle
@@ -44,5 +44,5 @@ compileJava.dependsOn avroSchemaSources
 processResources.dependsOn avroSchemaSources
 
 clean {
-  project.delete("src/main/resources/avro")
+  delete "src/main/resources/avro"
 }

--- a/metadata-models/build.gradle
+++ b/metadata-models/build.gradle
@@ -74,7 +74,6 @@ task openApiGenerate(type: GenerateSwaggerCode, dependsOn: 'generateJsonSchema')
 }
 tasks.getByName("compileJava").dependsOn(openApiGenerate)
 
-task cleanExtraDirs {
+clean {
   delete "$projectDir/src/generatedJsonSchema"
 }
-clean.finalizedBy(cleanExtraDirs)


### PR DESCRIPTION
Multiple fixes: 
Fixes in some misconfigured clean tasks
Some clean tasks incorrectly ran clean during configure phase -- which meant clean was *always* run even if not invoked.

Combine copy and rename into single task for metadata-events/mxe-schemas/build.gradle
Having these as two separate tasks caused copy to always be out-of-date when rename is run, and rename to be out-of-date when copy is done. Gradle does not like inplace updates of any files. By combining it, the copy+rename now will appear to produce a new artifact that will be up-to-date if no sources have changed. This caused lot of downstream jars to get rebuilt since this jar is always out-of-dat and rebuilt everytime.

Reuse versioning and git properties by running once at root project and copy the git.properties for all projects 


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
