### PR TITLE
build: use docker bake to build all images in a single step

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1148,8 +1148,8 @@ jobs:
           python-version: "3.10"
           cache: "pip"
 
-      #- uses: gradle/actions/setup-gradle@v4
-
+      - uses: gradle/actions/setup-gradle@v4
+        if: ${{ env.DEPOT_PROJECT_ID == '' }}
 
       - name: build images
         if: ${{ env.DOCKER_CACHE != 'DEPOT' || env.DEPOT_PROJECT_ID == '' }}
@@ -1162,7 +1162,8 @@ jobs:
 
           wait
           docker images
-
+        env:
+          DOCKER_CACHE: GITHUB
       - name: pull images from depot
         if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
         run: | 

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1151,7 +1151,7 @@ jobs:
       - name: run quickstart
         env:
           DATAHUB_TELEMETRY_ENABLED: false
-          DATAHUB_VERSION: ${{ needs.setup.outputs.unique_tag }}
+          DATAHUB_VERSION: pr-build
           DATAHUB_ACTIONS_IMAGE: ${{ env.DATAHUB_INGESTION_BASE_IMAGE }}
           ACTIONS_VERSION: ${{ needs.datahub_ingestion_slim_build.outputs.tag || 'head-slim' }}
           ACTIONS_EXTRA_PACKAGES: "acryl-datahub-actions[executor] acryl-datahub-actions"

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1152,7 +1152,7 @@ jobs:
         if: ${{ env.DEPOT_PROJECT_ID == '' }}
 
       - name: build images
-        if: ${{ env.DOCKER_CACHE != 'DEPOT' || env.DEPOT_PROJECT_ID == '' }}
+        if: ${{ env.DEPOT_PROJECT_ID == '' }}
         run: |
           docker pull confluentinc/cp-kafka:7.4.0 &
           docker pull mysql:8.2 &

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -158,6 +158,8 @@ jobs:
     name: Prepare all images
     runs-on: depot-ubuntu-24.04-4
     needs: setup
+    outputs:
+      build_id: ${{ steps.capture-build-id.outputs.build_id }}
     steps:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -195,12 +197,19 @@ jobs:
       - name: Build all Docker Contexts
         run: |
           ./gradlew :docker:buildImagesQuickstartDebugConsumers -PreleaseVersion=pr-build
+      
+      - name: Capture build Id
+        id: capture-build-id
+        run: |
+          pip install jq
+          DEPOT_BUILD_ID=$(jq -r '.["depot.build"]?.buildID' ${{ github.workspace }}/build/build-metadata.json)
+          echo DEPOT_BUILD_ID
+          echo "build_id=${DEPOT_BUILD_ID}" >> "$GITHUB_OUTPUT"
 
-
-      - uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
+      #- uses: actions/cache/save@v4
+      #  with:
+      #    path: ${{ github.workspace }}/build/dockerBuildContext/
+      #    key: ${{ runner.os }}-docker-${{ github.sha }}
 
 
   gms_build:
@@ -1113,15 +1122,15 @@ jobs:
         if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
         uses: depot/setup-action@v1
 
-      - name: configure-docker
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DOCKER_PROJECT_ID != '' }}
-        run: |
-          depot configure-docker
+      #- name: configure-docker
+      #  if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
+      #  run: |
+      #    depot configure-docker
 
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
+      #- uses: actions/cache/restore@v4
+      #  with:
+      #    path: ${{ github.workspace }}/build/dockerBuildContext/
+      #    key: ${{ runner.os }}-docker-${{ github.sha }}
   
       - uses: actions/setup-python@v5
         with:
@@ -1138,6 +1147,7 @@ jobs:
 #            password: ${{ secrets.ACRYL_DOCKER_PASSWORD }}
 
       - name: build images
+        if: false
         run: |
           docker pull confluentinc/cp-kafka:7.4.0 &
           docker pull mysql:8.2 &
@@ -1148,6 +1158,10 @@ jobs:
           wait
           docker images
 
