### PR TITLE
fix(sdk): fix bugs in v2 sdk search client

### DIFF
--- a/metadata-ingestion/src/datahub/errors.py
+++ b/metadata-ingestion/src/datahub/errors.py
@@ -31,5 +31,9 @@ class MultipleSubtypesWarning(Warning):
     pass
 
 
+class SearchFilterWarning(Warning):
+    pass
+
+
 class ExperimentalWarning(Warning):
     pass

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -873,7 +873,7 @@ class DataHubGraph(DatahubRestEmitter, EntityVersioningAPI):
         env: Optional[str] = None,
         query: Optional[str] = None,
         container: Optional[str] = None,
-        status: RemovedStatusFilter = RemovedStatusFilter.NOT_SOFT_DELETED,
+        status: Optional[RemovedStatusFilter] = RemovedStatusFilter.NOT_SOFT_DELETED,
         batch_size: int = 10000,
         extraFilters: Optional[List[RawSearchFilterRule]] = None,
         extra_or_filters: Optional[List[Dict[str, List[RawSearchFilterRule]]]] = None,

--- a/metadata-ingestion/src/datahub/sdk/search_client.py
+++ b/metadata-ingestion/src/datahub/sdk/search_client.py
@@ -10,10 +10,19 @@ from typing import (
 
 from datahub.ingestion.graph.filters import RawSearchFilterRule
 from datahub.metadata.urns import Urn
-from datahub.sdk.search_filters import Filter
+from datahub.sdk.search_filters import Filter, _EntityTypeFilter
 
 if TYPE_CHECKING:
     from datahub.sdk.main_client import DataHubClient
+
+
+def _has_any_field_filter(
+    filter: Optional[Filter], field_name: str
+) -> Optional[List[str]]:
+    if filter is None:
+        return None
+    # TODO
+    pass
 
 
 def compile_filters(
@@ -22,6 +31,9 @@ def compile_filters(
     # TODO: Not every filter type is supported for every entity type.
     # If we can detect issues with the filters at compile time, we should
     # raise an error.
+
+    # TODO: Make it clear that if no entity type filters are provided,
+    # we will default to searching a predefined set of entity types.
 
     if filter is None:
         return None
@@ -42,9 +54,14 @@ class SearchClient:
         query: Optional[str] = None,
         filter: Optional[Filter] = None,
     ) -> Iterable[Urn]:
+        entity_types = _has_any_field_filter(
+            filter, _EntityTypeFilter.ENTITY_TYPE_FIELD
+        )
+
         # TODO: Add better limit / pagination support.
         for urn in self._client._graph.get_urns_by_filter(
             query=query,
+            status=None,
             extra_or_filters=compile_filters(filter),
         ):
             yield Urn.from_string(urn)

--- a/metadata-ingestion/src/datahub/sdk/search_client.py
+++ b/metadata-ingestion/src/datahub/sdk/search_client.py
@@ -2,47 +2,105 @@ from __future__ import annotations
 
 from typing import (
     TYPE_CHECKING,
-    Dict,
     Iterable,
     List,
     Optional,
+    Tuple,
+    Type,
+    TypeVar,
 )
 
-from datahub.ingestion.graph.filters import RawSearchFilterRule
+from datahub.ingestion.graph.filters import RawSearchFilter, RemovedStatusFilter
 from datahub.metadata.urns import Urn
-from datahub.sdk.search_filters import Filter, _EntityTypeFilter
+from datahub.sdk.search_filters import (
+    Filter,
+    FilterDsl,
+    _EntityTypeFilter,
+    _OrFilters,
+    _StatusFilter,
+)
 
 if TYPE_CHECKING:
     from datahub.sdk.main_client import DataHubClient
 
 
-def _has_any_field_filter(
-    filter: Optional[Filter], field_name: str
-) -> Optional[List[str]]:
+_FilterType = TypeVar("_FilterType", bound=Filter)
+
+
+def _typed_dfs(
+    filter: Optional[_FilterType], type: Type[_FilterType]
+) -> Optional[List[_FilterType]]:
     if filter is None:
         return None
-    # TODO
-    pass
+
+    found: Optional[List[_FilterType]] = None
+    for f in filter.dfs():
+        if isinstance(f, type):
+            if found is None:
+                found = []
+            found.append(f)
+    return found
 
 
 def compile_filters(
     filter: Optional[Filter],
-) -> Optional[List[Dict[str, List[RawSearchFilterRule]]]]:
+) -> Tuple[Optional[List[str]], RawSearchFilter]:
     # TODO: Not every filter type is supported for every entity type.
     # If we can detect issues with the filters at compile time, we should
     # raise an error.
 
-    # TODO: Make it clear that if no entity type filters are provided,
-    # we will default to searching a predefined set of entity types.
+    existing_soft_deleted_filter = _typed_dfs(filter, _StatusFilter)
+    if existing_soft_deleted_filter is None:
+        soft_deleted_filter = FilterDsl.soft_deleted(
+            RemovedStatusFilter.NOT_SOFT_DELETED
+        )
+        if filter is None:
+            filter = soft_deleted_filter
+        else:
+            filter = FilterDsl.and_(filter, soft_deleted_filter)
 
-    if filter is None:
-        return None
+    # This should be safe - if filter were None coming in, then we would replace it
+    # with the soft-deleted filter.
+    assert filter is not None
 
     initial_filters = filter.compile()
-    return [
+
+    compiled_filters: RawSearchFilter = [
         {"and": [rule.to_raw() for rule in andClause["and"]]}
         for andClause in initial_filters
     ]
+
+    entity_types = compute_entity_types(initial_filters)
+
+    return entity_types, compiled_filters
+
+
+def compute_entity_types(
+    filters: _OrFilters,
+) -> Optional[List[str]]:
+    found_filters = False
+    found_positive_filters = False
+    entity_types: List[str] = []
+    for ands in filters:
+        for clause in ands["and"]:
+            if clause.field == _EntityTypeFilter.ENTITY_TYPE_FIELD:
+                found_filters = True
+                if not clause.negated:
+                    found_positive_filters = True
+
+                entity_types.extend(clause.values)
+
+    if not found_filters:
+        # If we didn't find any filters, use None so we use the default set.
+        return None
+
+    if not found_positive_filters:
+        # If we only found negated filters, then it's probably a query like
+        # "find me all entities except for dashboards". In that case, we
+        # still want to use the default set.
+        return None
+
+    return entity_types
 
 
 class SearchClient:
@@ -54,14 +112,12 @@ class SearchClient:
         query: Optional[str] = None,
         filter: Optional[Filter] = None,
     ) -> Iterable[Urn]:
-        entity_types = _has_any_field_filter(
-            filter, _EntityTypeFilter.ENTITY_TYPE_FIELD
-        )
-
         # TODO: Add better limit / pagination support.
+        types, compiled_filters = compile_filters(filter)
         for urn in self._client._graph.get_urns_by_filter(
             query=query,
             status=None,
-            extra_or_filters=compile_filters(filter),
+            extra_or_filters=compiled_filters,
+            entity_types=types,
         ):
             yield Urn.from_string(urn)

--- a/metadata-ingestion/src/datahub/sdk/search_filters.py
+++ b/metadata-ingestion/src/datahub/sdk/search_filters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 from typing import (
     Any,
+    ClassVar,
     List,
     Sequence,
     TypedDict,
@@ -47,13 +48,15 @@ def _flexible_entity_type_to_graphql(entity_type: str) -> str:
 
 
 class _EntityTypeFilter(_BaseFilter):
+    ENTITY_TYPE_FIELD: ClassVar[str] = "_entityType"
+
     entity_type: List[str] = pydantic.Field(
         description="The entity type to filter on. Can be 'dataset', 'chart', 'dashboard', 'corpuser', etc.",
     )
 
     def _build_rule(self) -> SearchFilterRule:
         return SearchFilterRule(
-            field="_entityType",
+            field=self.ENTITY_TYPE_FIELD,
             condition="EQUAL",
             values=[_flexible_entity_type_to_graphql(t) for t in self.entity_type],
         )

--- a/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
+++ b/metadata-ingestion/tests/unit/sdk_v2/test_search_client.py
@@ -184,7 +184,7 @@ def test_unsupported_not() -> None:
         F.not_(env_filter)
 
 
-_default_soft_deleted_filter = {
+_default_status_filter = {
     "field": "removed",
     "condition": "EQUAL",
     "values": ["true"],
@@ -232,7 +232,7 @@ def test_compile_filters() -> None:
                     "condition": "EQUAL",
                     "values": ["urn:li:dataPlatform:snowflake"],
                 },
-                _default_soft_deleted_filter,
+                _default_status_filter,
             ]
         },
         {
@@ -247,13 +247,39 @@ def test_compile_filters() -> None:
                     "condition": "EQUAL",
                     "values": ["urn:li:dataPlatform:snowflake"],
                 },
-                _default_soft_deleted_filter,
+                _default_status_filter,
             ]
         },
     ]
     types, compiled = compile_filters(filter)
     assert types is None
     assert compiled == expected_filters
