### PR TITLE
feat(openapi): add entity patch support

### DIFF
--- a/docs/how/updating-datahub.md
+++ b/docs/how/updating-datahub.md
@@ -28,6 +28,8 @@ This file documents any backwards-incompatible changes in DataHub and assists pe
 
 ### Other Notable Changes
 
+- OpenAPI v3 Patching Improvements
+
 ## 1.0.0
 
 ### Breaking Changes

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/GenericJsonPatch.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/GenericJsonPatch.java
@@ -22,9 +22,15 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GenericJsonPatch {
+  public static final String ARRAY_PRIMARY_KEYS_FIELD = "arrayPrimaryKeys";
+  public static final String PATCH_FIELD = "patch";
+
   @Nullable private Map<String, List<String>> arrayPrimaryKeys;
 
   @Nonnull private List<PatchOp> patch;
+
+  /** Bypass template engine even if a patch template exists */
+  private boolean forceGenericPatch;
 
   @Nonnull
   public Map<String, List<String>> getArrayPrimaryKeys() {

--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/ArrayMergingTemplate.java
@@ -45,8 +45,18 @@ public interface ArrayMergingTemplate<T extends RecordTemplate> extends Template
                     // if the keyField has a unit separator, we are working with a nested key
                     if (keyField.contains(UNIT_SEPARATOR_DELIMITER)) {
                       String[] keyParts = keyField.split(UNIT_SEPARATOR_DELIMITER);
-                      JsonNode keyObject = node.get(keyParts[0]);
-                      key = keyObject.get(keyParts[1]).asText();
+                      JsonNode keyObject = node;
+
+                      // Traverse through all parts of the key path
+                      for (int i = 0; i < keyParts.length - 1; i++) {
+                        keyObject = keyObject.get(keyParts[i]);
+                        // Handle null values to prevent NullPointerException
+                        if (keyObject == null) {
+                          throw new IllegalArgumentException("Invalid key path: " + keyField);
+                        }
+                      }
+
+                      key = keyObject.get(keyParts[keyParts.length - 1]).asText();
                     } else {
                       key = node.get(keyField).asText();
                     }

--- a/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImplTest.java
+++ b/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImplTest.java
@@ -1,0 +1,584 @@
+package com.linkedin.metadata.entity.ebean.batch;
+
+import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
+import static com.linkedin.metadata.Constants.DATASET_PROPERTIES_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.GLOBAL_TAGS_ASPECT_NAME;
+import static com.linkedin.metadata.Constants.STATUS_ASPECT_NAME;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.common.urn.UrnUtils;
+import com.linkedin.data.template.DataTemplateUtil;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.dataset.DatasetProperties;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.aspect.AspectRetriever;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
+import com.linkedin.metadata.aspect.patch.template.AspectTemplateEngine;
+import com.linkedin.metadata.models.registry.EntityRegistry;
+import com.linkedin.metadata.utils.GenericRecordUtils;
+import com.linkedin.metadata.utils.SystemMetadataUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.mxe.SystemMetadata;
+import io.datahubproject.metadata.context.OperationContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class PatchItemImplTest {
+
+  private final OperationContext opContext =
+      TestOperationContexts.systemContextNoSearchAuthorization();
+  private final ObjectMapper objectMapper = opContext.getObjectMapper();
+  private final EntityRegistry entityRegistry = opContext.getEntityRegistry();
+  private final AspectRetriever aspectRetriever = opContext.getAspectRetriever();
+  private final Urn urn =
+      UrnUtils.getUrn("urn:li:dataset:(urn:li:dataPlatform:hive,patchTest,PROD)");
+  ;
+  private final AuditStamp auditStamp =
+      new AuditStamp().setTime(1000L).setActor(UrnUtils.getUrn("urn:li:corpuser:testUser"));
+
+  @Test
+  public void testSimplePatch() {
+    // Create a simple JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // Build a PatchItemImpl
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // Verify the built object
+    assertEquals(patchItem.getUrn(), urn);
+    assertEquals(patchItem.getAspectName(), DATASET_PROPERTIES_ASPECT_NAME);
+    assertEquals(patchItem.getAuditStamp(), auditStamp);
+    assertEquals(patchItem.getPatch(), patch);
+    assertEquals(patchItem.getChangeType(), ChangeType.PATCH);
+    assertNotNull(
+        patchItem.getSystemMetadata(), "System metadata should be auto-generated if not provided");
+    assertNull(patchItem.getRecordTemplate(), "Record template should be null for PatchItemImpl");
+  }
+
+  @Test
+  public void testBuildWithMCP() {
+    // Create a MetadataChangeProposal
+    MetadataChangeProposal mcp = new MetadataChangeProposal();
+    mcp.setEntityUrn(urn);
+    mcp.setEntityType(DATASET_ENTITY_NAME);
+    mcp.setAspectName(DATASET_PROPERTIES_ASPECT_NAME);
+    mcp.setChangeType(ChangeType.PATCH);
+
+    // Create a JSON patch array string
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+    mcp.setAspect(GenericRecordUtils.serializePatch(patch));
+
+    // Build a PatchItemImpl with MCP
+    PatchItemImpl patchItem = PatchItemImpl.builder().build(mcp, auditStamp, entityRegistry);
+
+    // Verify the built object
+    assertEquals(patchItem.getUrn(), urn);
+    assertEquals(patchItem.getAspectName(), DATASET_PROPERTIES_ASPECT_NAME);
+    assertEquals(patchItem.getAuditStamp(), auditStamp);
+    assertNotNull(patchItem.getPatch(), "Patch should be extracted from MCP");
+    assertEquals(patchItem.getMetadataChangeProposal(), mcp);
+    assertEquals(patchItem.getChangeType(), ChangeType.PATCH);
+  }
+
+  @Test
+  public void testBuildWithGenericJsonPatch() throws Exception {
+    // Create a GenericJsonPatch
+    GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+    patchOp.setOp("add");
+    patchOp.setPath("/tags/urn:li:platformResource:my-source/urn:li:tag:tag1");
+    patchOp.setValue(
+        objectMapper.convertValue(
+            Map.of("tag", "urn:li:tag:tag1", "source", "urn:li:platformResource:my-source"),
+            JsonNode.class));
+
+    Map<String, List<String>> arrayPrimaryKeys = new HashMap<>();
+    arrayPrimaryKeys.put("tags", List.of("attribution", "source"));
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder()
+            .patch(List.of(patchOp))
+            .arrayPrimaryKeys(arrayPrimaryKeys)
+            .build();
+
+    // Create MCP with GenericJsonPatch
+    MetadataChangeProposal mcp = new MetadataChangeProposal();
+    mcp.setEntityUrn(urn);
+    mcp.setEntityType(DATASET_ENTITY_NAME);
+    mcp.setAspectName(GLOBAL_TAGS_ASPECT_NAME);
+    mcp.setChangeType(ChangeType.PATCH);
+    mcp.setAspect(GenericRecordUtils.serializePatch(genericJsonPatch, objectMapper));
+
+    // Build a PatchItemImpl with MCP containing GenericJsonPatch
+    PatchItemImpl patchItem = PatchItemImpl.builder().build(mcp, auditStamp, entityRegistry);
+
+    // Verify the built object
+    assertEquals(patchItem.getUrn(), urn);
+    assertEquals(patchItem.getAspectName(), GLOBAL_TAGS_ASPECT_NAME);
+    assertEquals(patchItem.getAuditStamp(), auditStamp);
+    assertNotNull(patchItem.getPatch(), "JsonPatch should be extracted from GenericJsonPatch");
+    assertNotNull(patchItem.getGenericJsonPatch(), "GenericJsonPatch should be extracted from MCP");
+    assertEquals(patchItem.getMetadataChangeProposal(), mcp);
+  }
+
+  @Test
+  public void testApplyPatchWithExistingRecord() throws Exception {
+    // Create a JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // Build a PatchItemImpl
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // Apply the patch
+    ChangeItemImpl result = patchItem.applyPatch(new DatasetProperties(), aspectRetriever);
+
+    // Verify the result
+    assertNotNull(result);
+    assertEquals(result.getUrn(), urn);
+    assertEquals(result.getAspectName(), DATASET_PROPERTIES_ASPECT_NAME);
+    assertEquals(
+        result.getRecordTemplate(),
+        new DatasetProperties().setDescription("Test description").setTags(new StringArray()));
+  }
+
+  @Test
+  public void testApplyPatchWithDefaultTemplate() throws Exception {
+    // Create a JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // Build a PatchItemImpl
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // Apply the patch with no existing record
+    ChangeItemImpl result = patchItem.applyPatch(null, aspectRetriever);
+
+    // Verify the result
+    assertNotNull(result);
+    assertEquals(result.getUrn(), urn);
+    assertEquals(result.getAspectName(), DATASET_PROPERTIES_ASPECT_NAME);
+    assertEquals(
+        result.getRecordTemplate(),
+        new DatasetProperties()
+            .setDescription("Test description")
+            .setTags(new StringArray())
+            .setCustomProperties(new StringMap()));
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testApplyPatchWithNoExistingOrDefaultTemplate() {
+    // Create a JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader("[{\"op\":\"add\",\"path\":\"/removed\",\"value\":false}]"))
+                .readArray());
+
+    // Build a PatchItemImpl
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(STATUS_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // This should throw UnsupportedOperationException
+    patchItem.applyPatch(null, aspectRetriever);
+  }
+
+  @Test
+  public void testGetMetadataChangeProposal() {
+    // Create a JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // Create SystemMetadata
+    SystemMetadata systemMetadata = new SystemMetadata();
+    systemMetadata.setRunId("test-run-id");
+
+    // Build a PatchItemImpl
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .systemMetadata(systemMetadata)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // Get the MCP
+    MetadataChangeProposal mcp = patchItem.getMetadataChangeProposal();
+
+    // Verify the MCP
+    assertNotNull(mcp);
+    assertEquals(mcp.getEntityUrn(), urn);
+    assertEquals(mcp.getAspectName(), DATASET_PROPERTIES_ASPECT_NAME);
+    assertEquals(mcp.getEntityType(), DATASET_ENTITY_NAME);
+    assertEquals(mcp.getChangeType(), ChangeType.PATCH);
+    assertNotNull(mcp.getAspect());
+    assertEquals(mcp.getSystemMetadata(), systemMetadata);
+    assertNotNull(mcp.getEntityKeyAspect());
+  }
+
+  @Test
+  public void testApplyGenericPatch() throws Exception {
+    // Create a GenericJsonPatch
+    GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+    patchOp.setOp("add");
+    patchOp.setPath("/description");
+    patchOp.setValue("Test description");
+
+    List<GenericJsonPatch.PatchOp> patchOps = new ArrayList<>();
+    patchOps.add(patchOp);
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder()
+            .patch(patchOps)
+            .arrayPrimaryKeys(Map.of())
+            .forceGenericPatch(true)
+            .build();
+
+    // Build PatchItemImpl with genericJsonPatch
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .genericJsonPatch(genericJsonPatch)
+            .patch(genericJsonPatch.getJsonPatch())
+            .build(entityRegistry);
+
+    assertNotNull(patchItem.getGenericJsonPatch());
+
+    // Apply the generic patch
+    ChangeItemImpl result = patchItem.applyPatch(new DatasetProperties(), aspectRetriever);
+
+    // Verify the result
+    assertTrue(
+        DataTemplateUtil.areEqual(
+            result.getRecordTemplate(),
+            new DatasetProperties().setDescription("Test description")));
+  }
+
+  @Test
+  public void testEqualsAndHashCode() {
+    // Create two identical JSON patches
+    JsonPatch patch1 =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+    JsonPatch patch2 =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // Create two identical system metadata objects
+    SystemMetadata systemMetadata = new SystemMetadata();
+    systemMetadata.setRunId("test-run-id");
+
+    // Build two PatchItemImpl objects with the same values
+    PatchItemImpl patchItem1 =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .systemMetadata(systemMetadata)
+            .patch(patch1)
+            .build(entityRegistry);
+
+    PatchItemImpl patchItem2 =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .systemMetadata(systemMetadata)
+            .patch(patch2)
+            .build(entityRegistry);
+
+    // Verify equals and hashCode
+    assertTrue(patchItem1.equals(patchItem2));
+    assertEquals(patchItem1.hashCode(), patchItem2.hashCode());
+
+    // Create a different patch
+    JsonPatch differentPatch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Different description\"}]"))
+                .readArray());
+
+    // Build a PatchItemImpl with a different patch
+    PatchItemImpl differentPatchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .systemMetadata(systemMetadata)
+            .patch(differentPatch)
+            .build(entityRegistry);
+
+    // Verify not equal
+    assertFalse(patchItem1.equals(differentPatchItem));
+    assertNotEquals(patchItem1.hashCode(), differentPatchItem.hashCode());
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testBuildWithUnsupportedChangeType() {
+    // Create a JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // This should throw UnsupportedOperationException
+    PatchItemImpl.builder()
+        .urn(urn)
+        .aspectName(STATUS_ASPECT_NAME)
+        .auditStamp(auditStamp)
+        .patch(patch)
+        .aspectSpec(entityRegistry.getAspectSpecs().get(STATUS_ASPECT_NAME))
+        .build(entityRegistry);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testBuildWithNullPatch() {
+    // This should throw IllegalArgumentException
+    PatchItemImpl.builder()
+        .urn(urn)
+        .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+        .auditStamp(auditStamp)
+        .patch(null)
+        .build(entityRegistry);
+  }
+
+  @Test
+  public void testSetSystemMetadata() {
+    // Create a JSON patch
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+
+    // Build a PatchItemImpl
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // Create a new SystemMetadata
+    SystemMetadata newSystemMetadata = new SystemMetadata();
+    newSystemMetadata.setRunId("new-run-id");
+
+    // Set the new SystemMetadata
+    patchItem.setSystemMetadata(newSystemMetadata);
+
+    // Verify the SystemMetadata was set
+    assertEquals(patchItem.getSystemMetadata(), newSystemMetadata);
+
+    // Get the MCP and verify it has the new SystemMetadata
+    MetadataChangeProposal mcp = patchItem.getMetadataChangeProposal();
+    assertEquals(mcp.getSystemMetadata(), newSystemMetadata);
+  }
+
+  @Test
+  public void testIsDatabaseDuplicateOf() {
+    // Create two identical JSON patches
+    JsonPatch patch1 =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+    JsonPatch patch2 =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Test description\"}]"))
+                .readArray());
+    SystemMetadata systemMetadata = SystemMetadataUtils.createDefaultSystemMetadata();
+
+    // Build two PatchItemImpl objects with the same values
+    PatchItemImpl patchItem1 =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch1)
+            .systemMetadata(systemMetadata)
+            .build(entityRegistry);
+
+    PatchItemImpl patchItem2 =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch2)
+            .systemMetadata(systemMetadata)
+            .build(entityRegistry);
+
+    // Verify isDatabaseDuplicateOf returns true for identical items
+    assertTrue(patchItem1.isDatabaseDuplicateOf(patchItem2));
+
+    // Create a different patch
+    JsonPatch differentPatch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/description\",\"value\":\"Different description\"}]"))
+                .readArray());
+
+    // Build a PatchItemImpl with a different patch
+    PatchItemImpl differentPatchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(differentPatch)
+            .build(entityRegistry);
+
+    // Verify isDatabaseDuplicateOf returns false for different items
+    assertFalse(patchItem1.isDatabaseDuplicateOf(differentPatchItem));
+  }
+
+  @Test
+  public void testApplyGenericPatchWithForceFlag() throws Exception {
+    // Create a GenericJsonPatch with force flag
+    GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+    patchOp.setOp("add");
+    patchOp.setPath("/description");
+    patchOp.setValue("Test description");
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder()
+            .patch(List.of(patchOp))
+            .arrayPrimaryKeys(Map.of()) // Empty primary keys
+            .forceGenericPatch(true) // Force generic patch
+            .build();
+
+    // Build PatchItemImpl with genericJsonPatch
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .genericJsonPatch(genericJsonPatch)
+            .patch(genericJsonPatch.getJsonPatch())
+            .build(entityRegistry);
+
+    // Apply the generic patch
+    ChangeItemImpl result = patchItem.applyPatch(new DatasetProperties(), aspectRetriever);
+
+    // Verify the result was processed by genericPatch method
+    assertNotNull(result);
+    assertEquals(
+        "Test description", ((DatasetProperties) result.getRecordTemplate()).getDescription());
+  }
+
+  @Test
+  public void testFallbackToTemplatePatchWhenGenericPatchConditionsNotMet() throws Exception {
+    // Create a GenericJsonPatch with empty primary keys and force flag false
+    GenericJsonPatch.PatchOp patchOp = new GenericJsonPatch.PatchOp();
+    patchOp.setOp("add");
+    patchOp.setPath("/description");
+    patchOp.setValue("Test description");
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder()
+            .patch(List.of(patchOp))
+            .arrayPrimaryKeys(Map.of()) // Empty primary keys
+            .forceGenericPatch(false) // Don't force generic patch
+            .build();
+
+    // Build PatchItemImpl with genericJsonPatch
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(urn)
+            .aspectName(DATASET_PROPERTIES_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .genericJsonPatch(genericJsonPatch)
+            .patch(genericJsonPatch.getJsonPatch())
+            .build(entityRegistry);
+
+    // Spies entity registry
+    EntityRegistry mockRegistry = spy(entityRegistry);
+    AspectTemplateEngine mockTemplateEngine = spy(entityRegistry.getAspectTemplateEngine());
+
+    // Mock aspectRetriever to verify which method is called
+    AspectRetriever mockAspectRetriever = mock(AspectRetriever.class);
+    when(mockAspectRetriever.getEntityRegistry()).thenReturn(mockRegistry);
+
+    // Create a template engine that will return a default template
+    when(mockRegistry.getAspectTemplateEngine()).thenReturn(mockTemplateEngine);
+
+    // Apply the patch - should use template patch
+    patchItem.applyPatch(new DatasetProperties(), mockAspectRetriever);
+
+    // Verify the template engine was called (indicating template patch was used)
+    verify(mockTemplateEngine).applyPatch(any(), any(), any());
+  }
+}

