### PR TITLE
fix(lint): update icon props in sidebar components to match IconProps type

### DIFF
--- a/datahub-web-react/src/app/domainV2/nestedDomains/DomainsSidebarHeader.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/DomainsSidebarHeader.tsx
@@ -40,8 +40,7 @@ export default function DomainsSidebarHeader() {
                     variant="filled"
                     color="violet"
                     isCircle
-                    icon="Plus"
-                    iconSource="phosphor"
+                    icon={{ icon: 'Plus', source: 'phosphor' }}
                     onClick={() => setIsCreatingDomain(true)}
                 />
             </Tooltip>

--- a/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
+++ b/datahub-web-react/src/app/domainV2/nestedDomains/ManageDomainsSidebar.tsx
@@ -87,8 +87,7 @@ export default function ManageDomainsSidebarV2({ isEntityProfile }: Props) {
                     color="gray"
                     size="lg"
                     isCircle
-                    icon={isClosed ? 'ArrowLineRight' : 'ArrowLineLeft'}
-                    iconSource="phosphor"
+                    icon={{ icon: isClosed ? 'ArrowLineRight' : 'ArrowLineLeft', source: 'phosphor' }}
                     isActive={!isClosed}
                     onClick={() => setIsClosed(!isClosed)}
                 />

--- a/datahub-web-react/src/app/glossaryV2/GlossarySidebar.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossarySidebar.tsx
@@ -74,8 +74,7 @@ export default function GlossarySidebar({ isEntityProfile }: Props) {
                             variant="filled"
                             color="violet"
                             isCircle
-                            icon="Plus"
-                            iconSource="phosphor"
+                            icon={{ icon: 'Plus', source: 'phosphor' }}
                             onClick={() => setIsCreateNodeModalVisible(true)}
                         />
                     </Tooltip>

--- a/datahub-web-react/src/app/searchV2/sidebar/BrowseSidebar.tsx
+++ b/datahub-web-react/src/app/searchV2/sidebar/BrowseSidebar.tsx
@@ -134,8 +134,7 @@ const BrowseSidebar = ({ visible }: Props) => {
                         color="gray"
                         size="lg"
                         isCircle
-                        icon={isClosed ? 'ArrowLineRight' : 'ArrowLineLeft'}
-                        iconSource="phosphor"
+                        icon={{ icon: isClosed ? 'ArrowLineRight' : 'ArrowLineLeft', source: 'phosphor' }}
                         isActive={!isClosed}
                         onClick={() => setIsClosed(!isClosed)}
                     />


### PR DESCRIPTION
- Updated all four files to use the correct IconProps format:
- DomainsSidebarHeader.tsx
- ManageDomainsSidebar.tsx
- GlossarySidebar.tsx
- BrowseSidebar.tsx



- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