+      - name: pull images from depot
+        run: | 
+          depot pull --project ${{ env.DEPOT_PROJECT_ID }} ${{ needs.base_build.outputs.build_id }}
+          docker images
       - name: run quickstart
         env:
           DATAHUB_TELEMETRY_ENABLED: false

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -1080,7 +1080,7 @@ jobs:
 
   smoke_test:
     name: Run Smoke Tests
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     needs:
       [
         setup,
@@ -1119,18 +1119,8 @@ jobs:
 
 
       - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
+        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
         uses: depot/setup-action@v1
-
-      #- name: configure-docker
-      #  if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
-      #  run: |
-      #    depot configure-docker
-
-      #- uses: actions/cache/restore@v4
-      #  with:
-      #    path: ${{ github.workspace }}/build/dockerBuildContext/
-      #    key: ${{ runner.os }}-docker-${{ github.sha }}
   
       - uses: actions/setup-python@v5
         with:
@@ -1139,26 +1129,21 @@ jobs:
 
       #- uses: gradle/actions/setup-gradle@v4
 
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v3
-#        if: ${{ needs.setup.outputs.docker-login == 'true' }}
-#        with:
-#            username: ${{ secrets.ACRYL_DOCKER_USERNAME }}
-#            password: ${{ secrets.ACRYL_DOCKER_PASSWORD }}
 
       - name: build images
-        if: false
+        if: ${{ env.DOCKER_CACHE != 'DEPOT' || env.DEPOT_PROJECT_ID == '' }}
         run: |
           docker pull confluentinc/cp-kafka:7.4.0 &
           docker pull mysql:8.2 &
           docker pull opensearchproject/opensearch:2.9.0 &
           docker pull ${{ env.DATAHUB_INGESTION_BASE_IMAGE }}:head-slim  &
-          ./gradlew :docker:buildImagesFromCacheQuickstartDebugConsumers -PreleaseVersion=pr-build &
+          ./gradlew :docker:buildImagesQuickstartDebugConsumers -PreleaseVersion=pr-build &
 
           wait
           docker images
 
       - name: pull images from depot
+        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
         run: | 
           depot pull --project ${{ env.DEPOT_PROJECT_ID }} ${{ needs.base_build.outputs.build_id }}
           docker images

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -195,40 +195,42 @@ jobs:
 
 
       - name: Build all Docker Contexts
+        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
         run: |
           ./gradlew :docker:buildImagesQuickstartDebugConsumers -PreleaseVersion=pr-build
       
       - name: Capture build Id
         id: capture-build-id
+        if: ${{ env.DOCKER_CACHE == 'DEPOT' && env.DEPOT_PROJECT_ID != '' }}
         run: |
           pip install jq
           DEPOT_BUILD_ID=$(jq -r '.["depot.build"]?.buildID' ${{ github.workspace }}/build/build-metadata.json)
-          echo DEPOT_BUILD_ID
+          
           echo "build_id=${DEPOT_BUILD_ID}" >> "$GITHUB_OUTPUT"
-
-      #- uses: actions/cache/save@v4
-      #  with:
-      #    path: ${{ github.workspace }}/build/dockerBuildContext/
-      #    key: ${{ runner.os }}-docker-${{ github.sha }}
 
 
   gms_build:
     name: Build and Push DataHub GMS Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
+      - name: Pre-build artifacts for docker image
+        run: |
+          ./gradlew :metadata-service:war:dockerPrepare
 
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
@@ -248,7 +250,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: "[Monitoring] Scan GMS images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, gms_build]
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
@@ -280,22 +282,27 @@ jobs:
 
   mae_consumer_build:
     name: Build and Push DataHub MAE Consumer Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, smoke_test_lint, base_build]
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
-
+      - name: Pre-build artifacts for docker image
+        run: |
+          ./gradlew :metadata-jobs:mae-consumer-job:dockerPrepare
+      
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -346,21 +353,22 @@ jobs:
 
   mce_consumer_build:
     name: Build and Push DataHub MCE Consumer Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}      
