### PR TITLE
Updated impact / explore switch to colors.violet[600]

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/tabs/Lineage/LineageTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Lineage/LineageTab.tsx
@@ -1,4 +1,5 @@
 import LineageGraph from '@app/lineageV2/LineageGraph';
+import { colors } from '@components';
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { LineageDirection } from '../../../../../types.generated';
@@ -20,7 +21,7 @@ const LineageTabWrapper = styled.div`
 `;
 
 const LineageSwitchWrapper = styled.div`
-    border: 1px solid #5d09c9;
+    border: 1px solid ${colors.violet[600]};
     border-radius: 4.5px;
     display: flex;
     margin: 13px 11px;
@@ -28,9 +29,9 @@ const LineageSwitchWrapper = styled.div`
 `;
 
 const LineageViewSwitch = styled.div<{ selected: boolean }>`
-    background: ${({ selected }) => (selected ? '#5d09c9' : '#fff')};
+    background: ${({ selected }) => (selected ? colors.violet[600] : '#fff')};
     border-radius: 3px;
-    color: ${({ selected }) => (selected ? '#fff' : '#5d09c9')};
+    color: ${({ selected }) => (selected ? '#fff' : colors.violet[600])};
     cursor: pointer;
     display: flex;
     font-size: 10px;


### PR DESCRIPTION
- Updated color


**Before**
<img width="224" alt="Screenshot 2025-04-08 at 11 44 41 AM" src="https://github.com/user-attachments/assets/5f8b526f-d4df-4712-8602-071c495a73d6" />
**After**
<img width="217" alt="Screenshot 2025-04-08 at 11 44 49 AM" src="https://github.com/user-attachments/assets/0fd0c72f-832d-47ef-9683-63b6c41b8cb2" />


**Before**
<img width="1776" alt="Screenshot 2025-04-08 at 11 44 39 AM" src="https://github.com/user-attachments/assets/8675c534-8585-4b4e-b829-4ea2d5965141" />
**After**
<img width="1820" alt="Screenshot 2025-04-08 at 11 44 31 AM" src="https://github.com/user-attachments/assets/16528717-9935-4fa1-931c-c89d6cd6d0e4" />


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
