### PR TITLE
update searchbar width in manage tags

### DIFF
--- a/datahub-web-react/src/app/tags/ManageTags.tsx
+++ b/datahub-web-react/src/app/tags/ManageTags.tsx
@@ -124,6 +124,7 @@ const ManageTags = () => {
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e)}
                     data-testid="tag-search-input"
+                    width="280px"
                 />
             </SearchContainer>
 


### PR DESCRIPTION
- Update searchbar to 280px


before
<img width="1840" alt="Screenshot 2025-04-02 at 3 03 42 PM" src="https://github.com/user-attachments/assets/230042ba-ac3b-4cca-add1-71f3066525c9" />


after 
<img width="1840" alt="Screenshot 2025-04-02 at 3 03 28 PM" src="https://github.com/user-attachments/assets/ea09c5c8-6dfb-404b-ab0d-805d564e0b1d" />


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