+      - name: Pre-build artifacts for docker image
+        run: |
+          ./gradlew :metadata-jobs:mce-consumer-job:dockerPrepare
+          
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -411,21 +419,26 @@ jobs:
 
   datahub_upgrade_build:
     name: Build and Push DataHub Upgrade Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
+      - name: Pre-build artifacts for docker image
+        run: |
+          ./gradlew :datahub-upgrade:dockerPrepare
 
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
@@ -441,7 +454,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
   datahub_upgrade_scan:
     name: "[Monitoring] Scan DataHub Upgrade images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, smoke_test_lint,datahub_upgrade_build]
     if: ${{ needs.setup.outputs.backend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     permissions:
@@ -477,21 +490,26 @@ jobs:
 
   frontend_build:
     name: Build and Push DataHub Frontend Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ needs.setup.outputs.frontend_change == 'true' || needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true'}}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v4
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
+      - name: Pre-build artifacts for docker image
+        run: |
+          ./gradlew :datahub-frontend:dockerPrepare -x test -x yarnTest -x yarnLint --parallel
 
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
@@ -507,7 +525,7 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
   frontend_scan:
     name: "[Monitoring] Scan Frontend images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-24.04
     needs: [setup, smoke_test_lint,frontend_build]
     if: ${{ needs.setup.outputs.frontend_change == 'true' || needs.setup.outputs.publish == 'true' }}
     permissions:
@@ -543,22 +561,17 @@ jobs:
 
   kafka_setup_build:
     name: Build and Push DataHub Kafka Setup Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ needs.setup.outputs.kafka_setup_change == 'true' || (needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true') }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
-
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
         with:
@@ -577,7 +590,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: "[Monitoring] Scan Kafka Setup images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [ setup, smoke_test_lint,kafka_setup_build]
     if: ${{ needs.setup.outputs.kafka_setup_change == 'true' || (needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true') }}
     steps:
@@ -609,21 +622,17 @@ jobs:
 
   mysql_setup_build:
     name: Build and Push DataHub MySQL Setup Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ false || needs.setup.outputs.mysql_setup_change == 'true' || (needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true') }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
 
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
@@ -643,7 +652,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: "[Monitoring] Scan MySQL Setup images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [ setup, smoke_test_lint,mysql_setup_build ]
     if: ${{ needs.setup.outputs.mysql_setup_change == 'true' || (needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true') }}
     steps:
@@ -675,21 +684,17 @@ jobs:
 
   elasticsearch_setup_build:
     name: Build and Push DataHub Elasticsearch Setup Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, base_build]
     if: ${{ needs.setup.outputs.elasticsearch_setup_change == 'true' || (needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true' ) }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
 
       - name: Build and push
         uses: ./.github/actions/docker-custom-build-and-push
@@ -709,7 +714,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: "[Monitoring] Scan ElasticSearch setup images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [ setup, elasticsearch_setup_build ]
     if: ${{ needs.setup.outputs.elasticsearch_setup_change == 'true' || (needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true' ) }}
     steps:
@@ -741,23 +746,19 @@ jobs:
 
   datahub_ingestion_base_build:
     name: Build and Push DataHub Ingestion (Base) Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     needs: setup
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true' }}
     steps:
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove 'dotnet-*' azure-cli || true
+          sudo rm -rf /usr/local/lib/android/ || true
+          sudo docker image prune -a -f || true
       - name: Check out the repo
         uses: acryldata/sane-checkout-action@v3
-
-      - name: Set up Depot CLI
-        if: ${{ env.DOCKER_CACHE == 'DEPOT' }}
-        uses: depot/setup-action@v1
-
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/build/dockerBuildContext/
-          key: ${{ runner.os }}-docker-${{ github.sha }}
 
       - name: Build and push Base Image
         if: ${{ needs.setup.outputs.ingestion_base_change == 'true' }}
@@ -778,7 +779,7 @@ jobs:
         run: echo "tag=${{ needs.setup.outputs.ingestion_base_change == 'true' && needs.setup.outputs.unique_tag || 'head' }}" >> "$GITHUB_OUTPUT"
   datahub_ingestion_base_slim_build:
     name: Build and Push DataHub Ingestion (Base-Slim) Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     needs: [setup, smoke_test_lint,datahub_ingestion_base_build]
@@ -825,7 +826,7 @@ jobs:
         run: echo "tag=${{ needs.setup.outputs.ingestion_base_change == 'true' && needs.setup.outputs.unique_slim_tag || 'head-slim' }}" >> "$GITHUB_OUTPUT"
   datahub_ingestion_base_full_build:
     name: Build and Push DataHub Ingestion (Base-Full) Docker Image
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     needs: [setup, smoke_test_lint,datahub_ingestion_base_build]
@@ -866,7 +867,7 @@ jobs:
 
   datahub_ingestion_slim_build:
     name: Build and Push DataHub Ingestion Docker Images
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       needs_artifact_download: ${{ needs.setup.outputs.ingestion_change == 'true' && ( needs.setup.outputs.publish != 'true' && needs.setup.outputs.pr-publish != 'true') }}
@@ -921,7 +922,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: "[Monitoring] Scan Datahub Ingestion Slim images for vulnerabilities"
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [setup, smoke_test_lint,datahub_ingestion_slim_build]
     if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' }}
     steps:
@@ -954,7 +955,7 @@ jobs:
 
   datahub_ingestion_full_build:
     name: Build and Push DataHub Ingestion (Full) Docker Images
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
       needs_artifact_download: ${{ needs.setup.outputs.ingestion_change == 'true' && ( needs.setup.outputs.publish != 'true' && needs.setup.outputs.pr-publish != 'true' ) }}
@@ -972,7 +973,7 @@ jobs:
         with:
           distribution: "zulu"
           java-version: 17
-      #- uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v4
       - name: Build codegen
         if: ${{ needs.setup.outputs.ingestion_change == 'true' || needs.setup.outputs.publish == 'true' || needs.setup.outputs.pr-publish == 'true' }}
         run: ./gradlew :metadata-ingestion:codegen
@@ -1041,7 +1042,7 @@ jobs:
 
   smoke_test_matrix:
     runs-on: depot-ubuntu-24.04-small
-    needs: setup
+    needs: [setup, determine_runner]
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       cypress_batch_count: ${{ steps.set-batch-count.outputs.cypress_batch_count }}
@@ -1053,8 +1054,13 @@ jobs:
         # python_batch_count is used to split pytests in the smoke-test (batches of actual test functions)
         # cypress_batch_count is used to split the collection of cypress test specs into batches.
         run: |
-          echo "cypress_batch_count=11" >> "$GITHUB_OUTPUT"
-          echo "python_batch_count=6" >> "$GITHUB_OUTPUT"
+          if [[ "${{ needs.determine_runner.outputs.runner_type }}" == "ubuntu-latest" ]]; then
+            echo "cypress_batch_count=5" >> "$GITHUB_OUTPUT"
+            echo "python_batch_count=3" >> "$GITHUB_OUTPUT"
+          else
+            echo "cypress_batch_count=11" >> "$GITHUB_OUTPUT"
+            echo "python_batch_count=6" >> "$GITHUB_OUTPUT"
+          fi
 
       - id: set-matrix
         # For m batches for python and n batches for cypress, we need a test matrix of python x m + cypress x n.
@@ -1078,15 +1084,30 @@ jobs:
           fi
           echo "matrix={\"include\":[$includes] }" >> "$GITHUB_OUTPUT"
 
+  determine_runner:
+    name: Determine Runner Type
+    runs-on: depot-ubuntu-24.04-small
+    needs: setup
+    outputs:
+      runner_type: ${{ steps.set-runner.outputs.runner_type }}
+    steps:
+      - id: set-runner
+        run: |
+          if [[ "${{ env.DOCKER_CACHE }}" == "DEPOT" && "${{ env.DEPOT_PROJECT_ID }}" != "" ]]; then
+            echo "runner_type=depot-ubuntu-24.04" >> "$GITHUB_OUTPUT"
+          else
+            echo "runner_type=ubuntu-latest" >> "$GITHUB_OUTPUT"
+          fi
+
   smoke_test:
     name: Run Smoke Tests
-    runs-on: depot-ubuntu-24.04
+    runs-on: ${{ needs.determine_runner.outputs.runner_type }}
     needs:
       [
         setup,
         smoke_test_matrix,
         base_build,
-        #datahub_ingestion_slim_build,
+        determine_runner
       ]
     strategy:
       fail-fast: false
@@ -1094,7 +1115,7 @@ jobs:
     if: ${{ always() && !failure() && !cancelled() && needs.smoke_test_matrix.outputs.matrix != '[]' }}
     steps:
       - name: Free up disk space
-        if: false  # dont need this on depot
+        if: ${{ needs.determine_runner.outputs.runner_type != 'depot-ubuntu-24.04' }}
         run: |
           sudo apt-get remove 'dotnet-*' azure-cli || true
           sudo rm -rf /usr/local/lib/android/ || true

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -194,7 +194,7 @@ jobs:
 
       - name: Build all Docker Contexts
         run: |
-          ./gradlew :docker:PrepareAllQuickStartConsumers
+          ./gradlew :docker:buildImagesQuickstartDebugConsumers -PreleaseVersion=pr-build
 
 
       - uses: actions/cache/save@v4
@@ -1139,11 +1139,11 @@ jobs:
 
       - name: build images
         run: |
-          ./gradlew :docker:buildImagesFromCacheQuickstartDebugConsumers -PreleaseVersion=${{ needs.setup.outputs.unique_tag }} &
           docker pull confluentinc/cp-kafka:7.4.0 &
           docker pull mysql:8.2 &
           docker pull opensearchproject/opensearch:2.9.0 &
           docker pull ${{ env.DATAHUB_INGESTION_BASE_IMAGE }}:head-slim  &
+          ./gradlew :docker:buildImagesFromCacheQuickstartDebugConsumers -PreleaseVersion=pr-build &
 
           wait
           docker images

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ plugins {
   id 'com.gorylenko.gradle-git-properties' version '2.4.1'
   id 'com.gradleup.shadow' version '8.3.5' apply false
   id 'com.palantir.docker' version '0.35.0' apply false
-  id 'com.avast.gradle.docker-compose' version '0.17.6'
+  id 'com.avast.gradle.docker-compose' version '0.17.12'
   id "com.diffplug.spotless" version "6.23.3"
   // https://blog.ltgt.net/javax-jakarta-mess-and-gradle-solution/
   // TODO id "org.gradlex.java-ecosystem-capabilities" version "1.0"

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -155,14 +155,6 @@ dockerCompose {
     }
 }
 
-// Configure dependencies for ComposeUp tasks
-quickstart_configs.each { taskName, config ->
-    if (config.modules) {
-        tasks.getByName("${taskName}ComposeUp").dependsOn(
-                config.modules.collect { it + ":${config.isDebug ? 'dockerTagDebug' : 'dockerTag'}" }
-        )
-    }
-}
 
 // Register all quickstart tasks
 quickstart_configs.each { taskName, config ->
@@ -179,34 +171,119 @@ quickstart_configs.each { taskName, config ->
     }
 }
 
+
 quickstart_configs.each { taskName, config ->
-    tasks.register("buildImagesFromCache${taskName}") {
+    tasks.register("buildImages${taskName}", Exec) {
+        ext{
+            bakeSpec = [:]
+        }
         group = 'quickstart-ci'
+        dependsOn(config.modules.collect { it + ':generateBakeSnippet' })
+        dependsOn(tasks.getByName("prepareAll${taskName}"))
+
+        def jsonFile = new File(rootProject.buildDir, "bake-spec-${taskName}.json")
+
+        def buildCmd = []
+        if (System.getenv("DOCKER_CACHE") == "GITHUB") {
+            buildCmd += ["docker",  "buildx"]
+            def githubToken = System.getenv("GITHUB_TOKEN")
+            if (githubToken) {
+                dockerCmd += ["--cache-from", "type=gha,token=${githubToken}"]
+                dockerCmd += ["--cache-to", "type=gha,mode=max,token=${githubToken}"]
+            } else {
+                dockerCmd += ["--cache-from", "type=gha"]
+                dockerCmd += ["--cache-to", "type=gha,mode=max"]
+            }
+        } else if (System.getenv("DOCKER_CACHE") == "DEPOT") {
+            buildCmd += ["depot" ]
+        } else {
+            buildCmd += ["docker",  "buildx" ]
+        }
+        buildCmd += ["bake", "-f",  "${jsonFile.absolutePath}"]
+        commandLine buildCmd
+        workingDir rootProject.projectDir
+
+        doFirst {
+            def bakeSnippets = [:]
+            def targets = []
+
+            config.modules.each { module ->
+                def moduleProject = project.project(module)
+                def generateBakeSnippetsTask = moduleProject.tasks.getByName("generateBakeSnippet")
+                bakeSnippets.putAll(generateBakeSnippetsTask.bakeSpec.target)
+                targets.addAll(generateBakeSnippetsTask.bakeSpec.target.keySet())
+            }
+
+            ext.bakeSpec.group = [ "default": ["targets": targets] ]
+            ext.bakeSpec.target = bakeSnippets
+
+            jsonFile.parentFile.mkdirs()
+            jsonFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(ext.bakeSpec))
+        }
     }
 }
 
+//TODO This is a copy of buildImages* tasks but without the prepareAll dependency. Need to refactor to avoid code duplication.
+quickstart_configs.each { taskName, config ->
+    tasks.register("buildImagesFromCache${taskName}", Exec) {
+        ext{
+            bakeSpec = [:]
+        }
+        group = 'quickstart-ci'
+        dependsOn(config.modules.collect { it + ':generateBakeSnippet' })
+
+        def jsonFile = new File(rootProject.buildDir, "bake-spec-${taskName}.json")
+
+        def buildCmd = []
+        if (System.getenv("DOCKER_CACHE") == "GITHUB") {
+            buildCmd += ["docker",  "buildx"]
+            def githubToken = System.getenv("GITHUB_TOKEN")
+            if (githubToken) {
+                dockerCmd += ["--cache-from", "type=gha,token=${githubToken}"]
+                dockerCmd += ["--cache-to", "type=gha,mode=max,token=${githubToken}"]
+            } else {
+                dockerCmd += ["--cache-from", "type=gha"]
+                dockerCmd += ["--cache-to", "type=gha,mode=max"]
+            }
+        } else if (System.getenv("DOCKER_CACHE") == "DEPOT") {
+            buildCmd += ["depot" ]
+        } else {
+            buildCmd += ["docker",  "buildx" ]
+        }
+        buildCmd += ["bake", "-f",  "${jsonFile.absolutePath}"]
+        commandLine buildCmd
+        workingDir rootProject.projectDir
+
+        doFirst {
+            def bakeSnippets = [:]
+            def targets = []
+
+            config.modules.each { module ->
+                def moduleProject = project.project(module)
+                def generateBakeSnippetsTask = moduleProject.tasks.getByName("generateBakeSnippet")
+                bakeSnippets.putAll(generateBakeSnippetsTask.bakeSpec.target)
+                targets.addAll(generateBakeSnippetsTask.bakeSpec.target.keySet())
+            }
+
+            ext.bakeSpec.group = [ "default": ["targets": targets] ]
+            ext.bakeSpec.target = bakeSnippets
+
+            jsonFile.parentFile.mkdirs()
+            jsonFile.text = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(ext.bakeSpec))
+        }
+    }
+}
+
+
+// Configure dependencies for ComposeUp tasks
 quickstart_configs.each { taskName, config ->
     if (config.modules) {
-        tasks.getByName("buildImagesFromCache${taskName}").dependsOn(
-            config.modules.collect { it + ':dockerFromCache' }
+        tasks.getByName("${taskName}ComposeUp").dependsOn(
+                tasks.getByName("buildImages${taskName}")
         )
     }
 }
 
-
-quickstart_configs.each { taskName, config ->
-    tasks.register("buildImages${taskName}") {
-        group = 'quickstart-ci'
-    }
-}
-
-quickstart_configs.each { taskName, config ->
-    if (config.modules) {
-        tasks.getByName("buildImages${taskName}").dependsOn(
-            config.modules.collect { it + ':dockerTag' }
-        )
-    }
-}
 
 tasks.register('minDockerCompose2.20', Exec) {
     executable 'bash'

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -183,9 +183,11 @@ quickstart_configs.each { taskName, config ->
 
         def jsonFile = new File(rootProject.buildDir, "bake-spec-${taskName}.json")
 
+        def bakeCmdArgs = ["bake", "-f",  "${jsonFile.absolutePath}"]
         def buildCmd = []
         if (System.getenv("DOCKER_CACHE") == "GITHUB") {
-            buildCmd += ["docker",  "buildx"]
+            buildCmd += ["docker",  "buildx" ]
+            buildCmd += bakeCmdArgs
             def githubToken = System.getenv("GITHUB_TOKEN")
             if (githubToken) {
                 dockerCmd += ["--cache-from", "type=gha,token=${githubToken}"]
@@ -195,11 +197,14 @@ quickstart_configs.each { taskName, config ->
                 dockerCmd += ["--cache-to", "type=gha,mode=max"]
             }
         } else if (System.getenv("DOCKER_CACHE") == "DEPOT") {
-            buildCmd += ["depot" ]
+            buildCmd << "depot"
+            buildCmd += bakeCmdArgs
+            buildCmd += ['--save', '--metadata-file', "${rootProject.buildDir}/build-metadata.json"]
         } else {
             buildCmd += ["docker",  "buildx" ]
+            buildCmd +=bakeCmdArgs
         }
-        buildCmd += ["bake", "-f",  "${jsonFile.absolutePath}"]
+        println(buildCmd.join(" "))
         commandLine buildCmd
         workingDir rootProject.projectDir
 
@@ -224,6 +229,7 @@ quickstart_configs.each { taskName, config ->
 }
 
 //TODO This is a copy of buildImages* tasks but without the prepareAll dependency. Need to refactor to avoid code duplication.
+/*
 quickstart_configs.each { taskName, config ->
     tasks.register("buildImagesFromCache${taskName}", Exec) {
         ext{
@@ -234,9 +240,11 @@ quickstart_configs.each { taskName, config ->
 
         def jsonFile = new File(rootProject.buildDir, "bake-spec-${taskName}.json")
 
+        bakeCmdArgs = ["bake", "-f",  "${jsonFile.absolutePath}"]
         def buildCmd = []
         if (System.getenv("DOCKER_CACHE") == "GITHUB") {
-            buildCmd += ["docker",  "buildx"]
+            buildCmd += ["docker",  "buildx" ]
+            buildCmd += bakeCmdArgs
             def githubToken = System.getenv("GITHUB_TOKEN")
             if (githubToken) {
                 dockerCmd += ["--cache-from", "type=gha,token=${githubToken}"]
@@ -246,11 +254,14 @@ quickstart_configs.each { taskName, config ->
                 dockerCmd += ["--cache-to", "type=gha,mode=max"]
             }
         } else if (System.getenv("DOCKER_CACHE") == "DEPOT") {
-            buildCmd += ["depot" ]
+            buildCmd << "depot"
+            buildCmd += bakeCmdArgs
+            buildCmd += ['--save', '--metadata-file', "${rootProject.buildDir}/build-metadata.json"]
         } else {
             buildCmd += ["docker",  "buildx" ]
+            buildCmd +=bakeCmdArgs
         }
-        buildCmd += ["bake", "-f",  "${jsonFile.absolutePath}"]
+        println(buildCmd.join(" "))
         commandLine buildCmd
         workingDir rootProject.projectDir
 
@@ -273,7 +284,7 @@ quickstart_configs.each { taskName, config ->
         }
     }
 }
-
+*/
 
 // Configure dependencies for ComposeUp tasks
 quickstart_configs.each { taskName, config ->

--- a/docker/build.gradle
+++ b/docker/build.gradle
@@ -185,18 +185,7 @@ quickstart_configs.each { taskName, config ->
 
         def bakeCmdArgs = ["bake", "-f",  "${jsonFile.absolutePath}"]
         def buildCmd = []
-        if (System.getenv("DOCKER_CACHE") == "GITHUB") {
-            buildCmd += ["docker",  "buildx" ]
-            buildCmd += bakeCmdArgs
-            def githubToken = System.getenv("GITHUB_TOKEN")
-            if (githubToken) {
-                dockerCmd += ["--cache-from", "type=gha,token=${githubToken}"]
-                dockerCmd += ["--cache-to", "type=gha,mode=max,token=${githubToken}"]
-            } else {
-                dockerCmd += ["--cache-from", "type=gha"]
-                dockerCmd += ["--cache-to", "type=gha,mode=max"]
-            }
-        } else if (System.getenv("DOCKER_CACHE") == "DEPOT") {
+        if (System.getenv("DOCKER_CACHE") == "DEPOT") {
             buildCmd << "depot"
             buildCmd += bakeCmdArgs
             buildCmd += ['--save', '--metadata-file', "${rootProject.buildDir}/build-metadata.json"]
@@ -204,7 +193,6 @@ quickstart_configs.each { taskName, config ->
             buildCmd += ["docker",  "buildx" ]
             buildCmd +=bakeCmdArgs
         }
-        println(buildCmd.join(" "))
         commandLine buildCmd
         workingDir rootProject.projectDir
 

--- a/gradle/docker/docker.gradle
+++ b/gradle/docker/docker.gradle
@@ -223,6 +223,30 @@ project.afterEvaluate {
     }
   }
 
+  project.tasks.register("generateBakeSnippet") {
+    ext.bakeSpec = []
+    group "docker"
+    description "Generates bake snippets for the project"
+
+    doLast {
+      def bake_spec_target = [
+        context: "${buildContext}",
+        dockerfile: "${extension.dockerfile.get().toPath()}",
+        tags: extension.tags.get().values()
+      ]
+      if (extension.buildArgs.get()) {
+        bake_spec_target.args = extension.buildArgs.get()
+      }
+      if (extension.platforms.get()) {
+        bake_spec_target.platforms = extension.platforms.get()
+      }
+
+      ext.bakeSpec = [
+        target: [ "${project.name}": bake_spec_target]
+      ]
+    }
+  }
+
   extension.tags.get().each { taskName, tag ->
     // For backward compatibility, can be removed if we dont really have a need post migration
     // TODO: Choice of task names is to retain current names so that downstream dependencies in quickstart still work

--- a/settings.gradle
+++ b/settings.gradle
@@ -98,6 +98,10 @@ buildCache {
 }
 
 def installPreCommitHooks() {
+    if (System.getenv("CI") == "true") {
+        println("Skipping pre-commit hooks in CI")
+        return 
+    }
     def preCommitInstalled = false
     try {
         def process = ["which", "pre-commit"].execute()


### PR DESCRIPTION
Building via bake makes better use of remote container builder resources with ~20 seconds to build all images
CI updates to use bake based builds and batch download of images from depot ephemeral registry
Disable pre-commit hooks in CI
Enabled PRs from forks that are not configured with depot to continue to use gha runners - which take about 20 min longer


## Checklist

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)
