### PR TITLE
Updating icons, gaps, and pills in selects

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/AutoCompleteSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/AutoCompleteSelect.tsx
@@ -224,7 +224,7 @@ function SelectActionButtons({
                     onClick={handleClearSelection}
                 />
             )}
-            <StyledIcon icon="ChevronLeft" rotate={isOpen ? '90' : '270'} size="lg" />
+            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
         </ActionButtonsContainer>
     );
 }

--- a/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/BasicSelect.tsx
@@ -43,7 +43,7 @@ const SelectActionButtons = ({
                     onClick={handleClearSelection}
                 />
             )}
-            <StyledIcon icon="ChevronLeft" rotate={isOpen ? '90' : '270'} size="lg" />
+            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
         </ActionButtonsContainer>
     );
 };

--- a/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/Nested/NestedSelect.tsx
@@ -5,7 +5,6 @@ import { Icon, Pill, colors } from '@components';
 import {
     ActionButtonsContainer,
     Container,
-    CountBadge,
     Dropdown,
     OptionList,
     Placeholder,
@@ -55,7 +54,7 @@ const SelectLabelDisplay = ({
             {showCount && selectedOptions.length > 0 ? (
                 <StyledCountBadgeContainer>
                     {placeholder}
-                    <CountBadge>{selectedOptions.length}</CountBadge>
+                    <Pill label={`${selectedOptions.length}`} size="sm" variant="filled" />
                 </StyledCountBadgeContainer>
             ) : (
                 !!selectedOptions.length &&
@@ -106,7 +105,7 @@ const SelectActionButtons = ({
                     data-testid="dropdown-option-clear-icon"
                 />
             )}
-            <Icon icon="ChevronLeft" rotate={isOpen ? '90' : '270'} size="xl" color="gray" />
+            <Icon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
         </ActionButtonsContainer>
     );
 };

--- a/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/SimpleSelect.tsx
@@ -40,7 +40,7 @@ const SelectActionButtons = ({
                     onClick={handleClearSelection}
                 />
             )}
-            <StyledIcon icon="ChevronLeft" rotate={isOpen ? '90' : '270'} size="lg" />
+            <StyledIcon icon="CaretDown" source="phosphor" rotate={isOpen ? '180' : '0'} size="md" color="gray" />
         </ActionButtonsContainer>
     );
 };

--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -180,13 +180,13 @@ export const DescriptionContainer = styled.span({
     marginTop: spacing.xxsm,
 });
 
-export const LabelsWrapper = styled.div({
+export const LabelsWrapper = styled.div<{ shouldShowGap?: boolean }>(({ shouldShowGap = false }) => ({
     display: 'flex',
     flexWrap: 'wrap',
-    gap: spacing.xxsm,
+    gap: shouldShowGap ? spacing.xxsm : '0px',
     maxHeight: '150px',
     maxWidth: '100%',
-});
+}));
 
 export const OptionLabel = styled.label<{
     isSelected: boolean;
@@ -276,14 +276,6 @@ export const StyledBubbleButton = styled(Button)({
     border: `1px solid ${colors.gray[200]}`,
     color: colors.black,
     padding: '1px',
-});
-
-export const CountBadge = styled.div({
-    backgroundColor: colors.gray[200],
-    color: colors.black,
-    padding: '3px 5px',
-    borderRadius: 50,
-    fontSize: typography.fontSizes.sm,
 });
 
 export const HighlightedLabel = styled.span`

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectCustom.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectCustom.tsx
@@ -13,7 +13,7 @@ export default function MultiSelectCustom({
     renderCustomSelectedValue,
 }: SelectLabelVariantProps) {
     return (
-        <LabelsWrapper>
+        <LabelsWrapper shouldShowGap={selectedOptions.length > 1}>
             {!selectedValues.length && <Placeholder>{placeholder}</Placeholder>}
             {!!selectedOptions.length &&
                 isMultiSelect &&

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectDefault.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectDefault.tsx
@@ -12,7 +12,7 @@ export default function MultiSelectDefault({
     isMultiSelect,
 }: SelectLabelVariantProps) {
     return (
-        <LabelsWrapper>
+        <LabelsWrapper shouldShowGap={selectedOptions.length > 1}>
             {!selectedValues.length && <Placeholder>{placeholder}</Placeholder>}
             {!!selectedOptions.length &&
                 isMultiSelect &&

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectLabeled.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/MultiSelectLabeled.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { ActionButtonsContainer, HighlightedLabel, LabelsWrapper, SelectValue } from '../../../components';
+import { Pill } from '@components';
+import { ActionButtonsContainer, LabelsWrapper, SelectValue } from '../../../components';
 import { SelectLabelVariantProps } from '../../../types';
 
 export default function MultiSelectLabeled({ selectedOptions, label }: SelectLabelVariantProps) {
     return (
-        <LabelsWrapper>
+        <LabelsWrapper shouldShowGap={false}>
             <ActionButtonsContainer>
                 <SelectValue>{label}</SelectValue>
-                <HighlightedLabel>{selectedOptions.length}</HighlightedLabel>
+                <Pill label={`${selectedOptions.length}`} size="sm" variant="filled" />
             </ActionButtonsContainer>
         </LabelsWrapper>
     );

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/SingleSelectCustom.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/SingleSelectCustom.tsx
@@ -17,7 +17,7 @@ export default function SingleSelectCustom({
     renderCustomSelectedValue,
 }: SelectLabelVariantProps) {
     return (
-        <LabelsWrapper>
+        <LabelsWrapper shouldShowGap={false}>
             {!selectedValues?.length && <Placeholder>{placeholder}</Placeholder>}
             {!isMultiSelect && !!selectedValues?.length && (
                 <>

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/SingleSelectDefault.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/SingleSelectDefault.tsx
@@ -16,7 +16,7 @@ export default function SingleSelectDefault({
     showDescriptions,
 }: SelectLabelVariantProps) {
     return (
-        <LabelsWrapper>
+        <LabelsWrapper shouldShowGap={false}>
             {!selectedValues.length && <Placeholder>{placeholder}</Placeholder>}
             {!isMultiSelect && (
                 <>

--- a/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/SingleSelectLabeled.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Select/private/SelectLabelRenderer/variants/SingleSelectLabeled.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
+import { Pill } from '@components';
 import {
     ActionButtonsContainer,
     DescriptionContainer,
-    HighlightedLabel,
     LabelsWrapper,
     Placeholder,
     SelectValue,
@@ -17,13 +17,13 @@ export default function SingleSelectLabeled({
     label,
 }: SelectLabelVariantProps) {
     return (
-        <LabelsWrapper>
+        <LabelsWrapper shouldShowGap={false}>
             {!selectedValues.length && <Placeholder>{placeholder}</Placeholder>}
 
             {!!selectedValues.length && (
                 <ActionButtonsContainer>
                     <SelectValue>{label}</SelectValue>
-                    <HighlightedLabel>{selectedOptions[0]?.label}</HighlightedLabel>
+                    <Pill label={selectedOptions[0]?.label} size="sm" variant="filled" />
                 </ActionButtonsContainer>
             )}
 


### PR DESCRIPTION
- Updating icons
- gaps
- pills

**Before:**
<img width="1840" alt="Screenshot 2025-04-06 at 8 40 29 PM" src="https://github.com/user-attachments/assets/fb30d291-9d60-4c53-b1bd-7ef013d81221" />
<img width="325" alt="Screenshot 2025-04-06 at 8 48 39 PM" src="https://github.com/user-attachments/assets/87de63de-3119-43db-ba33-14e2f41b6629" />

**After** 
<img width="1840" alt="Screenshot 2025-04-06 at 8 39 52 PM" src="https://github.com/user-attachments/assets/5f284589-e116-41b6-832f-ec733ce81a62" />
<img width="316" alt="Screenshot 2025-04-06 at 8 48 53 PM" src="https://github.com/user-attachments/assets/e75c67e8-98d1-45b5-9231-0ff1545b28de" />



**Before:**
<img width="535" alt="Screenshot 2025-04-06 at 8 42 48 PM" src="https://github.com/user-attachments/assets/ca212bfa-5bab-4f4c-a90d-50f2e950fb79" />
<img width="286" alt="Screenshot 2025-04-06 at 8 48 00 PM" src="https://github.com/user-attachments/assets/3a08ca17-02df-4a93-9d29-6fd313b03569" />

**After:**
<img width="535" alt="Screenshot 2025-04-06 at 8 43 09 PM" src="https://github.com/user-attachments/assets/4778dce9-8d08-4cd1-9b97-f988ec1758af" />
<img width="292" alt="Screenshot 2025-04-06 at 8 45 36 PM" src="https://github.com/user-attachments/assets/24ff8c3a-dd4d-41e2-903c-8cdd5608826d" />
<img width="277" alt="Screenshot 2025-04-06 at 8 45 59 PM" src="https://github.com/user-attachments/assets/e92fa31b-08db-46f6-9f68-0f9ab93a2df9" />





- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
