### PR TITLE
fix UI bugs on queries tab

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueriesListSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueriesListSection.tsx
@@ -20,7 +20,7 @@ const SectionWrapper = styled.div<{ $borderRadiusBottom?: boolean }>`
     padding: 24px;
     box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.08);
     ${(props) => (props.$borderRadiusBottom ? `border-radius: 0 0 10px 10px;` : `border-radius: 10px;`)}
-    height: 100%;
+    height: fit-content;
 `;
 
 const QueriesTitleSection = styled.div`

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueryFilters/QueryFilters.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Queries/QueryFilters/QueryFilters.tsx
@@ -79,6 +79,7 @@ export default function QueryFilters({
                     onChangeFilters={onChangeFilters}
                     activeFilters={[selectedColumnsFilter, selectedUsersFilter]}
                     labelStyle={selectedColumnsFilter.values?.length ? undefined : labelStyle}
+                    shouldUseAggregationsFromFilter
                 />
                 <SearchFilter
                     filter={usersFilter}
@@ -86,6 +87,7 @@ export default function QueryFilters({
                     onChangeFilters={onChangeFilters}
                     activeFilters={[selectedUsersFilter, selectedColumnsFilter]}
                     labelStyle={selectedUsersFilter.values?.length ? undefined : labelStyle}
+                    shouldUseAggregationsFromFilter
                 />
             </FiltersWrapper>
             <SelectedSearchFilters

--- a/datahub-web-react/src/app/searchV2/filters/SearchFilter.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/SearchFilter.tsx
@@ -12,13 +12,22 @@ interface Props {
     onChangeFilters: (newFilters: FacetFilterInput[]) => void;
     filterPredicates: FilterPredicate[];
     labelStyle?: CSSProperties;
+    shouldUseAggregationsFromFilter?: boolean;
 }
 
-export default function SearchFilter({ filter, filterPredicates, activeFilters, onChangeFilters, labelStyle }: Props) {
+export default function SearchFilter({
+    filter,
+    filterPredicates,
+    activeFilters,
+    onChangeFilters,
+    labelStyle,
+    shouldUseAggregationsFromFilter,
+}: Props) {
     const { finalAggregations, updateFilters, numActiveFilters, manuallyUpdateFilters } = useSearchFilterDropdown({
         filter,
         activeFilters,
         onChangeFilters,
+        shouldUseAggregationsFromFilter,
     });
     const filterIcon = getFilterDropdownIcon(filter.field);
 

--- a/datahub-web-react/src/app/searchV2/filters/useSearchFilterDropdown.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/useSearchFilterDropdown.tsx
@@ -9,11 +9,17 @@ interface Props {
     filter: FacetMetadata;
     activeFilters: FacetFilterInput[];
     onChangeFilters: (newFilters: FacetFilterInput[]) => void;
+    shouldUseAggregationsFromFilter?: boolean;
 }
 
-export default function useSearchFilterDropdown({ filter, activeFilters, onChangeFilters }: Props) {
+export default function useSearchFilterDropdown({
+    filter,
+    activeFilters,
+    onChangeFilters,
+    shouldUseAggregationsFromFilter,
+}: Props) {
     const numActiveFilters = getNumActiveFiltersForFilter(activeFilters, filter);
-    const shouldFetchAggregations: boolean = !!filter.field && numActiveFilters > 0;
+    const shouldFetchAggregations: boolean = !!filter.field && numActiveFilters > 0 && !shouldUseAggregationsFromFilter;
 
     const { entityFilters, query, orFilters, viewUrn } = useGetSearchQueryInputs(
         useMemo(() => [filter.field], [filter.field]),


### PR DESCRIPTION
Fix two related bugs in the queries tab on deploy-test:
1. Resolve issue where filter dropdown shows empty options when has selected options.
2. Prevent pagination overflow in the queries table by expanding the container instead of allowing scrolling.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
