### PR TITLE
Updated Button Component

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Button/types.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/types.ts
@@ -7,6 +7,7 @@ export enum ButtonVariantValues {
     filled = 'filled',
     outline = 'outline',
     text = 'text',
+    secondary = 'secondary',
 }
 export type ButtonVariant = keyof typeof ButtonVariantValues;
 

--- a/datahub-web-react/src/alchemy-components/components/Button/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Button/utils.ts
@@ -88,6 +88,20 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions): Colo
         };
     }
 
+    // Override styles for secondary variant
+    if (variant === 'secondary') {
+        return {
+            ...base,
+            bgColor: getColor('violet', 0),
+            hoverBgColor: getColor('violet', 100),
+            activeBgColor: getColor('violet', 200),
+            textColor: color500,
+            borderColor: 'transparent',
+            disabledBgColor: 'transparent',
+            disabledBorderColor: 'transparent',
+        };
+    }
+
     // Filled variable is the base style
     return base;
 };
@@ -96,16 +110,17 @@ const getButtonColorStyles = (variant: ButtonVariant, color: ColorOptions): Colo
 const getButtonVariantStyles = (variant: ButtonVariant, colorStyles: ColorStyles): CSSObject => {
     const variantStyles = {
         filled: {
-            backgroundColor: colorStyles.bgColor,
+            background: `radial-gradient(115.48% 144.44% at 50% -44.44%, var(--buttons-bg-2-for-gradient, #705EE4) 38.97%, var(--buttons-bg, #533FD1) 100%)`,
             border: `1px solid ${colorStyles.borderColor}`,
             color: colorStyles.textColor,
             '&:hover': {
-                backgroundColor: colorStyles.hoverBgColor,
+                background: `radial-gradient(115.48% 144.44% at 50% -44.44%, var(--buttons-bg-2-for-gradient, #705EE4) 38.97%, var(--buttons-bg, #533FD1) 100%)`,
                 border: `1px solid ${colorStyles.hoverBgColor}`,
                 boxShadow: shadows.sm,
             },
             '&:disabled': {
                 backgroundColor: colorStyles.disabledBgColor,
+                background: 'none',
                 border: `1px solid ${colorStyles.disabledBorderColor}`,
                 color: colorStyles.disabledTextColor,
                 boxShadow: shadows.xs,
@@ -138,6 +153,19 @@ const getButtonVariantStyles = (variant: ButtonVariant, colorStyles: ColorStyles
                 color: colorStyles.disabledTextColor,
             },
         },
+        secondary: {
+            backgroundColor: colorStyles.bgColor,
+            border: 'none',
+            color: colorStyles.textColor,
+            '&:hover': {
+                backgroundColor: colorStyles.hoverBgColor,
+                boxShadow: 'none',
+            },
+            '&:disabled': {
+                backgroundColor: colorStyles.disabledBgColor,
+                color: colorStyles.disabledTextColor,
+            },
+        },
     };
 
     return variantStyles[variant];
@@ -147,7 +175,7 @@ const getButtonVariantStyles = (variant: ButtonVariant, colorStyles: ColorStyles
 const getButtonFontStyles = (size: SizeOptions) => {
     const baseFontStyles = {
         fontFamily: typography.fonts.body,
-        fontWeight: typography.fontWeights.normal,
+        fontWeight: typography.fontWeights.semiBold,
         lineHeight: typography.lineHeights.none,
     };
 

--- a/datahub-web-react/src/app/glossaryV2/GlossaryContentProvider.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryContentProvider.tsx
@@ -66,7 +66,7 @@ const GlossaryContentProvider = (props: Props) => {
                     <Button
                         data-testid="add-term-group-button-v2"
                         id={BUSINESS_GLOSSARY_CREATE_TERM_GROUP_ID}
-                        size="lg"
+                        size="md"
                         icon={{ icon: 'Add', source: 'material' }}
                         // can not be disabled on acryl-main due to ability to propose
                         onClick={() => setIsCreateNodeModalVisible(true)}


### PR DESCRIPTION
- Added gradient for cool design tech feel 
- Added Secondary Button 
- Updated Button text weight 
(also updated create glossary button changed it to md because it was way too big) 

Button: 
<img width="226" alt="Screenshot 2025-04-08 at 10 12 13 AM" src="https://github.com/user-attachments/assets/09fec556-5f7c-486d-aa01-13d1d14dacd9" />
<img width="199" alt="Screenshot 2025-04-08 at 10 12 37 AM" src="https://github.com/user-attachments/assets/c15a736c-ce0e-40d2-b551-9a09ddeedd2e" />


Before:
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 34 AM" src="https://github.com/user-attachments/assets/c90bb030-19dd-47a5-ade3-d773a58402e9" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 40 AM" src="https://github.com/user-attachments/assets/6d8b6944-293b-4996-925b-accee2ab98e8" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 42 AM" src="https://github.com/user-attachments/assets/ebf78241-6d81-45af-ad77-0dc04e6e44c4" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 45 AM" src="https://github.com/user-attachments/assets/516c8ef1-59ef-4f2b-acf7-02430559172f" />



After:
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 08 AM" src="https://github.com/user-attachments/assets/5bac6926-d34a-48fc-bfe6-082258567a33" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 05 AM" src="https://github.com/user-attachments/assets/07f7e48e-0ab1-43bb-b6b5-e269f4e355b4" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 09 00 AM" src="https://github.com/user-attachments/assets/8d0c9084-b1fe-4a58-a410-497935d7292a" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 08 58 AM" src="https://github.com/user-attachments/assets/544263a5-6ac6-40ea-951d-e8a7237550b1" />
<img width="1728" alt="Screenshot 2025-04-08 at 10 08 53 AM" src="https://github.com/user-attachments/assets/269e69db-39e0-4435-a58a-815b4aecb71d" />


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
