### PR TITLE
fix(gms): bean not found

### DIFF
--- a/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
+++ b/metadata-service/openapi-servlet/src/main/java/io/datahubproject/openapi/controller/GenericRelationshipController.java
@@ -12,7 +12,7 @@ import com.linkedin.common.urn.UrnUtils;
 import com.linkedin.metadata.aspect.models.graph.Edge;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntities;
 import com.linkedin.metadata.aspect.models.graph.RelatedEntitiesScrollResult;
-import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
+import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.*;
 public abstract class GenericRelationshipController {
 
   @Autowired private EntityRegistry entityRegistry;
-  @Autowired private ElasticSearchGraphService graphService;
+  @Autowired private GraphService graphService;
   @Autowired private AuthorizerChain authorizationChain;
 
   @Qualifier("systemOperationContext")


### PR DESCRIPTION
This PR is intended to solve the following error:

***************************
APPLICATION FAILED TO START
***************************

Description:

Field graphService in io.datahubproject.openapi.controller.GenericRelationshipController required a bean of type 'com.linkedin.metadata.graph.elastic.ElasticSearchGraphService' that could not be found.

The injection point has the following annotations:
	- @org.springframework.beans.factory.annotation.Autowired(required=true)

