### PR TITLE
feat(searchBarAutocomplete): add autocomplete component to components library

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.stories.tsx
@@ -1,0 +1,122 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import AutoComplete from './AutoComplete';
+
+// Auto Docs
+const meta = {
+    title: 'Components / AutoComplete',
+    component: AutoComplete,
+
+    // Display Properties
+    parameters: {
+        layout: 'centered',
+        badges: [BADGE.STABLE, 'readyForDesignReview'],
+        docs: {
+            subtitle: 'This component allows to add autocompletion',
+        },
+    },
+
+    // Component-level argTypes
+    argTypes: {
+        dataTestId: {
+            description: 'Optional property to set data-testid',
+            control: 'text',
+        },
+        className: {
+            description: 'Optional class names to pass into AutoComplete',
+            control: 'text',
+        },
+        value: {
+            description: 'Value of input',
+        },
+        defaultValue: {
+            description: 'Selected option by default',
+        },
+        options: {
+            description: 'Options available in dropdown',
+            table: {
+                type: {
+                    summary: 'OptionType',
+                    detail: `{
+    label: React.ReactNode;
+    value?: string | number | null;
+    disabled?: boolean;
+    [name: string]: any;
+    children?: Omit<OptionType, 'children'>[];
+}
+                    `,
+                },
+            },
+        },
+        open: {
+            description: 'Controlled open state of dropdown',
+        },
+        defaultActiveFirstOption: {
+            description: 'Whether active first option by default',
+        },
+        filterOption: {
+            description: 'If true, filter options by input, if function, filter options against it',
+        },
+        dropdownContentHeight: {
+            description: "Height of dropdown's content",
+        },
+        onSelect: {
+            description: 'Called when a option is selected',
+        },
+        onSearch: {
+            description: 'Called when searching items',
+        },
+        onChange: {
+            description: 'Called when selecting an option or changing an input value',
+        },
+        onDropdownVisibleChange: {
+            description: 'Called when dropdown opened/closed',
+        },
+        onClear: {
+            description: 'Called when clear',
+        },
+        dropdownRender: {
+            description: 'Customize dropdown content',
+        },
+        dropdownAlign: {
+            description: "Adjust how the autocomplete's dropdown should be aligned",
+        },
+        style: {
+            description: 'Additional styles for the wrapper of the children',
+        },
+        dropdownStyle: {
+            description: 'Additional styles for the dropdown',
+        },
+        dropdownMatchSelectWidth: {
+            description:
+                'Determine whether the dropdown menu and the select input are the same width.' +
+                'Default set min-width same as input. Will ignore when value less than select width.',
+        },
+    },
+
+    // Define defaults
+    args: {
+        options: [
+            { label: 'test', value: 'test' },
+            { label: 'test2', value: 'test2' },
+        ],
+    },
+} satisfies Meta<typeof AutoComplete>;
+
+export default meta;
+
+// Stories
+
+type Story = StoryObj<typeof meta>;
+
+// Basic story is what is displayed 1st in storybook & is used as the code sandbox
+// Pass props to this so that it can be customized via the UI props panel
+export const sandbox: Story = {
+    tags: ['dev'],
+    render: (props) => (
+        <AutoComplete {...props}>
+            <input />
+        </AutoComplete>
+    ),
+};

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.tsx
@@ -1,0 +1,87 @@
+import { AutoComplete as AntdAutoComplete } from 'antd';
+import React, { useCallback, useEffect, useState } from 'react';
+import ClickOutside from '../Utils/ClickOutside/ClickOutside';
+import { DropdownWrapper } from './components';
+import { AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR, AUTOCOMPLETE_WRAPPER_CLASS_NAME, ESCAPE_KEY } from './constants';
+import { AutoCompleteProps, OptionType } from './types';
+import { OverlayClassProvider } from '../Utils';
+
+export default function AutoComplete({
+    children,
+    dropdownContentHeight,
+    dataTestId,
+    onDropdownVisibleChange,
+    onChange,
+    onClear,
+    value,
+    ...props
+}: React.PropsWithChildren<AutoCompleteProps>) {
+    const [internalValue, setInternalValue] = useState<string>(value || '');
+    const [internalOpen, setInternalOpen] = useState<boolean>(false);
+
+    useEffect(() => {
+        onDropdownVisibleChange?.(internalOpen);
+    }, [internalOpen, onDropdownVisibleChange]);
+
+    const onChangeHandler = (newValue: string, option: OptionType | OptionType[]) => {
+        setInternalValue(newValue);
+        if (!internalOpen && newValue !== '') setInternalOpen(true);
+        onChange?.(newValue, option);
+    };
+
+    const onKeyDownHandler = useCallback(
+        (event: React.KeyboardEvent) => {
+            if (event.key === ESCAPE_KEY) {
+                if (internalOpen) {
+                    setInternalOpen(false);
+                } else {
+                    setInternalValue('');
+                    onClear?.();
+                }
+            }
+        },
+        [internalOpen, setInternalValue, onClear],
+    );
+
+    const onBlur = (event: React.FocusEvent) => {
+        if (
+            event.relatedTarget &&
+            !(event.relatedTarget as HTMLElement).closest(AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR)
+        ) {
+            setInternalOpen(false);
+        }
+    };
+
+    return (
+        <ClickOutside
+            ignoreSelector={AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR}
+            onClickOutside={() => setInternalOpen(false)}
+        >
+            <AntdAutoComplete
+                open={internalOpen}
+                value={internalValue}
+                {...props}
+                listHeight={dropdownContentHeight}
+                data-testid={dataTestId}
+                onClick={() => setInternalOpen(true)}
+                onBlur={onBlur}
+                onClear={onClear}
+                onKeyDown={onKeyDownHandler}
+                onChange={onChangeHandler}
+                dropdownRender={(menu) => {
+                    return (
+                        // Pass overlay class name to children to add possibility not to close autocomplete by clicking on child's portals
+                        // as ClickOutside will ignore them
+                        <OverlayClassProvider overlayClassName={AUTOCOMPLETE_WRAPPER_CLASS_NAME}>
+                            <DropdownWrapper className={AUTOCOMPLETE_WRAPPER_CLASS_NAME}>
+                                {props?.dropdownRender?.(menu) ?? menu}
+                            </DropdownWrapper>
+                        </OverlayClassProvider>
+                    );
+                }}
+            >
+                {children}
+            </AntdAutoComplete>
+        </ClickOutside>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/components.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/components.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const DropdownWrapper = styled.div`
+    & .rc-virtual-list-scrollbar-thumb {
+        background: rgba(193, 196, 208, 0.8) !important;
+    }
+    & .rc-virtual-list-scrollbar-show {
+        background: rgba(193, 196, 208, 0.3) !important;
+    }
+`;

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/constants.ts
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/constants.ts
@@ -1,0 +1,3 @@
+export const AUTOCOMPLETE_WRAPPER_CLASS_NAME = 'autocomplete-wrapper';
+export const AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR = `.${AUTOCOMPLETE_WRAPPER_CLASS_NAME}`;
+export const ESCAPE_KEY = 'Escape';

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/index.ts
@@ -1,0 +1,3 @@
+import AutoComplete from './AutoComplete';
+
+export { AutoComplete };

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/types.ts
@@ -1,0 +1,35 @@
+import { DefaultOptionType } from 'antd/lib/select';
+import { AlignType } from 'rc-trigger/lib/interface';
+import React from 'react';
+
+export type ValueType = string;
+
+export type OptionType = DefaultOptionType;
+
+export interface AutoCompleteProps {
+    dataTestId?: string;
+    className?: string;
+
+    value?: ValueType;
+    defaultValue?: ValueType;
+    options: OptionType[];
+    open?: boolean;
+
+    defaultActiveFirstOption?: boolean;
+    filterOption?: boolean | ((inputValue: ValueType, option?: OptionType) => boolean);
+    dropdownContentHeight?: number;
+
+    onSelect?: (value: ValueType, option: OptionType) => void;
+    onSearch?: (value: ValueType) => void;
+    onChange?: (value: ValueType, option: OptionType | OptionType[]) => void;
+    onClear?: () => void;
+    onDropdownVisibleChange?: (isOpen: boolean) => void;
+
+    dropdownRender?: (menu: React.ReactElement) => React.ReactElement | undefined;
+    notFoundContent?: React.ReactNode;
+
+    dropdownAlign?: AlignType;
+    style?: React.CSSProperties;
+    dropdownStyle?: React.CSSProperties;
+    dropdownMatchSelectWidth?: boolean | number;
+}

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.stories.tsx
@@ -1,0 +1,57 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ClickOutside from './ClickOutside';
+
+// Auto Docs
+const meta = {
+    title: 'Utils / ClickOutside',
+    component: ClickOutside,
+
+    // Display Properties
+    parameters: {
+        layout: 'centered',
+        badges: [BADGE.STABLE, 'readyForDesignReview'],
+        docs: {
+            subtitle: 'This component allows to add autocompletion',
+        },
+    },
+
+    // Component-level argTypes
+    argTypes: {
+        onClickOutside: {
+            description: 'Called on clicking outside',
+        },
+        ignoreSelector: {
+            description: 'Optional CSS-selector to ignore handling of clicks as outside clicks',
+        },
+        outsideSelector: {
+            description: 'Optional CSS-selector to cosider clicked element as outside click',
+        },
+        ignoreWrapper: {
+            description: 'Enable to ignore clicking outside of wrapper',
+        },
+    },
+
+    // Define defaults
+    args: {
+        onClickOutside: () => console.log('Clicked outside'),
+    },
+} satisfies Meta<typeof ClickOutside>;
+
+export default meta;
+
+// Stories
+
+type Story = StoryObj<typeof meta>;
+
+// Basic story is what is displayed 1st in storybook & is used as the code sandbox
+// Pass props to this so that it can be customized via the UI props panel
+export const sandbox: Story = {
+    tags: ['dev'],
+    render: (props) => (
+        <ClickOutside {...props}>
+            <button type="button">Button</button>
+        </ClickOutside>
+    ),
+};

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef } from 'react';
+import { ClickOutsideProps } from './types';
+
+export default function ClickOutside({
+    children,
+    onClickOutside,
+    outsideSelector,
+    ignoreSelector,
+    ignoreWrapper,
+}: React.PropsWithChildren<ClickOutsideProps>) {
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        /**
+         * Handles click events outside the wrapper or based on selectors.
+         */
+        const handleClickOutside = (event: MouseEvent): void => {
+            const target = event.target as HTMLElement;
+
+            const isInsideOfWrapper = (wrapperRef.current as HTMLDivElement).contains((event.target as Node) || null);
+
+            // Ignore clicks on elements matching `ignoreSelector`
+            if (ignoreSelector && target.closest(ignoreSelector)) {
+                return;
+            }
+
+            // Trigger `onClickOutside` if the click is on an element matching `outsideSelector`
+            if (outsideSelector && target.closest(outsideSelector)) {
+                return;
+            }
+
+            // Trigger `onClickOutside` if the click is outside the wrapper
+            if (!ignoreWrapper && !isInsideOfWrapper) {
+                onClickOutside(event);
+            }
+        };
+
+        if (wrapperRef && wrapperRef.current) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [onClickOutside, ignoreSelector, outsideSelector, ignoreWrapper]);
+
+    return <div ref={wrapperRef}>{children}</div>;
+}

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/types.ts
@@ -1,0 +1,6 @@
+export interface ClickOutsideProps {
+    onClickOutside: (event: MouseEvent) => void;
+    outsideSelector?: string; // Selector for elements that should trigger `onClickOutside`
+    ignoreSelector?: string; // Selector for elements that should be ignored
+    ignoreWrapper?: boolean; // Enable to ignore click outside the wrapper
+}

