### PR TITLE
feat(ingest): allow MCPWs instead of workunits

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source.py
@@ -27,6 +27,7 @@ from typing_extensions import LiteralString, Self
 
 from datahub.configuration.common import ConfigModel
 from datahub.configuration.source_common import PlatformInstanceConfigMixin
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.emitter.mcp_builder import mcps_from_mce
 from datahub.ingestion.api.auto_work_units.auto_dataset_properties_aspect import (
     auto_patch_last_modified,
@@ -44,6 +45,7 @@ from datahub.ingestion.api.source_helpers import (
     auto_lowercase_urns,
     auto_materialize_referenced_tags_terms,
     auto_status_aspect,
+    auto_workunit,
     auto_workunit_reporter,
 )
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -473,10 +475,12 @@ class Source(Closeable, metaclass=ABCMeta):
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
         return self._apply_workunit_processors(
-            self.get_workunit_processors(), self.get_workunits_internal()
+            self.get_workunit_processors(), auto_workunit(self.get_workunits_internal())
         )
 
-    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
+    def get_workunits_internal(
+        self,
+    ) -> Iterable[Union[MetadataWorkUnit, MetadataChangeProposalWrapper]]:
         raise NotImplementedError(
             "get_workunits_internal must be implemented if get_workunits is not overriden."
         )

--- a/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/source_helpers.py
@@ -48,7 +48,9 @@ logger = logging.getLogger(__name__)
 
 
 def auto_workunit(
-    stream: Iterable[Union[MetadataChangeEventClass, MetadataChangeProposalWrapper]],
+    stream: Iterable[
+        Union[MetadataChangeEventClass, MetadataChangeProposalWrapper, MetadataWorkUnit]
+    ],
 ) -> Iterable[MetadataWorkUnit]:
     """Convert a stream of MCEs and MCPs to a stream of :class:`MetadataWorkUnit`s."""
 
@@ -58,8 +60,10 @@ def auto_workunit(
                 id=MetadataWorkUnit.generate_workunit_id(item),
                 mce=item,
             )
-        else:
+        elif isinstance(item, MetadataChangeProposalWrapper):
             yield item.as_workunit()
+        else:
+            yield item
 
 
 def create_dataset_props_patch_builder(

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_common.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import auto
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import more_itertools
 import pydantic
@@ -849,7 +849,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
         test_nodes: List[DBTNode],
         extra_custom_props: Dict[str, str],
         all_nodes_map: Dict[str, DBTNode],
-    ) -> Iterable[MetadataWorkUnit]:
+    ) -> Iterable[MetadataChangeProposalWrapper]:
         for node in sorted(test_nodes, key=lambda n: n.dbt_name):
             upstreams = get_upstreams_for_test(
                 test_node=node,
@@ -902,7 +902,7 @@ class DBTSourceBase(StatefulIngestionSourceBase):
                     yield MetadataChangeProposalWrapper(
                         entityUrn=assertion_urn,
                         aspect=self._make_data_platform_instance_aspect(),
-                    ).as_workunit()
+                    )
 
                     yield make_assertion_from_test(
                         custom_props,
@@ -949,7 +949,9 @@ class DBTSourceBase(StatefulIngestionSourceBase):
             ),
         )
 
-    def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
+    def get_workunits_internal(
+        self,
+    ) -> Iterable[Union[MetadataWorkUnit, MetadataChangeProposalWrapper]]:
         if self.config.write_semantics == "PATCH":
             self.ctx.require_graph("Using dbt with write_semantics=PATCH")
 

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt/dbt_tests.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 from datahub.emitter import mce_builder
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
-from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.metadata.schema_classes import (
     AssertionInfoClass,
     AssertionResultClass,
@@ -157,7 +156,7 @@ def make_assertion_from_test(
     node: "DBTNode",
     assertion_urn: str,
     upstream_urn: str,
-) -> MetadataWorkUnit:
+) -> MetadataChangeProposalWrapper:
     assert node.test_info
     qualified_test_name = node.test_info.qualified_test_name
     column_name = node.test_info.column_name
