### PR TITLE
fix(openapi): restore openapi v3 aspect version endpoint

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/AbstractMCLStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/AbstractMCLStep.java
@@ -113,8 +113,7 @@ public abstract class AbstractMCLStep implements UpgradeStep {
                   List<Pair<Future<?>, SystemAspect>> futures;
                   futures =
                       EntityUtils.toSystemAspectFromEbeanAspects(
-                              opContext.getRetrieverContext(),
-                              batch.collect(Collectors.toList()))
+                              opContext.getRetrieverContext(), batch.collect(Collectors.toList()))
                           .stream()
                           .map(
                               systemAspect -> {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/AbstractMCLStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/AbstractMCLStep.java
@@ -114,8 +114,7 @@ public abstract class AbstractMCLStep implements UpgradeStep {
                   futures =
                       EntityUtils.toSystemAspectFromEbeanAspects(
                               opContext.getRetrieverContext(),
-                              batch.collect(Collectors.toList()),
-                              false)
+                              batch.collect(Collectors.toList()))
                           .stream()
                           .map(
                               systemAspect -> {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/schemafield/GenerateSchemaFieldsFromSchemaMetadataStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/system/schemafield/GenerateSchemaFieldsFromSchemaMetadataStep.java
@@ -175,8 +175,7 @@ public class GenerateSchemaFieldsFromSchemaMetadataStep implements UpgradeStep {
                                       ebeanAspectV2 ->
                                           EntityUtils.toSystemAspectFromEbeanAspects(
                                               opContext.getRetrieverContext(),
-                                              Set.of(ebeanAspectV2),
-                                              true)
+                                              Set.of(ebeanAspectV2))
                                               .stream())
                                   .map(
                                       systemAspect ->

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -343,7 +343,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
 
     List<SystemAspect> systemAspects =
         EntityUtils.toSystemAspects(
-            opContext.getRetrieverContext(), batchGetResults.values(), false);
+            opContext.getRetrieverContext(), batchGetResults.values());
 
     systemAspects.stream()
         // for now, don't add the key aspect here we have already added it above
@@ -372,7 +372,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
         getLatestAspect(opContext, new HashSet<>(Arrays.asList(urn)), aspectNames, forUpdate);
 
     return EntityUtils.toSystemAspects(
-            opContext.getRetrieverContext(), batchGetResults.values(), false)
+            opContext.getRetrieverContext(), batchGetResults.values())
         .stream()
         .map(
             systemAspect -> Pair.of(systemAspect.getAspectName(), systemAspect.getRecordTemplate()))
@@ -802,7 +802,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     }
 
     return new ListResult<>(
-        EntityUtils.toSystemAspects(opContext.getRetrieverContext(), entityAspects, false).stream()
+        EntityUtils.toSystemAspects(opContext.getRetrieverContext(), entityAspects).stream()
             .map(SystemAspect::getRecordTemplate)
             .collect(Collectors.toList()),
         aspectMetadataList.getMetadata(),
@@ -1676,8 +1676,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                   List<SystemAspect> systemAspects =
                       EntityUtils.toSystemAspectFromEbeanAspects(
                           opContext.getRetrieverContext(),
-                          batch.collect(Collectors.toList()),
-                          false);
+                          batch.collect(Collectors.toList()));
 
                   RestoreIndicesResult result =
                       restoreIndices(opContext, systemAspects, logger, args.createDefaultAspects());
@@ -1730,8 +1729,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
         List<SystemAspect> systemAspects =
             EntityUtils.toSystemAspects(
                 opContext.getRetrieverContext(),
-                getLatestAspect(opContext, entityBatch.getValue(), aspectNames, false).values(),
-                false);
+                getLatestAspect(opContext, entityBatch.getValue(), aspectNames, false).values());
         long timeSqlQueryMs = System.currentTimeMillis() - startTime;
 
         RestoreIndicesResult result =
@@ -2839,7 +2837,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     final Map<EntityAspectIdentifier, EntityAspect> dbEntries = aspectDao.batchGet(dbKeys, false);
 
     List<SystemAspect> envelopedAspects =
