### PR TITLE
[wip] feat: make mlModelDeployment queriable & visible in UI

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelPropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mlmodel/mappers/MLModelPropertiesMapper.java
@@ -80,6 +80,12 @@ public class MLModelPropertiesMapper
               .collect(Collectors.toList()));
     }
 
+    if (mlModelProperties.getDeployments() != null) {
+      result.setDeployments(
+          mlModelProperties.getDeployments().stream()
+              .map(Urn::toString)
+              .collect(Collectors.toList()));
+    }
     if (mlModelProperties.getMlFeatures() != null) {
       result.setMlFeatures(
           mlModelProperties.getMlFeatures().stream()

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1231,6 +1231,11 @@ enum EntityType {
     A set of versioned entities, representing a single source / logical entity over time
     """
     VERSION_SET
+
+    """
+    Represents a deployment of an ML Model
+    """
+    ML_MODEL_DEPLOYMENT
 }
 
 """
@@ -10367,10 +10372,57 @@ type MLModelProperties {
     created: AuditStamp
 
     """
+    Deployments of this model
+    """
+    deployments: [String]
+
+    """
     Deprecated timestamp for model creation
     @deprecated Use 'created' field instead
     """
     date: Long @deprecated(reason: "Use `created` instead")
+}
+
+type MLModelDeployment implements Entity {
+    """
+    Urn of the deployment
+    """
+    urn: String!
+
+    """
+    A standard Entity Type
+    """
+    type: EntityType!
+
+    """
+    Name of the deployment 
+    """
+    name: String!
+
+    """
+    Platform information of the deployment
+    """
+    platform: String
+
+    """
+    Property information of the deployment
+    """
+    properties: MLModelDeploymentProperties
+
+    """
+    Relationship related to this deployment
+    Used to pull mlmodel
+    """  
+    relationships(input: RelationshipsInput!): EntityRelationshipsResult
+
+}
+
+type MLModelDeploymentProperties {
+    """
+    Description of the deployment
+    """
+    description: String
+
 }
 
 type MLFeatureProperties {
@@ -12793,7 +12845,7 @@ input CreateOwnershipTypeInput {
     """
     The description of the Custom Ownership Type
     """
-    description: String!
+    description: String
 }
 
 
@@ -13285,3 +13337,4 @@ extend type DataProcessInstance {
     """
     parentTemplate: Entity
 }
+

--- a/datahub-web-react/src/app/entityV2/mlModel/profile/MLModelSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/profile/MLModelSummary.tsx
@@ -120,6 +120,11 @@ export default function MLModelSummary() {
                     <InfoItem title="Source Run">
                         <InfoItemContent>{renderTrainingJobs()}</InfoItemContent>
                     </InfoItem>
+                    {model?.deployedTo?.relationships && (
+                        <InfoItem title="Deployment">
+                            <InfoItemContent>{model?.deployedTo?.relationships?.map((relationship) => relationship.entity)}</InfoItemContent>
+                        </InfoItem>
+                    )}
                 </InfoItemContainer>
                 <Typography.Title level={3}>Training Metrics</Typography.Title>
                 <Table

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -1075,6 +1075,7 @@ fragment nonRecursiveMLModel on MLModel {
             trainingJobs
             downstreamJobs
         }
+        deployments
     }
     globalTags {
         ...globalTagsFields

--- a/datahub-web-react/src/graphql/mlModel.graphql
+++ b/datahub-web-react/src/graphql/mlModel.graphql
@@ -37,6 +37,25 @@ query getMLModel($urn: String!) {
                 }
             }
         }
+        deployedTo: relationships(input: { types: ["DeployedTo"], direction: OUTGOING, start: 0, count: 100 }) {
+            start
+            count
+            total
+            relationships {
+                type
+                direction
+                entity {
+                    ...on MLModelDeployment {
+                        urn
+                        name
+                        platform
+                        properties {
+                            description
+                        }
+                    }
+                }
+            }
+        }
         privileges {
             ...entityPrivileges
         }


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)

** for some reason the relationship.entity is returning as null, I'm trying to figure out 
