### PR TITLE
fix(ingestion): Make workunit processor ensuring schema size more aggresive

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
@@ -23,6 +23,7 @@ class EnsureAspectSizeProcessor:
     ):
         self.report = report
         self.payload_constraint = payload_constraint
+        self.schema_size_constraint = self.payload_constraint - 500000
 
     def ensure_dataset_profile_size(
         self, dataset_urn: str, profile: DatasetProfileClass
@@ -68,7 +69,7 @@ class EnsureAspectSizeProcessor:
         for field in schema.fields:
             field_size = len(json.dumps(pre_json_transform(field.to_obj())))
             logger.debug(f"Field {field.fieldPath} takes total {field_size}")
-            if total_fields_size + field_size < self.payload_constraint:
+            if total_fields_size + field_size < self.schema_size_constraint:
                 accepted_fields.append(field)
                 total_fields_size += field_size
             else:

--- a/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
@@ -23,7 +23,7 @@ class EnsureAspectSizeProcessor:
     ):
         self.report = report
         self.payload_constraint = payload_constraint
-        self.schema_size_constraint = self.payload_constraint - 250000
+        self.schema_size_constraint = int(self.payload_constraint * 0.985)
 
     def ensure_dataset_profile_size(
         self, dataset_urn: str, profile: DatasetProfileClass

--- a/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/auto_work_units/auto_ensure_aspect_size.py
@@ -23,7 +23,7 @@ class EnsureAspectSizeProcessor:
     ):
         self.report = report
         self.payload_constraint = payload_constraint
-        self.schema_size_constraint = self.payload_constraint - 500000
+        self.schema_size_constraint = self.payload_constraint - 250000
 
     def ensure_dataset_profile_size(
         self, dataset_urn: str, profile: DatasetProfileClass


### PR DESCRIPTION
Our hard-limit for a payload is `16 000 000`. Currently we have a value used by the processor taken from global:
```python
INGEST_MAX_PAYLOAD_BYTES = 15 * 1024 * 1024
```
which equals to `15 728 640`, which gives us a little bit more than `281 000` characters as a buffer.
When we try to estimate size of a schema, field by field, we calculate their size separately, while in fact when they are serialized as part of an aspect, there are various things happening to them, such as additional escaping and additional nesting in the structure. Due to this the final size of the payload might have been `15 728 639 + X` where X was bigger than `281 000`. This would cause GMS to throw 400 response due to the payload exceeding allowed size (`16 000 000`). To avoid this situation I have limited constraint for the maximum total size of schema fields **counted separately**.