--- a/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/OverlayClassContext.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/OverlayClassContext.tsx
@@ -1,0 +1,39 @@
+import React, { useContext, useMemo } from 'react';
+import { DEFAULT_OVERLAY_CLASS_NAME, NESTED_OVERLAY_CLASS_NAME_SUFFIX } from './constants';
+
+export const OverlayClassStackContext = React.createContext<string[]>([]);
+
+export const useOverlayClassStackContext = () => useContext(OverlayClassStackContext);
+
+interface OverlayClassProviderProps {
+    overlayClassName: string;
+}
+
+/**
+ * Used to pass classes from parets to children saving the whole stack of them
+ */
+export const OverlayClassProvider = ({
+    children,
+    overlayClassName,
+}: React.PropsWithChildren<OverlayClassProviderProps>) => {
+    const overlayClassStack = useOverlayClassStackContext();
+
+    const nestedOverlayClassName = useMemo(() => {
+        if (overlayClassName) return overlayClassName;
+
+        return (
+            (overlayClassStack?.[overlayClassStack.length - 1] ?? DEFAULT_OVERLAY_CLASS_NAME) +
+            NESTED_OVERLAY_CLASS_NAME_SUFFIX
+        );
+    }, [overlayClassName, overlayClassStack]);
+
+    const updatedOverlayClassStack = useMemo(() => {
+        return [...overlayClassStack, nestedOverlayClassName];
+    }, [nestedOverlayClassName, overlayClassStack]);
+
+    return (
+        <OverlayClassStackContext.Provider value={updatedOverlayClassStack}>
+            {children}
+        </OverlayClassStackContext.Provider>
+    );
+};

