### PR TITLE
fix(ci): force depot to use oidc auth

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -34,7 +34,7 @@ env:
   DATAHUB_INGESTION_IMAGE: "acryldata/datahub-ingestion"
 
   DOCKER_CACHE: "DEPOT"
-  DEPOT_PROJECT_ID: "${{ vars.DEPOT_PROJECT_ID }}"
+  DEPOT_PROJECT_ID: s0gr1cr3jd
   DEPOT_TOKEN: "${{ secrets.DEPOT_TOKEN }}"
 
 
@@ -1113,9 +1113,11 @@ jobs:
       - name: Set up Depot CLI
         if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
         uses: depot/setup-action@v1
+        with:
+          oidc: true
 
       - name: configure-docker
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DOCKER_PROJECT_ID != '' }}
+        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
         run: |
           depot configure-docker
 

--- a/smoke-test/smoke.sh
+++ b/smoke-test/smoke.sh
@@ -21,7 +21,6 @@ else
   echo "test_user:test_pass" >> ~/.datahub/plugins/frontend/auth/user.props
   echo "datahub:datahub" > ~/.datahub/plugins/frontend/auth/user.props
 
-
   python3 -m venv venv
   set +x
   source venv/bin/activate


### PR DESCRIPTION
Helps with depot being used with PRs from forks -- PRs from forks do not have visibility to CI action vars and secrets.
## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