@@ -231,7 +230,7 @@ def make_assertion_from_test(
     return MetadataChangeProposalWrapper(
         entityUrn=assertion_urn,
         aspect=assertion_info,
-    ).as_workunit()
+    )
 
 
 def make_assertion_result_from_test(
@@ -240,7 +239,7 @@ def make_assertion_result_from_test(
     assertion_urn: str,
     upstream_urn: str,
     test_warnings_are_errors: bool,
-) -> MetadataWorkUnit:
+) -> MetadataChangeProposalWrapper:
     assertionResult = AssertionRunEventClass(
         timestampMillis=int(test_result.execution_time.timestamp() * 1000.0),
         assertionUrn=assertion_urn,
@@ -261,4 +260,4 @@ def make_assertion_result_from_test(
     return MetadataChangeProposalWrapper(
         entityUrn=assertion_urn,
         aspect=assertionResult,
-    ).as_workunit()
+    )

--- a/metadata-ingestion/src/datahub/sdk/entity.py
+++ b/metadata-ingestion/src/datahub/sdk/entity.py
@@ -150,7 +150,7 @@ class Entity:
         self._set_aspect(default_aspect)
         return default_aspect
 
-    def _as_mcps(
+    def as_mcps(
         self,
         change_type: Union[str, models.ChangeTypeClass] = models.ChangeTypeClass.UPSERT,
     ) -> List[MetadataChangeProposalWrapper]:
@@ -182,7 +182,7 @@ class Entity:
         Returns:
             A list of MetadataWorkUnit objects.
         """
-        return [mcp.as_workunit() for mcp in self._as_mcps()]
+        return [mcp.as_workunit() for mcp in self.as_mcps()]
 
     def _set_extra_aspects(self, extra_aspects: ExtraAspectsType) -> None:
         """Set additional aspects on the entity.

--- a/metadata-ingestion/src/datahub/sdk/entity_client.py
+++ b/metadata-ingestion/src/datahub/sdk/entity_client.py
@@ -95,7 +95,7 @@ class EntityClient:
                 changeType=models.ChangeTypeClass.CREATE_ENTITY,
             )
         )
-        mcps.extend(entity._as_mcps(models.ChangeTypeClass.CREATE))
+        mcps.extend(entity.as_mcps(models.ChangeTypeClass.CREATE))
 
         self._graph.emit_mcps(mcps)
 
@@ -108,7 +108,7 @@ class EntityClient:
             )
             # TODO: If there are no previous aspects but the entity exists, should we delete aspects that are not present here?
 
-        mcps = entity._as_mcps(models.ChangeTypeClass.UPSERT)
+        mcps = entity.as_mcps(models.ChangeTypeClass.UPSERT)
         self._graph.emit_mcps(mcps)
 
     def update(self, entity: Union[Entity, MetadataPatchProposal]) -> None:
@@ -123,7 +123,7 @@ class EntityClient:
         # TODO: respect If-Unmodified-Since?
         # -> probably add a "mode" parameter that can be "update" (e.g. if not modified) or "update_force"
 
-        mcps = entity._as_mcps(models.ChangeTypeClass.UPSERT)
+        mcps = entity.as_mcps(models.ChangeTypeClass.UPSERT)
         self._graph.emit_mcps(mcps)
 
     def _update_patch(

--- a/metadata-ingestion/tests/test_helpers/sdk_v2_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/sdk_v2_helpers.py
@@ -6,7 +6,7 @@ from tests.test_helpers import mce_helpers
 
 def assert_entity_golden(entity: Entity, golden_path: pathlib.Path) -> None:
     mce_helpers.check_goldens_stream(
-        outputs=entity._as_mcps(),
+        outputs=entity.as_mcps(),
         golden_path=golden_path,
         ignore_order=False,
     )


### PR DESCRIPTION
Also expands the `auto_workunit` helper to be a bit more flexible on types, allowing it to be used in more places.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
