### PR TITLE
feat(UI): improve Select components

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.stories.tsx
@@ -1,0 +1,122 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import AutoComplete from './AutoComplete';
+
+// Auto Docs
+const meta = {
+    title: 'Components / AutoComplete',
+    component: AutoComplete,
+
+    // Display Properties
+    parameters: {
+        layout: 'centered',
+        badges: [BADGE.STABLE, 'readyForDesignReview'],
+        docs: {
+            subtitle: 'This component allows to add autocompletion',
+        },
+    },
+
+    // Component-level argTypes
+    argTypes: {
+        dataTestId: {
+            description: 'Optional property to set data-testid',
+            control: 'text',
+        },
+        className: {
+            description: 'Optional class names to pass into AutoComplete',
+            control: 'text',
+        },
+        value: {
+            description: 'Value of input',
+        },
+        defaultValue: {
+            description: 'Selected option by default',
+        },
+        options: {
+            description: 'Options available in dropdown',
+            table: {
+                type: {
+                    summary: 'OptionType',
+                    detail: `{
+    label: React.ReactNode;
+    value?: string | number | null;
+    disabled?: boolean;
+    [name: string]: any;
+    children?: Omit<OptionType, 'children'>[];
+}
+                    `,
+                },
+            },
+        },
+        open: {
+            description: 'Controlled open state of dropdown',
+        },
+        defaultActiveFirstOption: {
+            description: 'Whether active first option by default',
+        },
+        filterOption: {
+            description: 'If true, filter options by input, if function, filter options against it',
+        },
+        dropdownContentHeight: {
+            description: "Height of dropdown's content",
+        },
+        onSelect: {
+            description: 'Called when a option is selected',
+        },
+        onSearch: {
+            description: 'Called when searching items',
+        },
+        onChange: {
+            description: 'Called when selecting an option or changing an input value',
+        },
+        onDropdownVisibleChange: {
+            description: 'Called when dropdown opened/closed',
+        },
+        onClear: {
+            description: 'Called when clear',
+        },
+        dropdownRender: {
+            description: 'Customize dropdown content',
+        },
+        dropdownAlign: {
+            description: "Adjust how the autocomplete's dropdown should be aligned",
+        },
+        style: {
+            description: 'Additional styles for the wrapper of the children',
+        },
+        dropdownStyle: {
+            description: 'Additional styles for the dropdown',
+        },
+        dropdownMatchSelectWidth: {
+            description:
+                'Determine whether the dropdown menu and the select input are the same width.' +
+                'Default set min-width same as input. Will ignore when value less than select width.',
+        },
+    },
+
+    // Define defaults
+    args: {
+        options: [
+            { label: 'test', value: 'test' },
+            { label: 'test2', value: 'test2' },
+        ],
+    },
+} satisfies Meta<typeof AutoComplete>;
+
+export default meta;
+
+// Stories
+
+type Story = StoryObj<typeof meta>;
+
+// Basic story is what is displayed 1st in storybook & is used as the code sandbox
+// Pass props to this so that it can be customized via the UI props panel
+export const sandbox: Story = {
+    tags: ['dev'],
+    render: (props) => (
+        <AutoComplete {...props}>
+            <input />
+        </AutoComplete>
+    ),
+};

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.tsx
@@ -1,0 +1,87 @@
+import { AutoComplete as AntdAutoComplete } from 'antd';
+import React, { useCallback, useEffect, useState } from 'react';
+import ClickOutside from '../Utils/ClickOutside/ClickOutside';
+import { DropdownWrapper } from './components';
+import { AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR, AUTOCOMPLETE_WRAPPER_CLASS_NAME, ESCAPE_KEY } from './constants';
+import { AutoCompleteProps, OptionType } from './types';
+import { OverlayClassProvider } from '../Utils';
+
+export default function AutoComplete({
+    children,
+    dropdownContentHeight,
+    dataTestId,
+    onDropdownVisibleChange,
+    onChange,
+    onClear,
+    value,
+    ...props
+}: React.PropsWithChildren<AutoCompleteProps>) {
+    const [internalValue, setInternalValue] = useState<string>(value || '');
+    const [internalOpen, setInternalOpen] = useState<boolean>(true);
+
+    useEffect(() => {
+        onDropdownVisibleChange?.(internalOpen);
+    }, [internalOpen, onDropdownVisibleChange]);
+
+    const onChangeHandler = (newValue: string, option: OptionType | OptionType[]) => {
+        setInternalValue(newValue);
+        if (!internalOpen && newValue !== '') setInternalOpen(true);
+        onChange?.(newValue, option);
+    };
+
+    const onKeyDownHandler = useCallback(
+        (event: React.KeyboardEvent) => {
+            if (event.key === ESCAPE_KEY) {
+                if (internalOpen) {
+                    setInternalOpen(false);
+                } else {
+                    setInternalValue('');
+                    onClear?.();
+                }
+            }
+        },
+        [internalOpen, setInternalValue, onClear],
+    );
+
+    const onBlur = (event: React.FocusEvent) => {
+        if (
+            event.relatedTarget &&
+            !(event.relatedTarget as HTMLElement).closest(AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR)
+        ) {
+            setInternalOpen(false);
+        }
+    };
+
+    return (
+        <ClickOutside
+            ignoreSelector={AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR}
+            onClickOutside={() => setInternalOpen(false)}
+        >
+            <AntdAutoComplete
+                open={internalOpen}
+                value={internalValue}
+                {...props}
+                listHeight={dropdownContentHeight}
+                data-testid={dataTestId}
+                onClick={() => setInternalOpen(true)}
+                onBlur={onBlur}
+                onClear={onClear}
+                onKeyDown={onKeyDownHandler}
+                onChange={onChangeHandler}
+                dropdownRender={(menu) => {
+                    return (
+                        // Pass overlay class name to children to add possibility not to close autocomplete by clicking on child's portals
+                        // as ClickOutside will ignore them
+                        <OverlayClassProvider overlayClassName={AUTOCOMPLETE_WRAPPER_CLASS_NAME}>
+                            <DropdownWrapper className={AUTOCOMPLETE_WRAPPER_CLASS_NAME}>
+                                {props?.dropdownRender?.(menu) ?? menu}
+                            </DropdownWrapper>
+                        </OverlayClassProvider>
+                    );
+                }}
+            >
+                {children}
+            </AntdAutoComplete>
+        </ClickOutside>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/AutoComplete.tsx
@@ -17,7 +17,7 @@ export default function AutoComplete({
     ...props
 }: React.PropsWithChildren<AutoCompleteProps>) {
     const [internalValue, setInternalValue] = useState<string>(value || '');
-    const [internalOpen, setInternalOpen] = useState<boolean>(true);
+    const [internalOpen, setInternalOpen] = useState<boolean>(false);
 
     useEffect(() => {
         onDropdownVisibleChange?.(internalOpen);

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/components.tsx
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/components.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const DropdownWrapper = styled.div`
+    & .rc-virtual-list-scrollbar-thumb {
+        background: rgba(193, 196, 208, 0.8) !important;
+    }
+    & .rc-virtual-list-scrollbar-show {
+        background: rgba(193, 196, 208, 0.3) !important;
+    }
+`;

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/constants.ts
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/constants.ts
@@ -1,0 +1,3 @@
+export const AUTOCOMPLETE_WRAPPER_CLASS_NAME = 'autocomplete-wrapper';
+export const AUTOCOMPLETE_WRAPPER_CLASS_CSS_SELECTOR = `.${AUTOCOMPLETE_WRAPPER_CLASS_NAME}`;
+export const ESCAPE_KEY = 'Escape';

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/index.ts
@@ -1,0 +1,3 @@
+import AutoComplete from './AutoComplete';
+
+export { AutoComplete };

--- a/datahub-web-react/src/alchemy-components/components/AutoComplete/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/AutoComplete/types.ts
@@ -1,0 +1,35 @@
+import { DefaultOptionType } from 'antd/lib/select';
+import { AlignType } from 'rc-trigger/lib/interface';
+import React from 'react';
+
+export type ValueType = string;
+
+export type OptionType = DefaultOptionType;
+
+export interface AutoCompleteProps {
+    dataTestId?: string;
+    className?: string;
+
+    value?: ValueType;
+    defaultValue?: ValueType;
+    options: OptionType[];
+    open?: boolean;
+
+    defaultActiveFirstOption?: boolean;
+    filterOption?: boolean | ((inputValue: ValueType, option?: OptionType) => boolean);
+    dropdownContentHeight?: number;
+
+    onSelect?: (value: ValueType, option: OptionType) => void;
+    onSearch?: (value: ValueType) => void;
+    onChange?: (value: ValueType, option: OptionType | OptionType[]) => void;
+    onClear?: () => void;
+    onDropdownVisibleChange?: (isOpen: boolean) => void;
+
+    dropdownRender?: (menu: React.ReactElement) => React.ReactElement | undefined;
+    notFoundContent?: React.ReactNode;
+
+    dropdownAlign?: AlignType;
+    style?: React.CSSProperties;
+    dropdownStyle?: React.CSSProperties;
+    dropdownMatchSelectWidth?: boolean | number;
+}

--- a/datahub-web-react/src/alchemy-components/components/Dropdown/Dropdown.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,60 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Dropdown from './Dropdown';
+
+// Auto Docs
+const meta = {
+    title: 'Components / Dropdown',
+    component: Dropdown,
+
+    // Display Properties
+    parameters: {
+        layout: 'centered',
+        badges: [BADGE.STABLE, 'readyForDesignReview'],
+        docs: {
+            subtitle: 'This component allows to add autocompletion',
+        },
+    },
+
+    // Component-level argTypes
+    argTypes: {
+        open: {
+            description: 'Controlled open state of dropdown',
+        },
+        dropdownRender: {
+            description: "Rendering function of dropdown's content",
+        },
+        disabled: {
+            description: 'Set to true to disable the dropdown',
+        },
+        overlayClassName: {
+            description: 'Class name of the dropdown',
+        },
+        onOpenChange: {
+            description: 'Called when dropdown opens/closes',
+        },
+    },
+
+    // Define defaults
+    args: {
+        dropdownRender: () => <div>Test content</div>,
+    },
+} satisfies Meta<typeof Dropdown>;
+
+export default meta;
+
+// Stories
+
+type Story = StoryObj<typeof meta>;
+
+// Basic story is what is displayed 1st in storybook & is used as the code sandbox
+// Pass props to this so that it can be customized via the UI props panel
+export const sandbox: Story = {
+    tags: ['dev'],
+    render: (props) => (
+        <Dropdown {...props}>
+            <button type="button">Click</button>
+        </Dropdown>
+    ),
+};

--- a/datahub-web-react/src/alchemy-components/components/Dropdown/Dropdown.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,21 @@
+import { Dropdown as AntdDropdown } from 'antd';
+import React, { useMemo } from 'react';
+import { useOverlayClassStackContext } from '../Utils/OverlayClassContext/OverlayClassContext';
+import { DropdownProps } from './types';
+
+export default function Dropdown({ children, overlayClassName, ...props }: React.PropsWithChildren<DropdownProps>) {
+    // Get all overlay classes from parents
+    const overlayClassNames = useOverlayClassStackContext();
+    const finalOverlayClassName = useMemo(() => {
+        if (overlayClassName) {
+            return [...overlayClassNames, overlayClassName].join(' ');
+        }
+        return overlayClassNames.join(' ');
+    }, [overlayClassName, overlayClassNames]);
+
+    return (
+        <AntdDropdown trigger={['click']} {...props} overlayClassName={finalOverlayClassName}>
+            {children}
+        </AntdDropdown>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/Dropdown/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Dropdown/index.ts
@@ -1,0 +1,1 @@
+export { default as Dropdown } from './Dropdown';

--- a/datahub-web-react/src/alchemy-components/components/Dropdown/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Dropdown/types.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export interface DropdownProps {
+    open?: boolean;
+    overlayClassName?: string;
+    disabled?: boolean;
+    dropdownRender?: (menus: React.ReactNode) => React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+}

--- a/datahub-web-react/src/alchemy-components/components/Pills/Pill.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Pills/Pill.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta = {
         label: {
             description: 'Label for the Pill.',
             table: {
-                defaultValue: { summary: defaults.label },
+                defaultValue: { summary: defaults.label as string },
             },
             control: {
                 type: 'text',

--- a/datahub-web-react/src/alchemy-components/components/Pills/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Pills/types.ts
@@ -9,7 +9,7 @@ export interface PillPropsDefaults {
 }
 
 export interface PillProps extends Partial<PillPropsDefaults>, Omit<HTMLAttributes<HTMLElement>, 'color'> {
-    label: string;
+    label: React.ReactNode;
     color?: ColorOptions;
     rightIcon?: string;
     leftIcon?: string;

--- a/datahub-web-react/src/alchemy-components/components/Select/AutoCompleteSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/AutoCompleteSelect.tsx
@@ -1,16 +1,16 @@
-import { Text } from '@components';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Dropdown, Text } from '@components';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Input } from '../Input';
 import {
     ActionButtonsContainer,
     Container,
-    Dropdown,
     LabelsWrapper,
     OptionContainer,
     OptionLabel,
     OptionList,
     Placeholder,
+    PortalDropdownContainer,
     SearchInputContainer,
     SelectBase,
     SelectLabel,
@@ -86,20 +86,6 @@ export default function AutoCompleteSelect<T>({
     const [query, setQuery] = useState('');
     const [isOpen, setIsOpen] = useState(false);
     const [selectedValue, setSelectedValue] = useState<Suggestion<T> | undefined>(undefined);
-    const selectRef = useRef<HTMLDivElement>(null);
-
-    const handleDocumentClick = useCallback((e: MouseEvent) => {
-        if (selectRef.current && !selectRef.current.contains(e.target as Node)) {
-            setIsOpen(false);
-        }
-    }, []);
-
-    useEffect(() => {
-        document.addEventListener('click', handleDocumentClick);
-        return () => {
-            document.removeEventListener('click', handleDocumentClick);
-        };
-    }, [handleDocumentClick]);
 
     const handleSelectClick = useCallback(() => {
         if (!isDisabled && !isReadOnly) {
@@ -134,75 +120,79 @@ export default function AutoCompleteSelect<T>({
 
     return (
         <Container
-            ref={selectRef}
             className={className}
             size={size || 'md'}
             width={props.width || 255}
             isSelected={selectedValue !== undefined}
         >
             {label && <SelectLabel onClick={handleSelectClick}>{label}</SelectLabel>}
-            <SelectBase
-                isDisabled={isDisabled}
-                isReadOnly={isReadOnly}
-                isRequired={isRequired}
-                isOpen={isOpen}
-                onClick={handleSelectClick}
-                fontSize={size}
-                {...props}
-            >
-                <SelectLabelContainer>
-                    {icon && <StyledIcon icon={icon} size="lg" />}
-                    <LabelsWrapper>
-                        {!selectedValue && placeholder && <Placeholder>{placeholder}</Placeholder>}
-                        {selectedValue && render(selectedValue.data)}
-                    </LabelsWrapper>
-                </SelectLabelContainer>
-                <SelectActionButtons
-                    selectedValues={selectedValue ? [selectedValue.value] : []}
-                    isOpen={isOpen}
-                    isDisabled={!!isDisabled}
-                    isReadOnly={!!isReadOnly}
-                    handleClearSelection={handleClearSelection}
-                    showClear
-                />
-            </SelectBase>
             <input type="hidden" name={name} value={selectedValue?.value || ''} readOnly />
-            {isOpen && (
-                <Dropdown>
-                    <SearchInputContainer>
-                        <Input
-                            label=""
-                            type="text"
-                            icon={{ name: 'MagnifyingGlass', source: 'phosphor' }}
-                            placeholder={searchPlaceholder || ''}
-                            value={query}
-                            onChange={(e) => {
-                                setQuery(e.target.value);
-                                onSearch(e.target.value);
-                            }}
-                        />
-                    </SearchInputContainer>
-                    <OptionList data-testid={optionListTestId}>
-                        {!displayedSuggestions.length && (
-                            <NoSuggestions>
-                                <Text type="span" color="gray" weight="semiBold">
-                                    No results found
-                                </Text>
-                            </NoSuggestions>
-                        )}
-                        {displayedSuggestions?.map((option) => (
-                            <OptionLabel
-                                key={option.value}
-                                onClick={() => handleOptionChange(option)}
-                                isSelected={selectedValue?.value === option.value}
-                                isDisabled={disabledValues?.includes(option.value)}
-                            >
-                                <OptionContainer>{render(option.data)}</OptionContainer>
-                            </OptionLabel>
-                        ))}
-                    </OptionList>
-                </Dropdown>
-            )}
+            <Dropdown
+                open={isOpen}
+                onOpenChange={(open) => setIsOpen(open)}
+                disabled={isDisabled}
+                dropdownRender={() => (
+                    <PortalDropdownContainer>
+                        <SearchInputContainer>
+                            <Input
+                                label=""
+                                type="text"
+                                icon={{ name: 'MagnifyingGlass', source: 'phosphor' }}
+                                placeholder={searchPlaceholder || ''}
+                                value={query}
+                                onChange={(e) => {
+                                    setQuery(e.target.value);
+                                    onSearch(e.target.value);
+                                }}
+                            />
+                        </SearchInputContainer>
+                        <OptionList data-testid={optionListTestId}>
+                            {!displayedSuggestions.length && (
+                                <NoSuggestions>
+                                    <Text type="span" color="gray" weight="semiBold">
+                                        No results found
+                                    </Text>
+                                </NoSuggestions>
+                            )}
+                            {displayedSuggestions?.map((option) => (
+                                <OptionLabel
+                                    key={option.value}
+                                    onClick={() => handleOptionChange(option)}
+                                    isSelected={selectedValue?.value === option.value}
+                                    isDisabled={disabledValues?.includes(option.value)}
+                                >
+                                    <OptionContainer>{render(option.data)}</OptionContainer>
+                                </OptionLabel>
+                            ))}
+                        </OptionList>
+                    </PortalDropdownContainer>
+                )}
+            >
+                <SelectBase
+                    isDisabled={isDisabled}
+                    isReadOnly={isReadOnly}
+                    isRequired={isRequired}
+                    isOpen={isOpen}
+                    fontSize={size}
+                    {...props}
+                >
+                    <SelectLabelContainer>
+                        {icon && <StyledIcon icon={icon} size="lg" />}
+                        <LabelsWrapper>
+                            {!selectedValue && placeholder && <Placeholder>{placeholder}</Placeholder>}
+                            {selectedValue && render(selectedValue.data)}
+                        </LabelsWrapper>
+                    </SelectLabelContainer>
+                    <SelectActionButtons
+                        selectedValues={selectedValue ? [selectedValue.value] : []}
+                        isOpen={isOpen}
+                        isDisabled={!!isDisabled}
+                        isReadOnly={!!isReadOnly}
+                        handleClearSelection={handleClearSelection}
+                        showClear
+                    />
+                </SelectBase>
+            </Dropdown>
         </Container>
     );
 }

--- a/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
@@ -66,7 +66,6 @@ export const BasicSelect = <OptionType extends SelectOption>({
     onSearch,
     filteringPredicate,
     selectLabelProps,
-    className,
     ...props
 }: SelectProps<OptionType>) => {
     const [searchQuery, setSearchQuery] = useState('');
@@ -164,7 +163,7 @@ export const BasicSelect = <OptionType extends SelectOption>({
     };
 
     return (
-        <Container size={size || 'md'} width={props.width} className={className}>
+        <Container size={size || 'md'} width={props.width}>
             {label && <SelectLabel onClick={handleSelectClick}>{label}</SelectLabel>}
             <Dropdown
                 open={isOpen}

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/filterNestedSelectOptions.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/filterNestedSelectOptions.test.ts
@@ -1,0 +1,76 @@
+import { SelectOption } from '../types';
+import { filterNestedSelectOptions } from '../utils';
+
+describe('filterNestedSelectOptions', () => {
+    const options: SelectOption[] = [
+        { value: 'p1', label: 'Parent 1', isParent: true },
+        { value: 'c1', label: 'Child 1', parentValue: 'p1' },
+        { value: 'c2', label: 'Child 2', parentValue: 'p1' },
+        { value: 'p2', label: 'Parent 2', isParent: true },
+        { value: 'c3', label: 'Child 3', parentValue: 'p2' },
+    ];
+
+    it('should return all options when query is empty', () => {
+        const result = filterNestedSelectOptions(options, '');
+        expect(result).toEqual(options);
+    });
+
+    it('should include parent of matched child and keep parent as parent', () => {
+        const query = 'Child 1';
+        const predicate = (option: SelectOption) => option.label === query;
+        const result = filterNestedSelectOptions(options, query, predicate);
+
+        expect(result).toEqual([
+            { value: 'p1', label: 'Parent 1', isParent: true },
+            { value: 'c1', label: 'Child 1', parentValue: 'p1' },
+        ]);
+    });
+
+    it('should mark parent as non-parent if no children are present in the result', () => {
+        const query = 'Parent 1';
+        const predicate = (option: SelectOption) => option.label === query;
+        const result = filterNestedSelectOptions(options, query, predicate);
+
+        expect(result).toEqual([{ value: 'p1', label: 'Parent 1', isParent: false }]);
+    });
+
+    it('should include multiple levels of parents if needed', () => {
+        const optionsWithGrandparent: SelectOption[] = [
+            { value: 'gp', label: 'Grandparent', isParent: true },
+            { value: 'p1', label: 'Parent 1', parentValue: 'gp', isParent: true },
+            { value: 'c1', label: 'Child 1', parentValue: 'p1' },
+        ];
+        const query = 'Child 1';
+        const predicate = (option: SelectOption) => option.label === query;
+        const result = filterNestedSelectOptions(optionsWithGrandparent, query, predicate);
+
+        expect(result).toEqual([
+            { value: 'gp', label: 'Grandparent', isParent: true },
+            { value: 'p1', label: 'Parent 1', parentValue: 'gp', isParent: true },
+            { value: 'c1', label: 'Child 1', parentValue: 'p1' },
+        ]);
+    });
+
+    it('should use default predicate if filteringPredicate was not provided', () => {
+        const query = 'child';
+        const result = filterNestedSelectOptions(options, query);
+
+        expect(result).toEqual([
+            { value: 'p1', label: 'Parent 1', isParent: true },
+            { value: 'c1', label: 'Child 1', parentValue: 'p1' },
+            { value: 'c2', label: 'Child 2', parentValue: 'p1' },
+            { value: 'p2', label: 'Parent 2', isParent: true },
+            { value: 'c3', label: 'Child 3', parentValue: 'p2' },
+        ]);
+    });
+
+    it('should keep parent as parent when both parent and child are matched', () => {
+        const query = '1';
+        const result = filterNestedSelectOptions(options, query);
+
+        expect(result).toEqual([
+            { value: 'p1', label: 'Parent 1', isParent: true },
+            { value: 'c1', label: 'Child 1', parentValue: 'p1' },
+        ]);
+    });
+});

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/getChainOfParents.test.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/__tests__/getChainOfParents.test.ts
@@ -1,0 +1,62 @@
+import { SelectOption } from '../types';
+import { getChainOfParents } from '../utils';
+
+describe('getChainOfParents', () => {
+    const options: SelectOption[] = [
+        { value: 'child', label: 'child', parentValue: 'parent' },
+        { value: 'parent', label: 'parent', parentValue: 'grandparent' },
+        { value: 'grandparent', label: 'grandparent' },
+        { value: 'orphan', label: 'orphan', parentValue: 'nonexistent' },
+    ];
+
+    it('should return empty array when option is undefined', () => {
+        const result = getChainOfParents(undefined, options);
+        expect(result).toEqual([]);
+    });
+
+    it('should return the option itself if it has no parent', () => {
+        const grandparent = options.find((o) => o.value === 'grandparent');
+        const result = getChainOfParents(grandparent, options);
+        expect(result).toEqual([grandparent]);
+    });
+
+    it('should return chain of parents for a child with multiple ancestors', () => {
+        const child = options.find((o) => o.value === 'child');
+        const parent = options.find((o) => o.value === 'parent');
+        const grandparent = options.find((o) => o.value === 'grandparent');
+        const result = getChainOfParents(child, options);
+        expect(result).toEqual([child, parent, grandparent]);
+    });
+
+    it('should return the option if its parent does not exist in options', () => {
+        const orphan = options.find((o) => o.value === 'orphan');
+        const result = getChainOfParents(orphan, options);
+        expect(result).toEqual([orphan]);
+    });
+
+    it('should stop chain when a parent in the hierarchy is missing', () => {
+        const optionsWithMissingParent: SelectOption[] = [
+            { value: 'child', label: 'child', parentValue: 'parent' },
+            { value: 'parent', label: 'parent', parentValue: 'missing' },
+        ];
+        const child = optionsWithMissingParent[0];
+        const parent = optionsWithMissingParent[1];
+        const result = getChainOfParents(child, optionsWithMissingParent);
+        expect(result).toEqual([child, parent]);
+    });
+
+    it('should handle deep nesting correctly', () => {
+        const deepOptions: SelectOption[] = [
+            { value: 'great-grandchild', label: 'great-grandchild', parentValue: 'grandchild' },
+            { value: 'grandchild', label: 'grandchild', parentValue: 'child' },
+            { value: 'child', label: 'child', parentValue: 'parent' },
+            { value: 'parent', label: 'parent' },
+        ];
+        const greatGrandchild = deepOptions[0];
+        const grandchild = deepOptions[1];
+        const child = deepOptions[2];
+        const parent = deepOptions[3];
+        const result = getChainOfParents(greatGrandchild, deepOptions);
+        expect(result).toEqual([greatGrandchild, grandchild, child, parent]);
+    });
+});

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/types.ts
@@ -1,9 +1,10 @@
 import { Entity } from '@src/types.generated';
+import { BaseSelectOption } from '../types';
 
-export interface SelectOption {
-    value: string;
-    label: string;
+export interface SelectOption extends BaseSelectOption {
     parentValue?: string;
     isParent?: boolean;
     entity?: Entity;
 }
+
+export type FilteringPredicate<Option extends SelectOption = SelectOption> = (option: Option, query: string) => boolean;

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/utils.ts
@@ -1,0 +1,61 @@
+import { defaultFilteringPredicate } from '../utils';
+import { FilteringPredicate, SelectOption } from './types';
+
+export function getChainOfParents(option: SelectOption | undefined, options: SelectOption[]) {
+    if (option === undefined) return [];
+    if (option.parentValue === undefined) return [option];
+
+    const parentOption = options.find((parentOptionCandidate) => parentOptionCandidate.value === option.parentValue);
+    return [option, ...getChainOfParents(parentOption, options)];
+}
+
+export function filterNestedSelectOptions(
+    options: SelectOption[],
+    query: string,
+    filteringPredicate?: FilteringPredicate,
+) {
+    if (query === '') return options;
+
+    const finalFilteringPredicate = filteringPredicate ?? defaultFilteringPredicate;
+    const filteredOptionsWithoutParents = options.filter((option) => finalFilteringPredicate(option, query));
+    const valuesOfFilteredOptions = filteredOptionsWithoutParents.map((option) => option.value);
+
+    const parentOptions = Array.from(
+        new Set(filteredOptionsWithoutParents.map((option) => getChainOfParents(option, options)).flat()),
+    );
+    const valuesOfParentOptions = parentOptions.map((option) => option.value);
+    const valuesToKeep = new Set([...valuesOfFilteredOptions, ...valuesOfParentOptions]);
+
+    const filteredOptionsWithParents = options.filter((option) => valuesToKeep.has(option.value));
+
+    return filteredOptionsWithParents.map((option) => {
+        if (!option.isParent) return option;
+
+        const remainsToBeParent = filteredOptionsWithParents.find(
+            (childOption) => childOption.parentValue === option.value,
+        );
+
+        if (remainsToBeParent) return option;
+
+        return {
+            ...option,
+            isParent: false,
+        };
+    });
+}
+
+export function areOptionsDifferent(optionsA: SelectOption[], optionsB: SelectOption[]) {
+    const toJson = (options: SelectOption[]) =>
+        JSON.stringify(
+            options.map((option) => {
+                // handle non-string labels as it is a ReactNode
+                const label = typeof option.label === 'string' ? option.label : option.value;
+                return { ...option, label };
+            }),
+        );
+
+    const jsonOptionsA = toJson(optionsA);
+    const jsonOptionsB = toJson(optionsB);
+
+    return jsonOptionsA !== jsonOptionsB;
+}

--- a/datahub-web-react/src/alchemy-components/components/Select/Select.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Select.stories.tsx
@@ -59,6 +59,19 @@ const meta: Meta = {
                 defaultValue: { summary: selectDefaults.showSearch?.toString() },
             },
         },
+        onSearch: {
+            description: 'Called when text in the search bar changed',
+        },
+        filteringPredicate: {
+            description:
+                'A function to replace default filtering predicate. The default predicate supports only string labels.',
+            table: {
+                type: {
+                    summary: 'FilteringPredicate',
+                    detail: '(option: Option, query: string) => boolean',
+                },
+            },
+        },
         isDisabled: {
             description: 'Whether the Select component is disabled.',
             control: {

--- a/datahub-web-react/src/alchemy-components/components/Select/Select.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Select.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BasicSelect } from './BasicSelect';
-import { SelectProps } from './types';
+import { SelectOption, SelectProps } from './types';
 
 export const selectDefaults: SelectProps = {
     options: [],
@@ -20,8 +20,8 @@ export const selectDefaults: SelectProps = {
     showDescriptions: false,
 };
 
-export const Select = ({
-    options = selectDefaults.options,
+export const Select = <OptionType extends SelectOption>({
+    options = [],
     label = selectDefaults.label,
     values = [],
     initialValues,
@@ -40,9 +40,9 @@ export const Select = ({
     selectAllLabel = selectDefaults.selectAllLabel,
     showDescriptions = selectDefaults.showDescriptions,
     ...props
-}: SelectProps) => {
+}: SelectProps<OptionType>) => {
     return (
-        <BasicSelect
+        <BasicSelect<OptionType>
             options={options}
             size={size}
             label={label}

--- a/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
@@ -66,7 +66,6 @@ export const SimpleSelect = <OptionType extends SelectOption>({
     optionSwitchable,
     selectLabelProps,
     filteringPredicate,
-    className,
     ...props
 }: SelectProps<OptionType>) => {
     const [searchQuery, setSearchQuery] = useState('');
@@ -141,7 +140,6 @@ export const SimpleSelect = <OptionType extends SelectOption>({
             width={props.width || 255}
             $selectLabelVariant={selectLabelProps?.variant}
             isSelected={selectedValues.length > 0}
-            className={className}
         >
             {label && <SelectLabel onClick={handleSelectClick}>{label}</SelectLabel>}
             <Dropdown

--- a/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
@@ -1,18 +1,15 @@
 import { Text } from '@components';
 import { isEqual } from 'lodash';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Dropdown from '../Dropdown/Dropdown';
 import {
     ActionButtonsContainer,
     Container,
-    Dropdown,
     LabelContainer,
     OptionContainer,
     OptionLabel,
     OptionList,
-    SearchIcon,
-    SearchInput,
-    SearchInputContainer,
-    SelectAllOption,
+    PortalDropdownContainer,
     SelectBase,
     SelectLabel,
     SelectLabelContainer,
@@ -20,8 +17,12 @@ import {
     StyledClearButton,
     StyledIcon,
 } from './components';
+import { simpleSelectDefaults } from './defaults';
+import DropdownSearchBar from './private/dropdown/DropdownSearchBar';
+import DropdownSelectAllOption from './private/dropdown/DropdownSelectAllOption';
 import SelectLabelRenderer from './private/SelectLabelRenderer/SelectLabelRenderer';
 import { ActionButtonsProps, SelectOption, SelectProps } from './types';
+import { defaultFilteringPredicate } from './utils';
 
 const SelectActionButtons = ({
     selectedValues,
@@ -41,51 +42,36 @@ const SelectActionButtons = ({
     );
 };
 
-export const selectDefaults: SelectProps = {
-    options: [],
-    label: '',
-    size: 'md',
-    showSearch: false,
-    isDisabled: false,
-    isReadOnly: false,
-    isRequired: false,
-    showClear: true,
-    width: 255,
-    isMultiSelect: false,
-    placeholder: 'Select an option ',
-    showSelectAll: false,
-    selectAllLabel: 'Select All',
-    showDescriptions: false,
-};
-
-export const SimpleSelect = ({
-    options = selectDefaults.options,
-    label = selectDefaults.label,
+export const SimpleSelect = <OptionType extends SelectOption>({
+    options = [],
+    label = simpleSelectDefaults.label,
     values = [],
     initialValues,
     onUpdate,
-    showSearch = selectDefaults.showSearch,
-    isDisabled = selectDefaults.isDisabled,
-    isReadOnly = selectDefaults.isReadOnly,
-    isRequired = selectDefaults.isRequired,
-    showClear = selectDefaults.showClear,
-    size = selectDefaults.size,
+    showSearch = simpleSelectDefaults.showSearch,
+    onSearch,
+    isDisabled = simpleSelectDefaults.isDisabled,
+    isReadOnly = simpleSelectDefaults.isReadOnly,
+    isRequired = simpleSelectDefaults.isRequired,
+    showClear = simpleSelectDefaults.showClear,
+    size = simpleSelectDefaults.size,
     icon,
-    isMultiSelect = selectDefaults.isMultiSelect,
-    placeholder = selectDefaults.placeholder,
+    isMultiSelect = simpleSelectDefaults.isMultiSelect,
+    placeholder = simpleSelectDefaults.placeholder,
     disabledValues = [],
-    showSelectAll = selectDefaults.showSelectAll,
-    selectAllLabel = selectDefaults.selectAllLabel,
-    showDescriptions = selectDefaults.showDescriptions,
+    showSelectAll = simpleSelectDefaults.showSelectAll,
+    selectAllLabel = simpleSelectDefaults.selectAllLabel,
+    showDescriptions = simpleSelectDefaults.showDescriptions,
     optionListTestId,
     optionSwitchable,
     selectLabelProps,
+    filteringPredicate,
+    className,
     ...props
-}: SelectProps) => {
+}: SelectProps<OptionType>) => {
     const [searchQuery, setSearchQuery] = useState('');
     const [isOpen, setIsOpen] = useState(false);
     const [selectedValues, setSelectedValues] = useState<string[]>(initialValues || values);
-    const selectRef = useRef<HTMLDivElement>(null);
     const [areAllSelected, setAreAllSelected] = useState(false);
 
     useEffect(() => {
@@ -94,27 +80,18 @@ export const SimpleSelect = ({
         }
     }, [values, selectedValues]);
 
-    useEffect(() => {
-        setAreAllSelected(selectedValues.length === options.length);
-    }, [options, selectedValues]);
-
-    const filteredOptions = useMemo(
-        () => options.filter((option) => option.label.toLowerCase().includes(searchQuery.toLowerCase())),
-        [options, searchQuery],
+    const onSearchHandler = useCallback(
+        (query: string) => {
+            setSearchQuery(query);
+            onSearch?.(query);
+        },
+        [onSearch],
     );
 
-    const handleDocumentClick = useCallback((e: MouseEvent) => {
-        if (selectRef.current && !selectRef.current.contains(e.target as Node)) {
-            setIsOpen(false);
-        }
-    }, []);
-
-    useEffect(() => {
-        document.addEventListener('click', handleDocumentClick);
-        return () => {
-            document.removeEventListener('click', handleDocumentClick);
-        };
-    }, [handleDocumentClick]);
+    const filteredOptions = useMemo(() => {
+        const predicate = filteringPredicate ?? defaultFilteringPredicate;
+        return options.filter((option) => predicate(option, searchQuery));
+    }, [options, searchQuery, filteringPredicate]);
 
     const handleSelectClick = useCallback(() => {
         if (!isDisabled && !isReadOnly) {
@@ -160,123 +137,117 @@ export const SimpleSelect = ({
 
     return (
         <Container
-            ref={selectRef}
             size={size || 'md'}
             width={props.width || 255}
             $selectLabelVariant={selectLabelProps?.variant}
             isSelected={selectedValues.length > 0}
+            className={className}
         >
             {label && <SelectLabel onClick={handleSelectClick}>{label}</SelectLabel>}
-            <SelectBase
-                isDisabled={isDisabled}
-                isReadOnly={isReadOnly}
-                isRequired={isRequired}
-                isOpen={isOpen}
-                onClick={handleSelectClick}
-                fontSize={size}
-                {...props}
-            >
-                <SelectLabelContainer>
-                    {icon && <StyledIcon icon={icon} size="lg" />}
-                    <SelectLabelRenderer
-                        selectedValues={selectedValues}
-                        options={options}
-                        placeholder={placeholder || 'Select an option'}
-                        isMultiSelect={isMultiSelect}
-                        removeOption={handleOptionChange}
-                        disabledValues={disabledValues}
-                        showDescriptions={showDescriptions}
-                        {...(selectLabelProps || {})}
-                    />
-                </SelectLabelContainer>
-                <SelectActionButtons
-                    selectedValues={selectedValues}
-                    isOpen={isOpen}
-                    isDisabled={!!isDisabled}
-                    isReadOnly={!!isReadOnly}
-                    handleClearSelection={handleClearSelection}
-                    showClear={!!showClear}
-                />
-            </SelectBase>
-            {isOpen && (
-                <Dropdown>
-                    {showSearch && (
-                        <SearchInputContainer>
-                            <SearchInput
-                                type="text"
+            <Dropdown
+                open={isOpen}
+                onOpenChange={(open) => setIsOpen(open)}
+                disabled={isDisabled}
+                dropdownRender={() => (
+                    <PortalDropdownContainer>
+                        {showSearch && (
+                            <DropdownSearchBar
                                 placeholder="Search…"
                                 value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
-                                style={{ fontSize: size || 'md' }}
+                                onChange={onSearchHandler}
+                                size={size}
                             />
-                            <SearchIcon icon="Search" size={size} color="gray" />
-                        </SearchInputContainer>
-                    )}
-                    <OptionList data-testid={optionListTestId}>
-                        {showSelectAll && isMultiSelect && (
-                            <SelectAllOption
-                                isSelected={areAllSelected}
-                                onClick={() => !(disabledValues.length === options.length) && handleSelectAll()}
-                                isDisabled={disabledValues.length === options.length}
-                            >
-                                <LabelContainer>
-                                    <span>{selectAllLabel}</span>
-                                    <StyledCheckbox
-                                        checked={areAllSelected}
-                                        disabled={disabledValues.length === options.length}
-                                    />
-                                </LabelContainer>
-                            </SelectAllOption>
                         )}
-                        {filteredOptions.map((option) => (
-                            <OptionLabel
-                                key={option.value}
-                                onClick={() => {
-                                    if (!isMultiSelect) {
-                                        if (optionSwitchable && selectedValues.includes(option.value)) {
-                                            handleClearSelection();
-                                        } else {
-                                            handleOptionChange(option);
+                        <OptionList data-testid={optionListTestId}>
+                            {showSelectAll && isMultiSelect && (
+                                <DropdownSelectAllOption
+                                    label={selectAllLabel}
+                                    selected={areAllSelected}
+                                    disabled={disabledValues.length === options.length}
+                                    onClick={() => !(disabledValues.length === options.length) && handleSelectAll()}
+                                />
+                            )}
+                            {filteredOptions.map((option) => (
+                                <OptionLabel
+                                    key={option.value}
+                                    onClick={() => {
+                                        if (!isMultiSelect) {
+                                            if (optionSwitchable && selectedValues.includes(option.value)) {
+                                                handleClearSelection();
+                                            } else {
+                                                handleOptionChange(option);
+                                            }
                                         }
-                                    }
-                                }}
-                                isSelected={selectedValues.includes(option.value)}
-                                isMultiSelect={isMultiSelect}
-                                isDisabled={disabledValues?.includes(option.value)}
-                            >
-                                {isMultiSelect ? (
-                                    <LabelContainer>
-                                        <span>{option.label}</span>
-                                        <StyledCheckbox
-                                            onClick={() => handleOptionChange(option)}
-                                            checked={selectedValues.includes(option.value)}
-                                            disabled={disabledValues?.includes(option.value)}
-                                        />
-                                    </LabelContainer>
-                                ) : (
-                                    <OptionContainer>
-                                        <ActionButtonsContainer>
-                                            {option.icon}
-                                            <Text
-                                                weight="semiBold"
-                                                size="md"
-                                                color={selectedValues.includes(option.value) ? 'violet' : 'gray'}
-                                            >
-                                                {option.label}
-                                            </Text>
-                                        </ActionButtonsContainer>
-                                        {!!option.description && (
-                                            <Text color="gray" weight="normal" size="sm">
-                                                {option.description}
-                                            </Text>
-                                        )}
-                                    </OptionContainer>
-                                )}
-                            </OptionLabel>
-                        ))}
-                    </OptionList>
-                </Dropdown>
-            )}
+                                    }}
+                                    isSelected={selectedValues.includes(option.value)}
+                                    isMultiSelect={isMultiSelect}
+                                    isDisabled={disabledValues?.includes(option.value)}
+                                >
+                                    {isMultiSelect ? (
+                                        <LabelContainer>
+                                            <span>{option.label}</span>
+                                            <StyledCheckbox
+                                                onClick={() => handleOptionChange(option)}
+                                                checked={selectedValues.includes(option.value)}
+                                                disabled={disabledValues?.includes(option.value)}
+                                            />
+                                        </LabelContainer>
+                                    ) : (
+                                        <OptionContainer>
+                                            <ActionButtonsContainer>
+                                                {option.icon}
+                                                <Text
+                                                    weight="semiBold"
+                                                    size="md"
+                                                    color={selectedValues.includes(option.value) ? 'violet' : 'gray'}
+                                                >
+                                                    {option.label}
+                                                </Text>
+                                            </ActionButtonsContainer>
+                                            {!!option.description && (
+                                                <Text color="gray" weight="normal" size="sm">
+                                                    {option.description}
+                                                </Text>
+                                            )}
+                                        </OptionContainer>
+                                    )}
+                                </OptionLabel>
+                            ))}
+                        </OptionList>
+                    </PortalDropdownContainer>
+                )}
+            >
+                <SelectBase
+                    isDisabled={isDisabled}
+                    isReadOnly={isReadOnly}
+                    isRequired={isRequired}
+                    isOpen={isOpen}
+                    fontSize={size}
+                    {...props}
+                >
+                    <SelectLabelContainer>
+                        {icon && <StyledIcon icon={icon} size="lg" />}
+                        <SelectLabelRenderer
+                            selectedValues={selectedValues}
+                            options={options}
+                            placeholder={placeholder || 'Select an option'}
+                            isMultiSelect={isMultiSelect}
+                            removeOption={handleOptionChange}
+                            disabledValues={disabledValues}
+                            showDescriptions={showDescriptions}
+                            {...(selectLabelProps || {})}
+                        />
+                    </SelectLabelContainer>
+                    <SelectActionButtons
+                        selectedValues={selectedValues}
+                        isOpen={isOpen}
+                        isDisabled={!!isDisabled}
+                        isReadOnly={!!isReadOnly}
+                        handleClearSelection={handleClearSelection}
+                        showClear={!!showClear}
+                    />
+                </SelectBase>
+            </Dropdown>
         </Container>
     );
 };

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -43,24 +43,31 @@ export const SelectLabelContainer = styled.div({
 // Container for the Basic Select component
 interface ContainerProps {
     size: SelectSizeOptions;
-    width?: number | 'full';
+    width?: number | 'full' | 'fit-content';
     $selectLabelVariant?: SelectLabelVariants;
     isSelected?: boolean;
 }
 
 export const Container = styled.div<ContainerProps>(({ size, width, $selectLabelVariant, isSelected }) => {
     const getMinWidth = () => {
+        if (width === 'fit-content') return undefined;
         if ($selectLabelVariant === 'labeled') {
             return isSelected ? '145px' : '103px';
         }
         return '175px';
     };
 
+    const getWidth = () => {
+        if (width === 'full') return '100%';
+        if (width === 'fit-content') return width;
+        return `${width}px`;
+    };
+
     return {
         position: 'relative',
         display: 'flex',
         flexDirection: 'column',
-        width: width === 'full' ? '100%' : `${width}px`,
+        width: getWidth(),
         gap: '4px',
         transition: sharedTransition,
         minWidth: getMinWidth(),
@@ -69,7 +76,7 @@ export const Container = styled.div<ContainerProps>(({ size, width, $selectLabel
     };
 });
 
-export const Dropdown = styled.div({
+export const DropdownContainer = styled.div({
     position: 'absolute',
     top: '100%',
     left: 0,
@@ -86,6 +93,22 @@ export const Dropdown = styled.div({
     marginTop: '4px',
     maxHeight: '360px',
     overflow: 'auto',
+});
+
+export const PortalDropdownContainer = styled.div({
+    borderRadius: radius.md,
+    background: colors.white,
+    zIndex: 950,
+    transition: sharedTransition,
+    boxShadow: shadows.dropdown,
+    padding: spacing.xsm,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    marginTop: '4px',
+    overflow: 'auto',
+    width: 'fit-content',
+    minWidth: '250px',
 });
 
 export const SearchInputContainer = styled.div({
@@ -152,11 +175,15 @@ export const FooterBase = styled.div({
 export const OptionList = styled.div({
     display: 'flex',
     flexDirection: 'column' as const,
+    maxHeight: '300px',
+    overflow: 'auto',
 });
 
 export const LabelContainer = styled.div({
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: '8px',
     width: '100%',
 });
 
@@ -207,17 +234,6 @@ export const SelectLabel = styled.label({
     ...formLabelTextStyles,
     marginBottom: spacing.xxsm,
     textAlign: 'left',
-});
-
-export const StyledCancelButton = styled(Button)({
-    backgroundColor: colors.violet[100],
-    color: colors.violet[500],
-    borderColor: colors.violet[100],
-
-    '&:hover': {
-        backgroundColor: colors.violet[200],
-        borderColor: colors.violet[200],
-    },
 });
 
 export const StyledIcon = styled(Icon)({

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -107,7 +107,7 @@ export const PortalDropdownContainer = styled.div({
     gap: '8px',
     marginTop: '4px',
     overflow: 'auto',
-    width: 'fit-content',
+    width: '100%',
     minWidth: '250px',
 });
 

--- a/datahub-web-react/src/alchemy-components/components/Select/defaults.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/defaults.tsx
@@ -1,0 +1,34 @@
+import { SelectProps } from './types';
+
+export const simpleSelectDefaults: SelectProps = {
+    options: [],
+    label: '',
+    size: 'md',
+    showSearch: false,
+    isDisabled: false,
+    isReadOnly: false,
+    isRequired: false,
+    showClear: true,
+    width: 255,
+    isMultiSelect: false,
+    placeholder: 'Select an option ',
+    showSelectAll: false,
+    selectAllLabel: 'Select All',
+    showDescriptions: false,
+};
+
+export const basicSelectDefaults: SelectProps = {
+    options: [],
+    label: '',
+    size: 'md',
+    showSearch: false,
+    isDisabled: false,
+    isReadOnly: false,
+    isRequired: false,
+    isMultiSelect: false,
+    showClear: false,
+    placeholder: 'Select an option',
+    showSelectAll: false,
+    selectAllLabel: 'Select All',
+    showDescriptions: false,
+};

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectLabeled.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectLabeled.tsx
@@ -7,7 +7,7 @@ export default function MultiSelectLabeled({ selectedOptions, label }: SelectLab
         <LabelsWrapper>
             <ActionButtonsContainer>
                 <SelectValue>{label}</SelectValue>
-                <HighlightedLabel>{selectedOptions.length}</HighlightedLabel>
+                {selectedOptions.length > 0 && <HighlightedLabel>{selectedOptions.length}</HighlightedLabel>}
             </ActionButtonsContainer>
         </LabelsWrapper>
     );

--- a/datahub-web-react/src/alchemy-components/components/Select/private/dropdown/DropdownFooter.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/dropdown/DropdownFooter.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Button } from '@components';
+import { colors, spacing } from '@src/alchemy-components/theme';
+import styled from 'styled-components';
+import { SelectSizeOptions } from '../../types';
+
+const FooterBase = styled.div({
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: spacing.sm,
+    paddingTop: spacing.sm,
+    borderTop: `1px solid ${colors.gray[100]}`,
+});
+
+interface Props {
+    onCancel?: () => void;
+    onUpdate?: () => void;
+    size?: SelectSizeOptions;
+}
+
+export default function DropdownFooter({ onCancel, onUpdate, size }: Props) {
+    return (
+        <FooterBase>
+            <Button onClick={onCancel} variant="text" size={size}>
+                Cancel
+            </Button>
+            <Button onClick={onUpdate} size={size} onFocus={(e) => e.stopPropagation()}>
+                Update
+            </Button>
+        </FooterBase>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/Select/private/dropdown/DropdownSearchBar.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/dropdown/DropdownSearchBar.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Icon } from '@components';
+import { borders, colors, radius, spacing, typography } from '@src/alchemy-components/theme';
+import styled from 'styled-components';
+import { SelectSizeOptions } from '../../types';
+
+const SearchInputContainer = styled.div({
+    position: 'relative',
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+});
+
+const SearchInput = styled.input({
+    width: '100%',
+    borderRadius: radius.md,
+    border: `1px solid ${colors.gray[200]}`,
+    color: colors.gray[500],
+    fontFamily: typography.fonts.body,
+    fontSize: typography.fontSizes.sm,
+    padding: spacing.xsm,
+    paddingRight: spacing.xlg,
+
+    '&:focus': {
+        borderColor: colors.violet[200],
+        outline: `${borders['1px']} ${colors.violet[200]}`,
+    },
+});
+
+const SearchIcon = styled(Icon)({
+    position: 'absolute',
+    right: spacing.sm,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    pointerEvents: 'none',
+});
+
+interface DropdownSearchBarProps {
+    placeholder?: string;
+    value?: string;
+    size?: SelectSizeOptions;
+    onChange?: (value: string) => void;
+}
+
+export default function DropdownSearchBar({ placeholder, value, size, onChange }: DropdownSearchBarProps) {
+    return (
+        <SearchInputContainer>
+            <SearchInput
+                type="text"
+                placeholder={placeholder || 'Search...'}
+                value={value}
+                onChange={(e) => onChange?.(e.target.value)}
+                style={{ fontSize: size || 'md' }}
+            />
+            <SearchIcon icon="Search" size={size} color="gray" />
+        </SearchInputContainer>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/Select/private/dropdown/DropdownSelectAllOption.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/dropdown/DropdownSelectAllOption.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { LabelContainer, SelectAllOption, StyledCheckbox } from '../../components';
+
+interface Props {
+    label?: string;
+    selected: boolean;
+    disabled?: boolean;
+    onClick?: () => void;
+}
+
+export default function DropdownSelectAllOption({ label, selected, onClick, disabled }: Props) {
+    return (
+        <SelectAllOption isSelected={selected} onClick={onClick} isDisabled={disabled}>
+            <LabelContainer>
+                <span>{label}</span>
+                <StyledCheckbox checked={selected} disabled={disabled} />
+            </LabelContainer>
+        </SelectAllOption>
+    );
+}

--- a/datahub-web-react/src/alchemy-components/components/Select/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/types.ts
@@ -32,9 +32,7 @@ export interface SelectProps<Option extends SelectOption = SelectOption> {
     icon?: IconNames;
     showSearch?: boolean;
     onSearch?: (query: string) => void;
-    // searchFilter?: (query: string, options: Option[]) => Option[];
     filteringPredicate?: FilteringPredicate<Option>;
-    // onSearchQueryChanged?: (query: string) => void;
     isDisabled?: boolean;
     isReadOnly?: boolean;
     isRequired?: boolean;
@@ -49,7 +47,6 @@ export interface SelectProps<Option extends SelectOption = SelectOption> {
     optionListTestId?: string;
     optionSwitchable?: boolean;
     selectLabelProps?: SelectLabelProps;
-    className?: string;
 }
 
 export interface SelectStyleProps {

--- a/datahub-web-react/src/alchemy-components/components/Select/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/types.ts
@@ -3,17 +3,26 @@ import { IconNames } from '../Icon';
 
 export type SelectSizeOptions = 'sm' | 'md' | 'lg';
 
-export interface SelectOption {
+export interface BaseSelectOption {
     value: string;
-    label: string;
+    label: React.ReactNode;
+}
+
+export interface SelectOption extends BaseSelectOption {
     description?: string;
     icon?: React.ReactNode;
 }
 
 export type SelectLabelVariants = 'default' | 'labeled';
+export interface SelectLabelProps {
+    variant: SelectLabelVariants;
+    label: string;
+}
 
-export interface SelectProps {
-    options: SelectOption[];
+export type FilteringPredicate<Option extends SelectOption = SelectOption> = (option: Option, query: string) => boolean;
+
+export interface SelectProps<Option extends SelectOption = SelectOption> {
+    options: Option[];
     label?: string;
     values?: string[];
     initialValues?: string[];
@@ -22,11 +31,15 @@ export interface SelectProps {
     size?: SelectSizeOptions;
     icon?: IconNames;
     showSearch?: boolean;
+    onSearch?: (query: string) => void;
+    // searchFilter?: (query: string, options: Option[]) => Option[];
+    filteringPredicate?: FilteringPredicate<Option>;
+    // onSearchQueryChanged?: (query: string) => void;
     isDisabled?: boolean;
     isReadOnly?: boolean;
     isRequired?: boolean;
     showClear?: boolean;
-    width?: number | 'full';
+    width?: number | 'full' | 'fit-content';
     isMultiSelect?: boolean;
     placeholder?: string;
     disabledValues?: string[];
@@ -35,10 +48,8 @@ export interface SelectProps {
     showDescriptions?: boolean;
     optionListTestId?: string;
     optionSwitchable?: boolean;
-    selectLabelProps?: {
-        variant: SelectLabelVariants;
-        label: string;
-    };
+    selectLabelProps?: SelectLabelProps;
+    className?: string;
 }
 
 export interface SelectStyleProps {
@@ -47,7 +58,7 @@ export interface SelectStyleProps {
     isReadOnly?: boolean;
     isRequired?: boolean;
     isOpen?: boolean;
-    width?: number | 'full';
+    width?: number | 'full' | 'fit-content';
 }
 
 export interface ActionButtonsProps {

--- a/datahub-web-react/src/alchemy-components/components/Select/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/utils.ts
@@ -1,7 +1,7 @@
 import { colors, radius, spacing, typography } from '@components/theme';
 import { getFontSize } from '@components/theme/utils';
 
-import { SelectStyleProps } from './types';
+import { BaseSelectOption, SelectStyleProps } from './types';
 
 export const getOptionLabelStyle = (isSelected: boolean, isMultiSelect?: boolean, isDisabled?: boolean) => {
     const color = isSelected ? colors.gray[600] : colors.gray[500];
@@ -128,3 +128,10 @@ export const getSelectStyle = (props: SelectStyleProps) => {
         ...paddingStyles,
     };
 };
+
+export function defaultFilteringPredicate(option: BaseSelectOption, query: string) {
+    if (typeof option.label !== 'string') return true; // just show all options as we don't know how to filter options
+
+    const label = option.label.toLowerCase();
+    return label.includes(query.toLowerCase());
+}

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.stories.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.stories.tsx
@@ -1,0 +1,57 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ClickOutside from './ClickOutside';
+
+// Auto Docs
+const meta = {
+    title: 'Utils / ClickOutside',
+    component: ClickOutside,
+
+    // Display Properties
+    parameters: {
+        layout: 'centered',
+        badges: [BADGE.STABLE, 'readyForDesignReview'],
+        docs: {
+            subtitle: 'This component allows to add autocompletion',
+        },
+    },
+
+    // Component-level argTypes
+    argTypes: {
+        onClickOutside: {
+            description: 'Called on clicking outside',
+        },
+        ignoreSelector: {
+            description: 'Optional CSS-selector to ignore handling of clicks as outside clicks',
+        },
+        outsideSelector: {
+            description: 'Optional CSS-selector to cosider clicked element as outside click',
+        },
+        ignoreWrapper: {
+            description: 'Enable to ignore clicking outside of wrapper',
+        },
+    },
+
+    // Define defaults
+    args: {
+        onClickOutside: () => console.log('Clicked outside'),
+    },
+} satisfies Meta<typeof ClickOutside>;
+
+export default meta;
+
+// Stories
+
+type Story = StoryObj<typeof meta>;
+
+// Basic story is what is displayed 1st in storybook & is used as the code sandbox
+// Pass props to this so that it can be customized via the UI props panel
+export const sandbox: Story = {
+    tags: ['dev'],
+    render: (props) => (
+        <ClickOutside {...props}>
+            <button type="button">Button</button>
+        </ClickOutside>
+    ),
+};

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+import { ClickOutsideProps } from './types';
+
+export default function ClickOutside({
+    children,
+    onClickOutside,
+    outsideSelector,
+    ignoreSelector,
+    ignoreWrapper,
+}: React.PropsWithChildren<ClickOutsideProps>) {
+    const wrapperRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        /**
+         * Handles click events outside the wrapper or based on selectors.
+         */
+        const handleClickOutside = (event: MouseEvent): void => {
+            const target = event.target as HTMLElement;
+
+            const isInsideOfWrapper = (wrapperRef.current as HTMLDivElement).contains((event.target as Node) || null);
+            console.log(event.target, wrapperRef.current);
+
+            // Ignore clicks on elements matching `ignoreSelector`
+            if (ignoreSelector && target.closest(ignoreSelector)) {
+                return;
+            }
+
+            // Trigger `onClickOutside` if the click is on an element matching `outsideSelector`
+            if (outsideSelector && target.closest(outsideSelector)) {
+                return;
+            }
+
+            // Trigger `onClickOutside` if the click is outside the wrapper
+            if (!ignoreWrapper && !isInsideOfWrapper) {
+                onClickOutside(event);
+            }
+        };
+
+        if (wrapperRef && wrapperRef.current) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [onClickOutside, ignoreSelector, outsideSelector, ignoreWrapper]);
+
+    return <div ref={wrapperRef}>{children}</div>;
+}

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/ClickOutside.tsx
@@ -18,7 +18,6 @@ export default function ClickOutside({
             const target = event.target as HTMLElement;
 
             const isInsideOfWrapper = (wrapperRef.current as HTMLDivElement).contains((event.target as Node) || null);
-            console.log(event.target, wrapperRef.current);
 
             // Ignore clicks on elements matching `ignoreSelector`
             if (ignoreSelector && target.closest(ignoreSelector)) {

--- a/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Utils/ClickOutside/types.ts
@@ -1,0 +1,6 @@
+export interface ClickOutsideProps {
+    onClickOutside: (event: MouseEvent) => void;
+    outsideSelector?: string; // Selector for elements that should trigger `onClickOutside`
+    ignoreSelector?: string; // Selector for elements that should be ignored
+    ignoreWrapper?: boolean; // Enable to ignore click outside the wrapper
+}

--- a/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/OverlayClassContext.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/OverlayClassContext.tsx
@@ -1,0 +1,39 @@
+import React, { useContext, useMemo } from 'react';
+import { DEFAULT_OVERLAY_CLASS_NAME, NESTED_OVERLAY_CLASS_NAME_SUFFIX } from './constants';
+
+export const OverlayClassStackContext = React.createContext<string[]>([]);
+
+export const useOverlayClassStackContext = () => useContext(OverlayClassStackContext);
+
+interface OverlayClassProviderProps {
+    overlayClassName: string;
+}
+
+/**
+ * Used to pass classes from parets to children saving the whole stack of them
+ */
+export const OverlayClassProvider = ({
+    children,
+    overlayClassName,
+}: React.PropsWithChildren<OverlayClassProviderProps>) => {
+    const overlayClassStack = useOverlayClassStackContext();
+
+    const nestedOverlayClassName = useMemo(() => {
+        if (overlayClassName) return overlayClassName;
+
+        return (
+            (overlayClassStack?.[overlayClassStack.length - 1] ?? DEFAULT_OVERLAY_CLASS_NAME) +
+            NESTED_OVERLAY_CLASS_NAME_SUFFIX
+        );
+    }, [overlayClassName, overlayClassStack]);
+
+    const updatedOverlayClassStack = useMemo(() => {
+        return [...overlayClassStack, nestedOverlayClassName];
+    }, [nestedOverlayClassName, overlayClassStack]);
+
+    return (
+        <OverlayClassStackContext.Provider value={updatedOverlayClassStack}>
+            {children}
+        </OverlayClassStackContext.Provider>
+    );
+};

--- a/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/constants.ts
+++ b/datahub-web-react/src/alchemy-components/components/Utils/OverlayClassContext/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_OVERLAY_CLASS_NAME = 'overlay-stack';
+export const NESTED_OVERLAY_CLASS_NAME_SUFFIX = 'nested';

--- a/datahub-web-react/src/alchemy-components/components/Utils/index.ts
+++ b/datahub-web-react/src/alchemy-components/components/Utils/index.ts
@@ -1,0 +1,6 @@
+export { default as ClickOutside } from './ClickOutside/ClickOutside';
+export {
+    OverlayClassProvider,
+    OverlayClassStackContext,
+    useOverlayClassStackContext,
+} from './OverlayClassContext/OverlayClassContext';

--- a/datahub-web-react/src/alchemy-components/index.ts
+++ b/datahub-web-react/src/alchemy-components/index.ts
@@ -2,6 +2,7 @@
 export * from './theme';
 
 // example usage: import { Button } from '@components';
+export * from './components/AutoComplete';
 export * from './components/Avatar';
 export * from './components/Badge';
 export * from './components/BarChart';
@@ -29,4 +30,5 @@ export * from './components/Text';
 export * from './components/TextArea';
 export * from './components/Timeline';
 export * from './components/Tooltip';
+export * from './components/Utils';
 export * from './components/WhiskerChart';

--- a/datahub-web-react/src/alchemy-components/index.ts
+++ b/datahub-web-react/src/alchemy-components/index.ts
@@ -12,6 +12,7 @@ export * from './components/Card';
 export * from './components/Checkbox';
 export * from './components/DatePicker';
 export * from './components/Drawer';
+export * from './components/Dropdown';
 export * from './components/GraphCard';
 export * from './components/Heading';
 export * from './components/Icon';

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/AcrylAssertionFilters.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/AssertionList/AcrylAssertionFilters.tsx
@@ -81,6 +81,10 @@ export const AcrylAssertionFilters: React.FC<AcrylAssertionFiltersProps> = ({
             showCount
             shouldAlwaysSyncParentValues
             hideParentCheckbox
+            selectLabelProps={{
+                variant: 'labeled',
+                label: 'Filter',
+            }}
         />
     );
 };

--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsForm.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsForm.tsx
@@ -100,6 +100,7 @@ const StructuredPropsForm = ({
                             }}
                             placeholder="Select Property Type"
                             options={valueTypes}
+                            width="full"
                             values={formValues?.valueType ? [formValues?.valueType] : undefined}
                             isDisabled={isEditMode}
                             showDescriptions


### PR DESCRIPTION
Added a basic `Dropdown` component

Select improvements:
- select's dropdown replaced with `Dropdown` component to support rendering of select's popups on the other popups (like in the autocompletion results)
- added support of `ReactNode` label for `SimpleSelect`, `Select`, `NestedSelect`
- added filtering to `NestedSelect` and a little improved in `SimpleSelect` and `Select` (added `filteringPredicate)
- added support of `SelectLabelRenderer` (variants to render select (default, labeled)) to `NestedSelect`
- added support of the new `width` option (`fit-content`) to `SimpleSelect`, `Select`, `NestedSelect`

Changes in the Pill component:
- added support of `ReactNode` label to support selects with pills in label (like default multiselect)

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
