### PR TITLE
fix(ui): advise users on correct chron syntax for scheduling

### DIFF
--- a/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
@@ -5,7 +5,7 @@ import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import styled from 'styled-components';
 import cronstrue from 'cronstrue';
-import { CheckCircleOutlined, WarningOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { CheckCircleOutlined } from '@ant-design/icons';
 import { SourceBuilderState, StepProps } from './types';
 import { TimezoneSelect } from './TimezoneSelect';
 import { ANTD_GRAY, REDESIGN_COLORS } from '../../../entity/shared/constants';
@@ -76,25 +76,9 @@ const WarningContainer = styled.div`
     color: ${ANTD_GRAY[7]};
 `;
 
-const StyledWarningOutlined = styled(WarningOutlined)`
+const StyledWarningOutlined = styled(CheckCircleOutlined)`
     margin-right: 4px;
     margin-top: 12px;
-`;
-
-const HashmarkNotice = styled.div`
-    margin-top: 8px;
-    padding: 8px;
-    background-color: #e6f7ff;
-    border: 1px solid #91d5ff;
-    border-radius: 4px;
-    display: flex;
-    align-items: flex-start;
-`;
-
-const InfoIcon = styled(InfoCircleOutlined)`
-    color: #1890ff;
-    margin-right: 8px;
-    margin-top: 3px;
 `;
 
 const containsHashmark = (cronExpression: string): boolean => {
@@ -197,26 +181,32 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                             />
                         )}
                         <AdvancedSchedule>
-                            <AdvancedCheckBox type="secondary">Show Advanced</AdvancedCheckBox>
-                            <Checkbox
-                                checked={advancedCronCheck}
-                                onChange={(event) => setAdvancedCronCheck(event.target.checked)}
-                            />
+                            <div style={{ display: 'flex', alignItems: 'center' }}>
+                                {advancedCronCheck && hasHashmark && (
+                                    <Typography.Text
+                                        style={{
+                                            color: '#1890ff',
+                                            marginRight: '8px',
+                                            fontSize: '12px',
+                                        }}
+                                    >
+                                        (Unsupported syntax detected)
+                                    </Typography.Text>
+                                )}
+                                <AdvancedCheckBox type="secondary">Show Advanced</AdvancedCheckBox>
+                                <Checkbox
+                                    checked={advancedCronCheck}
+                                    onChange={(event) => {
+                                        if (hasHashmark && advancedCronCheck && !event.target.checked) {
+                                            return;
+                                        }
+                                        setAdvancedCronCheck(event.target.checked);
+                                    }}
+                                    disabled={hasHashmark && advancedCronCheck}
+                                />
+                            </div>
                         </AdvancedSchedule>
                     </Schedule>
-                    {advancedCronCheck && hasHashmark && (
-                        <HashmarkNotice>
-                            <InfoIcon />
-                            <div>
-                                <Typography.Text strong>Special schedule syntax detected</Typography.Text>
-                                <Typography.Paragraph style={{ marginBottom: 0 }}>
-                                    Your schedule uses special syntax (# character) to run on a specific occurrence of a day each month.
-                                    Please combine the day of the month with the day of the week to achieve this schedule.
-                                    For example use '0 0 8-14 0 1' instead of '0 0 0 0 1#2' for the 2nd Monday of the month 
-                                </Typography.Paragraph>
-                            </div>
-                        </HashmarkNotice>
-                    )}
                     <CronText>
                         {cronAsText.error && <>Invalid cron schedule. Cron must be of UNIX form:</>}
                         {!cronAsText.text && (
@@ -244,7 +234,7 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                 <div>
                     <Button
                         data-testid="ingestion-schedule-next-button"
-                        disabled={!interval || interval.length === 0 || cronAsText.error}
+                        disabled={!scheduleCronInterval || scheduleCronInterval.length === 0 || cronAsText.error}
                         onClick={onClickNext}
                     >
                         Next

--- a/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
+++ b/datahub-web-react/src/app/ingest/source/builder/CreateScheduleStep.tsx
@@ -5,7 +5,7 @@ import { Cron } from 'react-js-cron';
 import 'react-js-cron/dist/styles.css';
 import styled from 'styled-components';
 import cronstrue from 'cronstrue';
-import { CheckCircleOutlined, WarningOutlined } from '@ant-design/icons';
+import { CheckCircleOutlined, WarningOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { SourceBuilderState, StepProps } from './types';
 import { TimezoneSelect } from './TimezoneSelect';
 import { ANTD_GRAY, REDESIGN_COLORS } from '../../../entity/shared/constants';
@@ -81,6 +81,26 @@ const StyledWarningOutlined = styled(WarningOutlined)`
     margin-top: 12px;
 `;
 
+const HashmarkNotice = styled.div`
+    margin-top: 8px;
+    padding: 8px;
+    background-color: #e6f7ff;
+    border: 1px solid #91d5ff;
+    border-radius: 4px;
+    display: flex;
+    align-items: flex-start;
+`;
+
+const InfoIcon = styled(InfoCircleOutlined)`
+    color: #1890ff;
+    margin-right: 8px;
+    margin-top: 3px;
+`;
+
+const containsHashmark = (cronExpression: string): boolean => {
+    return cronExpression.includes('#');
+};
+
 const ItemDescriptionText = styled(Typography.Paragraph)``;
 
 const DAILY_MIDNIGHT_CRON_INTERVAL = '0 0 * * *';
@@ -93,6 +113,7 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
     const [advancedCronCheck, setAdvancedCronCheck] = useState(false);
     const [scheduleCronInterval, setScheduleCronInterval] = useState(interval);
     const [scheduleTimezone, setScheduleTimezone] = useState(timezone);
+    const hasHashmark = useMemo(() => containsHashmark(scheduleCronInterval), [scheduleCronInterval]);
 
     const cronAsText = useMemo(() => {
         if (scheduleCronInterval) {
@@ -183,6 +204,19 @@ export const CreateScheduleStep = ({ state, updateState, goTo, prev }: StepProps
                             />
                         </AdvancedSchedule>
                     </Schedule>
+                    {advancedCronCheck && hasHashmark && (
+                        <HashmarkNotice>
+                            <InfoIcon />
+                            <div>
+                                <Typography.Text strong>Special schedule syntax detected</Typography.Text>
+                                <Typography.Paragraph style={{ marginBottom: 0 }}>
+                                    Your schedule uses special syntax (# character) to run on a specific occurrence of a day each month.
+                                    Please combine the day of the month with the day of the week to achieve this schedule.
+                                    For example use '0 0 8-14 0 1' instead of '0 0 0 0 1#2' for the 2nd Monday of the month 
+                                </Typography.Paragraph>
+                            </div>
+                        </HashmarkNotice>
+                    )}
                     <CronText>
                         {cronAsText.error && <>Invalid cron schedule. Cron must be of UNIX form:</>}
                         {!cronAsText.text && (

--- a/metadata-ingestion/schedule_docs/cron.md
+++ b/metadata-ingestion/schedule_docs/cron.md
@@ -25,4 +25,8 @@ We can use crontab to schedule ingestion to run five minutes after midnight, eve
 5 0 * * * datahub ingest -c /home/ubuntu/datahub_ingest/mysql_to_datahub.yml
 ```
 
+:::tip
+For scheduling on a specific occurrence of a weekday (e.g., 2nd Monday), use day ranges like 8-14 * 1 instead of hashmark syntax like * * 1#2. While both work, the the hashmark syntax is unsupported in the UI scheduler.
+:::
+
 Read through [crontab docs](https://man7.org/linux/man-pages/man5/crontab.5.html) for more options related to scheduling.


### PR DESCRIPTION
We recently added backend support for more advanced cron syntax. For example, to schedule ingestion on the 2nd Monday of every month you could do either "0 0 0 0 1#2" or "0 0 8-14 0 1". However, only the 2nd method is supported on the frontend. For example, when using the hashmark syntax, if you switch in and out of the advanced tab it will get erased: 
![image](https://github.com/user-attachments/assets/1a64a713-8881-4d93-ba2f-7908c41378d5)
![image](https://github.com/user-attachments/assets/57380e9f-4329-4c9c-8e69-27cd90430810)
![image](https://github.com/user-attachments/assets/603d6772-00ea-4314-841a-498c298e5a36)
But when using the other syntax, everything works:
![image](https://github.com/user-attachments/assets/02a8ef0e-4181-4986-a1ee-11dd538bc50b)
![image](https://github.com/user-attachments/assets/2b7487c8-011a-4df6-a589-26f8d845c867)
![image](https://github.com/user-attachments/assets/b3def10a-79a2-42e7-a8c2-27656446bb78)

Long story short: this is because the frontend uses two different libraries for cron: one that supports # and one that doesn't. I think these code changes are an acceptable alternative but I'm open to other ideas. The test I added is just for the backend to make sure both ways work.
With my changes, the user will not able to uncheck the advanced box if they use the hashmark. This is what you see when you put a hashmark in the schedule:
![image](https://github.com/user-attachments/assets/8e8dfa0c-b274-474a-9ea0-e4ef3ca20529)


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
