### PR TITLE
Clear icons were purple after adding button gradient

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Select/components.ts
+++ b/datahub-web-react/src/alchemy-components/components/Select/components.ts
@@ -176,9 +176,9 @@ export const StyledIcon = styled(Icon)({
     color: colors.gray[1800],
 });
 
-export const StyledClearButton = styled(Button)({
-    backgroundColor: colors.transparent,
-    border: 'none',
+export const StyledClearButton = styled(Button).attrs({
+    variant: 'text',
+})({
     color: colors.gray[1800],
     padding: '0px',
 


### PR DESCRIPTION
- Update minor icon issue 


Before:
<img width="308" alt="Screenshot 2025-04-08 at 4 07 12 PM" src="https://github.com/user-attachments/assets/85e2a604-b267-411c-8853-9a17d30a8df5" />
After: 
<img width="332" alt="Screenshot 2025-04-08 at 4 07 01 PM" src="https://github.com/user-attachments/assets/c1e01056-546b-4193-8089-71cbd58a49ce" />


- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
