### PR TITLE
fix(airflow): drop airflow 2.3 and 2.4 support

### DIFF
--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -45,7 +45,7 @@ jobs:
           - python-version: "3.11"
             extra_pip_requirements: "apache-airflow~=2.9.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt"
           - python-version: "3.11"
-            extra_pip_requirements: "apache-airflow~=2.10.5 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.11.txt"
+            extra_pip_requirements: "apache-airflow~=2.10.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt"
       fail-fast: false
     steps:
       - name: Set up JDK 17

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -34,7 +34,8 @@ jobs:
         include:
           # Note: this should be kept in sync with tox.ini.
           - python-version: "3.8"
-            extra_pip_requirements: "apache-airflow~=2.5.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.8.txt"
+            extra_pip_extras: test-airflow25
+            # extra_pip_requirements: "apache-airflow~=2.5.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.8.txt"
           - python-version: "3.10"
             extra_pip_requirements: "apache-airflow~=2.6.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt"
           - python-version: "3.10"
@@ -61,7 +62,7 @@ jobs:
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install airflow package and test (extras ${{ matrix.extra_pip_requirements }})
-        run: ./gradlew -Pextra_pip_requirements='${{ matrix.extra_pip_requirements }}' :metadata-ingestion-modules:airflow-plugin:build
+        run: ./gradlew -Pextra_pip_requirements='${{ matrix.extra_pip_requirements }}' -Pextra_pip_extras='${{ matrix.extra_pip_extras }}' :metadata-ingestion-modules:airflow-plugin:build
       - name: pip freeze show list installed
         if: always()
         run: source metadata-ingestion-modules/airflow-plugin/venv/bin/activate && uv pip freeze

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -34,11 +34,7 @@ jobs:
         include:
           # Note: this should be kept in sync with tox.ini.
           - python-version: "3.8"
-            extra_pip_requirements: "apache-airflow~=2.3.4"
-            extra_pip_extras: test-airflow23
-          - python-version: "3.10"
-            extra_pip_requirements: "apache-airflow~=2.4.3"
-            extra_pip_extras: test-airflow24
+            extra_pip_requirements: "apache-airflow~=2.5.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.8.txt"
           - python-version: "3.10"
             extra_pip_requirements: "apache-airflow~=2.6.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt"
           - python-version: "3.10"

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Install airflow package and test (extras ${{ matrix.extra_pip_requirements }})
-        run: ./gradlew -Pextra_pip_requirements='${{ matrix.extra_pip_requirements }}' -Pextra_pip_extras='${{ matrix.extra_pip_extras }}' :metadata-ingestion-modules:airflow-plugin:build
+        run: ./gradlew -Pextra_pip_requirements='${{ matrix.extra_pip_requirements }}' :metadata-ingestion-modules:airflow-plugin:build
       - name: pip freeze show list installed
         if: always()
         run: source metadata-ingestion-modules/airflow-plugin/venv/bin/activate && uv pip freeze

--- a/.github/workflows/airflow-plugin.yml
+++ b/.github/workflows/airflow-plugin.yml
@@ -45,7 +45,7 @@ jobs:
           - python-version: "3.11"
             extra_pip_requirements: "apache-airflow~=2.9.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt"
           - python-version: "3.11"
-            extra_pip_requirements: "apache-airflow~=2.10.3 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt"
+            extra_pip_requirements: "apache-airflow~=2.10.5 -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.11.txt"
       fail-fast: false
     steps:
       - name: Set up JDK 17

--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -20,6 +20,8 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Breaking Changes
 
+- #13004: The `acryl-datahub-airflow-plugin` dropped support for Airflow 2.3 and 2.4.
+
 ### Potential Downtime
 
 ### Deprecations
@@ -41,7 +43,6 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 - #12716: Fix the `platform_instance` being added twice to the URN. If you want to have the previous behavior back, you need to add your platform_instance twice (i.e. `plat.plat`).
 
 - #12797: Previously endpoints when used in ASYNC mode would not validate URNs, entity & aspect names immediately. Starting with this release, even in ASYNC mode, these requests will be returned with http code 400.
-
 
 ### Known Issues
 
@@ -84,7 +85,7 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 - #12020 - Removed `sql_parser` configuration from the Redash source, as Redash now exclusively uses the sqlglot-based parser for lineage extraction.
 - #12020 - Removed `datahub.utilities.sql_parser`, `datahub.utilities.sql_parser_base` and `datahub.utilities.sql_lineage_parser_impl` module along with `SqlLineageSQLParser` and `DefaultSQLParser`. Use `create_lineage_sql_parsed_result` from `datahub.sql_parsing.sqlglot_lineage` module instead.
 - #11518 - DataHub Garbage Collection: Various entities that are soft-deleted
-  (after 10d) or are timeseries *entities* (dataprocess, execution requests)
+  (after 10d) or are timeseries _entities_ (dataprocess, execution requests)
   will be removed automatically using logic in the `datahub-gc` ingestion
   source.
 - #12067 - Default behavior of DataJobPatchBuilder in Python sdk has been