-        EntityUtils.toSystemAspects(opContext.getRetrieverContext(), dbEntries.values(), false);
+        EntityUtils.toSystemAspects(opContext.getRetrieverContext(), dbEntries.values());
 
     return envelopedAspects.stream()
         .collect(

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityServiceImpl.java
@@ -342,8 +342,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     }
 
     List<SystemAspect> systemAspects =
-        EntityUtils.toSystemAspects(
-            opContext.getRetrieverContext(), batchGetResults.values());
+        EntityUtils.toSystemAspects(opContext.getRetrieverContext(), batchGetResults.values());
 
     systemAspects.stream()
         // for now, don't add the key aspect here we have already added it above
@@ -371,8 +370,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
     Map<EntityAspectIdentifier, EntityAspect> batchGetResults =
         getLatestAspect(opContext, new HashSet<>(Arrays.asList(urn)), aspectNames, forUpdate);
 
-    return EntityUtils.toSystemAspects(
-            opContext.getRetrieverContext(), batchGetResults.values())
+    return EntityUtils.toSystemAspects(opContext.getRetrieverContext(), batchGetResults.values())
         .stream()
         .map(
             systemAspect -> Pair.of(systemAspect.getAspectName(), systemAspect.getRecordTemplate()))
@@ -1675,8 +1673,7 @@ public class EntityServiceImpl implements EntityService<ChangeItemImpl> {
                 try {
                   List<SystemAspect> systemAspects =
                       EntityUtils.toSystemAspectFromEbeanAspects(
-                          opContext.getRetrieverContext(),
-                          batch.collect(Collectors.toList()));
+                          opContext.getRetrieverContext(), batch.collect(Collectors.toList()));
 
                   RestoreIndicesResult result =
                       restoreIndices(opContext, systemAspects, logger, args.createDefaultAspects());

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
@@ -215,8 +215,7 @@ public class EntityUtils {
 
   @Nonnull
   public static List<SystemAspect> toSystemAspectFromEbeanAspects(
-      @Nonnull RetrieverContext retrieverContext,
-      @Nonnull Collection<EbeanAspectV2> rawAspects) {
+      @Nonnull RetrieverContext retrieverContext, @Nonnull Collection<EbeanAspectV2> rawAspects) {
     return toSystemAspects(
         retrieverContext,
         rawAspects.stream().map(EbeanAspectV2::toEntityAspect).collect(Collectors.toList()));

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityUtils.java
@@ -170,7 +170,7 @@ public class EntityUtils {
       @Nullable EntityAspect entityAspect,
       boolean forUpdate) {
     return Optional.ofNullable(entityAspect)
-        .map(aspect -> toSystemAspects(retrieverContext, List.of(aspect), forUpdate))
+        .map(aspect -> toSystemAspects(retrieverContext, List.of(aspect)))
         .filter(systemAspects -> !systemAspects.isEmpty())
         .map(systemAspects -> systemAspects.get(0));
   }
@@ -186,15 +186,13 @@ public class EntityUtils {
   @Nonnull
   public static Map<String, Map<String, SystemAspect>> toSystemAspects(
       @Nonnull RetrieverContext retrieverContext,
-      @Nonnull Map<String, Map<String, EntityAspect>> rawAspects,
-      boolean forUpdate) {
+      @Nonnull Map<String, Map<String, EntityAspect>> rawAspects) {
     List<SystemAspect> systemAspects =
         toSystemAspects(
             retrieverContext,
             rawAspects.values().stream()
                 .flatMap(m -> m.values().stream())
-                .collect(Collectors.toList()),
-            forUpdate);
+                .collect(Collectors.toList()));
 
     // map the list into the desired shape
     return systemAspects.stream()
@@ -218,12 +216,10 @@ public class EntityUtils {
   @Nonnull
   public static List<SystemAspect> toSystemAspectFromEbeanAspects(
       @Nonnull RetrieverContext retrieverContext,
-      @Nonnull Collection<EbeanAspectV2> rawAspects,
-      boolean forUpdate) {
+      @Nonnull Collection<EbeanAspectV2> rawAspects) {
     return toSystemAspects(
         retrieverContext,
-        rawAspects.stream().map(EbeanAspectV2::toEntityAspect).collect(Collectors.toList()),
-        forUpdate);
+        rawAspects.stream().map(EbeanAspectV2::toEntityAspect).collect(Collectors.toList()));
   }
 
   /**
@@ -232,14 +228,14 @@ public class EntityUtils {
    * <p>This should be the 1 point that all conversions from database representations to java
    * objects happens since we need to enforce read mutations happen.
    *
+   * @param retrieverContext retriever context to fetch with
    * @param rawAspects raw aspects to convert
    * @return map converted aspects
    */
   @Nonnull
   public static List<SystemAspect> toSystemAspects(
       @Nonnull final RetrieverContext retrieverContext,
-      @Nonnull Collection<EntityAspect> rawAspects,
-      boolean forUpdate) {
+      @Nonnull Collection<EntityAspect> rawAspects) {
     EntityRegistry entityRegistry = retrieverContext.getAspectRetriever().getEntityRegistry();
 
     // Build
@@ -258,11 +254,7 @@ public class EntityUtils {
                       aspectSpec != null,
                       String.format("Aspect %s could not be found", raw.getAspect()));
 
-                  if (forUpdate) {
-                    return EntityAspect.EntitySystemAspect.builder().forUpdate(raw, entityRegistry);
-                  } else {
-                    return EntityAspect.EntitySystemAspect.builder().forInsert(raw, entityRegistry);
-                  }
+                  return EntityAspect.EntitySystemAspect.builder().forUpdate(raw, entityRegistry);
                 })
             .collect(Collectors.toList());
 

--- a/smoke-test/tests/openapi/v3/aspects.json
+++ b/smoke-test/tests/openapi/v3/aspects.json
@@ -1,0 +1,121 @@
+[
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29",
+      "description": "Remove test dataset 1",
+      "method": "delete"
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29/globaltags",
+      "params": {
+        "createIfNotExists": "false",
+        "createEntityIfNotExists": "false",
+        "async": "false"
+      },
+      "description": "Add 1 tag",
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "tag": "urn:li:tag:tag1"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29/globaltags",
+      "params": {
+        "createIfNotExists": "false",
+        "createEntityIfNotExists": "false",
+        "async": "false"
+      },
+      "description": "Add 2 tags",
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "tag": "urn:li:tag:tag1"
+            },
+            {
+              "tag": "urn:li:tag:tag2"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29/globaltags",
+      "params": {
+        "version": "0"
+      },
+      "method": "get",
+      "description": "Get version 0"
+    },
+    "response": {
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "tag": "urn:li:tag:tag1"
+            },
+            {
+              "tag": "urn:li:tag:tag2"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29/globaltags",
+      "params": {
+        "version": "2"
+      },
+      "method": "get",
+      "description": "Get version 2"
+    },
+    "response": {
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "tag": "urn:li:tag:tag1"
+            },
+            {
+              "tag": "urn:li:tag:tag2"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29/globaltags",
+      "params": {
+        "version": "1"
+      },
+      "method": "get",
+      "description": "Get version 1"
+    },
+    "response": {
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "tag": "urn:li:tag:tag1"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/smoke-test/tests/utilities/concurrent_openapi.py
+++ b/smoke-test/tests/utilities/concurrent_openapi.py
@@ -107,7 +107,9 @@ def run_tests(auth_session, fixture_globs, num_workers=3):
     """
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures = []
+        logger.info(f"Processing openapi test glob: {fixture_globs}")
         for fixture_glob in fixture_globs:
+            logger.info(f"Processing openapi test: {fixture_glob}")
             for test_fixture, test_data in load_tests(fixture_glob=fixture_glob):
                 futures.append(
                     executor.submit(


### PR DESCRIPTION
The error that is fixed is when using the endpoint for fetching versions > 0 (0 represents the latest version).

There is logic which handles the case when the requested version, say 10, is requested however the row in the database is actually 0. Instead of performing 2 round trips to the database (fetch version 10 and finding out it doesn't exist and then fetching version 0 to see if it is version 10), we perform a single query to fetch both versions 0 and 10 in 1 query.

The regression here is when version 10 exists and version 0 (in the database) represents say version 11. In this case we need to return the correct version of the two retrieved aspects. This wasn't possible since a utility method which converts a raw row from the database into another class failed to set a field which would have correctly identified the versions. This code was written prior to the existence of the version being present in systemMetadata  which would have been another way to determine the difference in the return aspects.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
