### PR TITLE
feat(ui): add custom dataset assertion description to data contract s…

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
@@ -51,6 +51,7 @@ export const DataQualityContractSummary = ({ contracts, showAction = false }: Pr
                 <>
                     {assertion.info?.datasetAssertion && (
                         <DatasetAssertionDescription
+                            description={assertion.info?.description}
                             assertionInfo={assertion.info?.datasetAssertion as DatasetAssertionInfo}
                         />
                     )}

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Dataset/Validations/contract/DataQualityContractSummary.tsx
@@ -51,6 +51,7 @@ export const DataQualityContractSummary = ({ contracts, showAction = false }: Pr
                 <>
                     {assertion.info?.datasetAssertion && (
                         <DatasetAssertionDescription
+                            description={assertion.info?.description}
                             assertionInfo={assertion.info?.datasetAssertion as DatasetAssertionInfo}
                         />
                     )}


### PR DESCRIPTION
# Summary

In this PR, I'm adding support for rendering a custom description for any dataset assertion in the Data Contract summary.

Previously, custom descriptions were rendered only in the Assertions list view. 

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
