### PR TITLE
fix(ui) Fix backwards compatibility bug with entity structured props

### DIFF
--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsDrawer.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsDrawer.tsx
@@ -190,11 +190,14 @@ const StructuredPropsDrawer = ({
             });
         } else {
             form.validateFields().then(() => {
+                const allowedTypes = form.getFieldValue(['typeQualifier', 'allowedTypes']) ?? [];
+                const typeQualifier = allowedTypes.length > 0 ? { allowedTypes } : undefined;
                 const createInput = {
                     ...form.getFieldsValue(),
                     qualifiedName: form.getFieldValue('qualifiedName') || undefined,
                     valueType: valueTypes.find((type) => type.value === form.getFieldValue('valueType'))?.urn,
                     allowedValues,
+                    typeQualifier,
                     cardinality,
                     settings: {
                         isHidden: form.getFieldValue(['settings', 'isHidden']) ?? false,

--- a/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsFormSection.tsx
+++ b/datahub-web-react/src/app/govern/structuredProperties/StructuredPropsFormSection.tsx
@@ -110,6 +110,7 @@ const StructuredPropsFormSection = ({
                                 values={formValues?.typeQualifier?.allowedTypes}
                                 disabledValues={disabledTypeQualifierValues}
                                 width="full"
+                                isDisabled={isEditMode ? !formValues?.typeQualifier?.allowedTypes?.length : false}
                             />
                         </Form.Item>
                     </Tooltip>

--- a/datahub-web-react/src/app/govern/structuredProperties/utils.ts
+++ b/datahub-web-react/src/app/govern/structuredProperties/utils.ts
@@ -151,7 +151,8 @@ export const getValueTypeLabel = (valueUrn: string, cardinality: PropertyCardina
 
 export const getNewAllowedTypes = (entity: StructuredPropertyEntity, values: StructuredProp) => {
     const currentTypeUrns = entity.definition.typeQualifier?.allowedTypes?.map((type) => type.urn);
-    return values.typeQualifier?.allowedTypes?.filter((type) => !currentTypeUrns?.includes(type));
+    const newAllowedTypes = values.typeQualifier?.allowedTypes?.filter((type) => !currentTypeUrns?.includes(type));
+    return (newAllowedTypes?.length || 0) > 0 ? newAllowedTypes : undefined;
 };
 
 export const getNewEntityTypes = (entity: StructuredPropertyEntity, values: StructuredProp) => {


### PR DESCRIPTION
Fixes some backwards compatibility issues with type qualifier/allowed types when creating and editing properties. If you add an entity type in the form and remove it, we submit an empty list instead of undefined which means we restrict you from adding any entity type. Now i submit undefined if it's an empty list since that's the intention to allow any types.


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
