### PR TITLE
Add Snowflake ingestion config options: allow_empty_schemas, skip_standard_edition_check

### DIFF
--- a/metadata-ingestion/docs/sources/snowflake/snowflake_recipe.yml
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_recipe.yml
@@ -28,6 +28,12 @@ source:
       # This option is recommended to reduce profiling time and costs.
       turn_off_expensive_profiling_metrics: true
 
+    # If set to True, assumes this is Datahub Enterprise Edition, and skips the check for standard edition. Default is False.
+    skip_standard_edition_check: True
+
+    # If set to True, allows schemas with no tables or views to be processed, without reporting generic permissions error. Default is False.
+    allow_empty_schemas: True
+
     # (Optional) Uncomment and update this section to filter profiled tables
     # profile_pattern:
     #   allow:

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_config.py
@@ -312,6 +312,16 @@ class SnowflakeV2Config(
         " Map of share name -> details of share.",
     )
 
+    skip_standard_edition_check: bool = Field(
+        default=False,
+        description="If set to True, assumes this is Datahub Enterprise Edition, and skips the check for standard edition.",
+    )
+
+    allow_empty_schemas: bool = Field(
+        default=False,
+        description="If set to True, allows schemas with no tables or views to be processed, without reporting generic permissions error.",
+    )
+    
     include_assertion_results: bool = Field(
         default=False,
         description="Whether to ingest assertion run results for assertions created using Datahub"

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake/snowflake_v2.py
@@ -550,10 +550,11 @@ class SnowflakeV2Source(
             len(discovered_tables) == 0
             and len(discovered_views) == 0
             and len(discovered_streams) == 0
+            and not self.config.allow_empty_schemas
         ):
             self.structured_reporter.failure(
                 GENERIC_PERMISSION_ERROR_KEY,
-                "No tables/views/streams found. Please check permissions.",
+                "No tables/views found and allow_empty_schemas is false. Please check permissions.",
             )
             return
 
@@ -732,6 +733,8 @@ class SnowflakeV2Source(
             return None
 
     def is_standard_edition(self) -> bool:
+        if self.config.skip_standard_edition_check:
+            return False
         try:
             self.connection.query(SnowflakeQuery.show_tags())
             return False


### PR DESCRIPTION
The following config options are added with this PR. allow_empty_schemas was added to avoid a generic permissions error that was being thrown when attempting to ingest schemas with no tables/views. skip_standard_edition_check was added in order to avoid redundant/repetitive/costly calls to `show_tags()` which was causing unnecessary "Cloud" compute credits to be spent in Snowflake. These config options have been tested thoroughly in Stage environment of Optum datahub fork.

`allow_empty_schemas` - If set to True, allows schemas with no tables or views to be processed, without reporting generic permissions error. Default is False.

`skip_standard_edition_check` - If set to True, assumes this is Datahub Enterprise Edition, and skips the check for standard edition. Default is False.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
