### PR TITLE
refactor(ui): Fix appearance of skeleton loading indicator for search bar 

### DIFF
--- a/datahub-web-react/src/app/searchV2/SearchBar.tsx
+++ b/datahub-web-react/src/app/searchV2/SearchBar.tsx
@@ -413,118 +413,120 @@ export const SearchBar = ({
     };
 
     return (
-        <AutoCompleteContainer
-            viewsEnabled={viewsEnabled}
-            $isShowNavBarRedesign={isShowNavBarRedesign}
-            id={id}
-            style={viewsEnabled ? viewsEnabledStyle : style}
-            ref={searchBarWrapperRef}
-        >
+        <>
             {isLoading ? (
                 <SkeletonContainer>
                     <SkeletonButton shape="square" active block />
                 </SkeletonContainer>
             ) : (
-                <StyledAutoComplete
-                    data-testid="search-bar"
+                <AutoCompleteContainer
+                    viewsEnabled={viewsEnabled}
                     $isShowNavBarRedesign={isShowNavBarRedesign}
-                    defaultActiveFirstOption={false}
-                    style={autoCompleteStyle}
-                    options={options}
-                    filterOption={false}
-                    onSelect={(value, option) => {
-                        // If the autocomplete option type is NOT an entity, then render as a normal search query.
-                        if (
-                            option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
-                            option.type === RELEVANCE_QUERY_OPTION_TYPE
-                        ) {
-                            handleSearch(
-                                `${filterSearchQuery(value as string)}`,
-                                getFiltersWithQuickFilter(selectedQuickFilter),
-                            );
-                            analytics.event({
-                                type: EventType.SelectAutoCompleteOption,
-                                optionType: option.type,
-                            } as Event);
-                        } else {
-                            // Navigate directly to the entity profile.
-                            history.push(getEntityPath(option.type, value as string, entityRegistry, false, false));
-                            setSelected('');
-                            analytics.event({
-                                type: EventType.SelectAutoCompleteOption,
-                                optionType: option.type,
-                                entityType: option.type,
-                                entityUrn: value,
-                            } as Event);
-                        }
-                    }}
-                    onSearch={showAutoCompleteResults ? onQueryChange : undefined}
-                    defaultValue={initialQuery || undefined}
-                    value={selected}
-                    onChange={(v) => setSelected(filterSearchQuery(v as string))}
-                    dropdownStyle={{
-                        maxHeight: 1000,
-                        overflowY: 'visible',
-                        position: (fixAutoComplete && 'fixed') || 'relative',
-                        ...(isShowNavBarRedesign ? { minWidth: '648px' } : {}),
-                    }}
-                    onDropdownVisibleChange={(isOpen) => {
-                        if (!isOpen) {
-                            setIsDropdownVisible(isOpen);
-                        } else {
-                            // set timeout so that we allow search bar to grow in width and therefore allow autocomplete to grow
-                            setTimeout(() => {
-                                setIsDropdownVisible(isOpen);
-                            }, 0);
-                        }
-                    }}
-                    open={isDropdownVisible}
-                    listHeight={480}
+                    id={id}
+                    style={viewsEnabled ? viewsEnabledStyle : style}
+                    ref={searchBarWrapperRef}
                 >
-                    <StyledSearchBar
-                        bordered={false}
-                        placeholder={placeholderText}
-                        onPressEnter={() => {
-                            handleSearch(
-                                filterSearchQuery(searchQuery || ''),
-                                getFiltersWithQuickFilter(selectedQuickFilter),
-                            );
-                        }}
-                        style={{ ...inputStyle, color: '#fff' }}
-                        value={searchQuery}
-                        onChange={(e) => setSearchQuery(e.target.value)}
-                        data-testid="search-input"
-                        onFocus={handleFocus}
-                        onBlur={handleBlur}
-                        viewsEnabled={viewsEnabled}
+                    <StyledAutoComplete
+                        data-testid="search-bar"
                         $isShowNavBarRedesign={isShowNavBarRedesign}
-                        allowClear={(isFocused && { clearIcon: <ClearIcon /> }) || false}
-                        prefix={
-                            <>
-                                <SearchIcon
-                                    $isShowNavBarRedesign={isShowNavBarRedesign}
-                                    onClick={() => {
-                                        handleSearch(
-                                            filterSearchQuery(searchQuery || ''),
-                                            getFiltersWithQuickFilter(selectedQuickFilter),
-                                        );
-                                    }}
-                                />
-                            </>
-                        }
-                        ref={searchInputRef}
-                        suffix={<>{(showCommandK && !isFocused && <CommandK />) || null}</>}
-                        $textColor={textColor}
-                        $placeholderColor={placeholderColor}
-                    />
-                </StyledAutoComplete>
+                        defaultActiveFirstOption={false}
+                        style={autoCompleteStyle}
+                        options={options}
+                        filterOption={false}
+                        onSelect={(value, option) => {
+                            // If the autocomplete option type is NOT an entity, then render as a normal search query.
+                            if (
+                                option.type === EXACT_AUTOCOMPLETE_OPTION_TYPE ||
+                                option.type === RELEVANCE_QUERY_OPTION_TYPE
+                            ) {
+                                handleSearch(
+                                    `${filterSearchQuery(value as string)}`,
+                                    getFiltersWithQuickFilter(selectedQuickFilter),
+                                );
+                                analytics.event({
+                                    type: EventType.SelectAutoCompleteOption,
+                                    optionType: option.type,
+                                } as Event);
+                            } else {
+                                // Navigate directly to the entity profile.
+                                history.push(getEntityPath(option.type, value as string, entityRegistry, false, false));
+                                setSelected('');
+                                analytics.event({
+                                    type: EventType.SelectAutoCompleteOption,
+                                    optionType: option.type,
+                                    entityType: option.type,
+                                    entityUrn: value,
+                                } as Event);
+                            }
+                        }}
+                        onSearch={showAutoCompleteResults ? onQueryChange : undefined}
+                        defaultValue={initialQuery || undefined}
+                        value={selected}
+                        onChange={(v) => setSelected(filterSearchQuery(v as string))}
+                        dropdownStyle={{
+                            maxHeight: 1000,
+                            overflowY: 'visible',
+                            position: (fixAutoComplete && 'fixed') || 'relative',
+                            ...(isShowNavBarRedesign ? { minWidth: '648px' } : {}),
+                        }}
+                        onDropdownVisibleChange={(isOpen) => {
+                            if (!isOpen) {
+                                setIsDropdownVisible(isOpen);
+                            } else {
+                                // set timeout so that we allow search bar to grow in width and therefore allow autocomplete to grow
+                                setTimeout(() => {
+                                    setIsDropdownVisible(isOpen);
+                                }, 0);
+                            }
+                        }}
+                        open={isDropdownVisible}
+                        listHeight={480}
+                    >
+                        <StyledSearchBar
+                            bordered={false}
+                            placeholder={placeholderText}
+                            onPressEnter={() => {
+                                handleSearch(
+                                    filterSearchQuery(searchQuery || ''),
+                                    getFiltersWithQuickFilter(selectedQuickFilter),
+                                );
+                            }}
+                            style={{ ...inputStyle, color: '#fff' }}
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            data-testid="search-input"
+                            onFocus={handleFocus}
+                            onBlur={handleBlur}
+                            viewsEnabled={viewsEnabled}
+                            $isShowNavBarRedesign={isShowNavBarRedesign}
+                            allowClear={(isFocused && { clearIcon: <ClearIcon /> }) || false}
+                            prefix={
+                                <>
+                                    <SearchIcon
+                                        $isShowNavBarRedesign={isShowNavBarRedesign}
+                                        onClick={() => {
+                                            handleSearch(
+                                                filterSearchQuery(searchQuery || ''),
+                                                getFiltersWithQuickFilter(selectedQuickFilter),
+                                            );
+                                        }}
+                                    />
+                                </>
+                            }
+                            ref={searchInputRef}
+                            suffix={<>{(showCommandK && !isFocused && <CommandK />) || null}</>}
+                            $textColor={textColor}
+                            $placeholderColor={placeholderColor}
+                        />
+                    </StyledAutoComplete>
+                    {viewsEnabled && (
+                        <ViewSelectContainer id={V2_SEARCH_BAR_VIEWS}>
+                            <ViewSelect />
+                        </ViewSelectContainer>
+                    )}
+                </AutoCompleteContainer>
             )}
-            {viewsEnabled && (
-                <ViewSelectContainer id={V2_SEARCH_BAR_VIEWS}>
-                    <ViewSelect />
-                </ViewSelectContainer>
-            )}
-        </AutoCompleteContainer>
+        </>
     );
 };
 


### PR DESCRIPTION
Before:

<img width="1175" alt="Screenshot 2025-03-28 at 12 37 30 PM" src="https://github.com/user-attachments/assets/23ba1903-9b22-41ad-96de-5c924cd5010f" />


After:


<img width="829" alt="Screenshot 2025-03-28 at 12 37 05 PM" src="https://github.com/user-attachments/assets/8dd64947-8f41-45ac-9acd-4b8a4a3263f3" />

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
