### PR TITLE
fix(ui/lineageV2): Convert toggle to hide data process instances instead of show

### DIFF
--- a/datahub-web-react/src/app/lineageV2/controls/LineageControls.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/LineageControls.tsx
@@ -106,7 +106,7 @@ export default function LineageControls() {
                         <FilterOutlined
                             style={{
                                 color:
-                                    hideTransformations || showDataProcessInstances || showGhostEntities
+                                    hideTransformations || !showDataProcessInstances || showGhostEntities
                                         ? REDESIGN_COLORS.BLUE
                                         : undefined,
                             }}

--- a/datahub-web-react/src/app/lineageV2/controls/LineageSearchFilters.tsx
+++ b/datahub-web-react/src/app/lineageV2/controls/LineageSearchFilters.tsx
@@ -80,13 +80,17 @@ export default function LineageSearchFilters() {
             <ToggleWrapper>
                 <span>
                     <ToggleLabel>
-                        Show Process Instances
+                        Hide Process Instances
                         <StyledInfoPopover
-                            content={<PopoverWrapper>Show task runs. Will not hide home node.</PopoverWrapper>}
+                            content={<PopoverWrapper>Hide task runs. Will not hide home node.</PopoverWrapper>}
                         />
                     </ToggleLabel>
                 </span>
-                <StyledSwitch size="small" checked={showDataProcessInstances} onChange={setShowDataProcessInstances} />
+                <StyledSwitch
+                    size="small"
+                    checked={!showDataProcessInstances}
+                    onChange={() => setShowDataProcessInstances(!showDataProcessInstances)}
+                />
             </ToggleWrapper>
             <ToggleWrapper>
                 <span>


### PR DESCRIPTION
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