--- a/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/constants.ts
+++ b/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_OVERLAY_CLASS_NAME = 'overlay-stack';
+export const NESTED_OVERLAY_CLASS_NAME_SUFFIX = 'nested';

--- a/datahub-web-react/src/alchemy-components/components/Utils/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Utils/index.ts
@@ -1,0 +1,6 @@
+export { default as ClickOutside } from './ClickOutside/ClickOutside';
+export {
+    OverlayClassProvider,
+    OverlayClassStackContext,
+    useOverlayClassStackContext,
+} from './OverlayClassContext/OverlayClassContext';

--- a/datahub-web-react/src/alchemy-components/index.ts
+++ b/datahub-web-react/src/alchemy-components/index.ts
@@ -2,6 +2,7 @@
 export * from './theme';
 
 // example usage: import { Button } from '@components';
+export * from './components/AutoComplete';
 export * from './components/Avatar';
 export * from './components/Badge';
 export * from './components/BarChart';

--- a/datahub-web-react/src/alchemy-components/index.ts
+++ b/datahub-web-react/src/alchemy-components/index.ts
@@ -30,6 +30,7 @@ export * from './components/Text';
 export * from './components/TextArea';
 export * from './components/Timeline';
 export * from './components/Tooltip';
+export * from './components/Utils';
 export * from './components/WhiskerChart';
 export * from './components/ColorPicker';
 export * from './components/Tooltip2';


### PR DESCRIPTION
Added the autocomplete component in the components library

Additionally added required utils to handle nested popups inside autocomplete:
- `ClickOutside` - wrapper to trigger callback when we click outside of our component
- `OverlayClassStackContext` - context to pass classes to children's popups that will be used in `ClickOutside` to ignore clicks with this classes

![image](https://github.com/user-attachments/assets/c4f0edbc-f5e7-4091-bfa9-06b139ea0f54)





## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
