### PR TITLE
fix(ui) Fix submitting when selecting replacement in deprecation modal

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/UpdateDeprecationModal.tsx
@@ -179,7 +179,12 @@ export const UpdateDeprecationModal = ({ urns, resourceRefs, onClose, refetch, z
                         </Button>
                     )}
                     {!replacementUrn && (
-                        <Button variant="outline" size="sm" onClick={() => setIsReplacementModalVisible(true)}>
+                        <Button
+                            variant="outline"
+                            type="button"
+                            size="sm"
+                            onClick={() => setIsReplacementModalVisible(true)}
+                        >
                             Select Replacement
                         </Button>
                     )}


### PR DESCRIPTION
Fixes auto-submitting deprecation when selecting a replacement by setting the button type to `button` instead of the default `submit`

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
