### PR TITLE
Updated Sidebar for Glossary and Domains to have same styling

### DIFF
--- a/datahub-web-react/src/app/domainV2/nestedDomains/DomainsSidebarHeader.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/DomainsSidebarHeader.tsx
@@ -1,15 +1,11 @@
 import { useApolloClient } from '@apollo/client';
-import { PlusCircleOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
-import { Tooltip } from '@components';
+import { Tooltip, Button } from '@components';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import CreateDomainModal from '../CreateDomainModal';
 import { updateListDomainsCache } from '../utils';
-import { REDESIGN_COLORS } from '../../entityV2/shared/constants';
 
 const Wrapper = styled.div`
-    color: ${REDESIGN_COLORS.TITLE_PURPLE};
     font-size: 20px;
     display: flex;
     align-items: center;
@@ -17,18 +13,19 @@ const Wrapper = styled.div`
     width: 100%;
 `;
 
-const StyledButton = styled(Button)`
-    padding: 0px 8px;
-    border: none;
-    box-shadow: none;
-    color: inherit;
-    font-size: inherit;
-`;
-
 const DomainTitle = styled.div`
     font-size: 16px;
     font-weight: bold;
     color: #374066;
+`;
+
+const StyledButton = styled(Button)`
+    padding: 2px;
+    margin-right: 4px;
+    svg {
+        width: 20px;
+        height: 20px;
+    }
 `;
 
 export default function DomainsSidebarHeader() {
@@ -39,9 +36,14 @@ export default function DomainsSidebarHeader() {
         <Wrapper>
             <DomainTitle>Domains</DomainTitle>
             <Tooltip showArrow={false} title="Create new Domain" placement="right">
-                <StyledButton onClick={() => setIsCreatingDomain(true)}>
-                    <PlusCircleOutlined style={{ fontSize: 'inherit' }} />
-                </StyledButton>
+                <StyledButton
+                    variant="filled"
+                    color="violet"
+                    isCircle
+                    icon="Plus"
+                    iconSource="phosphor"
+                    onClick={() => setIsCreatingDomain(true)}
+                />
             </Tooltip>
             {isCreatingDomain && (
                 <CreateDomainModal

--- a/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback, useState } from 'react';
 import { Button, Divider } from 'antd';
-import { Tooltip } from '@components';
+import { Tooltip, colors } from '@components';
 import styled from 'styled-components';
+import { CaretLeft } from '@phosphor-icons/react';
 import { useShowNavBarRedesign } from '@src/app/useShowNavBarRedesign';
 import useSidebarWidth from '../../sharedV2/sidebar/useSidebarWidth';
 import DomainsSidebarHeader from './DomainsSidebarHeader';
 import DomainNavigator from './domainNavigator/DomainNavigator';
 import DomainSearch from '../DomainSearch';
-import { ANTD_GRAY } from '../../entity/shared/constants';
-import SidebarBackArrow from '../../../images/sidebarBackArrow.svg?react';
 
 const PLATFORM_BROWSE_TRANSITION_MS = 300;
 
@@ -44,19 +43,27 @@ const Controls = styled.div<{ isCollapsed: boolean }>`
     display: flex;
     align-items: center;
     justify-content: ${(props) => (props.isCollapsed ? 'center' : 'space-between')};
-    padding: 15px 16px 10px 12px;
+    padding: 12px;
     overflow: hidden;
     height: 50px;
 `;
 
 const CloseButton = styled(Button)<{ $isActive }>`
-    margin: 0px;
-    padding: 2px 0px;
+    margin: 0;
+    padding: 0;
     display: flex;
     align-items: center;
-    transition: transform ${PLATFORM_BROWSE_TRANSITION_MS}ms ease;
-    && {
-        color: ${(props) => (props.$isActive ? ANTD_GRAY[9] : '#8088a3')};
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    min-width: 24px;
+    min-height: 24px;
+    border-radius: 50%;
+    transition: background-color 0.2s ease-in-out;
+
+    &:hover {
+        background-color: ${colors.gray[1600]};
+        color: ${colors.gray[1800]};
     }
 `;
 
@@ -65,8 +72,11 @@ const ThinDivider = styled(Divider)`
     padding: 0px;
 `;
 
-const StyledSidebarBackArrow = styled(SidebarBackArrow)<{ direction: 'left' | 'right' }>`
+const StyledCaretLeft = styled(CaretLeft)<{ direction: 'left' | 'right' }>`
     cursor: pointer;
+    color: ${colors.gray[1700]};
+    width: 20px;
+    height: 20px;
     ${(props) => (props.direction === 'right' && 'transform: scaleX(-1);') || undefined}
 `;
 
@@ -108,7 +118,7 @@ export default function ManageDomainsSidebarV2({ isEntityProfile }: Props) {
                     mouseLeaveDelay={0}
                 >
                     <CloseButton $isActive={!isClosed} type="link" onClick={() => setIsClosed(!isClosed)}>
-                        <StyledSidebarBackArrow direction={isClosed ? 'left' : 'right'} />
+                        <StyledCaretLeft direction={isClosed ? 'left' : 'right'} size={20} />
                     </CloseButton>
                 </Tooltip>
             </Controls>

--- a/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNode.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/domainNavigator/DomainNode.tsx
@@ -1,5 +1,5 @@
 import { Typography } from 'antd';
-import { Tooltip } from '@components';
+import { colors, Tooltip } from '@components';
 import React, { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
@@ -14,20 +14,18 @@ import { DomainColoredIcon } from '../../../entityV2/shared/links/DomainColoredI
 import { REDESIGN_COLORS, SEARCH_COLORS } from '../../../entityV2/shared/constants';
 
 const Count = styled.div`
-    color: ${REDESIGN_COLORS.BLACK};
+    color: ${colors.gray[1700]};
     font-size: 12px;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding: 0 8px;
     margin-left: 8px;
-    border-radius: 11px;
-    background-color: ${REDESIGN_COLORS.SIDE_BAR};
-    width: 20%;
+    border-radius: 20px;
+    background-color: ${colors.gray[100]};
     height: 22px;
-    display: flex;
+    min-width: 28px;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    max-width: 32px;
-    transition: opacity 0.3s ease; /* add a smooth transition effect */
+    flex-shrink: 0;
 `;
 
 const NameWrapper = styled(Typography.Text)<{ $isSelected: boolean; $addLeftPadding: boolean }>`

--- a/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/NodeItem.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryBrowser/NodeItem.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { LoadingOutlined } from '@ant-design/icons';
+import { colors } from '@components';
 import { KeyboardArrowDownRounded, KeyboardArrowRightRounded } from '@mui/icons-material';
 import styled from 'styled-components/macro';
 import { Entity, EntityType, GlossaryNode, GlossaryTerm } from '../../../types.generated';
@@ -83,15 +84,18 @@ const LoadingWrapper = styled.div`
 `;
 
 const ChildrenCount = styled.div`
-    padding: 1px 8px;
-    display: flex;
+    padding: 0 8px;
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
-    border-radius: 10px;
-    background-color: #eeecfa;
-    color: #434863;
-    font-size: 10px;
+    border-radius: 20px;
+    background-color: ${colors.gray[100]};
+    color: ${colors.gray[1700]};
+    font-size: 12px;
+    height: 22px;
+    min-width: 28px;
     font-weight: 400;
-    margin-right: 13px;
+    margin-right: 12px;
 `;
 
 const StyledDivider = styled.div<{ depth: number }>`

--- a/datahub-web-react/src/app/glossaryV2/GlossarySidebar.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossarySidebar.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { Button } from 'antd';
-import { Tooltip } from '@components';
-import { PlusCircleOutlined } from '@ant-design/icons';
+import { Tooltip, Button } from '@components';
 import styled from 'styled-components/macro';
 import { REDESIGN_COLORS } from '../entityV2/shared/constants';
 import useSidebarWidth from '../sharedV2/sidebar/useSidebarWidth';
@@ -26,26 +24,24 @@ const SidebarTitleWrapper = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 15px 12px 10px 12px;
+    padding: 12px;
     border-bottom: 1px solid ${REDESIGN_COLORS.BORDER_3};
     height: 50px;
-
-    color: ${REDESIGN_COLORS.TITLE_PURPLE};
     font-size: 20px;
-`;
-
-const StyledButton = styled(Button)`
-    padding: 0;
-    border: none;
-    box-shadow: none;
-    color: inherit;
-    font-size: inherit;
 `;
 
 const GlossaryTitle = styled.div`
     font-size: 16px;
     font-weight: bold;
     color: #374066;
+`;
+
+const StyledButton = styled(Button)`
+    padding: 2px;
+    svg {
+        width: 20px;
+        height: 20px;
+    }
 `;
 
 type Props = {
@@ -74,9 +70,14 @@ export default function GlossarySidebar({ isEntityProfile }: Props) {
                 <SidebarTitleWrapper>
                     <GlossaryTitle>Business Glossary</GlossaryTitle>
                     <Tooltip title="Create Glossary" placement="left" showArrow={false}>
-                        <StyledButton onClick={() => setIsCreateNodeModalVisible(true)}>
-                            <PlusCircleOutlined style={{ fontSize: 'inherit' }} />
-                        </StyledButton>
+                        <StyledButton
+                            variant="filled"
+                            color="violet"
+                            isCircle
+                            icon="Plus"
+                            iconSource="phosphor"
+                            onClick={() => setIsCreateNodeModalVisible(true)}
+                        />
                     </Tooltip>
                 </SidebarTitleWrapper>
                 <GlossarySearch />


### PR DESCRIPTION
- Updated add buttons to component buttons for calling attention to adding domains and glossary
- Updated collapse icon to phosphor with hover styling 
- Updated count pill next to both domains and glossary terms so it does not wrap


Before:
<img width="1728" alt="Screenshot 2025-03-28 at 10 35 25 AM" src="https://github.com/user-attachments/assets/18e10fb9-f25d-41f2-bbe4-c8990c14fb7c" />
<img width="1728" alt="Screenshot 2025-03-28 at 10 35 29 AM" src="https://github.com/user-attachments/assets/e7b13c90-0b6a-4400-a8b8-83a0eccc6b51" />


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