--- a/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v3/models/GenericEntityV3.java
+++ b/metadata-service/openapi-servlet/models/src/main/java/io/datahubproject/openapi/v3/models/GenericEntityV3.java
@@ -8,6 +8,7 @@ import com.linkedin.common.urn.Urn;
 import io.datahubproject.openapi.models.GenericEntity;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,10 +52,12 @@ public class GenericEntityV3 extends LinkedHashMap<String, Object>
                     try {
                       String aspectName = entry.getKey();
                       Map<String, Object> aspectValueMap =
-                          objectMapper.readValue(
-                              RecordUtils.toJsonString(entry.getValue().getAspect())
-                                  .getBytes(StandardCharsets.UTF_8),
-                              new TypeReference<>() {});
+                          entry.getValue().getAspect() != null
+                              ? objectMapper.readValue(
+                                  RecordUtils.toJsonString(entry.getValue().getAspect())
+                                      .getBytes(StandardCharsets.UTF_8),
+                                  new TypeReference<>() {})
+                              : Collections.emptyMap();
 
                       Map<String, Object> systemMetadata =
                           entry.getValue().getSystemMetadata() != null

--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericEntitiesController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericEntitiesController.java
@@ -19,16 +19,15 @@ import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.EnvelopedAspect;
+import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.AspectRetriever;
 import com.linkedin.metadata.aspect.batch.AspectsBatch;
 import com.linkedin.metadata.aspect.batch.ChangeMCP;
 import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
-import com.linkedin.metadata.aspect.patch.template.common.GenericPatchTemplate;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.IngestResult;
 import com.linkedin.metadata.entity.UpdateAspectResult;
 import com.linkedin.metadata.entity.ebean.batch.AspectsBatchImpl;
-import com.linkedin.metadata.entity.ebean.batch.ChangeItemImpl;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -45,6 +44,7 @@ import com.linkedin.metadata.utils.AuditStampUtils;
 import com.linkedin.metadata.utils.CriterionUtils;
 import com.linkedin.metadata.utils.GenericRecordUtils;
 import com.linkedin.metadata.utils.SearchUtil;
+import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.timeseries.TimeseriesAspectBase;
 import com.linkedin.util.Pair;
@@ -61,7 +61,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -697,67 +696,50 @@ public abstract class GenericEntitiesController<
       @PathVariable("entityName") String entityName,
       @PathVariable("entityUrn") String entityUrn,
       @PathVariable("aspectName") String aspectName,
+      @RequestParam(value = "async", required = false, defaultValue = "false") Boolean async,
       @RequestParam(value = "systemMetadata", required = false, defaultValue = "false")
           Boolean withSystemMetadata,
       @RequestBody @Nonnull GenericJsonPatch patch)
