### PR TITLE
fix(ui) Fix query tab filter dropdowns showing raw urns (#5230)

### DIFF
--- a/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/__tests__/utils.test.tsx
@@ -21,8 +21,10 @@ import {
     canCreateViewFromFilters,
     isAnyOptionSelected,
     getStructuredPropFilterDisplayName,
+    getFilterDisplayName,
 } from '../utils';
 import { ENTITY_SUB_TYPE_FILTER_NAME } from '../../utils/constants';
+import { FieldType, FilterField } from '../types';
 
 describe('filter utils - getNewFilters', () => {
     it('should get the correct list of filters when adding filters where the filter field did not already exist', () => {
@@ -465,5 +467,25 @@ describe('filter utils - getStructuredPropFilterDisplayName', () => {
                 '`test` _value_ for a [rich](www.google.com) text **situation** right here!',
             ),
         ).toBe('test value for a rich text situation right here!');
+    });
+});
+
+describe('filter utils - getFilterDisplayName', () => {
+    it('should return the displayName for an option if it exists', () => {
+        const option = { value: 'testValue', displayName: 'test name' };
+        const field: FilterField = { type: FieldType.ENUM, field: 'test', displayName: 'test' };
+        expect(getFilterDisplayName(option, field)).toBe('test name');
+    });
+
+    it('should return undefined if no display name and field is not a structured property filter', () => {
+        const option = { value: 'testValue' };
+        const field: FilterField = { type: FieldType.ENUM, field: 'structuredProperties.test', displayName: 'test' };
+        expect(getFilterDisplayName(option, field)).toBe('testValue');
+    });
+
+    it('should return the structured property value properly if this is a structured property filter (structured prop value is tested above)', () => {
+        const option = { value: 'testValue' };
+        const field: FilterField = { type: FieldType.ENUM, field: 'test', displayName: 'test' };
+        expect(getFilterDisplayName(option, field)).toBe(undefined);
     });
 });

--- a/datahub-web-react/src/app/searchV2/filters/utils.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/utils.tsx
@@ -52,7 +52,14 @@ import { EntityRegistry } from '../../../entityRegistryContext';
 import { ANTD_GRAY } from '../../entity/shared/constants';
 import { GetAutoCompleteMultipleResultsQuery } from '../../../graphql/search.generated';
 import { FACETS_TO_ENTITY_TYPES } from './constants';
-import { FieldType, FilterField, FilterOperatorType, FilterOptionType, FilterPredicate } from './types';
+import {
+    FieldType,
+    FilterField,
+    FilterOperatorType,
+    FilterOptionType,
+    FilterPredicate,
+    FilterValueOption,
+} from './types';
 import { capitalizeFirstLetterOnly, forcePluralize, pluralizeIfIrregular } from '../../shared/textUtil';
 import { convertBackendToFrontendOperatorType } from './operator/operator';
 import { ALL_FILTER_FIELDS, STRUCTURED_PROPERTY_FILTER } from './field/fields';
@@ -671,4 +678,14 @@ export function getIsDateRangeFilter(field: FilterField | FacetMetadata) {
         return (field.entity as StructuredPropertyEntity).definition?.valueType?.urn === DATE_TYPE_URN;
     }
     return false;
+}
+
+export function getFilterDisplayName(option: FilterValueOption, field: FilterField) {
+    if (option.displayName) {
+        return option.displayName;
+    }
+
+    return field.field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME)
+        ? getStructuredPropFilterDisplayName(field.field, option.value)
+        : undefined;
 }

--- a/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
+++ b/datahub-web-react/src/app/searchV2/filters/value/EnumValueMenu.tsx
@@ -5,8 +5,7 @@ import { useEntityRegistry } from '../../../useEntityRegistry';
 import OptionsDropdownMenu from '../OptionsDropdownMenu';
 import { deduplicateOptions, useFilterOptionsBySearchQuery, useLoadAggregationOptions } from './utils';
 import { OptionMenu } from './styledComponents';
-import { getStructuredPropFilterDisplayName, useFilterDisplayName } from '../utils';
-import { STRUCTURED_PROPERTIES_FILTER_NAME } from '../../utils/constants';
+import { getFilterDisplayName, useFilterDisplayName } from '../utils';
 
 interface Props {
     field: FilterField;
@@ -52,10 +51,7 @@ export default function EnumValueMenu({
                 value: option.value,
                 count: option.count,
                 entity: option.entity,
-                displayName:
-                    option.displayName || field.field.startsWith(STRUCTURED_PROPERTIES_FILTER_NAME)
-                        ? getStructuredPropFilterDisplayName(field.field, option.value)
-                        : undefined,
+                displayName: getFilterDisplayName(option, field),
             },
             entityRegistry,
             selectedFilterOptions: values.map((value) => {


### PR DESCRIPTION
Fixes the query tab filters in the UI that were showing urns for values instead of their display names. There was a bug with the way we were getting `displayName` before from a filter, so i broke it out into its own function and added tests.

**Before:**
<img width="584" alt="image" src="https://github.com/user-attachments/assets/88a57a2f-ca68-41a6-98bc-34440c988b00" />


**After:**
<img width="637" alt="image" src="https://github.com/user-attachments/assets/c3608310-8237-45eb-a77a-b3cbca75b066" />



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
