### PR TITLE
feat(froms) Add validator preventing duplicate form prompt IDs globally

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/forms/validation/FormPromptValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/forms/validation/FormPromptValidator.java
@@ -1,0 +1,100 @@
+package com.linkedin.metadata.forms.validation;
+
+import static com.linkedin.metadata.Constants.*;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.linkedin.form.FormInfo;
+import com.linkedin.form.FormPrompt;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.batch.BatchItem;
+import com.linkedin.metadata.aspect.batch.ChangeMCP;
+import com.linkedin.metadata.aspect.plugins.config.AspectPluginConfig;
+import com.linkedin.metadata.aspect.plugins.validation.AspectPayloadValidator;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
+import com.linkedin.metadata.aspect.plugins.validation.ValidationExceptionCollection;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.utils.elasticsearch.FilterUtils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+
+@Setter
+@Getter
+@Slf4j
+@Accessors(chain = true)
+public class FormPromptValidator extends AspectPayloadValidator {
+
+  @Nonnull private AspectPluginConfig config;
+
+  private static final String PROMPT_ID_FIELD = "promptId";
+
+  @Override
+  protected Stream<AspectValidationException> validateProposedAspects(
+      @Nonnull Collection<? extends BatchItem> mcpItems,
+      @Nonnull RetrieverContext retrieverContext) {
+    return validateFormInfoUpserts(mcpItems, retrieverContext);
+  }
+
+  @Override
+  protected Stream<AspectValidationException> validatePreCommitAspects(
+      @Nonnull Collection<ChangeMCP> changeMCPs, @Nonnull RetrieverContext retrieverContext) {
+    return Stream.empty();
+  }
+
+  @VisibleForTesting
+  public static Stream<AspectValidationException> validateFormInfoUpserts(
+      @Nonnull Collection<? extends BatchItem> mcpItems,
+      @Nonnull RetrieverContext retrieverContext) {
+    ValidationExceptionCollection exceptions = ValidationExceptionCollection.newCollection();
+    for (BatchItem mcpItem : mcpItems) {
+      FormInfo formInfo = mcpItem.getAspect(FormInfo.class);
+      if (formInfo != null) {
+        List<String> promptIds =
+            formInfo.getPrompts().stream().map(FormPrompt::getId).collect(Collectors.toList());
+        Set<String> uniquePromptIds = new HashSet<>(promptIds);
+        if (promptIds.size() != uniquePromptIds.size()) {
+          exceptions.addException(
+              mcpItem,
+              String.format(
+                  "Prompt IDs must be unique, there are duplicate prompt IDs given: %s",
+                  promptIds));
+        }
+        // Search to find other forms with prompts with the same ID as any of this form's prompts
+        SearchRetriever searchRetriever = retrieverContext.getSearchRetriever();
+        ScrollResult scrollResult =
+            searchRetriever.scroll(
+                Collections.singletonList(FORM_ENTITY_NAME),
+                FilterUtils.createValuesFilter(PROMPT_ID_FIELD, promptIds),
+                null,
+                10,
+                new ArrayList<>(),
+                SearchRetriever.RETRIEVER_SEARCH_FLAGS_NO_CACHE_ALL_VERSIONS);
+
+        if (CollectionUtils.isNotEmpty(scrollResult.getEntities())) {
+          if (scrollResult.getEntities().size() > 0) {
+            exceptions.addException(
+                mcpItem,
+                "Cannot have duplicate prompt IDs across any form, all prompt IDs must be globally unique. Form urns with prompt IDs matching given prompt IDs:"
+                    + scrollResult.getEntities().stream()
+                        .map(SearchEntity::getEntity)
+                        .collect(Collectors.toList()));
+          }
+        }
+      }
+    }
+    return exceptions.streamAllExceptions();
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/forms/validators/FormPromptValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/forms/validators/FormPromptValidatorTest.java
@@ -1,0 +1,148 @@
+package com.linkedin.metadata.forms.validators;
+
+import static com.linkedin.metadata.Constants.FORM_ENTITY_NAME;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.form.FormInfo;
+import com.linkedin.form.FormPrompt;
+import com.linkedin.form.FormPromptArray;
+import com.linkedin.form.FormType;
+import com.linkedin.metadata.aspect.CachingAspectRetriever;
+import com.linkedin.metadata.aspect.GraphRetriever;
+import com.linkedin.metadata.aspect.RetrieverContext;
+import com.linkedin.metadata.aspect.plugins.validation.AspectValidationException;
+import com.linkedin.metadata.entity.SearchRetriever;
+import com.linkedin.metadata.forms.validation.FormPromptValidator;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.query.SearchFlags;
+import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.ScrollResult;
+import com.linkedin.metadata.search.SearchEntity;
+import com.linkedin.metadata.search.SearchEntityArray;
+import com.linkedin.test.metadata.aspect.TestEntityRegistry;
+import com.linkedin.test.metadata.aspect.batch.TestMCP;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class FormPromptValidatorTest {
+
+  private static final EntityRegistry TEST_REGISTRY = new TestEntityRegistry();
+  private static final Urn TEST_FORM_URN = UrnUtils.getUrn("urn:li:form:form1");
+  private static final Urn TEST_FORM_URN_2 = UrnUtils.getUrn("urn:li:form:form2");
+
+  private SearchRetriever mockSearchRetriever;
+  private CachingAspectRetriever mockAspectRetriever;
+  private GraphRetriever mockGraphRetriever;
+  private RetrieverContext retrieverContext;
+
+  @BeforeMethod
+  public void setup() {
+    mockSearchRetriever = Mockito.mock(SearchRetriever.class);
+    mockGraphRetriever = Mockito.mock(GraphRetriever.class);
+    mockAspectRetriever = Mockito.mock(CachingAspectRetriever.class);
+    retrieverContext =
+        io.datahubproject.metadata.context.RetrieverContext.builder()
+            .searchRetriever(mockSearchRetriever)
+            .graphRetriever(mockGraphRetriever)
+            .cachingAspectRetriever(mockAspectRetriever)
+            .build();
+  }
+
+  @Test
+  public void testValidUpsert() {
+    FormPromptArray prompts = new FormPromptArray();
+    prompts.add(new FormPrompt().setId("test1"));
+    FormInfo formInfo =
+        new FormInfo().setName("test form").setType(FormType.VERIFICATION).setPrompts(prompts);
+
+    Mockito.when(
+            mockSearchRetriever.scroll(
+                Mockito.eq(Collections.singletonList(FORM_ENTITY_NAME)),
+                Mockito.any(Filter.class),
+                Mockito.eq(null),
+                Mockito.eq(10),
+                Mockito.eq(new ArrayList<>()),
+                Mockito.any(SearchFlags.class)))
+        .thenReturn(new ScrollResult().setEntities(new SearchEntityArray()));
+
+    // Test validation
+    Stream<AspectValidationException> validationResult =
+        FormPromptValidator.validateFormInfoUpserts(
+            TestMCP.ofOneUpsertItem(TEST_FORM_URN, formInfo, TEST_REGISTRY), retrieverContext);
+
+    // Assert no validation exceptions
+    Assert.assertTrue(validationResult.findAny().isEmpty());
+  }
+
+  @Test
+  public void testInvalidUpsertWithDuplicatePromptIdsInOneForm() {
+    // two prompts with the same ID
+    FormPromptArray prompts = new FormPromptArray();
+    prompts.add(new FormPrompt().setId("test1"));
+    prompts.add(new FormPrompt().setId("test1"));
+    prompts.add(new FormPrompt().setId("test3"));
+    FormInfo formInfo =
+        new FormInfo().setName("test form").setType(FormType.VERIFICATION).setPrompts(prompts);
+
+    // Mock search results with no matches
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setEntities(new SearchEntityArray());
+    Mockito.when(
+            mockSearchRetriever.scroll(
+                Mockito.eq(Collections.singletonList(FORM_ENTITY_NAME)),
+                Mockito.any(Filter.class),
+                Mockito.eq(null),
+                Mockito.eq(10),
+                Mockito.eq(new ArrayList<>()),
+                Mockito.any(SearchFlags.class)))
+        .thenReturn(mockResult);
+
+    // Test validation
+    Stream<AspectValidationException> validationResult =
+        FormPromptValidator.validateFormInfoUpserts(
+            TestMCP.ofOneUpsertItem(TEST_FORM_URN, formInfo, TEST_REGISTRY), retrieverContext);
+
+    // Assert validation exception exists
+    Assert.assertFalse(validationResult.findAny().isEmpty());
+  }
+
+  @Test
+  public void testInvalidUpsertWithDuplicatePromptIdsInDifferentForm() {
+    // two prompts with the same ID
+    FormPromptArray prompts = new FormPromptArray();
+    prompts.add(new FormPrompt().setId("test1"));
+    prompts.add(new FormPrompt().setId("test2"));
+    prompts.add(new FormPrompt().setId("test3"));
+    FormInfo formInfo =
+        new FormInfo().setName("test form").setType(FormType.VERIFICATION).setPrompts(prompts);
+
+    // Mock search results with a match - meaning another form has
+    SearchEntity existingForm = new SearchEntity();
+    existingForm.setEntity(TEST_FORM_URN_2);
+    ScrollResult mockResult = new ScrollResult();
+    mockResult.setEntities(new SearchEntityArray(Collections.singletonList(existingForm)));
+    Mockito.when(
+            mockSearchRetriever.scroll(
+                Mockito.eq(Collections.singletonList(FORM_ENTITY_NAME)),
+                Mockito.any(Filter.class),
+                Mockito.eq(null),
+                Mockito.eq(10),
+                Mockito.eq(new ArrayList<>()),
+                Mockito.any(SearchFlags.class)))
+        .thenReturn(mockResult);
+
+    // Test validation
+    Stream<AspectValidationException> validationResult =
+        FormPromptValidator.validateFormInfoUpserts(
+            TestMCP.ofOneUpsertItem(TEST_FORM_URN, formInfo, TEST_REGISTRY), retrieverContext);
+
+    // Assert validation exception exists
+    Assert.assertFalse(validationResult.findAny().isEmpty());
+  }
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/form/FormPrompt.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/form/FormPrompt.pdl
@@ -9,6 +9,11 @@ record FormPrompt {
   /**
    * The unique id for this prompt. This must be GLOBALLY unique.
    */
+  @Searchable = {
+    "fieldType": "KEYWORD",
+    "fieldName": "promptId",
+    "queryByDefault": false,
+  }
   id: string
 
   /**

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/plugins/SpringStandardPluginConfiguration.java
@@ -17,6 +17,7 @@ import com.linkedin.metadata.entity.versioning.sideeffects.VersionPropertiesSide
 import com.linkedin.metadata.entity.versioning.sideeffects.VersionSetSideEffect;
 import com.linkedin.metadata.entity.versioning.validation.VersionPropertiesValidator;
 import com.linkedin.metadata.entity.versioning.validation.VersionSetPropertiesValidator;
+import com.linkedin.metadata.forms.validation.FormPromptValidator;
 import com.linkedin.metadata.schemafields.sideeffects.SchemaFieldSideEffect;
 import com.linkedin.metadata.structuredproperties.validation.HidePropertyValidator;
 import com.linkedin.metadata.structuredproperties.validation.ShowPropertyAsBadgeValidator;
@@ -189,6 +190,24 @@ public class SpringStandardPluginConfiguration {
                         AspectPluginConfig.EntityAspectName.builder()
                             .entityName(STRUCTURED_PROPERTY_ENTITY_NAME)
                             .aspectName(STRUCTURED_PROPERTY_SETTINGS_ASPECT_NAME)
+                            .build()))
+                .build());
+  }
+
+  @Bean
+  public AspectPayloadValidator formPromptValidator() {
+    return new FormPromptValidator()
+        .setConfig(
+            AspectPluginConfig.builder()
+                .className(FormPromptValidator.class.getName())
+                .enabled(true)
+                .supportedOperations(
+                    List.of("UPSERT", "UPDATE", "CREATE", "CREATE_ENTITY", "RESTATE"))
+                .supportedEntityAspectNames(
+                    List.of(
+                        AspectPluginConfig.EntityAspectName.builder()
+                            .entityName(FORM_ENTITY_NAME)
+                            .aspectName(FORM_INFO_ASPECT_NAME)
                             .build()))
                 .build());
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreFormInfoIndicesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/RestoreFormInfoIndicesStep.java
@@ -22,7 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RestoreFormInfoIndicesStep extends UpgradeStep {
-  private static final String VERSION = "1";
+  private static final String VERSION = "2";
   private static final String UPGRADE_ID = "restore-form-info-indices";
   private static final Integer BATCH_SIZE = 1000;
 

--- a/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreFormInfoIndicesStepTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/metadata/boot/steps/RestoreFormInfoIndicesStepTest.java
@@ -37,8 +37,8 @@ import org.testng.annotations.Test;
 
 public class RestoreFormInfoIndicesStepTest {
 
-  private static final String VERSION_1 = "1";
-  private static final String VERSION_2 = "2";
+  private static final String CURRENT_VERSION = "2";
+  private static final String NEW_VERSION = "3";
   private static final String FORM_INFO_UPGRADE_URN =
       String.format(
           "urn:li:%s:%s", Constants.DATA_HUB_UPGRADE_ENTITY_NAME, "restore-form-info-indices");
@@ -51,7 +51,7 @@ public class RestoreFormInfoIndicesStepTest {
     final OperationContext mockContext = mock(OperationContext.class);
     when(mockContext.getEntityRegistry()).thenReturn(mockRegistry);
 
-    mockGetUpgradeStep(mockContext, false, VERSION_1, mockService);
+    mockGetUpgradeStep(mockContext, false, CURRENT_VERSION, mockService);
     mockGetFormInfo(mockContext, formUrn, mockService);
 
     final AspectSpec aspectSpec = mockAspectSpecs(mockRegistry);
@@ -90,7 +90,7 @@ public class RestoreFormInfoIndicesStepTest {
     final OperationContext mockContext = mock(OperationContext.class);
     when(mockContext.getEntityRegistry()).thenReturn(mockRegistry);
 
-    mockGetUpgradeStep(mockContext, true, VERSION_2, mockService);
+    mockGetUpgradeStep(mockContext, true, NEW_VERSION, mockService);
     mockGetFormInfo(mockContext, formUrn, mockService);
 
     final AspectSpec aspectSpec = mockAspectSpecs(mockRegistry);
@@ -129,7 +129,7 @@ public class RestoreFormInfoIndicesStepTest {
     final OperationContext mockContext = mock(OperationContext.class);
     when(mockContext.getEntityRegistry()).thenReturn(mockRegistry);
 
-    mockGetUpgradeStep(mockContext, true, VERSION_1, mockService);
+    mockGetUpgradeStep(mockContext, true, CURRENT_VERSION, mockService);
     mockGetFormInfo(mockContext, formUrn, mockService);
 
     final AspectSpec aspectSpec = mockAspectSpecs(mockRegistry);


### PR DESCRIPTION
We want prompt IDs to be globally unique within a form or across forms. This PR adds the validator that will ensure this is the case. In order for this to work, prompt IDs need to be searchable on forms, though. So I add a searchable annotation and update the version to an existing backfill job to restore the indices of formInfo aspects. There should be very few of these on any given instance.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
