### PR TITLE
fix(ui) Render assets owned by groups you are member of as your own assets

### DIFF
--- a/datahub-web-react/src/app/entity/user/UserAssets.tsx
+++ b/datahub-web-react/src/app/entity/user/UserAssets.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import useGetUserGroupUrns from '@src/app/entityV2/user/useGetUserGroupUrns';
 import { UnionType } from '../../search/utils/constants';
 import { EmbeddedListSearchSection } from '../shared/components/styled/search/EmbeddedListSearchSection';
 
@@ -13,13 +14,17 @@ type Props = {
 };
 
 export const UserAssets = ({ urn }: Props) => {
+    const { groupUrns, data, loading } = useGetUserGroupUrns(urn);
+
+    if (!data || loading) return null;
+
     return (
         <UserAssetsWrapper>
             <EmbeddedListSearchSection
                 skipCache
                 fixedFilters={{
                     unionType: UnionType.AND,
-                    filters: [{ field: 'owners', values: [urn] }],
+                    filters: [{ field: 'owners', values: [urn, ...groupUrns] }],
                 }}
                 emptySearchQuery="*"
                 placeholderText="Filter entities..."

--- a/datahub-web-react/src/app/entityV2/group/GroupMembersSidebarSectionContent.tsx
+++ b/datahub-web-react/src/app/entityV2/group/GroupMembersSidebarSectionContent.tsx
@@ -22,6 +22,11 @@ export default function GroupMembersSidebarSectionContent({ groupMemberRelations
     const entityRegistry = useEntityRegistry();
     const relationshipsTotal = groupMemberRelationships?.total || 0;
     const relationshipsAvailableCount = groupMemberRelationships.relationships?.length || 0;
+
+    const hasHiddenEntities = relationshipsTotal > relationshipsAvailableCount;
+    const isShowingMaxEntities = entityCount >= relationshipsAvailableCount;
+    const showAndMoreText = hasHiddenEntities && isShowingMaxEntities;
+
     return (
         <>
             <TagsSection>
@@ -42,7 +47,7 @@ export default function GroupMembersSidebarSectionContent({ groupMemberRelations
                     showMaxEntity={DEFAULT_MAX_ENTITIES_TO_SHOW}
                 />
             )}
-            {relationshipsTotal > relationshipsAvailableCount && entityCount >= relationshipsAvailableCount && (
+            {showAndMoreText && (
                 <ShowMoreButton onClick={() => history.replace(`${url}/${TabType.Members.toLocaleLowerCase()}`)}>
                     View all members
                 </ShowMoreButton>

--- a/datahub-web-react/src/app/entityV2/shared/SidebarStyledComponents.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/SidebarStyledComponents.tsx
@@ -377,16 +377,24 @@ export const WhiteEditOutlinedIconStyle = styled(EditOutlinedIcon)`
     }
 `;
 
-export const ShowMoreButton = styled.div`
+const showMoreStyles = `
     margin-top: 8px;
     padding: 0px;
     color: ${ANTD_GRAY[7]};
     text-align: left;
+`;
+
+export const ShowMoreButton = styled.div`
+    ${showMoreStyles}
     :hover {
         cursor: pointer;
         color: ${ANTD_GRAY[8]};
         text-decoration: underline;
     }
+`;
+
+export const ShowMoreText = styled.div`
+    ${showMoreStyles}
 `;
 
 export const CountStyle = styled.div`

--- a/datahub-web-react/src/app/entityV2/shared/sidebarSection/UserOwnershipSideBarSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/sidebarSection/UserOwnershipSideBarSection.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Col } from 'antd';
-import { OwnershipContainer } from '../SidebarStyledComponents';
+import { OwnershipContainer, ShowMoreText } from '../SidebarStyledComponents';
 import { SidebarSection } from '../containers/profile/sidebar/SidebarSection';
 import { EntityLink } from '../../../homeV2/reference/sections/EntityLink';
-import { SearchResult } from '../../../../types.generated';
+import { SearchResults } from '../../../../types.generated';
 import { ShowMoreSection } from './ShowMoreSection';
 
 const DEFAULT_MAX_ENTITIES_TO_SHOW = 4;
@@ -15,17 +15,24 @@ const entityLinkTextStyle = {
 };
 
 type Props = {
-    ownedEntities: SearchResult[] | undefined;
+    ownershipResults: SearchResults | undefined;
 };
 
-export const UserOwnershipSidebarSection = ({ ownedEntities }: Props) => {
+export const UserOwnershipSidebarSection = ({ ownershipResults }: Props) => {
     const [entityCount, setEntityCount] = useState(DEFAULT_MAX_ENTITIES_TO_SHOW);
-    const ownedEntitiesCount = ownedEntities?.length || 0;
+    const ownedEntitiesTotal = ownershipResults?.total || 0;
+    const ownedEntities = ownershipResults?.searchResults;
+    const entitiesAvailableCount = ownedEntities?.length || 0;
+
+    const hasHiddenEntities = ownedEntitiesTotal > entitiesAvailableCount;
+    const isShowingMaxEntities = entityCount >= entitiesAvailableCount;
+    const showAndMoreText = hasHiddenEntities && isShowingMaxEntities;
 
     return (
         <SidebarSection
             title="Owner Of"
-            count={ownedEntities?.length}
+            count={ownedEntitiesTotal}
+            showFullCount
             content={
                 <>
                     <OwnershipContainer>
@@ -44,13 +51,16 @@ export const UserOwnershipSidebarSection = ({ ownedEntities }: Props) => {
                             );
                         })}
                     </OwnershipContainer>
-                    {ownedEntitiesCount > entityCount && (
+                    {entitiesAvailableCount > entityCount && (
                         <ShowMoreSection
-                            totalCount={ownedEntitiesCount}
+                            totalCount={entitiesAvailableCount}
                             entityCount={entityCount}
                             setEntityCount={setEntityCount}
                             showMaxEntity={DEFAULT_MAX_ENTITIES_TO_SHOW}
                         />
+                    )}
+                    {showAndMoreText && (
+                        <ShowMoreText>+ {ownedEntitiesTotal - entitiesAvailableCount} more</ShowMoreText>
                     )}
                 </>
             }

--- a/datahub-web-react/src/app/entityV2/user/UserAssets.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserAssets.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { UnionType } from '../../search/utils/constants';
 import { EmbeddedListSearchSection } from '../shared/components/styled/search/EmbeddedListSearchSection';
+import useGetUserGroupUrns from './useGetUserGroupUrns';
 
 const UserAssetsWrapper = styled.div`
     height: 100%;
@@ -12,13 +13,17 @@ type Props = {
 };
 
 export const UserAssets = ({ urn }: Props) => {
+    const { groupUrns, data, loading } = useGetUserGroupUrns(urn);
+
+    if (!data || loading) return null;
+
     return (
         <UserAssetsWrapper>
             <EmbeddedListSearchSection
                 skipCache
                 fixedFilters={{
                     unionType: UnionType.AND,
-                    filters: [{ field: 'owners', values: [urn] }],
+                    filters: [{ field: 'owners', values: [urn, ...groupUrns] }],
                 }}
                 emptySearchQuery="*"
                 placeholderText="Filter entities..."

--- a/datahub-web-react/src/app/entityV2/user/UserProfile.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserProfile.tsx
@@ -24,6 +24,7 @@ import { EntitySidebarTabs } from '../shared/containers/profile/sidebar/EntitySi
 import EntitySidebarSectionsTab from '../shared/containers/profile/sidebar/EntitySidebarSectionsTab';
 import EntitySidebarContext from '../../sharedV2/EntitySidebarContext';
 import SidebarCollapsibleHeader from '../shared/containers/profile/sidebar/SidebarCollapsibleHeader';
+import useGetUserGroupUrns from './useGetUserGroupUrns';
 
 export interface Props {
     urn: string;
@@ -106,7 +107,9 @@ export default function UserProfile({ urn }: Props) {
     const userRoles: Array<EntityRelationship> =
         castedCorpUser?.roles?.relationships?.map((relationship) => relationship as EntityRelationship) || [];
 
-    const { data: userOwnedAsset } = useGetUserOwnedAssetsQuery({ variables: { urn } });
+    const { groupUrns } = useGetUserGroupUrns(urn);
+
+    const { data: userOwnedAsset } = useGetUserOwnedAssetsQuery({ variables: { urns: [urn, ...groupUrns] } });
     // Routed Tabs Constants
     const getTabs = () => {
         return [
@@ -153,7 +156,7 @@ export default function UserProfile({ urn }: Props) {
         aboutText: data?.corpUser?.editableProperties?.aboutMe || undefined,
         groupsDetails: userGroups,
         dataHubRoles: userRoles,
-        ownerships: userOwnedAsset?.searchAcrossEntities?.searchResults || undefined,
+        ownershipResults: userOwnedAsset?.searchAcrossEntities || undefined,
         urn,
     };
 

--- a/datahub-web-react/src/app/entityV2/user/UserProfileInfoCard.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserProfileInfoCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Col } from 'antd';
-import { EntityRelationship, SearchResult } from '../../../types.generated';
+import { EntityRelationship, SearchResults } from '../../../types.generated';
 import SectionActionButton from '../shared/containers/profile/sidebar/SectionActionButton';
 import UserEditProfileModal from './UserEditProfileModal';
 import CustomAvatar from '../../shared/avatar/CustomAvatar';
@@ -31,7 +31,7 @@ export type SidebarData = {
     phone: string | undefined;
     aboutText: string | undefined;
     groupsDetails: Array<EntityRelationship>;
-    ownerships: Array<SearchResult> | undefined;
+    ownershipResults: SearchResults | undefined;
     urn: string | undefined;
     dataHubRoles: Array<EntityRelationship>;
 };

--- a/datahub-web-react/src/app/entityV2/user/UserSidebar.tsx
+++ b/datahub-web-react/src/app/entityV2/user/UserSidebar.tsx
@@ -18,7 +18,7 @@ type Props = {
  * UserSidebar- Sidebar section for users profiles.
  */
 export default function UserSidebar({ sidebarData, refetch }: Props) {
-    const { aboutText, groupsDetails, dataHubRoles, urn, ownerships } = sidebarData;
+    const { aboutText, groupsDetails, dataHubRoles, urn, ownershipResults } = sidebarData;
 
     const [updateCorpUserPropertiesMutation] = useUpdateCorpUserPropertiesMutation();
 
@@ -66,7 +66,7 @@ export default function UserSidebar({ sidebarData, refetch }: Props) {
                     isProfileOwner={isProfileOwner}
                     onSaveAboutMe={onSaveAboutMe}
                 />
-                <UserOwnershipSidebarSection ownedEntities={ownerships} />
+                <UserOwnershipSidebarSection ownershipResults={ownershipResults} />
                 <UserGroupSideBarSection groupsDetails={groupsDetails} />
             </Content>
         </SideBar>

--- a/datahub-web-react/src/app/entityV2/user/useGetUserGroupUrns.ts
+++ b/datahub-web-react/src/app/entityV2/user/useGetUserGroupUrns.ts
@@ -1,0 +1,15 @@
+import { useGetUserGroupsUrnsQuery } from '@src/graphql/user.generated';
+
+const NUM_GROUP_URNS_TO_FETCH = 100;
+
+export default function useGetUserGroupUrns(userUrn: string) {
+    const { data, loading } = useGetUserGroupsUrnsQuery({
+        variables: { urn: userUrn, start: 0, count: NUM_GROUP_URNS_TO_FETCH },
+        fetchPolicy: 'cache-first',
+    });
+
+    const groupUrns: string[] =
+        data?.corpUser?.relationships?.relationships.map((r) => r.entity?.urn || '').filter((u) => !!u) || [];
+
+    return { groupUrns, data, loading };
+}

--- a/datahub-web-react/src/app/homeV2/reference/sections/assets/AssetsYouOwn.tsx
+++ b/datahub-web-react/src/app/homeV2/reference/sections/assets/AssetsYouOwn.tsx
@@ -1,13 +1,9 @@
 import React, { useState } from 'react';
+import useGetUserGroupUrns from '@src/app/entityV2/user/useGetUserGroupUrns';
 import { useUserContext } from '../../../../context/useUserContext';
 import { EntityLinkList } from '../EntityLinkList';
 import { EmbeddedListSearchModal } from '../../../../entityV2/shared/components/styled/search/EmbeddedListSearchModal';
-import {
-    ASSET_ENTITY_TYPES,
-    ENTITY_FILTER_NAME,
-    OWNERS_FILTER_NAME,
-    UnionType,
-} from '../../../../searchV2/utils/constants';
+import { OWNERS_FILTER_NAME, UnionType } from '../../../../searchV2/utils/constants';
 import { useGetAssetsYouOwn } from './useGetAssetsYouOwn';
 import { EmptyAssetsYouOwn } from './EmptyAssetsYouOwn';
 import { ReferenceSectionProps } from '../../types';
@@ -21,6 +17,7 @@ export const AssetsYouOwn = ({ hideIfEmpty }: ReferenceSectionProps) => {
     const { user } = userContext;
     const [entityCount, setEntityCount] = useState(DEFAULT_MAX_ENTITIES_TO_SHOW);
     const [showModal, setShowModal] = useState(false);
+    const { groupUrns } = useGetUserGroupUrns(user?.urn || '');
     const { entities, loading } = useGetAssetsYouOwn(user);
 
     if (hideIfEmpty && entities.length === 0) {
@@ -49,10 +46,7 @@ export const AssetsYouOwn = ({ hideIfEmpty }: ReferenceSectionProps) => {
                     title="Your assets"
                     fixedFilters={{
                         unionType: UnionType.AND,
-                        filters: [
-                            { field: OWNERS_FILTER_NAME, values: [user?.urn as string] },
-                            { field: ENTITY_FILTER_NAME, values: [...ASSET_ENTITY_TYPES] },
-                        ],
+                        filters: [{ field: OWNERS_FILTER_NAME, values: [user?.urn as string, ...groupUrns] }],
                     }}
                     onClose={() => setShowModal(false)}
                     placeholderText="Filter assets you own..."

--- a/datahub-web-react/src/graphql/user.graphql
+++ b/datahub-web-react/src/graphql/user.graphql
@@ -135,6 +135,29 @@ query getUserGroups($urn: String!, $start: Int!, $count: Int!) {
     }
 }
 
+query getUserGroupsUrns($urn: String!, $start: Int!, $count: Int!) {
+    corpUser(urn: $urn) {
+        relationships(
+            input: {
+                types: ["IsMemberOfGroup", "IsMemberOfNativeGroup"]
+                direction: OUTGOING
+                start: $start
+                count: $count
+            }
+        ) {
+            start
+            count
+            total
+            relationships {
+                entity {
+                    urn
+                    type
+                }
+            }
+        }
+    }
+}
+
 query listUsers($input: ListUsersInput!) {
     listUsers(input: $input) {
         start
@@ -245,8 +268,8 @@ mutation updateCorpUserViewsSettings($input: UpdateCorpUserViewsSettingsInput!) 
     updateCorpUserViewsSettings(input: $input)
 }
 
-query getUserOwnedAssets($urn: String!) {
-    searchAcrossEntities(input: { query: "", filters: [{ field: "owners", values: [$urn] }] }) {
+query getUserOwnedAssets($urns: [String!]!) {
+    searchAcrossEntities(input: { query: "", filters: [{ field: "owners", values: $urns }] }) {
         ...searchResults
     }
 }


### PR DESCRIPTION
Everywhere we show you "assets you own" we should also be showing you the assets that the groups you are a member of own as well - this is how our permissioning system works anyways.

This PR takes care of that in both the V1 and V2 UI. I do this by creating a reusable hook that gets the groups you are a member of and passes those group urns into the queries to get assets that the user owns.

In the V1 UI this is only on the user profile page under the tab for these assets.

In the V2 UI it is on the user profile page tab just like v1 UI, as well as the user profile page sidebar. It also shows up on the home page on the left sidebar section under your profile image.



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