-      throws InvalidUrnException,
-          NoSuchMethodException,
-          InvocationTargetException,
-          InstantiationException,
-          IllegalAccessException {
+      throws InvalidUrnException {
 
     Urn urn = validatedUrn(entityUrn);
     EntitySpec entitySpec = entityRegistry.getEntitySpec(entityName);
     Authentication authentication = AuthenticationContext.getAuthentication();
+    Actor actor = authentication.getActor();
     OperationContext opContext =
         OperationContext.asSession(
             systemOperationContext,
             RequestContext.builder()
-                .buildOpenapi(
-                    authentication.getActor().toUrnStr(), request, "patchAspect", entityName),
+                .buildOpenapi(actor.toUrnStr(), request, "patchAspect", entityName),
             authorizationChain,
             authentication,
             true);
 
     if (!AuthUtil.isAPIAuthorizedEntityUrns(opContext, UPDATE, List.of(urn))) {
       throw new UnauthorizedException(
-          authentication.getActor().toUrnStr() + " is unauthorized to " + UPDATE + " entities.");
+          actor.toUrnStr() + " is unauthorized to " + UPDATE + " entities.");
     }
 
     AspectSpec aspectSpec = RequestInputUtil.lookupAspectSpec(entitySpec, aspectName).get();
-    RecordTemplate currentValue = entityService.getAspect(opContext, urn, aspectSpec.getName(), 0);
 
-    GenericPatchTemplate<? extends RecordTemplate> genericPatchTemplate =
-        GenericPatchTemplate.builder()
-            .genericJsonPatch(patch)
-            .templateType(aspectSpec.getDataTemplateClass())
-            .templateDefault(
-                aspectSpec.getDataTemplateClass().getDeclaredConstructor().newInstance())
-            .build();
-    ChangeMCP upsert =
-        toUpsertItem(
-            opContext.getRetrieverContext().getAspectRetriever(),
-            validatedUrn(entityUrn),
-            aspectSpec,
-            currentValue,
-            genericPatchTemplate,
-            authentication.getActor());
+    MetadataChangeProposal mcp =
+        new MetadataChangeProposal()
+            .setEntityUrn(urn)
+            .setEntityType(urn.getEntityType())
+            .setAspectName(aspectSpec.getName())
+            .setChangeType(ChangeType.PATCH)
+            .setAspect(GenericRecordUtils.serializePatch(patch, objectMapper));
 
-    List<UpdateAspectResult> results =
-        entityService.ingestAspects(
-            opContext,
-            AspectsBatchImpl.builder()
-                .retrieverContext(opContext.getRetrieverContext())
-                .items(List.of(upsert))
-                .build(),
-            true,
-            true);
+    IngestResult result =
+        entityService.ingestProposal(
+            opContext, mcp, AuditStampUtils.createAuditStamp(actor.toUrnStr()), async);
 
-    return results.stream()
-        .findFirst()
-        .map(result -> buildGenericEntity(aspectSpec.getName(), result, withSystemMetadata))
-        .map(ResponseEntity::ok)
-        .orElse(ResponseEntity.notFound().header(NOT_FOUND_HEADER, "ENTITY").build());
+    if (result != null) {
+      return ResponseEntity.ok(
+          buildGenericEntity(aspectSpec.getName(), result, withSystemMetadata));
+    } else {
+      return ResponseEntity.notFound().header(NOT_FOUND_HEADER, "ENTITY").build();
+    }
   }
 
   protected Boolean exists(
@@ -834,22 +816,6 @@ public abstract class GenericEntitiesController<
       String jsonAspect,
       Actor actor)
       throws URISyntaxException, JsonProcessingException;
