### PR TITLE
fix(ingest): warn when API tracing is unexpectedly inactive

### DIFF
--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -74,6 +74,8 @@ filterwarnings =
     ignore::datahub.configuration.pydantic_migration_helpers.PydanticDeprecatedSince20
     ignore::datahub.configuration.common.ConfigurationWarning
     ignore:The new datahub SDK:datahub.errors.ExperimentalWarning
+    # We should not be unexpectedly seeing API tracing warnings.
+    error::datahub.errors.APITracingWarning
 
 [coverage:run]
 # Because of some quirks in the way setup.cfg, coverage.py, pytest-cov,

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -125,9 +125,7 @@ def parse_ts_millis(ts: Optional[float]) -> Optional[datetime]:
 
 
 def make_data_platform_urn(platform: str) -> str:
-    if platform.startswith("urn:li:dataPlatform:"):
-        return platform
-    return DataPlatformUrn.create_from_id(platform).urn()
+    return DataPlatformUrn(platform).urn()
 
 
 def make_dataset_urn(platform: str, name: str, env: str = DEFAULT_ENV) -> str:

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import time
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -749,6 +750,10 @@ class DataHubRestEmitter(Closeable, Emitter):
             trace_flag if trace_flag is not None else self._default_trace_mode
         )
         resolved_async_flag = async_flag if async_flag is not None else async_default
+        if resolved_trace_flag and not resolved_async_flag:
+            warnings.warn(
+                "API tracing is only available with async ingestion. For synchronous ingestion, API errors will be surfaced directly as an API response. "
+            )
         return resolved_trace_flag and resolved_async_flag
 
     def __repr__(self) -> str:

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -51,6 +51,7 @@ from datahub.emitter.response_helper import (
     extract_trace_data_from_mcps,
 )
 from datahub.emitter.serialization_helper import pre_json_transform
+from datahub.errors import APITracingWarning
 from datahub.ingestion.api.closeable import Closeable
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
     MetadataChangeEvent,
@@ -752,7 +753,9 @@ class DataHubRestEmitter(Closeable, Emitter):
         resolved_async_flag = async_flag if async_flag is not None else async_default
         if resolved_trace_flag and not resolved_async_flag:
             warnings.warn(
-                "API tracing is only available with async ingestion. For synchronous ingestion, API errors will be surfaced directly as an API response. "
+                "API tracing is only available with async ingestion. For sync mode, API errors will be surfaced as exceptions.",
+                APITracingWarning,
+                stacklevel=3,
             )
         return resolved_trace_flag and resolved_async_flag
 

--- a/metadata-ingestion/src/datahub/errors.py
+++ b/metadata-ingestion/src/datahub/errors.py
@@ -33,3 +33,7 @@ class MultipleSubtypesWarning(Warning):
 
 class ExperimentalWarning(Warning):
     pass
+
+
+class APITracingWarning(Warning):
+    pass

--- a/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
+++ b/metadata-ingestion/tests/unit/sdk/test_rest_emitter.py
@@ -16,6 +16,7 @@ from datahub.emitter.rest_emitter import (
     DatahubRestEmitter,
     logger,
 )
+from datahub.errors import APITracingWarning
 from datahub.metadata.com.linkedin.pegasus2avro.common import (
     Status,
 )
@@ -514,10 +515,14 @@ def test_openapi_emitter_missing_trace_header(openapi_emitter):
             aspect=Status(removed=False),
         )
 
-        # Should not raise exception but log warning
-        openapi_emitter.emit_mcp(
-            item, async_flag=True, trace_flag=True, trace_timeout=timedelta(seconds=10)
-        )
+        # Should not raise exception but log a warning.
+        with pytest.warns(APITracingWarning):
+            openapi_emitter.emit_mcp(
+                item,
+                async_flag=True,
+                trace_flag=True,
+                trace_timeout=timedelta(seconds=10),
+            )
 
 
 def test_openapi_emitter_invalid_status_code(openapi_emitter):


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
