### PR TITLE
fix(ingest): add mutator for ownership types

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
@@ -1,0 +1,97 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import static com.linkedin.metadata.Constants.OWNERSHIP_ASPECT_NAME;
+
+import com.linkedin.common.*;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.aspect.ReadItem;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.hooks.MutationHook;
+import com.linkedin.util.Pair;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+public class OwnershipOwnerTypes extends MutationHook {
+  @Nonnull private AspectPluginConfig config;
+
+  protected Stream<Pair<ChangeMCP, Boolean>> writeMutation(
+      @Nonnull Collection<ChangeMCP> changeMCPS, @Nonnull RetrieverContext retrieverContext) {
+    List<Pair<ChangeMCP, Boolean>> results = new LinkedList<>();
+    for (ChangeMCP item : changeMCPS) {
+      if (aspectFilter(item)) {
+        results.add(Pair.of(item, processOwnershipAspect(item)));
+      } else {
+        results.add(Pair.of(item, false));
+      }
+    }
+    return results.stream();
+  }
+
+  private static boolean aspectFilter(ReadItem item) {
+    return item.getAspectName().equals(OWNERSHIP_ASPECT_NAME);
+  }
+
+  public static boolean processOwnershipAspect(ChangeMCP item) {
+    boolean mutated = false;
+    Ownership ownership = item.getAspect(Ownership.class);
+    if (ownership == null) {
+      return false;
+    }
+    UrnArrayMap ownerTypes = ownership.getOwnerTypes();
+    if (ownerTypes == null) {
+      ownerTypes = ownership.getOwnerTypes();
+      ownership.setOwnerTypes(ownerTypes);
+      mutated = true;
+    }
+    OwnerArray owners = ownership.getOwners();
+    for (Owner owner : owners) {
+      Urn typeUrn = owner.getTypeUrn();
+      String typeUrnStr = null;
+      if (typeUrn != null) {
+        typeUrnStr = typeUrn.toString();
+      }
+      UrnArray ownerOfType;
+      boolean found = false;
+      if (typeUrnStr == null) {
+        OwnershipType type = owner.getType();
+        String typeStr = "urn:li:ownershipType:__system__" + type.toString().toLowerCase();
+        if (ownerTypes.containsKey(typeStr)) {
+          ownerOfType = ownerTypes.get(typeUrnStr);
+        } else {
+          ownerOfType = new UrnArray();
+          ownerTypes.put(typeStr, ownerOfType);
+          mutated = true;
+        }
+      } else {
+        if (ownerTypes.containsKey(typeUrnStr)) {
+          ownerOfType = ownerTypes.get(typeUrnStr);
+        } else {
+          ownerOfType = new UrnArray();
+          ownerTypes.put(typeUrnStr, ownerOfType);
+          mutated = true;
+        }
+      }
+      for (Urn ownerUrn : ownerOfType) {
+        if (ownerUrn.equals(owner.getOwner())) {
+          found = true;
+        }
+      }
+      if (!found) {
+        ownerOfType.add(owner.getOwner());
+        mutated = true;
+      }
+    }
+    return mutated;
+  }
+}

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
@@ -66,10 +66,6 @@ public class OwnershipOwnerTypes extends MutationHook {
     if (ownership == null) {
       return false;
     }
-    log.info(
-        "ownership input is **** owners={}, types={}",
-        ownership.getOwners(),
-        ownership.getOwnerTypes());
     UrnArrayMap ownerTypes = ownership.getOwnerTypes();
     Map<String, List<Urn>> ownerTypesMap;
     if (ownerTypes == null) {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypes.java
@@ -66,6 +66,10 @@ public class OwnershipOwnerTypes extends MutationHook {
     if (ownership == null) {
       return false;
     }
+    log.info(
+        "ownership input is **** owners={}, types={}",
+        ownership.getOwners(),
+        ownership.getOwnerTypes());
     UrnArrayMap ownerTypes = ownership.getOwnerTypes();
     Map<String, List<Urn>> ownerTypesMap;
     if (ownerTypes == null) {
@@ -87,7 +91,7 @@ public class OwnershipOwnerTypes extends MutationHook {
         OwnershipType type = owner.getType();
         String typeStr = "urn:li:ownershipType:__system__" + type.toString().toLowerCase();
         if (ownerTypesMap.containsKey(typeStr)) {
-          ownerOfType = ownerTypes.get(typeStr);
+          ownerOfType = ownerTypesMap.get(typeStr);
         } else {
           ownerOfType = new ArrayList<>();
           ownerTypesMap.put(typeStr, ownerOfType);

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
@@ -1,0 +1,119 @@
+package com.linkedin.metadata.aspect.hooks;
+
+import static com.linkedin.metadata.Constants.OWNERSHIP_ASPECT_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.linkedin.common.*;
+import com.linkedin.common.urn.DatasetUrn;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.test.metadata.aspect.TestEntityRegistry;
+import com.linkedin.test.metadata.aspect.batch.TestMCP;
+import com.linkedin.util.Pair;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class OwnershipOwnerTypeTest {
+
+  private EntityRegistry entityRegistry;
+  private RetrieverContext mockRetrieverContext;
+  private DatasetUrn testDatasetUrn;
+  private final OwnershipOwnerTypes test =
+      new OwnershipOwnerTypes().setConfig(mock(AspectPluginConfig.class));
+
+  @BeforeTest
+  public void init() throws URISyntaxException {
+    testDatasetUrn =
+        DatasetUrn.createFromUrn(
+            UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,test,PROD)"));
+
+    entityRegistry = new TestEntityRegistry();
+    AspectRetriever mockAspectRetriever = mock(AspectRetriever.class);
+    when(mockAspectRetriever.getEntityRegistry()).thenReturn(entityRegistry);
+    GraphRetriever mockGraphRetriever = mock(GraphRetriever.class);
+    mockRetrieverContext = mock(RetrieverContext.class);
+    when(mockRetrieverContext.getAspectRetriever()).thenReturn(mockAspectRetriever);
+    when(mockRetrieverContext.getGraphRetriever()).thenReturn(mockGraphRetriever);
+  }
+
+  @Test
+  public void testNoChange() throws URISyntaxException {
+    Ownership ownership = getOwnership(true, true);
+    TestMCP mcp = getTestMcpBuilder().recordTemplate(ownership).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.writeMutation(Set.of(mcp), mockRetrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    Pair<ChangeMCP, Boolean> resulted = result.get(0);
+    assertEquals(resulted.getSecond(), false);
+  }
+
+  @Test
+  public void testChangeAddBusinessOwnerType() throws URISyntaxException {
+    Ownership ownership = getOwnership(true, false);
+    TestMCP mcp = getTestMcpBuilder().recordTemplate(ownership).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.writeMutation(Set.of(mcp), mockRetrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    Pair<ChangeMCP, Boolean> resulted = result.get(0);
+    assertEquals(resulted.getSecond(), true);
+    Ownership resultOwnership = resulted.getFirst().getAspect(Ownership.class);
+    assertEquals(resultOwnership.getOwnerTypes().keySet().size(), 1);
+  }
+
+  private TestMCP.TestMCPBuilder getTestMcpBuilder() {
+    return TestMCP.builder()
+        .changeType(ChangeType.UPSERT)
+        .urn(testDatasetUrn)
+        .entitySpec(entityRegistry.getEntitySpec(testDatasetUrn.getEntityType()))
+        .aspectSpec(
+            entityRegistry
+                .getEntitySpec(testDatasetUrn.getEntityType())
+                .getAspectSpec(OWNERSHIP_ASPECT_NAME));
+  }
+
+  private Ownership getOwnership(
+      final boolean has_business_owner, final boolean has_business_owner_in_owner_type)
+      throws URISyntaxException {
+
+    Ownership ownership = new Ownership();
+    OwnerArray ownerArray = new OwnerArray();
+    if (has_business_owner) {
+      Owner businessOwner =
+          new Owner().setOwner(getBusinessOwner()).setType(OwnershipType.BUSINESS_OWNER);
+      ownerArray.add(businessOwner);
+    }
+
+    if (!ownerArray.isEmpty()) {
+      ownership.setOwners(ownerArray);
+    }
+    UrnArrayMap ownerTypes = new UrnArrayMap();
+    if (has_business_owner_in_owner_type) {
+      ownerTypes.put(
+          "urn:li:ownershipType:__system__business_owner", new UrnArray(getBusinessOwner()));
+    }
+    if (!ownerTypes.isEmpty()) {
+      ownership.setOwnerTypes(ownerTypes);
+    }
+    return ownership;
+  }
+
+  private Urn getBusinessOwner() throws URISyntaxException {
+    return new Urn("urn:li:corpGroup:business_group");
+  }
+}

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/hooks/OwnershipOwnerTypeTest.java
@@ -50,7 +50,7 @@ public class OwnershipOwnerTypeTest {
 
   @Test
   public void testNoChange() throws URISyntaxException {
-    Ownership ownership = getOwnership(true, true);
+    Ownership ownership = getOwnership(true, true, false);
     TestMCP mcp = getTestMcpBuilder().recordTemplate(ownership).build();
 
     List<Pair<ChangeMCP, Boolean>> result =
@@ -63,7 +63,7 @@ public class OwnershipOwnerTypeTest {
 
   @Test
   public void testChangeAddBusinessOwnerType() throws URISyntaxException {
-    Ownership ownership = getOwnership(true, false);
+    Ownership ownership = getOwnership(true, false, false);
     TestMCP mcp = getTestMcpBuilder().recordTemplate(ownership).build();
 
     List<Pair<ChangeMCP, Boolean>> result =
@@ -74,6 +74,29 @@ public class OwnershipOwnerTypeTest {
     assertEquals(resulted.getSecond(), true);
     Ownership resultOwnership = resulted.getFirst().getAspect(Ownership.class);
     assertEquals(resultOwnership.getOwnerTypes().keySet().size(), 1);
+  }
+
+  @Test
+  public void testChangeAddBusinessOwnerTypeUrn() throws URISyntaxException {
+    Ownership ownership = getOwnership(false, false, true);
+    TestMCP mcp = getTestMcpBuilder().recordTemplate(ownership).build();
+
+    List<Pair<ChangeMCP, Boolean>> result =
+        test.writeMutation(Set.of(mcp), mockRetrieverContext).toList();
+
+    assertEquals(result.size(), 1);
+    Pair<ChangeMCP, Boolean> resulted = result.get(0);
+    assertEquals(resulted.getSecond(), true);
+    Ownership resultOwnership = resulted.getFirst().getAspect(Ownership.class);
+    Set<String> ownerTypes = resultOwnership.getOwnerTypes().keySet();
+    assertEquals(ownerTypes, Set.of("urn:li:ownershipType:__system__business_owner"));
+    assertEquals(
+        resultOwnership
+            .getOwnerTypes()
+            .get("urn:li:ownershipType:__system__business_owner")
+            .get(0)
+            .toString(),
+        "urn:li:corpGroup:business_group");
   }
 
   private TestMCP.TestMCPBuilder getTestMcpBuilder() {
@@ -88,14 +111,23 @@ public class OwnershipOwnerTypeTest {
   }
 
   private Ownership getOwnership(
-      final boolean has_business_owner, final boolean has_business_owner_in_owner_type)
+      final boolean has_business_owner_with_type,
+      final boolean has_business_owner_in_owner_type,
+      final boolean has_business_owner_with_type_urn)
       throws URISyntaxException {
 
     Ownership ownership = new Ownership();
     OwnerArray ownerArray = new OwnerArray();
-    if (has_business_owner) {
+    if (has_business_owner_with_type) {
       Owner businessOwner =
           new Owner().setOwner(getBusinessOwner()).setType(OwnershipType.BUSINESS_OWNER);
+      ownerArray.add(businessOwner);
+    }
+    if (has_business_owner_with_type_urn) {
+      Owner businessOwner =
+          new Owner()
+              .setOwner(getBusinessOwner())
+              .setTypeUrn(new Urn("urn:li:ownershipType:__system__business_owner"));
       ownerArray.add(businessOwner);
     }
 

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -759,6 +759,12 @@ plugins:
           aspectName: 'editableSchemaMetadata'
     - className: 'com.linkedin.metadata.aspect.hooks.OwnershipOwnerTypes'
       enabled: true
+      supportedOperations:
+        - CREATE
+        - UPSERT
+        - UPDATE
+        - RESTATE
+        - PATCH
       supportedEntityAspectNames:
         - entityName: '*'
           aspectName: 'ownership'

--- a/metadata-models/src/main/resources/entity-registry.yml
+++ b/metadata-models/src/main/resources/entity-registry.yml
@@ -757,6 +757,11 @@ plugins:
           aspectName: 'schemaMetadata'
         - entityName: '*'
           aspectName: 'editableSchemaMetadata'
+    - className: 'com.linkedin.metadata.aspect.hooks.OwnershipOwnerTypes'
+      enabled: true
+      supportedEntityAspectNames:
+        - entityName: '*'
+          aspectName: 'ownership'
     - className: 'com.linkedin.metadata.aspect.plugins.hooks.MutationHook'
       enabled: true
       spring:


### PR DESCRIPTION
Currently when ownership aspect is sent the internal `ownerTypes` was not being populated. This can cause the search filtering to not work. This adds a mutator for ownership so the ownerTypes is filled correctly.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
