### PR TITLE
docs(ingest/snowflake): update docs to capture key pair auth section

### DIFF
--- a/docs/quick-ingestion-guides/snowflake/setup.md
+++ b/docs/quick-ingestion-guides/snowflake/setup.md
@@ -20,7 +20,7 @@ In order to configure ingestion from Snowflake, you'll first have to ensure you 
 2. Create a DataHub-specific user by executing the following queries. Replace `<your-password>` with a strong password. Replace `<your-warehouse>` with the same warehouse used above.
 
    ```sql
-   create user datahub_user display_name = 'DataHub' password='<your-password>' default_role = datahub_role default_warehouse = '<your-warehouse>';
+   create user datahub_user display_name = 'DataHub' password='<your-password>' default_role = datahub_role type='LEGACY_SERVICE' default_warehouse = '<your-warehouse>';
    -- Grant access to the DataHub role created above
    grant role datahub_role to user datahub_user;
    ```

--- a/metadata-ingestion/docs/sources/snowflake/snowflake_pre.md
+++ b/metadata-ingestion/docs/sources/snowflake/snowflake_pre.md
@@ -75,6 +75,20 @@ Authentication is most simply done via a Snowflake user and password.
 
 Alternatively, other authentication methods are supported via the `authentication_type` config option.
 
+#### Key Pair Authentication
+To set up Key Pair authentication, follow the three steps in [this guide](https://docs.snowflake.com/en/user-guide/key-pair-auth#configuring-key-pair-authentication)
+  - Generate the private key
+  - Generate the public key
+  - Assign the public key to datahub user to be configured in recipe.
+
+Pass in the following values in recipe config instead of password:
+```yml
+private_key: <Private key in a form of '-----BEGIN PRIVATE KEY-----\nprivate-key\n-----END PRIVATE KEY-----'>
+
+# Optional - if using encrypted private key
+private_key_password: <Password for your private key>
+```
+
 #### Okta OAuth
 To set up Okta OAuth authentication, roughly follow the four steps in [this guide](https://docs.snowflake.com/en/user-guide/oauth-okta).
 


### PR DESCRIPTION
Also
- update quickstart guide to create 'LEGACY_SERVICE' user instead of human user.

This update is triggered by snowflake security update [here](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification/). From April, human users will need MFA when using password.

Once DataHub Ingestion UI form natively supports key-pair authenbtication, the quickstart guide can be updated with new recommendations for configuring key-pair authentication and related screenshots.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