+
+
+def test_compile_no_default_status() -> None:
+    filter = F.and_(
+        F.platform("snowflake"), F.soft_deleted(RemovedStatusFilter.ONLY_SOFT_DELETED)
+    )
+
+    _, compiled = compile_filters(filter)
+
+    # Check that no status filter was added.
+    assert compiled == [
+        {
+            "and": [
+                {
+                    "condition": "EQUAL",
+                    "field": "platform.keyword",
+                    "values": ["urn:li:dataPlatform:snowflake"],
+                },
+                {
+                    "condition": "EQUAL",
+                    "field": "removed",
+                    "values": ["true"],
+                },
+            ],
+        },
+    ]
 
 
 def test_generate_filters() -> None:
@@ -273,7 +299,7 @@ def test_generate_filters() -> None:
                     "condition": "EQUAL",
                     "values": ["urn:li:dataPlatform:snowflake"],
                 },
-                _default_soft_deleted_filter,
+                _default_status_filter,
             ]
         }
     ]
@@ -291,7 +317,7 @@ def test_generate_filters() -> None:
             "and": [
                 # This filter appears twice - once from the compiled filters, and once
                 # from the status arg to generate_filter.
-                _default_soft_deleted_filter,
+                _default_status_filter,
                 {
                     "field": "_entityType",
                     "condition": "EQUAL",
@@ -302,7 +328,7 @@ def test_generate_filters() -> None:
                     "condition": "EQUAL",
                     "values": ["urn:li:dataPlatform:snowflake"],
                 },
-                _default_soft_deleted_filter,
+                _default_status_filter,
             ]
         }
     ]


### PR DESCRIPTION
- Fixes a bug in the handling of extra_of_filters in generate_filter.
- Enables searches across entities on entity types that are not in the default searchable list.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
