### PR TITLE
fix(test): improve test stability

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
@@ -279,29 +279,41 @@ public class EbeanEntityServiceOptimizationTest {
           statementMap.getOrDefault("UNKNOWN", List.of()).size(),
           0,
           String.format(
-              "(%s) Expected all SQL statements to be categorized: %s",
-              description, statementMap.get("UNKNOWN")));
+              "(%s) Expected all SQL statements to be categorized:\n%s",
+              description, formatUnknownStatements(statementMap.get("UNKNOWN"))));
       assertEquals(
           statementMap.getOrDefault("SELECT", List.of()).size(),
           expectedSelectCount,
           String.format(
-              "(%s) Expected SELECT SQL count mismatch filtering for (%s): %s",
-              description, mustInclude, statementMap.get("SELECT")));
+              "(%s) Expected SELECT SQL count mismatch filtering for (%s):\n%s",
+              description, mustInclude, formatUnknownStatements(statementMap.get("SELECT"))));
       assertEquals(
           statementMap.getOrDefault("INSERT", List.of()).size(),
           expectedInsertCount,
           String.format(
-              "(%s) Expected INSERT SQL count mismatch filtering for (%s): %s",
-              description, mustInclude, statementMap.get("INSERT")));
+              "(%s) Expected INSERT SQL count mismatch filtering for (%s):\n%s",
+              description, mustInclude, formatUnknownStatements(statementMap.get("INSERT"))));
       assertEquals(
           statementMap.getOrDefault("UPDATE", List.of()).size(),
           expectedUpdateCount,
           String.format(
-              "(%s), Expected UPDATE SQL count mismatch filtering for (%s): %s",
-              description, mustInclude, statementMap.get("UPDATE")));
+              "(%s), Expected UPDATE SQL count mismatch filtering for (%s):\n%s",
+              description, mustInclude, formatUnknownStatements(statementMap.get("UPDATE"))));
     } finally {
       // Ensure logging is stopped even if assertions fail
       LoggedSql.stop();
     }
+  }
+
+  private static String formatUnknownStatements(List<String> statements) {
+    if (statements == null || statements.isEmpty()) {
+      return "  No unknown statements";
+    }
+
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < statements.size(); i++) {
+      builder.append("  ").append(i + 1).append(". ").append(statements.get(i)).append("\n");
+    }
+    return builder.toString();
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceOptimizationTest.java
@@ -233,10 +233,16 @@ public class EbeanEntityServiceOptimizationTest {
     try {
       entityService.ingestProposal(opContext, batch, false);
       // First collect all SQL statements that start with "txn[]"
-      List<String> allSqlStatements =
-          LoggedSql.collect().stream()
-              .filter(sql -> sql.startsWith("txn[]"))
-              .collect(Collectors.toList());
+      List<String> allSqlStatements = new ArrayList<>();
+      for (String sqlGroup : LoggedSql.collect()) {
+        // Split by "txn[]" but preserve the prefix
+        String[] parts = sqlGroup.split("(?=txn\\[\\])");
+        for (String part : parts) {
+          if (part.startsWith("txn[]")) {
+            allSqlStatements.add(part);
+          }
+        }
+      }
 
       // Then process them to fold comments into previous lines
       List<String> txnLog = new ArrayList<>();


### PR DESCRIPTION
The *test* code analyzes SQL log statements, however the upstream code will log statements from concurrent tests. This tries to address the log parsing by splitting the txn statements better to be filtered by an expected string in each statement.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
