### PR TITLE
docs: making top level blog links point to medium directly

### DIFF
--- a/docs-website/docusaurus.config.js
+++ b/docs-website/docusaurus.config.js
@@ -156,7 +156,7 @@ module.exports = {
               label: "Adoption Stories",
             },
             {
-              href: "https://blog.datahubproject.io/",
+              href: "https://medium.com/datahub-project",
               label: "Blog",
             },
             {
@@ -247,7 +247,7 @@ module.exports = {
             },
             {
               label: "Blog",
-              href: "https://blog.datahubproject.io/",
+              href: "https://medium.com/datahub-project",
             },
             {
               label: "Town Halls",

--- a/docs-website/src/pages/_components/SocialMedia/index.js
+++ b/docs-website/src/pages/_components/SocialMedia/index.js
@@ -185,7 +185,7 @@ const SocialMedia = ({}) => {
                 className={styles.visitPageIcon}
               />
             </Link>
-            <Link className={styles.statItem}  to="https://blog.datahubproject.io/">
+            <Link className={styles.statItem}  to="https://medium.com/datahub-project">
               <div className={styles.styledIcon}>
                 <MediumWorkmarkOutlined
                   width={38}

--- a/docs-website/src/theme/Navbar/learnCardDropdownContent.js
+++ b/docs-website/src/theme/Navbar/learnCardDropdownContent.js
@@ -17,7 +17,7 @@ const learCardDropdownContent = [
         {
             title: "Blog",
             iconImage: "/img/icon-champions.png",
-            href: "https://blog.datahubproject.io/",
+            href: "https://medium.com/datahub-project",
         },
         {
             title: "Youtube",


### PR DESCRIPTION
Medium seems to be having a hard time routing to our custom domain. 
Fixing the top-level blog links so people can at least navigate to it from the main menu bar.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
