### PR TITLE
fix(cypress) Fix flaky manage_policies cypress test

### DIFF
--- a/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
+++ b/datahub-web-react/src/app/permissions/policy/ManagePolicies.tsx
@@ -387,8 +387,9 @@ export const ManagePolicies = () => {
                             value={statusFilter}
                             onChange={(selection) => onStatusChange(selection as StatusType)}
                             style={{ width: 100 }}
+                            data-testid="policy-filter"
                         >
-                            <Select.Option value={StatusType.ALL} key="ALL">
+                            <Select.Option value={StatusType.ALL} key="ALL" data-testid="all-policies-option">
                                 All
                             </Select.Option>
                             <Select.Option value={StatusType.ACTIVE} key="ACTIVE">

--- a/smoke-test/tests/cypress/cypress/e2e/settings/manage_policies.js
+++ b/smoke-test/tests/cypress/cypress/e2e/settings/manage_policies.js
@@ -5,6 +5,7 @@ const metadata_policy_name = `Metadata test policy ${test_id}`;
 const metadata_policy_edited = `Metadata test policy ${test_id} EDITED`;
 
 function searchForPolicy(metadataPolicyName) {
+  cy.wait(1000);
   cy.get('[data-testid="search-input"]').should("be.visible");
   cy.get('[data-testid="search-input"]').eq(1).type(metadataPolicyName);
   cy.get('[data-testid="search-input"]').eq(1).blur();
@@ -28,6 +29,12 @@ function updateAndSave(Id, groupName, text) {
 
 function clickOnButton(saveButton) {
   cy.get(`#${saveButton}`).click();
+}
+
+function changeFilterToAll(saveButton) {
+  cy.get("[data-testid='policy-filter']").click();
+  cy.get("[data-testid='all-policies-option']").click();
+  cy.wait(1000);
 }
 
 function createPolicy(decription, policyName) {
@@ -83,6 +90,7 @@ describe("create and manage platform and metadata policies", () => {
 
   it("create platform policy", () => {
     cy.waitTextVisible("Manage Permissions");
+    changeFilterToAll();
     cy.clickOptionWithText("Create new policy");
     clickFocusAndType("policy-name", platform_policy_name);
     cy.get('[data-testid="policy-type"] [title="Metadata"]').click();
@@ -94,6 +102,7 @@ describe("create and manage platform and metadata policies", () => {
   });
 
   it("edit platform policy", () => {
+    changeFilterToAll();
     editPolicy(
       `${platform_policy_name}`,
       platform_policy_edited,
@@ -104,6 +113,7 @@ describe("create and manage platform and metadata policies", () => {
   });
 
   it("deactivate and activate platform policy", () => {
+    changeFilterToAll();
     deletePolicy(
       `${platform_policy_edited}`,
       `Delete ${platform_policy_edited}`,
@@ -112,6 +122,7 @@ describe("create and manage platform and metadata policies", () => {
   });
 
   it("create metadata policy", () => {
+    changeFilterToAll();
     cy.clickOptionWithText("Create new policy");
     clickFocusAndType("policy-name", metadata_policy_name);
     cy.get('[data-testid="policy-type"]').should("have.text", "Metadata");
@@ -122,6 +133,7 @@ describe("create and manage platform and metadata policies", () => {
   });
 
   it("edit metadata policy", () => {
+    changeFilterToAll();
     editPolicy(
       `${metadata_policy_name}`,
       metadata_policy_edited,
@@ -132,6 +144,7 @@ describe("create and manage platform and metadata policies", () => {
   });
 
   it("deactivate and activate metadata policy", () => {
+    changeFilterToAll();
     deletePolicy(
       `${metadata_policy_name}`,
       `Delete ${metadata_policy_name}`,


### PR DESCRIPTION
Fixes some flakiness in the manage_policies cypress test by making sure we adjust the filter to see all policies and adding a 1 second wait before we search filter to make sure the apollo cache gets updated before we do so. Otherwise we sometimes miss a policy we want to see in the list because we either filter it out or move too quickly before we update.

## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
