### PR TITLE
refactor(ui): UI hotfixes for the deprecated popover + sidebar logic section

### DIFF
--- a/datahub-web-react/src/alchemy-components/components/Pills/utils.ts
+++ b/datahub-web-react/src/alchemy-components/components/Pills/utils.ts
@@ -25,7 +25,7 @@ function getPillColorStyles(variant: PillVariantOptions, color: ColorOptions): C
         primaryColor: getColor(color, 500),
         bgColor: color === 'gray' ? getColor(color, 100) : getColor(color, 0),
         hoverColor: color === 'gray' ? getColor(color, 100) : getColor(color, 1100),
-        borderColor: getColor('gray', 1400),
+        borderColor: getColor('gray', 1800),
     };
 }
 

--- a/datahub-web-react/src/alchemy-components/components/Tooltip2/Tooltip2.tsx
+++ b/datahub-web-react/src/alchemy-components/components/Tooltip2/Tooltip2.tsx
@@ -50,7 +50,7 @@ export function Tooltip2(props: Tooltip2Props & TooltipProps) {
             overlayInnerStyle={{
                 fontFamily: 'Mulish',
                 padding: '12px',
-                borderRadius: '8px',
+                borderRadius: '12px',
             }}
         >
             {props.children}

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
@@ -1,6 +1,6 @@
-import { Button } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { Button } from '@src/alchemy-components';
 import { Editor } from './editor/Editor';
 
 const LINE_HEIGHT = 1.5;
@@ -30,8 +30,7 @@ const MarkdownContainer = styled.div<{ lineLimit?: number | null }>`
 `;
 
 const CustomButton = styled(Button)`
-    padding: 0;
-    color: #676b75;
+    padding: 8px 0px;
 `;
 
 const MarkdownViewContainer = styled.div<{ scrollableY: boolean }>`
@@ -149,8 +148,15 @@ export default function CompactMarkdownViewer({
                 (isShowingMore || isTruncated) && ( // "show more" when isTruncated, "show less" when isShowingMore
                     <ShowMoreWrapper>
                         <CustomButton
-                            type="link"
-                            onClick={() => (handleShowMore ? handleShowMore() : setIsShowingMore(!isShowingMore))}
+                            variant="text"
+                            onClick={(e) => {
+                                if (handleShowMore) {
+                                    handleShowMore();
+                                } else {
+                                    setIsShowingMore(!isShowingMore);
+                                }
+                                e.stopPropagation();
+                            }}
                         >
                             {isShowingMore ? 'show less' : 'show more'}
                         </CustomButton>

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/DeprecationIcon.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/DeprecationIcon.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Popover, Tooltip } from '@components';
+import { colors, Tooltip } from '@components';
 import { Divider, Modal, Typography, message } from 'antd';
 import moment from 'moment';
 import { TooltipPlacement } from 'antd/es/tooltip';
+import { Tooltip2 } from '@src/alchemy-components/components/Tooltip2';
+import CompactMarkdownViewer from '@src/app/entity/shared/tabs/Documentation/components/CompactMarkdownViewer';
 import DeprecatedIcon from '../../../../../images/deprecated-status.svg?react';
 import { useBatchUpdateDeprecationMutation } from '../../../../../graphql/mutations.generated';
 import { Deprecation, SubResourceType } from '../../../../../types.generated';
 import { EntityLink } from '../../../../homeV2/reference/sections/EntityLink';
 import { getV1FieldPathFromSchemaFieldUrn } from '../../../../lineageV2/lineageUtils';
-import { getLocaleTimezone, toLocalDateString } from '../../../../shared/time/timeUtils';
+import { toLocalDateString } from '../../../../shared/time/timeUtils';
 import { REDESIGN_COLORS } from '../../constants';
 import MarkAsDeprecatedButton from './MarkAsDeprecatedButton';
 
@@ -23,7 +25,7 @@ const DeprecatedContainer = styled.div`
 
 const DeprecatedTitle = styled(Typography.Text)`
     display: block;
-    font-size: 14px;
+    font-size: 16px;
     margin-bottom: 5px;
     font-weight: bold;
     color: ${REDESIGN_COLORS.TEXT_HEADING};
@@ -32,10 +34,8 @@ const DeprecatedTitle = styled(Typography.Text)`
 const DeprecatedSubTitle = styled(Typography.Text)`
     display: block;
     margin-bottom: 5px;
+    font-size: 12px;
     color: ${REDESIGN_COLORS.TEXT_HEADING};
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     max-width: 100%;
 `;
 
@@ -44,7 +44,8 @@ const LastEvaluatedAtLabel = styled.div`
     margin: 0;
     display: flex;
     align-items: center;
-    color: ${REDESIGN_COLORS.SUB_TEXT};
+    color: ${colors.gray[1800]};
+    font-size: 14px;
 `;
 
 const ReplacementContainer = styled.span`
@@ -105,7 +106,6 @@ export const DeprecationIcon = ({
     popoverPlacement = 'bottom',
 }: Props) => {
     const [batchUpdateDeprecationMutation] = useBatchUpdateDeprecationMutation();
-    const localeTimezone = getLocaleTimezone(); // Deprecation Decommission Timestamp
 
     let decommissionTimeSeconds;
     if (deprecation.decommissionTime) {
@@ -118,9 +118,7 @@ export const DeprecationIcon = ({
     }
     const decommissionTimeLocal =
         (decommissionTimeSeconds &&
-            `Scheduled to be decommissioned on ${toLocalDateString(
-                decommissionTimeSeconds * 1000,
-            )} (${localeTimezone})`) ||
+            `Scheduled to be decommissioned on ${toLocalDateString(decommissionTimeSeconds * 1000)}`) ||
         undefined;
     const decommissionTimeGMT =
         decommissionTimeSeconds && moment.unix(decommissionTimeSeconds).utc().format('dddd, DD/MMM/YYYY HH:mm:ss z');
@@ -156,15 +154,14 @@ export const DeprecationIcon = ({
     const entityTypeDisplayName = subResourceType === SubResourceType.DatasetField ? 'column' : 'asset';
 
     return (
-        <Popover
-            overlayStyle={{ maxWidth: 240 }}
+        <Tooltip2
             zIndex={zIndexOverride || 999} // set to 999 to ensure it is below the 1000 mark of the entity popover if on the entity level
             placement={popoverPlacement}
-            content={
+            width={340}
+            title={
                 hasDetails ? (
                     <>
                         <DeprecatedTitle>This {entityTypeDisplayName} is deprecated</DeprecatedTitle>
-                        {isDividerNeeded && <ThinDivider />}
                         {deprecation.replacement && (
                             <DeprecatedSubTitle>
                                 {isReplacementSchemaField ? (
@@ -181,13 +178,15 @@ export const DeprecationIcon = ({
                                 )}
                             </DeprecatedSubTitle>
                         )}
-                        {deprecation?.note !== '' && <DeprecatedSubTitle>{deprecation.note}</DeprecatedSubTitle>}
+                        {deprecation?.note && (
+                            <DeprecatedSubTitle>
+                                <CompactMarkdownViewer content={deprecation.note} />
+                            </DeprecatedSubTitle>
+                        )}
                         {deprecation?.decommissionTime !== null && (
-                            <Typography.Text type="secondary">
-                                <Tooltip placement="right" title={decommissionTimeGMT}>
-                                    <LastEvaluatedAtLabel>{decommissionTimeLocal}</LastEvaluatedAtLabel>
-                                </Tooltip>
-                            </Typography.Text>
+                            <Tooltip placement="right" title={decommissionTimeGMT}>
+                                <LastEvaluatedAtLabel>{decommissionTimeLocal}</LastEvaluatedAtLabel>
+                            </Tooltip>
                         )}
                         {isDividerNeeded && showUndeprecate ? <ThinDivider /> : null}
                         {showUndeprecate && (
@@ -219,6 +218,6 @@ export const DeprecationIcon = ({
                 <StyledDeprecatedIcon />
                 {showText ? 'Deprecated' : null}
             </DeprecatedContainer>
-        </Popover>
+        </Tooltip2>
     );
 };

--- a/datahub-web-react/src/app/entityV2/shared/components/styled/MarkAsDeprecatedButton.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/components/styled/MarkAsDeprecatedButton.tsx
@@ -1,18 +1,11 @@
-import { Button } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
+import { Button } from '@src/alchemy-components';
 import DeprecatedIcon from '../../../../../images/deprecated-status.svg?react';
-import { REDESIGN_COLORS } from '../../constants';
 
-// Styled Components
-// Todo(Gabe): replace this with the @components button once it supports text buttons with hover states
 const StyledButton = styled(Button)`
     padding: 4px;
     margin-top: -8px;
-    color: ${REDESIGN_COLORS.LINK_GREY};
-    :hover {
-        color: ${REDESIGN_COLORS.LINK_GREY};
-    }
 `;
 
 const FlexContainer = styled.div`
@@ -52,7 +45,7 @@ export const MarkAsDeprecatedButtonContents = ({ internalText }: MarkAsDeprecate
 // Main Component
 const MarkAsDeprecatedButton = ({ onClick, internalText }: DeprecatedButtonProps) => {
     return (
-        <StyledButton onClick={onClick} type="text">
+        <StyledButton onClick={onClick} variant="text">
             <MarkAsDeprecatedButtonContents internalText={internalText} />
         </StyledButton>
     );

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SidebarLogicSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/SidebarLogicSection.tsx
@@ -17,18 +17,15 @@ import { SidebarSection } from './SidebarSection';
 
 const PreviewSyntax = styled(SyntaxHighlighter)`
     max-width: 100%;
-    max-height: 150px;
+    max-height: 600px;
     overflow: hidden;
-    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 80%, rgba(255, 0, 0, 0.5) 85%, rgba(255, 0, 0, 0) 90%);
-
+    mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1) 85%, rgba(0, 0, 0, 0) 100%);
     span {
         font-family: 'Roboto Mono', monospace;
     }
 `;
 
-const ModalSyntaxContainer = styled.div`
-    margin: 20px;
-`;
+const ModalSyntaxContainer = styled.div``;
 
 export const ViewHeader = styled.div`
     display: flex;

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer.tsx
@@ -1,7 +1,6 @@
-import { Button } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { REDESIGN_COLORS } from '../../../constants';
+import { Button } from '@src/alchemy-components';
 import { Editor } from './editor/Editor';
 
 const LINE_HEIGHT = 1.5;
@@ -31,8 +30,7 @@ const MarkdownContainer = styled.div<{ lineLimit?: number | null }>`
 `;
 
 const CustomButton = styled(Button)`
-    padding: 0;
-    color: ${REDESIGN_COLORS.ACTION_ICON_GREY};
+    padding: 8px 0px;
 `;
 
 const MarkdownViewContainer = styled.div<{ scrollableY: boolean }>`
@@ -150,8 +148,15 @@ export default function CompactMarkdownViewer({
                 (isShowingMore || isTruncated) && ( // "show more" when isTruncated, "show less" when isShowingMore
                     <ShowMoreWrapper>
                         <CustomButton
-                            type="link"
-                            onClick={() => (handleShowMore ? handleShowMore() : setIsShowingMore(!isShowingMore))}
+                            variant="text"
+                            onClick={(e) => {
+                                if (handleShowMore) {
+                                    handleShowMore();
+                                } else {
+                                    setIsShowingMore(!isShowingMore);
+                                }
+                                e.stopPropagation();
+                            }}
                         >
                             {isShowingMore ? 'show less' : 'show more'}
                         </CustomButton>

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -40,9 +40,9 @@ import DefaultPreviewCardFooter from './DefaultPreviewCardFooter';
 import EntityHeader from './EntityHeader';
 
 import { useEntityContext, useEntityData } from '../entity/shared/EntityContext';
-import { removeMarkdown } from '../entityV2/shared/components/styled/StripMarkdownText';
 import { DashboardLastUpdatedMs, DatasetLastUpdatedMs } from '../entityV2/shared/utils';
 import { useRemoveDataProductAssets, useRemoveDomainAssets, useRemoveGlossaryTermAssets } from './utils';
+import CompactMarkdownViewer from '../entityV2/shared/tabs/Documentation/components/CompactMarkdownViewer';
 
 const TransparentButton = styled(Button)`
     color: ${REDESIGN_COLORS.TITLE_PURPLE};
@@ -67,10 +67,10 @@ const TransparentButton = styled(Button)`
 const PreviewContainer = styled.div`
     display: flex;
     flex-direction: column;
+    height: auto;
     width: 100%;
     justify-content: space-between;
     align-items: start;
-
     .entityCount {
         margin-bottom: 2px;
     }
@@ -105,14 +105,9 @@ const InsightIconContainer = styled.span`
 `;
 
 const Documentation = styled.div`
-    width: 90%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 12px;
-    font-weight: 500;
-    color: ${REDESIGN_COLORS.SUB_TEXT};
     margin-top: 8px;
+    max-height: 300px;
+    overflow-y: auto;
 `;
 
 const ENTITY_TYPES_WITH_DESCRIPTION_PREVIEW = new Set([
@@ -263,6 +258,10 @@ export default function DefaultPreviewCard({
             previewData={previewData}
         />
     );
+
+    const markdownContent =
+        '# Project Title - Here is a super super long title my guy\n Here is a suoserknserkjnse skjenrksjenrksjenr sejrnsekjrnse rsjkenrksjenrse rkjsenrksjenrskjernskjernskjenrskjenrskjernskejnrekjsrnk\nasujhasduahsdiuhas\n\n\n\n\n\n\nasdkjahsduihasdiuhasdiuahsdiuahsd\n\n\n\n\n\najnasdiasdiahsdiuashdiuashdiaushdiaushd\n\n\n\nasdahsduyahsdiusahd\n\n\n\n\nashdaiushdaiushdaiushdaisuhdaiusdhaiushda\n\n\n\n\nasdasdiuahsdiuahsdiuahsdiuashd**hi**asdasdasdiuhasdiuhasdiuahs\n\n\n\nasuidhasiudhasiudhasiudhaisud\n\\nn\nasduahsdiuahsdiuahsdiuashdiaushd\n\n\n\n\nasdiuahsdiuahsdiuahdaiushd\n\n\n\nasdiahsdiuashdiaushdaiushd\n\n\n\nasdiuashdiaushdaiushdaiusdh\n\n\n\n\nasdaiushdaiushdaiushdaiusd';
+
     return (
         <PreviewContainer data-testid={dataTestID ?? `preview-${urn}`}>
             {(entityType === EntityType.GlossaryNode || entityType === EntityType.GlossaryTerm) && (
@@ -319,9 +318,9 @@ export default function DefaultPreviewCard({
                     {(previewType === PreviewType.HOVER_CARD ||
                         ENTITY_TYPES_WITH_DESCRIPTION_PREVIEW.has(entityType)) &&
                     description ? (
-                        <RowContainer>
-                            <Documentation>{removeMarkdown(description)}</Documentation>
-                        </RowContainer>
+                        <Documentation>
+                            <CompactMarkdownViewer content={markdownContent} />
+                        </Documentation>
                     ) : null}
                 </>
             ) : (

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -259,9 +259,6 @@ export default function DefaultPreviewCard({
         />
     );
 
-    const markdownContent =
-        '# Project Title - Here is a super super long title my guy\n Here is a suoserknserkjnse skjenrksjenrksjenr sejrnsekjrnse rsjkenrksjenrse rkjsenrksjenrskjernskjernskjenrskjenrskjernskejnrekjsrnk\nasujhasduahsdiuhas\n\n\n\n\n\n\nasdkjahsduihasdiuhasdiuahsdiuahsd\n\n\n\n\n\najnasdiasdiahsdiuashdiuashdiaushdiaushd\n\n\n\nasdahsduyahsdiusahd\n\n\n\n\nashdaiushdaiushdaiushdaisuhdaiusdhaiushda\n\n\n\n\nasdasdiuahsdiuahsdiuahsdiuashd**hi**asdasdasdiuhasdiuhasdiuahs\n\n\n\nasuidhasiudhasiudhasiudhaisud\n\\nn\nasduahsdiuahsdiuahsdiuashdiaushd\n\n\n\n\nasdiuahsdiuahsdiuahdaiushd\n\n\n\nasdiahsdiuashdiaushdaiushd\n\n\n\nasdiuashdiaushdaiushdaiusdh\n\n\n\n\nasdaiushdaiushdaiushdaiusd';
-
     return (
         <PreviewContainer data-testid={dataTestID ?? `preview-${urn}`}>
             {(entityType === EntityType.GlossaryNode || entityType === EntityType.GlossaryTerm) && (
@@ -319,7 +316,7 @@ export default function DefaultPreviewCard({
                         ENTITY_TYPES_WITH_DESCRIPTION_PREVIEW.has(entityType)) &&
                     description ? (
                         <Documentation>
-                            <CompactMarkdownViewer content={markdownContent} />
+                            <CompactMarkdownViewer content={description} />
                         </Documentation>
                     ) : null}
                 </>

--- a/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Entity } from '../../../../types.generated';
 import { PreviewType } from '../../../entity/Entity';
 import { useEntityRegistry } from '../../../useEntityRegistry';
-import { useEmbeddedProfileLinkProps } from '../../../shared/useEmbeddedProfileLinkProps';
 import { HoverEntityTooltipContext } from '../../HoverEntityTooltipContext';
 
 type Props = {
@@ -26,17 +25,15 @@ export const HoverEntityTooltip = ({
     placement,
     showArrow,
     width = 360,
-    maxWidth = 450,
+    maxWidth = 500,
     entityCount = undefined,
 }: Props) => {
     const entityRegistry = useEntityRegistry();
-    const linkProps = useEmbeddedProfileLinkProps();
 
     if (!entity || !entity.type || !entity.urn) {
         return <>{children}</>;
     }
 
-    const url = entityRegistry.getEntityUrl(entity.type, entity.urn);
     return (
         <HoverEntityTooltipContext.Provider value={{ entityCount }}>
             <Tooltip
@@ -46,11 +43,7 @@ export const HoverEntityTooltip = ({
                 placement={placement || 'bottom'}
                 overlayStyle={{ minWidth: width, maxWidth, zIndex: 1100 }}
                 overlayInnerStyle={{ padding: 20, borderRadius: 20, overflow: 'hidden', position: 'relative' }}
-                title={
-                    <a href={url} {...linkProps}>
-                        {entityRegistry.renderPreview(entity.type, PreviewType.HOVER_CARD, entity)}
-                    </a>
-                }
+                title={entityRegistry.renderPreview(entity.type, PreviewType.HOVER_CARD, entity)}
                 zIndex={1000}
             >
                 {children}


### PR DESCRIPTION
# Summary

in this pr we add hotfixes for deprecated popover to use our component lib, and sidebar logic section to make it less compact so users can see more of their query.

updated uis:

https://www.loom.com/share/d708dd69a191475baba276417d73ff56?sid=5707334f-7930-4c42-b4ea-cc78fdd81d31

<img width="784" alt="Screenshot 2025-04-08 at 3 40 02 PM" src="https://github.com/user-attachments/assets/c4a85c28-01e9-4dab-8212-dbe1b4013d42" />
<img width="974" alt="Screenshot 2025-04-08 at 4 04 53 PM" src="https://github.com/user-attachments/assets/d3a89f2a-3b89-4cf5-9fa5-8539ee91a393" />
<img width="709" alt="Screenshot 2025-04-08 at 4 07 26 PM" src="https://github.com/user-attachments/assets/b3465ab6-152c-4f7d-9d79-866604154c3b" />
<img width="517" alt="Screenshot 2025-04-08 at 4 07 30 PM" src="https://github.com/user-attachments/assets/606dd3de-5179-4869-9864-bac82b45583a" />



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
