### PR TITLE
fix(ui) Hide default filters we want to hide from impact analysis

### DIFF
--- a/datahub-web-react/src/app/search/SimpleSearchFilters.tsx
+++ b/datahub-web-react/src/app/search/SimpleSearchFilters.tsx
@@ -8,12 +8,19 @@ import {
     DEGREE_FILTER_NAME,
     ENTITY_FILTER_NAME,
     ENTITY_INDEX_FILTER_NAME,
+    ENTITY_SUB_TYPE_FILTER_NAME,
     LEGACY_ENTITY_FILTER_NAME,
+    SCHEMA_FIELD_ALIASES_FILTER_NAME,
 } from './utils/constants';
 
 const TOP_FILTERS = ['degree', ENTITY_FILTER_NAME, 'platform', 'tags', 'glossaryTerms', 'domains', 'owners'];
 
-const FILTERS_TO_EXCLUDE = [LEGACY_ENTITY_FILTER_NAME, ENTITY_INDEX_FILTER_NAME];
+const FILTERS_TO_EXCLUDE = [
+    LEGACY_ENTITY_FILTER_NAME,
+    ENTITY_INDEX_FILTER_NAME,
+    ENTITY_SUB_TYPE_FILTER_NAME,
+    SCHEMA_FIELD_ALIASES_FILTER_NAME,
+];
 
 interface Props {
     facets: Array<FacetMetadata>;

--- a/datahub-web-react/src/app/search/utils/constants.ts
+++ b/datahub-web-react/src/app/search/utils/constants.ts
@@ -40,6 +40,7 @@ export const INCOMPLETE_FORMS_FILTER_NAME = 'incompleteForms';
 export const VERIFIED_FORMS_FILTER_NAME = 'verifiedForms';
 export const COMPLETED_FORMS_COMPLETED_PROMPT_IDS_FILTER_NAME = 'completedFormsCompletedPromptIds';
 export const INCOMPLETE_FORMS_COMPLETED_PROMPT_IDS_FILTER_NAME = 'incompleteFormsCompletedPromptIds';
+export const SCHEMA_FIELD_ALIASES_FILTER_NAME = 'schemaFieldAliases';
 
 export const LEGACY_ENTITY_FILTER_FIELDS = [ENTITY_FILTER_NAME, LEGACY_ENTITY_FILTER_NAME];
 

--- a/datahub-web-react/src/app/searchV2/SimpleSearchFilters.tsx
+++ b/datahub-web-react/src/app/searchV2/SimpleSearchFilters.tsx
@@ -11,10 +11,16 @@ import {
     ENTITY_SUB_TYPE_FILTER_NAME,
     DEGREE_FILTER_NAME,
 } from './utils/constants';
+import { SCHEMA_FIELD_ALIASES_FILTER_NAME } from '../search/utils/constants';
 
 const TOP_FILTERS = ['degree', ENTITY_FILTER_NAME, 'platform', 'tags', 'glossaryTerms', 'domains', 'owners'];
 
-const FILTERS_TO_EXCLUDE = [LEGACY_ENTITY_FILTER_NAME, ENTITY_INDEX_FILTER_NAME, ENTITY_SUB_TYPE_FILTER_NAME];
+const FILTERS_TO_EXCLUDE = [
+    LEGACY_ENTITY_FILTER_NAME,
+    ENTITY_INDEX_FILTER_NAME,
+    ENTITY_SUB_TYPE_FILTER_NAME,
+    SCHEMA_FIELD_ALIASES_FILTER_NAME,
+];
 
 interface Props {
     facets: Array<FacetMetadata>;


### PR DESCRIPTION
There's a few filters we get back by default in impact analysis that we don't actually want to show in the UI. We already have a way to hide default filters, so this PR just extends that to hide these two we noticed.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
