### PR TITLE
fix(cypress) Fix broken searchFilters.js cypress test

### DIFF
--- a/smoke-test/tests/cypress/cypress/e2e/search/searchFilters.js
+++ b/smoke-test/tests/cypress/cypress/e2e/search/searchFilters.js
@@ -44,9 +44,13 @@ describe("search", () => {
     cy.visit("/");
     cy.get("input[data-testid=search-input]").type("*{enter}");
 
-    // click tag filter dropdown inside of "More Filters"
-    cy.get("[data-testid=more-filters-dropdown").click({ force: true });
-    cy.get("[data-testid=more-filter-Tag").click({ force: true });
+    // open up more filters so we can see all filters at once
+    cy.get("[data-testid=more-filters-dropdown]").click();
+
+    // look for the high level tag filter first and select the more filter tag if it doesn't exist
+    cy.get("[data-testid=filter-dropdown-Tag], [data-testid=more-filter-Tag]")
+      .first()
+      .click();
 
     // click and search for tag, save that tag
     cy.get("[data-testid=search-bar").eq(1).type("cypress");


### PR DESCRIPTION
Something changed in our cypress data where the tags filter is no longer showing up in the More filter dropdown but as a top level filter now. I updated the test to check for the filter in both places so it's resilient either way.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