-
-  protected ChangeMCP toUpsertItem(
-      @Nonnull AspectRetriever aspectRetriever,
-      @Nonnull Urn urn,
-      @Nonnull AspectSpec aspectSpec,
-      @Nullable RecordTemplate currentValue,
-      @Nonnull GenericPatchTemplate<? extends RecordTemplate> genericPatchTemplate,
-      @Nonnull Actor actor) {
-    return ChangeItemImpl.fromPatch(
-        urn,
-        aspectSpec,
-        currentValue,
-        genericPatchTemplate,
-        AuditStampUtils.createAuditStamp(actor.toUrnStr()),
-        aspectRetriever);
-  }
 
   protected static Urn validatedUrn(String urn) throws InvalidUrnException {
     try {

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/GenericRecordUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/GenericRecordUtils.java
@@ -1,28 +1,46 @@
 package com.linkedin.metadata.utils;
 
 import com.datahub.util.RecordUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.ByteString;
+import com.linkedin.data.DataList;
 import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.ArrayDataSchema;
+import com.linkedin.data.schema.BooleanDataSchema;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.FloatDataSchema;
+import com.linkedin.data.schema.IntegerDataSchema;
+import com.linkedin.data.schema.Name;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.StringDataSchema;
+import com.linkedin.data.template.DynamicRecordTemplate;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.entity.Aspect;
 import com.linkedin.entity.EntityResponse;
 import com.linkedin.metadata.aspect.EnvelopedSystemAspect;
 import com.linkedin.metadata.aspect.SystemAspect;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.GenericPayload;
+import jakarta.json.JsonPatch;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 public class GenericRecordUtils {
   public static final String JSON = "application/json";
+  public static final String JSON_PATCH = "application/json-patch+json";
 
   private GenericRecordUtils() {}
 
@@ -99,6 +117,39 @@ public class GenericRecordUtils {
   }
 
   @Nonnull
+  public static GenericAspect serializePatch(@Nonnull JsonPatch jsonPatch) {
+    GenericAspect genericAspect = new GenericAspect();
+    genericAspect.setValue(
+        ByteString.unsafeWrap(jsonPatch.toString().getBytes(StandardCharsets.UTF_8)));
+    genericAspect.setContentType(GenericRecordUtils.JSON_PATCH);
+    return genericAspect;
+  }
+
+  @Nonnull
+  public static GenericAspect serializePatch(@Nonnull JsonNode jsonPatch) {
+    GenericAspect genericAspect = new GenericAspect();
+    genericAspect.setValue(
+        ByteString.unsafeWrap(jsonPatch.toString().getBytes(StandardCharsets.UTF_8)));
+    genericAspect.setContentType(GenericRecordUtils.JSON_PATCH);
+    return genericAspect;
+  }
+
+  @Nonnull
+  public static GenericAspect serializePatch(
+      @Nonnull GenericJsonPatch jsonPatch, @Nonnull ObjectMapper objectMapper) {
+    try {
+      GenericAspect genericAspect = new GenericAspect();
+      genericAspect.setValue(
+          ByteString.unsafeWrap(
+              objectMapper.writeValueAsString(jsonPatch).getBytes(StandardCharsets.UTF_8)));
+      genericAspect.setContentType(GenericRecordUtils.JSON_PATCH);
+      return genericAspect;
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nonnull
   public static GenericPayload serializePayload(@Nonnull RecordTemplate payload) {
     GenericPayload genericPayload = new GenericPayload();
     genericPayload.setValue(
@@ -144,5 +195,165 @@ public class GenericRecordUtils {
                                             entry.getKey().getEntityType()))))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /**
+   * Converts a JsonNode to a DynamicRecordTemplate. Useful for API responses where we're not going
+   * to persist the RecordTemplate.
+   *
+   * @param rootNode json node
+   * @param schemaName some internal name for the schema that is inferred
+   * @return a RecordTemplate object
+   */
+  public static DynamicRecordTemplate fromJson(JsonNode rootNode, String schemaName) {
+    // Create the schema
+    RecordDataSchema schema = inferSchemaFromJsonNode(rootNode, schemaName);
+
+    // Convert JsonNode to DataMap
+    DataMap dataMap = toDataMap(rootNode);
+
+    // Create and return the DynamicRecordTemplate
+    return new DynamicRecordTemplate(dataMap, schema);
+  }
+
+  private static RecordDataSchema inferSchemaFromJsonNode(JsonNode rootNode, String schemaName) {
+    // Create name object for the schema
+    Name name = new Name(schemaName);
+
+    // Create the record schema
+    RecordDataSchema schema = new RecordDataSchema(name, RecordDataSchema.RecordType.RECORD);
+
+    if (rootNode.isObject()) {
+      // Create list to hold all fields
+      List<RecordDataSchema.Field> fields = new ArrayList<>();
+
+      Iterator<Map.Entry<String, JsonNode>> fieldsIterator = rootNode.fields();
+      while (fieldsIterator.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fieldsIterator.next();
+        String fieldName = entry.getKey();
+        JsonNode fieldValue = entry.getValue();
+
+        // Create field schema based on the value type
+        DataSchema fieldSchema = inferFieldSchema(fieldValue, fieldName);
+
+        // Create and configure the field
+        RecordDataSchema.Field field = new RecordDataSchema.Field(fieldSchema);
+
+        // Set the field name
+        StringBuilder errorBuilder = new StringBuilder();
+        boolean nameSetSuccessfully = field.setName(fieldName, errorBuilder);
+        if (!nameSetSuccessfully) {
+          System.err.println("Warning: Field name issue: " + errorBuilder.toString());
+          continue;
+        }
+
+        // Set optional if value is null
+        if (fieldValue.isNull()) {
+          field.setOptional(true);
+        }
+
+        // Add field to list
+        fields.add(field);
+      }
+
+      // Set all fields in the schema with proper error handling
+      StringBuilder errorBuilder = new StringBuilder();
+      boolean fieldsSetSuccessfully = schema.setFields(fields, errorBuilder);
+      if (!fieldsSetSuccessfully) {
+        System.err.println("Warning: Schema field issues: " + errorBuilder.toString());
+      }
+    }
+
+    return schema;
+  }
+
+  private static DataSchema inferFieldSchema(JsonNode node, String baseName) {
+    if (node.isTextual()) {
+      return new StringDataSchema();
+    } else if (node.isNumber()) {
+      if (node.isInt()) {
+        return new IntegerDataSchema();
+      } else {
+        return new FloatDataSchema();
+      }
+    } else if (node.isBoolean()) {
+      return new BooleanDataSchema();
+    } else if (node.isObject()) {
+      return inferSchemaFromJsonNode(node, baseName + "Record");
+    } else if (node.isArray()) {
+      // For simplicity, use first element to determine item type
+      if (node.size() > 0) {
+        DataSchema itemSchema = inferFieldSchema(node.get(0), baseName + "Item");
+        return new ArrayDataSchema(itemSchema);
+      } else {
+        // Default to string schema for empty arrays
+        return new ArrayDataSchema(new StringDataSchema());
+      }
+    } else if (node.isNull()) {
+      // For null values, default to string schema
+      return new StringDataSchema();
+    }
+
+    // Default to string for unknown types
+    return new StringDataSchema();
+  }
+
+  private static DataMap toDataMap(JsonNode node) {
+    if (node == null || !node.isObject()) {
+      return new DataMap();
+    }
+
+    DataMap dataMap = new DataMap();
+    Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+
+    while (fields.hasNext()) {
+      Map.Entry<String, JsonNode> entry = fields.next();
+      String key = entry.getKey();
+      JsonNode value = entry.getValue();
+
+      // Only add non-null values to the DataMap, as DataMap doesn't accept null values
+      if (!value.isNull()) {
+        Object convertedValue = convertJsonValue(value);
+        if (convertedValue != null) {
+          dataMap.put(key, convertedValue);
+        }
+      }
+    }
+
+    return dataMap;
+  }
+
+  private static Object convertJsonValue(JsonNode node) {
+    if (node.isNull()) {
+      // Return null, which will be handled by the caller
+      return null;
+    } else if (node.isTextual()) {
+      return node.textValue();
+    } else if (node.isInt()) {
+      return node.intValue();
+    } else if (node.isLong()) {
+      return node.longValue();
+    } else if (node.isDouble() || node.isFloat()) {
+      return node.doubleValue();
+    } else if (node.isBoolean()) {
+      return node.booleanValue();
+    } else if (node.isObject()) {
+      return toDataMap(node);
+    } else if (node.isArray()) {
+      DataList dataList = new DataList();
+      for (JsonNode item : node) {
+        // Skip null values in arrays
+        if (!item.isNull()) {
+          Object convertedItem = convertJsonValue(item);
+          if (convertedItem != null) {
+            dataList.add(convertedItem);
+          }
+        }
+      }
+      return dataList;
+    }
+
+    // Default - convert to string
+    return node.toString();
   }
 }

--- a/metadata-utils/src/test/java/com/linkedin/metadata/utils/GenericRecordUtilsTest.java
+++ b/metadata-utils/src/test/java/com/linkedin/metadata/utils/GenericRecordUtilsTest.java
@@ -1,0 +1,446 @@
+package com.linkedin.metadata.utils;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.linkedin.data.ByteString;
+import com.linkedin.data.DataList;
+import com.linkedin.data.DataMap;
+import com.linkedin.data.schema.ArrayDataSchema;
+import com.linkedin.data.schema.BooleanDataSchema;
+import com.linkedin.data.schema.FloatDataSchema;
+import com.linkedin.data.schema.IntegerDataSchema;
+import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.StringDataSchema;
+import com.linkedin.data.template.DynamicRecordTemplate;
+import com.linkedin.metadata.aspect.patch.GenericJsonPatch;
+import com.linkedin.mxe.GenericAspect;
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import jakarta.json.JsonPatchBuilder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.testng.annotations.Test;
+
+public class GenericRecordUtilsTest {
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+  private final String expectedPathStr =
+      "[{\"op\":\"add\",\"path\":\"/name\",\"value\":\"John Doe\"},{\"op\":\"replace\",\"path\":\"/age\",\"value\":30},{\"op\":\"remove\",\"path\":\"/address\"}]";
+
+  @Test
+  public void testSerializePatchWithJsonPatch() throws Exception {
+    // Create a JsonPatch instance
+    JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
+    patchBuilder.add("/name", "John Doe");
+    patchBuilder.replace("/age", 30);
+    patchBuilder.remove("/address");
+    JsonPatch jsonPatch = patchBuilder.build();
+
+    assertEquals(jsonPatch.toString(), expectedPathStr);
+
+    // Call the method under test
+    GenericAspect result = GenericRecordUtils.serializePatch(jsonPatch);
+
+    // Verify the result
+    assertNotNull(result);
+    assertEquals(result.getContentType(), GenericRecordUtils.JSON_PATCH);
+
+    // Verify the serialized content
+    String patchContent = result.getValue().asString(StandardCharsets.UTF_8);
+    assertNotNull(patchContent);
+
+    // Verify the patch content contains expected operations
+    // (exact format may vary based on JsonPatch implementation)
+    String expectedContent = jsonPatch.toString();
+    assertEquals(expectedContent, patchContent);
+  }
+
+  @Test
+  public void testSerializePatchWithJsonNode() throws Exception {
+    // Create a JsonNode representing a patch
+    String patchJson =
+        "["
+            + "{\"op\":\"add\",\"path\":\"/name\",\"value\":\"John Doe\"},"
+            + "{\"op\":\"replace\",\"path\":\"/age\",\"value\":30},"
+            + "{\"op\":\"remove\",\"path\":\"/address\"}"
+            + "]";
+    JsonNode jsonNode = objectMapper.readTree(patchJson);
+    assertEquals(jsonNode.toString(), expectedPathStr);
+
+    // Call the method under test
+    GenericAspect result = GenericRecordUtils.serializePatch(jsonNode);
+
+    // Verify the result
+    assertNotNull(result);
+    assertEquals(result.getContentType(), GenericRecordUtils.JSON_PATCH);
+
+    // Verify the serialized content
+    String patchContent = result.getValue().asString(StandardCharsets.UTF_8);
+    assertNotNull(patchContent);
+
+    // Verify the patch content matches the expected JSON
+    assertEquals(jsonNode.toString(), patchContent);
+  }
+
+  @Test
+  public void testSerializePatchWithGenericJsonPatch() throws Exception {
+    GenericJsonPatch.PatchOp addOp = new GenericJsonPatch.PatchOp();
+    addOp.setOp("add");
+    addOp.setPath("/name");
+    addOp.setValue("John Doe");
+
+    GenericJsonPatch.PatchOp replaceOp = new GenericJsonPatch.PatchOp();
+    replaceOp.setOp("replace");
+    replaceOp.setPath("/age");
+    replaceOp.setValue(30);
+
+    GenericJsonPatch.PatchOp removeOp = new GenericJsonPatch.PatchOp();
+    removeOp.setOp("remove");
+    removeOp.setPath("/address");
+
+    GenericJsonPatch genericJsonPatch =
+        GenericJsonPatch.builder().patch(List.of(addOp, replaceOp, removeOp)).build();
+
+    // Call the method under test
+    GenericAspect result = GenericRecordUtils.serializePatch(genericJsonPatch, objectMapper);
+
+    // Verify the result
+    assertNotNull(result);
+    assertEquals(result.getContentType(), GenericRecordUtils.JSON_PATCH);
+
+    // Verify the serialized content
+    String patchContent = result.getValue().asString(StandardCharsets.UTF_8);
+    assertNotNull(patchContent);
+
+    // Verify the patch content matches
+    assertEquals(
+        patchContent,
+        String.format(
+            "{\"arrayPrimaryKeys\":{},\"patch\":%s,\"forceGenericPatch\":false}", expectedPathStr));
+  }
+
+  @Test
+  public void testSerializePatchContentTypeIsCorrect() throws Exception {
+    // This test specifically verifies that the content type is set correctly
+    JsonPatchBuilder patchBuilder = Json.createPatchBuilder();
+    patchBuilder.add("/test", "value");
+    JsonPatch jsonPatch = patchBuilder.build();
+
+    GenericAspect result = GenericRecordUtils.serializePatch(jsonPatch);
+
+    assertEquals(result.getContentType(), GenericRecordUtils.JSON_PATCH);
+    assertEquals(result.getContentType(), "application/json-patch+json");
+  }
+
+  @Test
+  public void testSerializePatchWithEmptyPatch() throws Exception {
+    // Test with an empty patch
+    JsonPatch emptyPatch = Json.createPatchBuilder().build();
+
+    GenericAspect result = GenericRecordUtils.serializePatch(emptyPatch);
+
+    assertNotNull(result);
+    assertEquals(result.getContentType(), GenericRecordUtils.JSON_PATCH);
+
+    String patchContent = result.getValue().asString(StandardCharsets.UTF_8);
+    assertEquals(emptyPatch.toString(), patchContent);
+  }
+
+  @Test
+  public void testSerializePatchByteStringEncoding() throws Exception {
+    // Test that the ByteString is correctly encoded
+    String patchJson = "[{\"op\":\"add\",\"path\":\"/test\",\"value\":\"value\"}]";
+    JsonNode jsonNode = objectMapper.readTree(patchJson);
+
+    GenericAspect result = GenericRecordUtils.serializePatch(jsonNode);
+
+    ByteString byteString = result.getValue();
+    byte[] bytes = patchJson.getBytes(StandardCharsets.UTF_8);
+
+    // Compare the byte representation of the patch
+    String resultString = new String(byteString.copyBytes(), StandardCharsets.UTF_8);
+    assertEquals(jsonNode.toString(), resultString);
+  }
+
+  @Test
+  public void testSerializePatchWithSpecialCharacters() throws Exception {
+    // Test with JSON containing special characters
+    String specialJson =
+        "[{\"op\":\"add\",\"path\":\"/message\",\"value\":\"Special characters: áéíóú ñ €\"}]";
+    JsonNode jsonNode = objectMapper.readTree(specialJson);
+
+    GenericAspect result = GenericRecordUtils.serializePatch(jsonNode);
+
+    String resultString = result.getValue().asString(StandardCharsets.UTF_8);
+    assertEquals(jsonNode.toString(), resultString);
+  }
+
+  @Test
+  public void testFromJsonWithSimpleTypes() throws Exception {
+    // Create a JSON object with various simple types
+    ObjectNode rootNode = objectMapper.createObjectNode();
+    rootNode.put("stringField", "test string");
+    rootNode.put("intField", 42);
+    rootNode.put("floatField", 3.14);
+    rootNode.put("booleanField", true);
+    rootNode.putNull("nullField");
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "SimpleTypeSchema");
+
+    // Verify the schema
+    RecordDataSchema schema = result.schema();
+    assertEquals(schema.getName(), "SimpleTypeSchema");
+    assertEquals(schema.getFields().size(), 5);
+
+    // Verify field types
+    assertTrue(schema.getField("stringField").getType() instanceof StringDataSchema);
+    assertTrue(schema.getField("intField").getType() instanceof IntegerDataSchema);
+    assertTrue(schema.getField("floatField").getType() instanceof FloatDataSchema);
+    assertTrue(schema.getField("booleanField").getType() instanceof BooleanDataSchema);
+    assertTrue(schema.getField("nullField").getType() instanceof StringDataSchema);
+    assertTrue(schema.getField("nullField").getOptional());
+
+    // Verify data values
+    DataMap dataMap = result.data();
+    assertEquals(dataMap.getString("stringField"), "test string");
+    assertEquals(dataMap.getInteger("intField"), Integer.valueOf(42));
+    assertEquals(dataMap.getDouble("floatField"), Double.valueOf(3.14));
+    assertEquals(dataMap.getBoolean("booleanField"), Boolean.TRUE);
+    assertNull(dataMap.get("nullField"));
+  }
+
+  @Test
+  public void testFromJsonWithNestedObject() throws Exception {
+    // Create a JSON object with a nested object
+    ObjectNode addressNode = objectMapper.createObjectNode();
+    addressNode.put("street", "123 Main St");
+    addressNode.put("city", "San Francisco");
+    addressNode.put("zipCode", 94105);
+
+    ObjectNode rootNode = objectMapper.createObjectNode();
+    rootNode.put("name", "John Doe");
+    rootNode.set("address", addressNode);
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "PersonSchema");
+
+    // Verify the schema
+    RecordDataSchema schema = result.schema();
+    assertEquals(schema.getName(), "PersonSchema");
+    assertEquals(schema.getFields().size(), 2);
+
+    // Verify the nested object field
+    RecordDataSchema.Field addressField = schema.getField("address");
+    assertTrue(addressField.getType() instanceof RecordDataSchema);
+
+    RecordDataSchema addressSchema = (RecordDataSchema) addressField.getType();
+    assertEquals(addressSchema.getName(), "addressRecord");
+    assertEquals(addressSchema.getFields().size(), 3);
+
+    // Verify data
+    DataMap dataMap = result.data();
+    assertEquals(dataMap.getString("name"), "John Doe");
+
+    DataMap addressData = dataMap.getDataMap("address");
+    assertEquals(addressData.getString("street"), "123 Main St");
+    assertEquals(addressData.getString("city"), "San Francisco");
+    assertEquals(addressData.getInteger("zipCode"), Integer.valueOf(94105));
+  }
+
+  @Test
+  public void testFromJsonWithArrays() throws Exception {
+    // Create a JSON object with arrays
+    ArrayNode phoneNumbers = objectMapper.createArrayNode();
+    phoneNumbers.add("555-1234");
+    phoneNumbers.add("555-5678");
+
+    ArrayNode scores = objectMapper.createArrayNode();
+    scores.add(85);
+    scores.add(92);
+    scores.add(78);
+
+    ObjectNode rootNode = objectMapper.createObjectNode();
+    rootNode.put("name", "Jane Smith");
+    rootNode.set("phoneNumbers", phoneNumbers);
+    rootNode.set("scores", scores);
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "ContactSchema");
+
+    // Verify the schema
+    RecordDataSchema schema = result.schema();
+    assertEquals(schema.getName(), "ContactSchema");
+    assertEquals(schema.getFields().size(), 3);
+
+    // Verify array fields
+    RecordDataSchema.Field phonesField = schema.getField("phoneNumbers");
+    assertTrue(phonesField.getType() instanceof ArrayDataSchema);
+    assertTrue(((ArrayDataSchema) phonesField.getType()).getItems() instanceof StringDataSchema);
+
+    RecordDataSchema.Field scoresField = schema.getField("scores");
+    assertTrue(scoresField.getType() instanceof ArrayDataSchema);
+    assertTrue(((ArrayDataSchema) scoresField.getType()).getItems() instanceof IntegerDataSchema);
+
+    // Verify data
+    DataMap dataMap = result.data();
+    assertEquals(dataMap.getString("name"), "Jane Smith");
+
+    DataList phonesList = dataMap.getDataList("phoneNumbers");
+    assertEquals(phonesList.size(), 2);
+    assertEquals(phonesList.get(0), "555-1234");
+    assertEquals(phonesList.get(1), "555-5678");
+
+    DataList scoresList = dataMap.getDataList("scores");
+    assertEquals(scoresList.size(), 3);
+    assertEquals(scoresList.get(0), Integer.valueOf(85));
+    assertEquals(scoresList.get(1), Integer.valueOf(92));
+    assertEquals(scoresList.get(2), Integer.valueOf(78));
+  }
+
+  @Test
+  public void testFromJsonWithEmptyArray() throws Exception {
+    // Create a JSON object with an empty array
+    ObjectNode rootNode = objectMapper.createObjectNode();
+    rootNode.set("tags", objectMapper.createArrayNode());
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "EmptyArraySchema");
+
+    // Verify the schema
+    RecordDataSchema schema = result.schema();
+    assertEquals(schema.getName(), "EmptyArraySchema");
+    assertEquals(schema.getFields().size(), 1);
+
+    // Verify empty array field - should default to string items
+    RecordDataSchema.Field tagsField = schema.getField("tags");
+    assertTrue(tagsField.getType() instanceof ArrayDataSchema);
+    assertTrue(((ArrayDataSchema) tagsField.getType()).getItems() instanceof StringDataSchema);
+
+    // Verify data
+    DataMap dataMap = result.data();
+    DataList tagsList = dataMap.getDataList("tags");
+    assertEquals(tagsList.size(), 0);
+  }
+
+  @Test
+  public void testFromJsonWithComplexNestedStructure() throws Exception {
+    // Create a complex nested JSON structure
+    ObjectNode addressNode = objectMapper.createObjectNode();
+    addressNode.put("street", "456 Market St");
+    addressNode.put("city", "San Francisco");
+
+    ArrayNode phoneNumbers = objectMapper.createArrayNode();
+
+    ObjectNode homePhone = objectMapper.createObjectNode();
+    homePhone.put("type", "home");
+    homePhone.put("number", "555-1234");
+
+    ObjectNode workPhone = objectMapper.createObjectNode();
+    workPhone.put("type", "work");
+    workPhone.put("number", "555-5678");
+
+    phoneNumbers.add(homePhone);
+    phoneNumbers.add(workPhone);
+
+    ObjectNode rootNode = objectMapper.createObjectNode();
+    rootNode.put("id", 1001);
+    rootNode.put("name", "Alice Johnson");
+    rootNode.put("active", true);
+    rootNode.set("address", addressNode);
+    rootNode.set("phoneNumbers", phoneNumbers);
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "ComplexSchema");
+
+    // Verify the schema
+    RecordDataSchema schema = result.schema();
+    assertEquals(schema.getName(), "ComplexSchema");
+    assertEquals(schema.getFields().size(), 5);
+
+    // Verify the nested structures in schema
+    assertTrue(schema.getField("address").getType() instanceof RecordDataSchema);
+    assertTrue(schema.getField("phoneNumbers").getType() instanceof ArrayDataSchema);
+
+    ArrayDataSchema phoneArraySchema = (ArrayDataSchema) schema.getField("phoneNumbers").getType();
+    assertTrue(phoneArraySchema.getItems() instanceof RecordDataSchema);
+
+    // Verify data
+    DataMap dataMap = result.data();
+    assertEquals(dataMap.getInteger("id"), Integer.valueOf(1001));
+    assertEquals(dataMap.getString("name"), "Alice Johnson");
+    assertEquals(dataMap.getBoolean("active"), Boolean.TRUE);
+
+    DataMap addressData = dataMap.getDataMap("address");
+    assertEquals(addressData.getString("street"), "456 Market St");
+    assertEquals(addressData.getString("city"), "San Francisco");
+
+    DataList phoneList = dataMap.getDataList("phoneNumbers");
+    assertEquals(phoneList.size(), 2);
+
+    DataMap homePhoneData = (DataMap) phoneList.get(0);
+    assertEquals(homePhoneData.getString("type"), "home");
+    assertEquals(homePhoneData.getString("number"), "555-1234");
+
+    DataMap workPhoneData = (DataMap) phoneList.get(1);
+    assertEquals(workPhoneData.getString("type"), "work");
+    assertEquals(workPhoneData.getString("number"), "555-5678");
+  }
+
+  @Test
+  public void testFromJsonWithEmptyObject() throws Exception {
+    // Create an empty JSON object
+    ObjectNode rootNode = objectMapper.createObjectNode();
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "EmptySchema");
+
+    // Verify the schema has no fields
+    RecordDataSchema schema = result.schema();
+    assertEquals(schema.getName(), "EmptySchema");
+    assertEquals(schema.getFields().size(), 0);
+
+    // Verify data is empty
+    DataMap dataMap = result.data();
+    assertTrue(dataMap.isEmpty());
+  }
+
+  @Test
+  public void testFromJsonWithSpecialCharacters() throws Exception {
+    // Create a JSON with special characters in field names
+    ObjectNode rootNode = objectMapper.createObjectNode();
+    rootNode.put("normal_field", "normal value");
+    rootNode.put("field-with-dashes", "dashed value");
+    rootNode.put("field.with.dots", "dotted value");
+
+    // Convert to DynamicRecordTemplate
+    DynamicRecordTemplate result = GenericRecordUtils.fromJson(rootNode, "SpecialCharsSchema");
+
+    // Verify schema and data
+    // Note: Some special characters might be transformed or cause warnings during schema creation
+    RecordDataSchema schema = result.schema();
+    DataMap dataMap = result.data();
+
+    // Fields that should definitely exist
+    assertTrue(dataMap.containsKey("normal_field"));
+    assertEquals(dataMap.getString("normal_field"), "normal value");
+
+    // Check if other fields exist - they may have been transformed or skipped
+    if (dataMap.containsKey("field-with-dashes")) {
+      assertEquals(dataMap.getString("field-with-dashes"), "dashed value");
+    }
+
+    if (dataMap.containsKey("field.with.dots")) {
+      assertEquals(dataMap.getString("field.with.dots"), "dotted value");
+    }
+  }
+}

