### PR TITLE
feat(ingest/mode): fix issue in mode request validation

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/request_helper.py
+++ b/metadata-ingestion/src/datahub/emitter/request_helper.py
@@ -1,6 +1,6 @@
 import itertools
 import shlex
-from typing import List, Union
+from typing import List, Optional, Union
 
 import requests
 
@@ -12,7 +12,7 @@ def _format_header(name: str, value: Union[str, bytes]) -> str:
 
 
 def make_curl_command(
-    session: requests.Session, method: str, url: str, payload: str
+    session: requests.Session, method: str, url: str, payload: Optional[str] = None
 ) -> str:
     fragments: List[str] = [
         "curl",
@@ -20,7 +20,7 @@ def make_curl_command(
             *[
                 ("-X", method),
                 *[("-H", _format_header(k, v)) for (k, v) in session.headers.items()],
-                ("--data", payload),
+                ("--data", payload) if payload else [],
             ]
         ),
         url,

--- a/metadata-ingestion/src/datahub/emitter/request_helper.py
+++ b/metadata-ingestion/src/datahub/emitter/request_helper.py
@@ -1,8 +1,8 @@
-import itertools
 import shlex
 from typing import List, Optional, Union
 
 import requests
+from requests.auth import HTTPBasicAuth
 
 
 def _format_header(name: str, value: Union[str, bytes]) -> str:
@@ -14,15 +14,20 @@ def _format_header(name: str, value: Union[str, bytes]) -> str:
 def make_curl_command(
     session: requests.Session, method: str, url: str, payload: Optional[str] = None
 ) -> str:
-    fragments: List[str] = [
-        "curl",
-        *itertools.chain(
-            *[
-                ("-X", method),
-                *[("-H", _format_header(k, v)) for (k, v) in session.headers.items()],
-                ("--data", payload) if payload else [],
-            ]
-        ),
-        url,
-    ]
+    fragments: List[str] = ["curl", "-X", method]
+
+    for header_name, header_value in session.headers.items():
+        fragments.extend(["-H", _format_header(header_name, header_value)])
+
+    if session.auth:
+        if isinstance(session.auth, HTTPBasicAuth):
+            fragments.extend(["-u", f"{session.auth.username}:<redacted>"])
+        else:
+            # For other auth types, they should be handled via headers
+            fragments.extend(["-H", "<unknown auth type>"])
+
+    if payload:
+        fragments.extend(["--data", payload])
+
+    fragments.append(url)
     return shlex.join(fragments)

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -340,7 +340,8 @@ class ModeSource(StatefulIngestionSourceBase):
 
         # Test the connection
         try:
-            self._get_request_json(f"{self.config.connect_uri}/api/verify")
+            key_info = self._get_request_json(f"{self.config.connect_uri}/api/verify")
+            logger.debug(f"Auth info: {key_info}")
         except ModeRequestError as e:
             self.report.report_failure(
                 title="Failed to Connect",

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -33,6 +33,7 @@ from datahub.emitter.mcp_builder import (
     add_dataset_to_container,
     gen_containers,
 )
+from datahub.emitter.request_helper import make_curl_command
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.decorators import (
     SourceCapability,
@@ -1485,6 +1486,8 @@ class ModeSource(StatefulIngestionSourceBase):
 
         @r.wraps
         def get_request():
+            curl_command = make_curl_command(self.session, "GET", url, "")
+            logger.debug(f"Issuing request; curl equivalent: {curl_command}")
             try:
                 response = self.session.get(
                     url, timeout=self.config.api_options.timeout

--- a/metadata-ingestion/tests/integration/mode/test_mode.py
+++ b/metadata-ingestion/tests/integration/mode/test_mode.py
@@ -68,6 +68,17 @@ class MockResponse:
             self.json_data = data
         return self
 
+    @property
+    def text(self) -> str:
+        return json.dumps(self.json_data)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise HTTPError(
+                f"MockResponse for {self.url} has status code {self.status_code}",
+                response=self,
+            )
+
 
 class MockResponseJson(MockResponse):
     def __init__(


### PR DESCRIPTION
The main bug here was a missing `response.raise_for_status()` error. That would cause requests that returned a 401 / other error to silently pass validation. The second issue was that our response parsing logic was very lenient on missing fields, causing us to think there were just no spaces returned when auth might've failed beforehand.

To debug this, I also improved the error request logging to show curl-equivalents for every request made, with secrets redacted of course.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
