### PR TITLE
ci(docs): adjust build and test workflow for doc only PRs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
Branch protection rules require build and test workflow to run for all PRs, but the ignore path spec causes this workflow to not run on doc only PRs, and those PRs cannot be merged without selecting bypass branch protection rules. . The CI optimization will anyway cause the doc-only PRs to not run through the full set of tests, after just a few steps without the full tests.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
