### PR TITLE
fix(ci): make depot remote container builder optional

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -34,8 +34,9 @@ env:
   DATAHUB_INGESTION_IMAGE: "acryldata/datahub-ingestion"
 
   DOCKER_CACHE: "DEPOT"
-  DEPOT_PROJECT_ID: ${{ vars.DEPOT_PROJECT_ID }}
-  DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
+  DEPOT_PROJECT_ID: "${{ vars.DEPOT_PROJECT_ID }}"
+  DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
+
 
 permissions:
   contents: read
@@ -1132,7 +1133,7 @@ jobs:
         uses: depot/setup-action@v1
 
       - name: configure-docker
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}  
+        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DOCKER_PROJECT_ID != '' }}
         run: |
           depot configure-docker
 

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -21,6 +21,7 @@ else
   echo "test_user:test_pass" >> ~/.datahub/plugins/frontend/auth/user.props
   echo "datahub:datahub" > ~/.datahub/plugins/frontend/auth/user.props
 
+
   python3 -m venv venv
   set +x
   source venv/bin/activate


### PR DESCRIPTION
PRs from forks do not have the project ID and token visible and by skipping the `depot configure docker` step, the regular local docker builds continue to work for PRs from forks.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
