### PR TITLE
fix(doc): re-enable Algolia search

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -289,6 +289,15 @@ module.exports = {
       // darkTheme: require("prism-react-renderer/themes/vsDark"),
       additionalLanguages: ["ini", "java", "graphql", "shell-session"],
     },
+    algolia: {
+      // This is the "Search API Key" in Algolia, which means that it is ok to be public.
+      apiKey: "2adf840a044a5ecbf7bdaac88cbf9ee5",
+      appId: "RK0UG797F3",
+      indexName: "datahubproject",
+      insights: true,
+      contextualSearch: true,
+      // debug: true,
+    },
   },
   presets: [
     [

--- a/docs-website/src/theme/Layout/index.js
+++ b/docs-website/src/theme/Layout/index.js
@@ -9,7 +9,7 @@ export default function LayoutWrapper(props) {
         <SecondNavbar />
         {props.children}
       </Layout>
-      <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=92db07cf-8934-4b30-857a-3fcfda4c86dd" />
+      <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=92db07cf-8934-4b30-857a-3fcfda4c86dd" style={{ display: 'none' }} />
     </>
   );
 }


### PR DESCRIPTION
This reverts commit b9f3d07455873c67b48b23123bccbcc5a5daf9ed / PR #12831 with a rotated API key.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