--- a/docs/lineage/airflow.md
+++ b/docs/lineage/airflow.md
@@ -17,10 +17,10 @@ There's two implementations of the plugin, with different Airflow version suppor
 
 | Approach  | Airflow Versions | Notes                                                                                   |
 | --------- | ---------------- | --------------------------------------------------------------------------------------- |
-| Plugin v2 | 2.3.4+           | Recommended. Requires Python 3.8+                                                       |
-| Plugin v1 | 2.3 - 2.8        | Deprecated. No automatic lineage extraction; may not extract lineage if the task fails. |
+| Plugin v2 | 2.5+             | Recommended. Requires Python 3.8+                                                       |
+| Plugin v1 | 2.5 - 2.8        | Deprecated. No automatic lineage extraction; may not extract lineage if the task fails. |
 
-If you're using Airflow older than 2.3, it's possible to use the v1 plugin with older versions of `acryl-datahub-airflow-plugin`. See the [compatibility section](#compatibility) for more details.
+If you're using Airflow older than 2.5, it's possible to use the plugin with older versions of `acryl-datahub-airflow-plugin`. See the [compatibility section](#compatibility) for more details.
 
 <!-- TODO: Update the local Airflow guide and link to it here. -->
 <!-- If you are looking to run Airflow and DataHub using docker locally, follow the guide [here](../../docker/airflow/local_airflow.md). -->
@@ -376,12 +376,15 @@ This will immediately disable the plugin without requiring a restart.
 
 ## Compatibility
 
-We no longer officially support Airflow <2.3. However, you can use older versions of `acryl-datahub-airflow-plugin` with older versions of Airflow.
-The first two options support Python 3.7+, and the last option supports Python 3.8+.
+We try to support Airflow releases for ~2 years after their release. This is a best-effort guarantee - it's not always possible due to dependency / security issues cropping up in older versions.
+
+We no longer officially support Airflow <2.5. However, you can use older versions of `acryl-datahub-airflow-plugin` with older versions of Airflow.
+The first two options support Python 3.7+, and the others require Python 3.8+.
 
 - Airflow 1.10.x, use DataHub plugin v1 with acryl-datahub-airflow-plugin <= 0.9.1.0.
 - Airflow 2.0.x, use DataHub plugin v1 with acryl-datahub-airflow-plugin <= 0.11.0.1.
 - Airflow 2.2.x, use DataHub plugin v2 with acryl-datahub-airflow-plugin <= 0.14.1.5.
+- Airflow 2.3 - 2.4.3, use DataHub plugin v2 with acryl-datahub-airflow-plugin <= 1.0.0.
 
 DataHub also previously supported an Airflow [lineage backend](https://airflow.apache.org/docs/apache-airflow/2.2.0/lineage.html#lineage-backend) implementation. While the implementation is still in our codebase, it is deprecated and will be removed in a future release.
 Note that the lineage backend did not support automatic lineage extraction, did not capture task failures, and did not work in AWS MWAA.

--- a/metadata-ingestion-modules/airflow-plugin/setup.py
+++ b/metadata-ingestion-modules/airflow-plugin/setup.py
@@ -106,19 +106,6 @@ integration_test_requirements = {
     "virtualenv",  # needed by PythonVirtualenvOperator
     "apache-airflow-providers-sqlite",
 }
-per_version_test_requirements = {
-    "test-airflow23": {
-        "pendulum<3.0",
-        "Flask-Session<0.6.0",
-        "connexion<3.0",
-    },
-    "test-airflow24": {
-        "pendulum<3.0",
-        "Flask-Session<0.6.0",
-        "connexion<3.0",
-        "marshmallow<3.24.0",
-    },
-}
 
 
 entry_points = {
@@ -173,9 +160,5 @@ setuptools.setup(
         **{plugin: list(dependencies) for plugin, dependencies in plugins.items()},
         "dev": list(dev_requirements),
         "integration-tests": list(integration_test_requirements),
-        **{
-            plugin: list(dependencies)
-            for plugin, dependencies in per_version_test_requirements.items()
-        },
     },
 )

--- a/metadata-ingestion-modules/airflow-plugin/setup.py
+++ b/metadata-ingestion-modules/airflow-plugin/setup.py
@@ -24,8 +24,9 @@ _self_pin = (
 
 base_requirements = {
     f"acryl-datahub[datahub-rest]{_self_pin}",
-    # We require Airflow 2.3.x, since we need the new DAG listener API.
-    "apache-airflow>=2.3.0",
+    # We require Airflow 2.3.x at minimum, since we need the new DAG listener API.
+    # We pin to 2.5.x, since we also need typing-extensions>=4.5 in acryl-datahub.
+    "apache-airflow>=2.5.0",
 }
 
 plugins: Dict[str, Set[str]] = {
@@ -106,6 +107,14 @@ integration_test_requirements = {
     "virtualenv",  # needed by PythonVirtualenvOperator
     "apache-airflow-providers-sqlite",
 }
+per_version_test_requirements = {
+    "test-airflow25": {
+        "pendulum<3.0",
+        "Flask-Session<0.6.0",
+        "connexion<3.0",
+        "marshmallow<3.24.0",
+    },
+}
 
 
 entry_points = {
@@ -160,5 +169,9 @@ setuptools.setup(
         **{plugin: list(dependencies) for plugin, dependencies in plugins.items()},
         "dev": list(dev_requirements),
         "integration-tests": list(integration_test_requirements),
+        **{
+            plugin: list(dependencies)
+            for plugin, dependencies in per_version_test_requirements.items()
+        },
     },
 )

--- a/metadata-ingestion-modules/airflow-plugin/setup.py
+++ b/metadata-ingestion-modules/airflow-plugin/setup.py
@@ -113,6 +113,7 @@ per_version_test_requirements = {
         "Flask-Session<0.6.0",
         "connexion<3.0",
         "marshmallow<3.24.0",
+        "apache-airflow-providers-amazon==7.3.0",
     },
 }
 

--- a/metadata-ingestion-modules/airflow-plugin/setup.py
+++ b/metadata-ingestion-modules/airflow-plugin/setup.py
@@ -45,7 +45,7 @@ plugins: Dict[str, Set[str]] = {
         # We remain restrictive on the versions allowed here to prevent
         # us from being broken by backwards-incompatible changes in the
         # underlying package.
-        "openlineage-airflow>=1.2.0,<=1.25.0",
+        "openlineage-airflow>=1.2.0,<=1.30.1",
     },
 }
 

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -13,6 +13,9 @@ extras =
     integration-tests
     plugin-v1
     plugin-v2
+    # For older versions of Airflow (where we can't use constraints),
+    # we need to add a couple extra constraints.
+    airflow25: test-airflow25
 
 deps =
     # This should be kept in sync with the Github Actions matrix.
@@ -26,12 +29,9 @@ deps =
     airflow210: apache-airflow~=2.10.0
 
     # Respect the Airflow constraints files.
-    # We can't make ourselves work with the constraints of Airflow <= 2.3.
-    ; py38-airflow23: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.3.4/constraints-3.8.txt
-    # The Airflow 2.4 constraints file requires a version of the sqlite provider whose
-    # hook type is missing the `conn_name_attr` property.
-    ; py310-airflow24: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.10.txt
-    py38-airflow25: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.8.txt
+    # We can't make ourselves work with the constraints of Airflow < 2.5 due to typing-extensions.
+    # We don't work with Airflow 2.5's constraints due to an incompatibility between older versions of pydantic 1.10 and mypy 1.x.
+    ; py38-airflow25: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.8.txt
     py310-airflow26: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt
     py310-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -36,7 +36,7 @@ deps =
     py310-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt
     py311-airflow29: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt
-    py311-airflow210: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt
+    py311-airflow210: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.11.txt
 
     # Before pinning to the constraint files, we previously left the dependencies
     # more open. There were a number of packages for which this caused issues.

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -36,7 +36,7 @@ deps =
     py310-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt
     py311-airflow29: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.9.3/constraints-3.11.txt
-    py311-airflow210: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.5/constraints-3.11.txt
+    py311-airflow210: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.10.3/constraints-3.11.txt
 
     # Before pinning to the constraint files, we previously left the dependencies
     # more open. There were a number of packages for which this caused issues.

--- a/metadata-ingestion-modules/airflow-plugin/tox.ini
+++ b/metadata-ingestion-modules/airflow-plugin/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38-airflow23, py310-airflow24, py310-airflow26, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
+envlist = py38-airflow25, py310-airflow26, py310-airflow27, py310-airflow28, py311-airflow29, py311-airflow210
 
 [testenv]
 use_develop = true
@@ -13,16 +13,12 @@ extras =
     integration-tests
     plugin-v1
     plugin-v2
-    # For Airflow 2.3 and 2.4, add a few extra requirements.
-    airflow23: test-airflow23
-    airflow24: test-airflow24
 
 deps =
     # This should be kept in sync with the Github Actions matrix.
     -e ../../metadata-ingestion/
     # Airflow version
-    airflow23: apache-airflow~=2.3.0
-    airflow24: apache-airflow~=2.4.0
+    airflow25: apache-airflow~=2.5.0
     airflow26: apache-airflow~=2.6.0
     airflow27: apache-airflow~=2.7.0
     airflow28: apache-airflow~=2.8.0
@@ -35,6 +31,7 @@ deps =
     # The Airflow 2.4 constraints file requires a version of the sqlite provider whose
     # hook type is missing the `conn_name_attr` property.
     ; py310-airflow24: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.4.3/constraints-3.10.txt
+    py38-airflow25: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.8.txt
     py310-airflow26: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.6.3/constraints-3.10.txt
     py310-airflow27: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.7.3/constraints-3.10.txt
     py310-airflow28: -c https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.10.txt


### PR DESCRIPTION
As part of https://github.com/datahub-project/datahub/pull/12982, we need to depend on `typing-extensions` 4.5.0. The constraint files Airflow 2.3 and 2.4 require 4.4.0 or older.

I was considering reverting that change, but decided that we should be dropping support for Airflow <2.5 anyways. We haven't been compatible with the constraints for those for a while, and our telemetry shows that they don't have much usage anymore (just a handful of stragglers representing ~0.5% of our Airflow plugin users).


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
