### PR TITLE
Fix Scrolling lag on Dataset Schema Tables

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -250,8 +250,9 @@ export default function SchemaTable({
     }, [expandedRowsFromFilter]);
 
     const [VT, setVT] = useVT(() => ({ scroll: { y: tableHeight } }), [tableHeight]);
-
     useMemo(() => setVT({ body: { row: SchemaRow } }), [setVT]);
+    const scrollConfig = rows.length > 40 ? undefined : { y: tableHeight };
+    const componentsConfig = rows.length > 40 ? undefined : VT;
 
     return (
         <FkContext.Provider value={selectedFkFieldPath}>
@@ -270,8 +271,8 @@ export default function SchemaTable({
                         columns={allColumns}
                         dataSource={rows}
                         rowKey="fieldPath"
-                        scroll={{ y: tableHeight }}
-                        components={VT}
+                        scroll={scrollConfig}
+                        components={componentsConfig}
                         expandable={{
                             expandedRowKeys: [...Array.from(expandedRows)],
                             defaultExpandAllRows: false,


### PR DESCRIPTION
## Fix scroll lag on dataset schema tables
Navigating to a "Dataset" and viewing the table under the "Schema" tab will sometimes cause scroll wheel lag or auto movement when there are over a certain amount of schema fields that are being rendered.

## Change
- If the number of rows is under 40 the scroll wheel will remain, otherwise, there is a check added to see if there are over 40 rows to remove the scroll wheel entirely to prevent lag and render all fields at once

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