--- a/smoke-test/tests/openapi/v3/advanced_patching.json
+++ b/smoke-test/tests/openapi/v3/advanced_patching.json
@@ -1,0 +1,235 @@
+[
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CadvancedPatchEntityV3%2CPROD%29",
+      "description": "Remove advanced PATCH test",
+      "method": "delete"
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset",
+      "method": "patch",
+      "description": "Patch dataset with attributed tags",
+      "params": {
+        "async": false
+      },
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,advancedPatchEntityV3,PROD)",
+          "globalTags": {
+            "value": {
+              "patch": [
+                {
+                  "op": "add",
+                  "path": "/tags/urn:li:platformResource:source1/urn:li:tag:tag1",
+                  "value": {
+                    "tag": "urn:li:tag:tag1",
+                    "attribution": {
+                      "source": "urn:li:platformResource:source1",
+                      "actor": "urn:li:corpuser:user",
+                      "time": 0
+                    }
+                  }
+                },
+                {
+                  "op": "add",
+                  "path": "/tags/urn:li:platformResource:source1/urn:li:tag:tag2",
+                  "value": {
+                    "tag": "urn:li:tag:tag2",
+                    "attribution": {
+                      "source": "urn:li:platformResource:source1",
+                      "actor": "urn:li:corpuser:user",
+                      "time": 0
+                    }
+                  }
+                },
+                {
+                  "op": "add",
+                  "path": "/tags/urn:li:platformResource:source2/urn:li:tag:tag1",
+                  "value": {
+                    "tag": "urn:li:tag:tag1",
+                    "attribution": {
+                      "source": "urn:li:platformResource:source2",
+                      "actor": "urn:li:corpuser:user",
+                      "time": 0
+                    }
+                  }
+                }
+              ],
+              "arrayPrimaryKeys": {
+                "tags": [
+                  "attribution␟source",
+                  "tag"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "response": [
+      {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:test,advancedPatchEntityV3,PROD)",
+        "globalTags": {
+          "value": {
+            "tags": [
+              {
+                "attribution": {
+                  "actor": "urn:li:corpuser:user",
+                  "time": 0,
+                  "source": "urn:li:platformResource:source1"
+                },
+                "tag": "urn:li:tag:tag1"
+              },
+              {
+                "attribution": {
+                  "actor": "urn:li:corpuser:user",
+                  "time": 0,
+                  "source": "urn:li:platformResource:source1"
+                },
+                "tag": "urn:li:tag:tag2"
+              },
+              {
+                "attribution": {
+                  "actor": "urn:li:corpuser:user",
+                  "time": 0,
+                  "source": "urn:li:platformResource:source2"
+                },
+                "tag": "urn:li:tag:tag1"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CadvancedPatchEntityV3%2CPROD%29/globalTags",
+      "method": "get",
+      "description": "Get the patched global tags with multiple attributed tags"
+    },
+    "response": {
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "attribution": {
+                "actor": "urn:li:corpuser:user",
+                "time": 0,
+                "source": "urn:li:platformResource:source1"
+              },
+              "tag": "urn:li:tag:tag1"
+            },
+            {
+              "attribution": {
+                "actor": "urn:li:corpuser:user",
+                "time": 0,
+                "source": "urn:li:platformResource:source1"
+              },
+              "tag": "urn:li:tag:tag2"
+            },
+            {
+              "attribution": {
+                "actor": "urn:li:corpuser:user",
+                "time": 0,
+                "source": "urn:li:platformResource:source2"
+              },
+              "tag": "urn:li:tag:tag1"
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset",
+      "method": "patch",
+      "description": "Patch REMOVE the tag from source1 but not source2",
+      "params": {
+        "async": false
+      },
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,advancedPatchEntityV3,PROD)",
+          "globalTags": {
+            "value": {
+              "patch": [
+                {
+                  "op": "remove",
+                  "path": "/tags/urn:li:platformResource:source1/urn:li:tag:tag1"
+                }
+              ],
+              "arrayPrimaryKeys": {
+                "tags": [
+                  "attribution␟source",
+                  "tag"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "response": [
+      {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:test,advancedPatchEntityV3,PROD)",
+        "globalTags": {
+          "value": {
+            "tags": [
+              {
+                "attribution": {
+                  "actor": "urn:li:corpuser:user",
+                  "time": 0,
+                  "source": "urn:li:platformResource:source1"
+                },
+                "tag": "urn:li:tag:tag2"
+              },
+              {
+                "attribution": {
+                  "actor": "urn:li:corpuser:user",
+                  "time": 0,
+                  "source": "urn:li:platformResource:source2"
+                },
+                "tag": "urn:li:tag:tag1"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CadvancedPatchEntityV3%2CPROD%29/globalTags",
+      "method": "get",
+      "description": "Get the patched dataset with REMOVED only source1 tag1"
+    },
+    "response": {
+      "json": {
+        "value": {
+          "tags": [
+            {
+              "attribution": {
+                "actor": "urn:li:corpuser:user",
+                "time": 0,
+                "source": "urn:li:platformResource:source1"
+              },
+              "tag": "urn:li:tag:tag2"
+            },
+            {
+              "attribution": {
+                "actor": "urn:li:corpuser:user",
+                "time": 0,
+                "source": "urn:li:platformResource:source2"
+              },
+              "tag": "urn:li:tag:tag1"
+            }
+          ]
+        }
+      }
+    }
+  }
+]

--- a/smoke-test/tests/openapi/v3/aspects.json
+++ b/smoke-test/tests/openapi/v3/aspects.json
@@ -8,6 +8,13 @@
   },
   {
     "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CF%2CPROD%29",
+      "description": "Remove PATCH aspect test",
+      "method": "delete"
+    }
+  },
+  {
+    "request": {
       "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset1AspectV3%2CPROD%29/globaltags",
       "params": {
         "createIfNotExists": "false",
@@ -115,6 +122,82 @@
             }
           ]
         }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchAspectV3%2CPROD%29/datasetProperties",
+      "method": "patch",
+      "description": "Patch aspect datasetProperties with description",
+      "json": {
+        "patch": [
+          {
+            "op": "add",
+            "path": "/description",
+            "value": "Test description"
+          }
+        ]
+      }
+    },
+    "response": {
+      "json": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchAspectV3,PROD)",
+        "datasetProperties": {
+          "value": {
+            "description": "Test description",
+            "tags": [],
+            "customProperties": {}
+          }
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchAspectV3%2CPROD%29/datasetProperties",
+      "method": "get",
+      "description": "Get the patched aspect with description"
+    },
+    "response": {
+      "value": {
+        "description": "Test description",
+        "customProperties": {},
+        "tags": []
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchAspectV3%2CPROD%29/datasetProperties",
+      "method": "patch",
+      "description": "Patch REMOVE aspect description",
+      "json": {
+        "patch": [
+          {
+            "op": "remove",
+            "path": "/description"
+          }
+        ]
+      }
+    },
+    "response": {
+      "value": {
+        "customProperties": {},
+        "tags": []
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchAspectV3%2CPROD%29/datasetProperties",
+      "method": "get",
+      "description": "Get the patched aspect with REMOVED description"
+    },
+    "response": {
+      "value": {
+        "customProperties": {},
+        "tags": []
       }
     }
   }

--- a/smoke-test/tests/openapi/v3/entities.json
+++ b/smoke-test/tests/openapi/v3/entities.json
@@ -29,6 +29,13 @@
   },
   {
     "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchEntityV3%2CPROD%29",
+      "description": "Remove PATCH test",
+      "method": "delete"
+    }
+  },
+  {
+    "request": {
       "url": "/openapi/v3/entity/dataset",
       "params": {
         "createIfNotExists": "false",
@@ -195,25 +202,7 @@
     "request": {
       "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2Cdataset%2FEntityV3%2CPROD%29",
       "method": "get",
-      "description": "Get dataset with %2F",
-      "json": [
-        {
-          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,dataset/EntityV3,PROD)",
-          "datasetProperties": {
-            "value": {
-              "name": "dataset/EntityV3",
-              "qualifiedName": "entities.dataset/EntityV3",
-              "customProperties": {},
-              "tags": []
-            }
-          },
-          "status": {
-            "value": {
-              "removed": false
-            }
-          }
-        }
-      ]
+      "description": "Get dataset with %2F"
     },
     "response": {
       "json": {
@@ -250,6 +239,148 @@
         "status": {
           "value": {
             "removed": false
+          }
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset",
+      "method": "patch",
+      "description": "Patch dataset with description",
+      "params": {
+        "async": false
+      },
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchEntityV3,PROD)",
+          "datasetProperties": {
+            "value": {
+              "patch": [
+                {
+                  "op": "add",
+                  "path": "/description",
+                  "value": "Test description"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "response": {
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchEntityV3,PROD)",
+          "browsePathsV2": {
+            "value": {
+              "path": [
+                {
+                  "id": "Default"
+                }
+              ]
+            }
+          },
+          "datasetKey": {
+            "value": {
+              "name": "datasetPatchEntityV3",
+              "platform": "urn:li:dataPlatform:test",
+              "origin": "PROD"
+            }
+          },
+          "dataPlatformInstance": {
+            "value": {
+              "platform": "urn:li:dataPlatform:test"
+            }
+          },
+          "datasetProperties": {
+            "value": {
+              "description": "Test description",
+              "tags": [],
+              "customProperties": {}
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchEntityV3%2CPROD%29",
+      "method": "get",
+      "description": "Get the patched dataset with description",
+      "params": {
+        "aspects": "datasetProperties"
+      }
+    },
+    "response": {
+      "json": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchEntityV3,PROD)",
+        "datasetProperties": {
+          "value": {
+            "description": "Test description",
+            "tags": [],
+            "customProperties": {}
+          }
+        }
+      }
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset",
+      "method": "patch",
+      "description": "Patch REMOVE dataset description",
+      "params": {
+        "async": false
+      },
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchEntityV3,PROD)",
+          "datasetProperties": {
+            "value": {
+              "patch": [
+                {
+                  "op": "remove",
+                  "path": "/description"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "response": {
+      "json": [
+        {
+          "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchEntityV3,PROD)",
+          "datasetProperties": {
+            "value": {
+              "tags": [],
+              "customProperties": {}
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "request": {
+      "url": "/openapi/v3/entity/dataset/urn%3Ali%3Adataset%3A%28urn%3Ali%3AdataPlatform%3Atest%2CdatasetPatchEntityV3%2CPROD%29",
+      "method": "get",
+      "description": "Get the patched dataset with REMOVED description",
+      "params": {
+        "aspects": "datasetProperties"
+      }
+    },
+    "response": {
+      "json": {
+        "urn": "urn:li:dataset:(urn:li:dataPlatform:test,datasetPatchEntityV3,PROD)",
+        "datasetProperties": {
+          "value": {
+            "tags": [],
+            "customProperties": {}
           }
         }
       }


### PR DESCRIPTION
Docs for Generic Patching
https://github.com/datahub-project/datahub/blob/a31d5a028bbc5bd87b2b9fd5466e934bfa9cb32e/docs/api/openapi/openapi-usage-guide.md#generic-patching

Adds support for patching to the OpenAPI endpoints in a non-experimental way. Provides backwards compatible patching as well as a new generic patching interface.
![Screenshot 2025-04-10 at 3 14 44 PM](https://github.com/user-attachments/assets/78c3839d-0679-448f-a990-5e76db9de825)



## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
