### PR TITLE
docs(ingest): make fail_safe_threshold config visable in docs

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stale_entity_removal_handler.py
@@ -45,7 +45,6 @@ class StatefulStaleMetadataRemovalConfig(StatefulIngestionConfig):
         description="Prevents large amount of soft deletes & the state from committing from accidental changes to the source configuration if the relative change percent in entities compared to the previous state is above the 'fail_safe_threshold'.",
         le=100.0,
         ge=0.0,
-        hidden_from_docs=True,
     )
 
 


### PR DESCRIPTION
`fail_safe_threshold` in `StatefulStaleMetadataRemovalConfig` is currently hidden from the docs. This this be included in the docs as it's a useful configuration and has a default value set that could catch users out. It's also being omitted from the [ingestion JSON Schema](https://datahubproject.io/schemas/datahub_ingestion_schema.json), so IDE syntax validation and other json schema validations fail for valid recipe. 

It looks like this [stateful ingestion failsafe was disabled](https://github.com/datahub-project/datahub/commit/4db51b4c4f2b78173892e204bc0ca980c599f834) and config hidden. When [failsafe was re-enabled](https://github.com/datahub-project/datahub/commit/37bc423b50d5157a0dc9b6617cec288b498fe437) the config was not unhidden.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
